### PR TITLE
Update internal metadata modules

### DIFF
--- a/packages/container/libraries/core/src/error/models/InversifyCoreErrorKind.ts
+++ b/packages/container/libraries/core/src/error/models/InversifyCoreErrorKind.ts
@@ -1,4 +1,5 @@
 export enum InversifyCoreErrorKind {
+  injectionDecoratorConflict,
   missingInjectionDecorator,
   unknown,
 }

--- a/packages/container/libraries/core/src/metadata/decorators/injectBase.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/injectBase.spec.ts
@@ -22,7 +22,6 @@ import { updateMaybeClassMetadataConstructorArgument } from '../actions/updateMa
 import { updateMaybeClassMetadataProperty } from '../actions/updateMaybeClassMetadataProperty';
 import { getDefaultClassMetadata } from '../calculations/getDefaultClassMetadata';
 import { ClassMetadata } from '../models/ClassMetadata';
-import { ManagedClassElementMetadata } from '../models/ManagedClassElementMetadata';
 import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
 import { MaybeClassMetadata } from '../models/MaybeClassMetadata';
 import { injectBase } from './injectBase';
@@ -30,16 +29,16 @@ import { injectBase } from './injectBase';
 describe(injectBase.name, () => {
   let updateMetadataMock: jest.Mock<
     (
-      classMetadata: MaybeClassElementMetadata | undefined,
-    ) => ManagedClassElementMetadata
+      metadata: MaybeClassElementMetadata | undefined,
+    ) => MaybeClassElementMetadata
   >;
 
   beforeAll(() => {
     updateMetadataMock =
       jest.fn<
         (
-          classMetadata: MaybeClassElementMetadata | undefined,
-        ) => ManagedClassElementMetadata
+          metadata: MaybeClassElementMetadata | undefined,
+        ) => MaybeClassElementMetadata
       >();
   });
 

--- a/packages/container/libraries/core/src/metadata/decorators/injectBase.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/injectBase.ts
@@ -4,13 +4,12 @@ import { classMetadataReflectKey } from '../../reflectMetadata/data/classMetadat
 import { updateMaybeClassMetadataConstructorArgument } from '../actions/updateMaybeClassMetadataConstructorArgument';
 import { updateMaybeClassMetadataProperty } from '../actions/updateMaybeClassMetadataProperty';
 import { getDefaultClassMetadata } from '../calculations/getDefaultClassMetadata';
-import { ManagedClassElementMetadata } from '../models/ManagedClassElementMetadata';
 import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
 
 export function injectBase(
   updateMetadata: (
-    classMetadata: MaybeClassElementMetadata | undefined,
-  ) => ManagedClassElementMetadata,
+    metadata: MaybeClassElementMetadata | undefined,
+  ) => MaybeClassElementMetadata,
 ): ParameterDecorator & PropertyDecorator {
   const decorator: ParameterDecorator & PropertyDecorator = (
     target: object,
@@ -29,8 +28,8 @@ export function injectBase(
 
 function injectParameter(
   updateMetadata: (
-    classMetadata: MaybeClassElementMetadata | undefined,
-  ) => ManagedClassElementMetadata,
+    metadata: MaybeClassElementMetadata | undefined,
+  ) => MaybeClassElementMetadata,
 ): ParameterDecorator {
   return (
     target: object,
@@ -60,8 +59,8 @@ Found @inject decorator at method "${
 
 function injectProperty(
   updateMetadata: (
-    classMetadata: MaybeClassElementMetadata | undefined,
-  ) => ManagedClassElementMetadata,
+    metadata: MaybeClassElementMetadata | undefined,
+  ) => MaybeClassElementMetadata,
 ): PropertyDecorator {
   return (target: object, propertyKey: string | symbol): void => {
     updateReflectMetadata(

--- a/packages/container/libraries/core/src/metadata/models/MaybeManagedClassElementMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/models/MaybeManagedClassElementMetadata.ts
@@ -1,5 +1,3 @@
-import { LazyServiceIdentifier, ServiceIdentifier } from '@inversifyjs/common';
-
 import { BaseClassElementMetadata } from './BaseClassElementMetadata';
 import { MaybeClassElementMetadataKind } from './MaybeClassElementMetadataKind';
 import { MetadataName } from './MetadataName';
@@ -9,8 +7,7 @@ import { MetadataTargetName } from './MetadataTargetName';
 export interface MaybeManagedClassElementMetadata
   extends BaseClassElementMetadata<MaybeClassElementMetadataKind.unknown> {
   name: MetadataName | undefined;
-  optional: boolean | undefined;
+  optional: boolean;
   tags: Map<MetadataTag, unknown>;
   targetName: MetadataTargetName | undefined;
-  value: ServiceIdentifier | LazyServiceIdentifier | undefined;
 }


### PR DESCRIPTION
### Changed
- Updated `MaybeManagedClassElementMetadata`.
- Updated `injectBase` with a more generic `updateMetadata` param.
- Updated `InversifyCoreErrorKind` with `injectionDecoratorConflict`.