### PR TITLE
Update renovatebot to avoid updating peer dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,12 @@
   "ignoreDeps": [],
   "packageRules": [
     {
+      "enabled": false,
+      "matchDepTypes": [
+        "peerDependencies"
+      ]
+    },
+    {
       "groupName": "auto merge on patch or minor",
       "automerge": true,
       "matchUpdateTypes": ["patch", "minor"],


### PR DESCRIPTION
### Changed
- Updated renovatebot to avoid updating peer dependencies.