### PR TITLE
Add inject base decorator

### DIFF
--- a/packages/container/libraries/core/src/metadata/actions/updateMaybeClassMetadataConstructorArgument.spec.ts
+++ b/packages/container/libraries/core/src/metadata/actions/updateMaybeClassMetadataConstructorArgument.spec.ts
@@ -1,0 +1,84 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { ManagedClassElementMetadata } from '../models/ManagedClassElementMetadata';
+import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
+import { MaybeClassMetadata } from '../models/MaybeClassMetadata';
+import { updateMaybeClassMetadataConstructorArgument } from './updateMaybeClassMetadataConstructorArgument';
+
+describe(updateMaybeClassMetadataConstructorArgument.name, () => {
+  let updateMetadataMock: jest.Mock<
+    (
+      classMetadata: MaybeClassElementMetadata | undefined,
+    ) => MaybeClassElementMetadata
+  >;
+  let classMetadataFixture: MaybeClassMetadata;
+  let originalClassMetadataFixture: MaybeClassMetadata;
+  let indexFixture: number;
+
+  beforeAll(() => {
+    updateMetadataMock = jest.fn();
+
+    classMetadataFixture = {
+      constructorArguments: [],
+      lifecycle: {
+        postConstructMethodName: undefined,
+        preDestroyMethodName: undefined,
+      },
+      properties: new Map(),
+    };
+
+    originalClassMetadataFixture = {
+      constructorArguments: [],
+      lifecycle: {
+        postConstructMethodName: undefined,
+        preDestroyMethodName: undefined,
+      },
+      properties: new Map(),
+    };
+
+    indexFixture = 0;
+  });
+
+  describe('when called', () => {
+    let classElementMetadataFixture: ManagedClassElementMetadata;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      classElementMetadataFixture = {
+        kind: ClassElementMetadataKind.singleInjection,
+        name: undefined,
+        optional: false,
+        tags: new Map(),
+        targetName: undefined,
+        value: Symbol(),
+      };
+
+      updateMetadataMock.mockReturnValueOnce(classElementMetadataFixture);
+
+      result = updateMaybeClassMetadataConstructorArgument(
+        updateMetadataMock,
+        indexFixture,
+      )(classMetadataFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call updateMetadata()', () => {
+      expect(updateMetadataMock).toHaveBeenCalledTimes(1);
+      expect(updateMetadataMock).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should return MaybeClassMetadata', () => {
+      const expected: MaybeClassMetadata = {
+        ...originalClassMetadataFixture,
+        constructorArguments: [classElementMetadataFixture],
+      };
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/actions/updateMaybeClassMetadataConstructorArgument.ts
+++ b/packages/container/libraries/core/src/metadata/actions/updateMaybeClassMetadataConstructorArgument.ts
@@ -1,0 +1,19 @@
+import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
+import { MaybeClassMetadata } from '../models/MaybeClassMetadata';
+
+export function updateMaybeClassMetadataConstructorArgument(
+  updateMetadata: (
+    classMetadata: MaybeClassElementMetadata | undefined,
+  ) => MaybeClassElementMetadata,
+  index: number,
+): (classMetadata: MaybeClassMetadata) => MaybeClassMetadata {
+  return (classMetadata: MaybeClassMetadata): MaybeClassMetadata => {
+    const propertyMetadata: MaybeClassElementMetadata | undefined =
+      classMetadata.constructorArguments[index];
+
+    classMetadata.constructorArguments[index] =
+      updateMetadata(propertyMetadata);
+
+    return classMetadata;
+  };
+}

--- a/packages/container/libraries/core/src/metadata/actions/updateMaybeClassMetadataProperty.spec.ts
+++ b/packages/container/libraries/core/src/metadata/actions/updateMaybeClassMetadataProperty.spec.ts
@@ -1,0 +1,86 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { ManagedClassElementMetadata } from '../models/ManagedClassElementMetadata';
+import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
+import { MaybeClassMetadata } from '../models/MaybeClassMetadata';
+import { updateMaybeClassMetadataProperty } from './updateMaybeClassMetadataProperty';
+
+describe(updateMaybeClassMetadataProperty.name, () => {
+  let updateMetadataMock: jest.Mock<
+    (
+      classMetadata: MaybeClassElementMetadata | undefined,
+    ) => MaybeClassElementMetadata
+  >;
+  let classMetadataFixture: MaybeClassMetadata;
+  let originalClassMetadataFixture: MaybeClassMetadata;
+  let propertyKeyFixture: string;
+
+  beforeAll(() => {
+    updateMetadataMock = jest.fn();
+
+    classMetadataFixture = {
+      constructorArguments: [],
+      lifecycle: {
+        postConstructMethodName: undefined,
+        preDestroyMethodName: undefined,
+      },
+      properties: new Map(),
+    };
+
+    originalClassMetadataFixture = {
+      constructorArguments: [],
+      lifecycle: {
+        postConstructMethodName: undefined,
+        preDestroyMethodName: undefined,
+      },
+      properties: new Map(),
+    };
+
+    propertyKeyFixture = 'property-key-fixture';
+  });
+
+  describe('when called', () => {
+    let classElementMetadataFixture: ManagedClassElementMetadata;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      classElementMetadataFixture = {
+        kind: ClassElementMetadataKind.singleInjection,
+        name: undefined,
+        optional: false,
+        tags: new Map(),
+        targetName: undefined,
+        value: Symbol(),
+      };
+
+      updateMetadataMock.mockReturnValueOnce(classElementMetadataFixture);
+
+      result = updateMaybeClassMetadataProperty(
+        updateMetadataMock,
+        propertyKeyFixture,
+      )(classMetadataFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call updateMetadata()', () => {
+      expect(updateMetadataMock).toHaveBeenCalledTimes(1);
+      expect(updateMetadataMock).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should return MaybeClassMetadata', () => {
+      const expected: MaybeClassMetadata = {
+        ...originalClassMetadataFixture,
+        properties: new Map([
+          [propertyKeyFixture, classElementMetadataFixture],
+        ]),
+      };
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/actions/updateMaybeClassMetadataProperty.ts
+++ b/packages/container/libraries/core/src/metadata/actions/updateMaybeClassMetadataProperty.ts
@@ -1,0 +1,18 @@
+import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
+import { MaybeClassMetadata } from '../models/MaybeClassMetadata';
+
+export function updateMaybeClassMetadataProperty(
+  updateMetadata: (
+    classElementMetadata: MaybeClassElementMetadata | undefined,
+  ) => MaybeClassElementMetadata,
+  propertyKey: string | symbol,
+): (classMetadata: MaybeClassMetadata) => MaybeClassMetadata {
+  return (classMetadata: MaybeClassMetadata): MaybeClassMetadata => {
+    const propertyMetadata: MaybeClassElementMetadata | undefined =
+      classMetadata.properties.get(propertyKey);
+
+    classMetadata.properties.set(propertyKey, updateMetadata(propertyMetadata));
+
+    return classMetadata;
+  };
+}

--- a/packages/container/libraries/core/src/metadata/calculations/getClassElementMetadataFromLegacyMetadata.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/getClassElementMetadataFromLegacyMetadata.spec.ts
@@ -139,7 +139,16 @@ describe(getClassElementMetadataFromLegacyMetadata.name, () => {
     },
   );
 
-  describe.each<[string, ClassElementMetadataKind, LegacyMetadata]>([
+  describe.each<
+    [
+      string,
+      (
+        | ClassElementMetadataKind.multipleInjection
+        | ClassElementMetadataKind.singleInjection
+      ),
+      LegacyMetadata,
+    ]
+  >([
     [
       'inject',
       ClassElementMetadataKind.singleInjection,
@@ -160,7 +169,9 @@ describe(getClassElementMetadataFromLegacyMetadata.name, () => {
     'having a metadata list with % metadata',
     (
       _: string,
-      classElementMetadataKind: ClassElementMetadataKind,
+      classElementMetadataKind:
+        | ClassElementMetadataKind.multipleInjection
+        | ClassElementMetadataKind.singleInjection,
       metadata: LegacyMetadata,
     ) => {
       let metadataListFixture: LegacyMetadata[];
@@ -193,7 +204,16 @@ describe(getClassElementMetadataFromLegacyMetadata.name, () => {
     },
   );
 
-  describe.each<[string, ClassElementMetadataKind, LegacyMetadata]>([
+  describe.each<
+    [
+      string,
+      (
+        | ClassElementMetadataKind.multipleInjection
+        | ClassElementMetadataKind.singleInjection
+      ),
+      LegacyMetadata,
+    ]
+  >([
     [
       'inject',
       ClassElementMetadataKind.singleInjection,
@@ -214,7 +234,9 @@ describe(getClassElementMetadataFromLegacyMetadata.name, () => {
     'having a metadata list with % metadata',
     (
       _: string,
-      classElementMetadataKind: ClassElementMetadataKind,
+      classElementMetadataKind:
+        | ClassElementMetadataKind.multipleInjection
+        | ClassElementMetadataKind.singleInjection,
       metadata: LegacyMetadata,
     ) => {
       let customTagMetadataFixture: LegacyMetadata;

--- a/packages/container/libraries/core/src/metadata/calculations/getDefaultClassMetadata.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/getDefaultClassMetadata.spec.ts
@@ -1,0 +1,27 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { ClassMetadata } from '../models/ClassMetadata';
+import { getDefaultClassMetadata } from './getDefaultClassMetadata';
+
+describe(getDefaultClassMetadata.name, () => {
+  describe('when called', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      result = getDefaultClassMetadata();
+    });
+
+    it('should return ClassMetadata', () => {
+      const expected: ClassMetadata = {
+        constructorArguments: [],
+        lifecycle: {
+          postConstructMethodName: undefined,
+          preDestroyMethodName: undefined,
+        },
+        properties: new Map(),
+      };
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/calculations/getDefaultClassMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/getDefaultClassMetadata.ts
@@ -1,0 +1,12 @@
+import { ClassMetadata } from '../models/ClassMetadata';
+
+export function getDefaultClassMetadata(): ClassMetadata {
+  return {
+    constructorArguments: [],
+    lifecycle: {
+      postConstructMethodName: undefined,
+      preDestroyMethodName: undefined,
+    },
+    properties: new Map(),
+  };
+}

--- a/packages/container/libraries/core/src/metadata/decorators/injectBase.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/injectBase.spec.ts
@@ -1,0 +1,177 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import 'reflect-metadata';
+
+jest.mock('@inversifyjs/reflect-metadata-utils');
+
+jest.mock('../actions/updateMaybeClassMetadataConstructorArgument', () => ({
+  updateMaybeClassMetadataConstructorArgument: jest.fn(),
+}));
+
+jest.mock('../actions/updateMaybeClassMetadataProperty', () => ({
+  updateMaybeClassMetadataProperty: jest.fn(),
+}));
+
+jest.mock('../calculations/getDefaultClassMetadata');
+
+import { Newable } from '@inversifyjs/common';
+import { updateReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+
+import { classMetadataReflectKey } from '../../reflectMetadata/data/classMetadataReflectKey';
+import { updateMaybeClassMetadataConstructorArgument } from '../actions/updateMaybeClassMetadataConstructorArgument';
+import { updateMaybeClassMetadataProperty } from '../actions/updateMaybeClassMetadataProperty';
+import { getDefaultClassMetadata } from '../calculations/getDefaultClassMetadata';
+import { ClassMetadata } from '../models/ClassMetadata';
+import { ManagedClassElementMetadata } from '../models/ManagedClassElementMetadata';
+import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
+import { MaybeClassMetadata } from '../models/MaybeClassMetadata';
+import { injectBase } from './injectBase';
+
+describe(injectBase.name, () => {
+  let updateMetadataMock: jest.Mock<
+    (
+      classMetadata: MaybeClassElementMetadata | undefined,
+    ) => ManagedClassElementMetadata
+  >;
+
+  beforeAll(() => {
+    updateMetadataMock =
+      jest.fn<
+        (
+          classMetadata: MaybeClassElementMetadata | undefined,
+        ) => ManagedClassElementMetadata
+      >();
+  });
+
+  describe('when called, as property decorator', () => {
+    let defaultClassMetadataFixture: ClassMetadata;
+    let targetFixture: Newable;
+    let updateMaybeClassMetadataPropertyResult: jest.Mock<
+      (classMetadata: MaybeClassMetadata) => MaybeClassMetadata
+    >;
+
+    beforeAll(() => {
+      defaultClassMetadataFixture = {
+        [Symbol()]: Symbol(),
+      } as unknown as ClassMetadata;
+
+      updateMaybeClassMetadataPropertyResult = jest.fn();
+
+      (
+        getDefaultClassMetadata as jest.Mock<typeof getDefaultClassMetadata>
+      ).mockReturnValueOnce(defaultClassMetadataFixture);
+
+      (
+        updateMaybeClassMetadataProperty as jest.Mock<
+          typeof updateMaybeClassMetadataProperty
+        >
+      ).mockReturnValueOnce(updateMaybeClassMetadataPropertyResult);
+
+      class TargetFixture {
+        @injectBase(updateMetadataMock)
+        public foo: string | undefined;
+      }
+
+      targetFixture = TargetFixture;
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call updateReflectMetadata()', () => {
+      expect(updateReflectMetadata).toHaveBeenCalledTimes(1);
+      expect(updateReflectMetadata).toHaveBeenCalledWith(
+        targetFixture,
+        classMetadataReflectKey,
+        defaultClassMetadataFixture,
+        updateMaybeClassMetadataPropertyResult,
+      );
+    });
+  });
+
+  describe('when called, as constructor parameter decorator', () => {
+    let defaultClassMetadataFixture: ClassMetadata;
+    let targetFixture: Newable;
+    let updateMaybeClassMetadataConstructorArgumentsResult: jest.Mock<
+      (classMetadata: MaybeClassMetadata) => MaybeClassMetadata
+    >;
+
+    beforeAll(() => {
+      defaultClassMetadataFixture = {
+        [Symbol()]: Symbol(),
+      } as unknown as ClassMetadata;
+
+      updateMaybeClassMetadataConstructorArgumentsResult = jest.fn();
+
+      (
+        getDefaultClassMetadata as jest.Mock<typeof getDefaultClassMetadata>
+      ).mockReturnValueOnce(defaultClassMetadataFixture);
+
+      (
+        updateMaybeClassMetadataConstructorArgument as jest.Mock<
+          typeof updateMaybeClassMetadataConstructorArgument
+        >
+      ).mockReturnValueOnce(updateMaybeClassMetadataConstructorArgumentsResult);
+
+      class TargetFixture {
+        constructor(
+          @injectBase(updateMetadataMock)
+          public foo: string | undefined,
+        ) {}
+      }
+
+      targetFixture = TargetFixture;
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call updateReflectMetadata()', () => {
+      expect(updateReflectMetadata).toHaveBeenCalledTimes(1);
+      expect(updateReflectMetadata).toHaveBeenCalledWith(
+        targetFixture,
+        classMetadataReflectKey,
+        expect.anything(),
+        updateMaybeClassMetadataConstructorArgumentsResult,
+      );
+    });
+  });
+
+  describe('when called, as non constructor parameter decorator', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        class TargetFixture {
+          public doSomethingWithFoo(
+            @injectBase(updateMetadataMock)
+            foo: string | undefined,
+          ) {
+            console.log(foo ?? '?');
+          }
+        }
+      } catch (error: unknown) {
+        result = error;
+      }
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should throw an error', () => {
+      const expectedPartialError: Partial<Error> = {
+        message: `Found an @inject decorator in a non constructor parameter.
+Found @inject decorator at method "doSomethingWithFoo" at class "TargetFixture"`,
+      };
+
+      expect(result).toBeInstanceOf(Error);
+      expect(result).toStrictEqual(
+        expect.objectContaining(expectedPartialError),
+      );
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/decorators/injectBase.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/injectBase.ts
@@ -1,0 +1,81 @@
+import { updateReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+
+import { classMetadataReflectKey } from '../../reflectMetadata/data/classMetadataReflectKey';
+import { updateMaybeClassMetadataConstructorArgument } from '../actions/updateMaybeClassMetadataConstructorArgument';
+import { updateMaybeClassMetadataProperty } from '../actions/updateMaybeClassMetadataProperty';
+import { getDefaultClassMetadata } from '../calculations/getDefaultClassMetadata';
+import { ManagedClassElementMetadata } from '../models/ManagedClassElementMetadata';
+import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
+
+export function injectBase(
+  updateMetadata: (
+    classMetadata: MaybeClassElementMetadata | undefined,
+  ) => ManagedClassElementMetadata,
+): ParameterDecorator & PropertyDecorator {
+  const decorator: ParameterDecorator & PropertyDecorator = (
+    target: object,
+    propertyKey: string | symbol | undefined,
+    parameterIndex?: number,
+  ): void => {
+    if (parameterIndex === undefined) {
+      injectProperty(updateMetadata)(target, propertyKey as string | symbol);
+    } else {
+      injectParameter(updateMetadata)(target, propertyKey, parameterIndex);
+    }
+  };
+
+  return decorator;
+}
+
+function injectParameter(
+  updateMetadata: (
+    classMetadata: MaybeClassElementMetadata | undefined,
+  ) => ManagedClassElementMetadata,
+): ParameterDecorator {
+  return (
+    target: object,
+    propertyKey: string | symbol | undefined,
+    parameterIndex: number,
+  ): void => {
+    if (isConstructorParameter(target, propertyKey)) {
+      updateReflectMetadata(
+        target,
+        classMetadataReflectKey,
+        getDefaultClassMetadata(),
+        updateMaybeClassMetadataConstructorArgument(
+          updateMetadata,
+          parameterIndex,
+        ),
+      );
+    } else {
+      throw new Error(
+        `Found an @inject decorator in a non constructor parameter.
+Found @inject decorator at method "${
+          propertyKey?.toString() ?? ''
+        }" at class "${target.constructor.name}"`,
+      );
+    }
+  };
+}
+
+function injectProperty(
+  updateMetadata: (
+    classMetadata: MaybeClassElementMetadata | undefined,
+  ) => ManagedClassElementMetadata,
+): PropertyDecorator {
+  return (target: object, propertyKey: string | symbol): void => {
+    updateReflectMetadata(
+      target.constructor,
+      classMetadataReflectKey,
+      getDefaultClassMetadata(),
+      updateMaybeClassMetadataProperty(updateMetadata, propertyKey),
+    );
+  };
+}
+
+function isConstructorParameter(
+  target: unknown,
+  propertyKey: string | symbol | undefined,
+): boolean {
+  return typeof target === 'function' && propertyKey === undefined;
+}

--- a/packages/container/libraries/core/src/metadata/models/BaseClassElementMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/models/BaseClassElementMetadata.ts
@@ -1,7 +1,3 @@
-import { ClassElementMetadataKind } from './ClassElementMetadataKind';
-
-export interface BaseClassElementMetadata<
-  TKind extends ClassElementMetadataKind,
-> {
+export interface BaseClassElementMetadata<TKind> {
   kind: TKind;
 }

--- a/packages/container/libraries/core/src/metadata/models/ManagedClassElementMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/models/ManagedClassElementMetadata.ts
@@ -11,9 +11,9 @@ export interface ManagedClassElementMetadata
     | ClassElementMetadataKind.singleInjection
     | ClassElementMetadataKind.multipleInjection
   > {
-  value: ServiceIdentifier | LazyServiceIdentifier;
   name: MetadataName | undefined;
   optional: boolean;
   tags: Map<MetadataTag, unknown>;
   targetName: MetadataTargetName | undefined;
+  value: ServiceIdentifier | LazyServiceIdentifier;
 }

--- a/packages/container/libraries/core/src/metadata/models/MaybeClassElementMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/models/MaybeClassElementMetadata.ts
@@ -1,0 +1,8 @@
+import { ManagedClassElementMetadata } from './ManagedClassElementMetadata';
+import { MaybeManagedClassElementMetadata } from './MaybeManagedClassElementMetadata';
+import { UnmanagedClassElementMetadata } from './UnmanagedClassElementMetadata';
+
+export type MaybeClassElementMetadata =
+  | ManagedClassElementMetadata
+  | MaybeManagedClassElementMetadata
+  | UnmanagedClassElementMetadata;

--- a/packages/container/libraries/core/src/metadata/models/MaybeClassElementMetadataKind.ts
+++ b/packages/container/libraries/core/src/metadata/models/MaybeClassElementMetadataKind.ts
@@ -1,0 +1,3 @@
+export enum MaybeClassElementMetadataKind {
+  unknown,
+}

--- a/packages/container/libraries/core/src/metadata/models/MaybeClassMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/models/MaybeClassMetadata.ts
@@ -1,0 +1,8 @@
+import { ClassMetadataLifecycle } from './ClassMetadataLifecycle';
+import { MaybeClassElementMetadata } from './MaybeClassElementMetadata';
+
+export interface MaybeClassMetadata {
+  constructorArguments: MaybeClassElementMetadata[];
+  lifecycle: ClassMetadataLifecycle;
+  properties: Map<string | symbol, MaybeClassElementMetadata>;
+}

--- a/packages/container/libraries/core/src/metadata/models/MaybeManagedClassElementMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/models/MaybeManagedClassElementMetadata.ts
@@ -1,0 +1,16 @@
+import { LazyServiceIdentifier, ServiceIdentifier } from '@inversifyjs/common';
+
+import { BaseClassElementMetadata } from './BaseClassElementMetadata';
+import { MaybeClassElementMetadataKind } from './MaybeClassElementMetadataKind';
+import { MetadataName } from './MetadataName';
+import { MetadataTag } from './MetadataTag';
+import { MetadataTargetName } from './MetadataTargetName';
+
+export interface MaybeManagedClassElementMetadata
+  extends BaseClassElementMetadata<MaybeClassElementMetadataKind.unknown> {
+  name: MetadataName | undefined;
+  optional: boolean | undefined;
+  tags: Map<MetadataTag, unknown>;
+  targetName: MetadataTargetName | undefined;
+  value: ServiceIdentifier | LazyServiceIdentifier | undefined;
+}

--- a/packages/container/libraries/core/src/reflectMetadata/data/classMetadataReflectKey.ts
+++ b/packages/container/libraries/core/src/reflectMetadata/data/classMetadataReflectKey.ts
@@ -1,0 +1,2 @@
+export const classMetadataReflectKey: string =
+  '@inversifyjs/core/classMetadataReflectKey';


### PR DESCRIPTION
### Added
- Added `injectBase`.
- Added `updateMaybeClassMetadataProperty`.
- Added `updateMaybeClassMetadataConstructorArgument`.
- Added `MaybeClassMetadata`.
- Added `classMetadataReflectKey`.
- Added `getDefaultClassMetadata`.

### Changed
- Updated `BaseClassElementMetadata` without generic constraint.
- Updated `ManagedClassElementMetadata` property order.
