### PR TITLE
Remove wrong devEngines packages constraint

### DIFF
--- a/.changeset/polite-dogs-occur.md
+++ b/.changeset/polite-dogs-occur.md
@@ -1,0 +1,7 @@
+---
+"@inversifyjs/reflect-metadata-utils": patch
+"@inversifyjs/common": patch
+"@inversifyjs/core": patch
+---
+
+Removed wrong dev engines constraint.

--- a/packages/container/libraries/common/package.json
+++ b/packages/container/libraries/common/package.json
@@ -21,10 +21,6 @@
     "ts-node": "10.9.2",
     "typescript": "5.6.3"
   },
-  "devEngines": {
-    "node": "^20.18.0",
-    "pnpm": "^9.12.1"
-  },
   "homepage": "https://inversify.io",
   "keywords": [
     "dependency injection",

--- a/packages/container/libraries/core/package.json
+++ b/packages/container/libraries/core/package.json
@@ -25,10 +25,6 @@
     "ts-node": "10.9.2",
     "typescript": "5.6.3"
   },
-  "devEngines": {
-    "node": "^20.18.0",
-    "pnpm": "^9.12.1"
-  },
   "homepage": "https://inversify.io",
   "keywords": [
     "dependency injection",

--- a/packages/foundation/libraries/reflect-metadata-utils/package.json
+++ b/packages/foundation/libraries/reflect-metadata-utils/package.json
@@ -47,10 +47,6 @@
     "ts-node": "10.9.2",
     "typescript": "5.6.3"
   },
-  "devEngines": {
-    "node": "^20.18.0",
-    "pnpm": "^9.12.1"
-  },
   "homepage": "https://inversify.io",
   "os": [
     "darwin",


### PR DESCRIPTION
### Changed
- Removed wrong `devEngines` packages constraint.

### Context
Related to https://github.com/inversify/InversifyJS/issues/1607.