### PR TITLE
Update LazyServiceIdentifier.is to support nullish values

### DIFF
--- a/.changeset/eight-waves-roll.md
+++ b/.changeset/eight-waves-roll.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/common": patch
+---
+
+Updated LazyServiceIdentifier.is to support nullish values

--- a/packages/container/libraries/common/src/services/models/LazyServiceIdentifier.spec.ts
+++ b/packages/container/libraries/common/src/services/models/LazyServiceIdentifier.spec.ts
@@ -15,6 +15,46 @@ describe(LazyServiceIdentifier.name, () => {
   });
 
   describe('.is', () => {
+    describe('having a non object', () => {
+      let valueFixture: unknown;
+
+      beforeAll(() => {
+        valueFixture = Symbol();
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = LazyServiceIdentifier.is(valueFixture);
+        });
+
+        it('should return false', () => {
+          expect(result).toBe(false);
+        });
+      });
+    });
+
+    describe('having a null object', () => {
+      let valueFixture: null;
+
+      beforeAll(() => {
+        valueFixture = null;
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = LazyServiceIdentifier.is(valueFixture);
+        });
+
+        it('should return false', () => {
+          expect(result).toBe(false);
+        });
+      });
+    });
+
     describe('having an object with islazyServiceIdentifierSymbol property', () => {
       let valueFixture: LazyServiceIdentifier;
 

--- a/packages/container/libraries/common/src/services/models/LazyServiceIdentifier.ts
+++ b/packages/container/libraries/common/src/services/models/LazyServiceIdentifier.ts
@@ -18,6 +18,8 @@ export class LazyServiceIdentifier<TInstance = unknown> {
     value: unknown,
   ): value is LazyServiceIdentifier<TInstance> {
     return (
+      typeof value === 'object' &&
+      value !== null &&
       (value as Partial<LazyServiceIdentifier>)[
         islazyServiceIdentifierSymbol
       ] === true


### PR DESCRIPTION
### Changed
- Updated `LazyServiceIdentifier.is` to support nullish values.