### PR TITLE
Update LegacyTarget service identifier

### DIFF
--- a/packages/container/libraries/core/src/legacyTarget/models/LegacyTarget.ts
+++ b/packages/container/libraries/core/src/legacyTarget/models/LegacyTarget.ts
@@ -1,4 +1,4 @@
-import { LazyServiceIdentifier, ServiceIdentifier } from '@inversifyjs/common';
+import { ServiceIdentifier } from '@inversifyjs/common';
 
 import { LegacyMetadata } from '../../metadata/models/LegacyMetadata';
 import { MetadataName } from '../../metadata/models/MetadataName';
@@ -8,7 +8,7 @@ import { LegacyTargetType } from './LegacyTargetType';
 
 export interface LegacyTarget {
   id: number;
-  serviceIdentifier: ServiceIdentifier | LazyServiceIdentifier;
+  serviceIdentifier: ServiceIdentifier;
   type: LegacyTargetType;
   name: LegacyQueryableString;
   identifier: string | symbol;

--- a/packages/container/libraries/core/src/legacyTarget/models/LegacyTargetImpl.spec.ts
+++ b/packages/container/libraries/core/src/legacyTarget/models/LegacyTargetImpl.spec.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 jest.mock('../../metadata/calculations/getLegacyMetadata');
 jest.mock('../calculations/getTargetId');
 
-import { ServiceIdentifier } from '@inversifyjs/common';
+import { LazyServiceIdentifier, ServiceIdentifier } from '@inversifyjs/common';
 
 import { getLegacyMetadata } from '../../metadata/calculations/getLegacyMetadata';
 import { ClassElementMetadataKind } from '../../metadata/models/ClassElementMetadataKind';
@@ -156,15 +156,83 @@ describe(LegacyTargetImpl.name, () => {
   });
 
   describe('.serviceIdentifier', () => {
-    describe('when called', () => {
-      let result: unknown;
+    describe('having a LegacyTargetImpl with class element metadata with serviceIdentifier', () => {
+      let serviceIdentifierFixture: ServiceIdentifier;
+      let legacyTargetImpl: LegacyTargetImpl;
 
       beforeAll(() => {
-        result = legacyTargetImpl.serviceIdentifier;
+        serviceIdentifierFixture = 'service-id-fixture';
+        const identifierFixture: string | symbol = 'identifier-fixture';
+
+        const managedClassElementMetadataFixture: ManagedClassElementMetadata =
+          {
+            kind: ClassElementMetadataKind.multipleInjection,
+            name: 'name-fixture',
+            optional: false,
+            tags: new Map(),
+            targetName: undefined,
+            value: serviceIdentifierFixture,
+          };
+
+        const legacyTargetTypeFixture: LegacyTargetType = 'ClassProperty';
+
+        legacyTargetImpl = new LegacyTargetImpl(
+          identifierFixture,
+          managedClassElementMetadataFixture,
+          legacyTargetTypeFixture,
+        );
       });
 
-      it('should return target serviceIdentifier', () => {
-        expect(result).toBe(managedClassElementMetadataFixture.value);
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = legacyTargetImpl.serviceIdentifier;
+        });
+
+        it('should return service identifier', () => {
+          expect(result).toBe(serviceIdentifierFixture);
+        });
+      });
+    });
+
+    describe('having a LegacyTargetImpl with class element metadata with lazy service identifier', () => {
+      let serviceIdentifierFixture: ServiceIdentifier;
+      let legacyTargetImpl: LegacyTargetImpl;
+
+      beforeAll(() => {
+        serviceIdentifierFixture = 'service-id-fixture';
+        const identifierFixture: string | symbol = 'identifier-fixture';
+
+        const managedClassElementMetadataFixture: ManagedClassElementMetadata =
+          {
+            kind: ClassElementMetadataKind.multipleInjection,
+            name: undefined,
+            optional: false,
+            tags: new Map(),
+            targetName: undefined,
+            value: new LazyServiceIdentifier(() => serviceIdentifierFixture),
+          };
+
+        const legacyTargetTypeFixture: LegacyTargetType = 'ClassProperty';
+
+        legacyTargetImpl = new LegacyTargetImpl(
+          identifierFixture,
+          managedClassElementMetadataFixture,
+          legacyTargetTypeFixture,
+        );
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = legacyTargetImpl.serviceIdentifier;
+        });
+
+        it('should return null', () => {
+          expect(result).toBe(serviceIdentifierFixture);
+        });
       });
     });
   });

--- a/packages/container/libraries/core/src/legacyTarget/models/LegacyTargetImpl.ts
+++ b/packages/container/libraries/core/src/legacyTarget/models/LegacyTargetImpl.ts
@@ -64,8 +64,12 @@ export class LegacyTargetImpl implements LegacyTarget {
     return this.#type;
   }
 
-  public get serviceIdentifier(): ServiceIdentifier | LazyServiceIdentifier {
-    return this.#metadata.value;
+  public get serviceIdentifier(): ServiceIdentifier {
+    if (LazyServiceIdentifier.is(this.#metadata.value)) {
+      return this.#metadata.value.unwrap();
+    } else {
+      return this.#metadata.value;
+    }
   }
 
   public getCustomTags(): LegacyMetadata[] | null {


### PR DESCRIPTION
### Changed
- Updated `LegacyTarget.serviceIdentifier` to be a `ServiceIdentifier`.