### PR TITLE
Fix strong typed esm build

### DIFF
--- a/packages/container/libraries/strongly-typed/package.json
+++ b/packages/container/libraries/strongly-typed/package.json
@@ -46,7 +46,7 @@
   },
   "name": "@inversifyjs/strongly-typed",
   "peerDependencies": {
-    "inversify": ">=6.0.3"
+    "inversify": "^6.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/container/libraries/strongly-typed/package.json
+++ b/packages/container/libraries/strongly-typed/package.json
@@ -16,7 +16,9 @@
     "rimraf": "6.0.1",
     "ts-jest": "29.2.5",
     "ts-loader": "9.5.1",
-    "typescript": "5.6.3"
+    "typescript": "5.6.3",
+    "webpack": "5.96.1",
+    "webpack-cli": "5.1.4"
   },
   "devEngines": {
     "node": "^20.18.0",

--- a/packages/container/libraries/strongly-typed/webpack.config.mjs
+++ b/packages/container/libraries/strongly-typed/webpack.config.mjs
@@ -9,4 +9,5 @@ const outputPath = path.resolve(import.meta.dirname, 'lib/esm');
 /** @type {!import("webpack").Configuration} */
 export default {
   ...buildWebpackConfig(outputPath),
+  externals: ['inversify'],
 };


### PR DESCRIPTION
### Changed
- Updated ESM build without packing `inversify`.
- Updated `inversify` peer dependencies constraint.