### PR TITLE
Add unmanaged decorator

### DIFF
--- a/packages/container/libraries/core/src/metadata/calculations/buildClassElementMetadataFromMaybeClassElementMetadata.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildClassElementMetadataFromMaybeClassElementMetadata.spec.ts
@@ -1,0 +1,201 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { InversifyCoreError } from '../../error/models/InversifyCoreError';
+import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
+import { ClassElementMetadata } from '../models/ClassElementMetadata';
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { MaybeClassElementMetadataKind } from '../models/MaybeClassElementMetadataKind';
+import { MaybeManagedClassElementMetadata } from '../models/MaybeManagedClassElementMetadata';
+import { UnmanagedClassElementMetadata } from '../models/UnmanagedClassElementMetadata';
+import { buildClassElementMetadataFromMaybeClassElementMetadata } from './buildClassElementMetadataFromMaybeClassElementMetadata';
+
+describe(buildClassElementMetadataFromMaybeClassElementMetadata.name, () => {
+  describe('having undefined metadatada', () => {
+    let buildDefaultMetadataMock: jest.Mock<
+      (...params: unknown[]) => ClassElementMetadata
+    >;
+    let buildMetadataFromMaybeManagedMetadataMock: jest.Mock<
+      (
+        metadata: MaybeManagedClassElementMetadata,
+        ...params: unknown[]
+      ) => ClassElementMetadata
+    >;
+    let metadataFixture: undefined;
+
+    beforeAll(() => {
+      buildDefaultMetadataMock = jest.fn();
+      buildMetadataFromMaybeManagedMetadataMock = jest.fn();
+      metadataFixture = undefined;
+    });
+
+    describe('when called', () => {
+      let classElementMetadataFixture: ClassElementMetadata;
+      let paramsFixture: unknown[];
+
+      let result: unknown;
+
+      beforeAll(() => {
+        classElementMetadataFixture = {
+          kind: ClassElementMetadataKind.unmanaged,
+        };
+
+        paramsFixture = [Symbol()];
+
+        buildDefaultMetadataMock.mockReturnValueOnce(
+          classElementMetadataFixture,
+        );
+
+        result = buildClassElementMetadataFromMaybeClassElementMetadata(
+          buildDefaultMetadataMock,
+          buildMetadataFromMaybeManagedMetadataMock,
+        )(...paramsFixture)(metadataFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call buildDefaultMetadata()', () => {
+        expect(buildDefaultMetadataMock).toHaveBeenCalledTimes(1);
+        expect(buildDefaultMetadataMock).toHaveBeenCalledWith(...paramsFixture);
+      });
+
+      it('should return ClassElementMetadata', () => {
+        expect(result).toBe(classElementMetadataFixture);
+      });
+    });
+  });
+
+  describe('having unknown metadatada kind', () => {
+    let buildDefaultMetadataMock: jest.Mock<
+      (...params: unknown[]) => ClassElementMetadata
+    >;
+    let buildMetadataFromMaybeManagedMetadataMock: jest.Mock<
+      (
+        metadata: MaybeManagedClassElementMetadata,
+        ...params: unknown[]
+      ) => ClassElementMetadata
+    >;
+    let metadataFixture: MaybeManagedClassElementMetadata;
+
+    beforeAll(() => {
+      buildDefaultMetadataMock = jest.fn();
+      buildMetadataFromMaybeManagedMetadataMock = jest.fn();
+      metadataFixture = {
+        kind: MaybeClassElementMetadataKind.unknown,
+        name: undefined,
+        optional: false,
+        tags: new Map(),
+        targetName: undefined,
+      };
+    });
+
+    describe('when called', () => {
+      let classElementMetadataFixture: ClassElementMetadata;
+      let paramsFixture: unknown[];
+
+      let result: unknown;
+
+      beforeAll(() => {
+        classElementMetadataFixture = {
+          kind: ClassElementMetadataKind.unmanaged,
+        };
+
+        paramsFixture = [Symbol()];
+
+        buildMetadataFromMaybeManagedMetadataMock.mockReturnValueOnce(
+          classElementMetadataFixture,
+        );
+
+        result = buildClassElementMetadataFromMaybeClassElementMetadata(
+          buildDefaultMetadataMock,
+          buildMetadataFromMaybeManagedMetadataMock,
+        )(...paramsFixture)(metadataFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call buildMetadataFromMaybeManagedMetadata()', () => {
+        expect(buildMetadataFromMaybeManagedMetadataMock).toHaveBeenCalledTimes(
+          1,
+        );
+        expect(buildMetadataFromMaybeManagedMetadataMock).toHaveBeenCalledWith(
+          metadataFixture,
+          ...paramsFixture,
+        );
+      });
+
+      it('should return ClassElementMetadata', () => {
+        expect(result).toBe(classElementMetadataFixture);
+      });
+    });
+  });
+
+  describe('having non unknown metadatada kind', () => {
+    let buildDefaultMetadataMock: jest.Mock<
+      (...params: unknown[]) => ClassElementMetadata
+    >;
+    let buildMetadataFromMaybeManagedMetadataMock: jest.Mock<
+      (
+        metadata: MaybeManagedClassElementMetadata,
+        ...params: unknown[]
+      ) => ClassElementMetadata
+    >;
+    let metadataFixture: UnmanagedClassElementMetadata;
+
+    beforeAll(() => {
+      buildDefaultMetadataMock = jest.fn();
+      buildMetadataFromMaybeManagedMetadataMock = jest.fn();
+      metadataFixture = {
+        kind: ClassElementMetadataKind.unmanaged,
+      };
+    });
+
+    describe('when called', () => {
+      let classElementMetadataFixture: ClassElementMetadata;
+      let paramsFixture: unknown[];
+
+      let result: unknown;
+
+      beforeAll(() => {
+        classElementMetadataFixture = {
+          kind: ClassElementMetadataKind.unmanaged,
+        };
+
+        paramsFixture = [Symbol()];
+
+        buildMetadataFromMaybeManagedMetadataMock.mockReturnValueOnce(
+          classElementMetadataFixture,
+        );
+
+        try {
+          buildClassElementMetadataFromMaybeClassElementMetadata(
+            buildDefaultMetadataMock,
+            buildMetadataFromMaybeManagedMetadataMock,
+          )(...paramsFixture)(metadataFixture);
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should throw an Error', () => {
+        const expectedErrorProperties: Partial<InversifyCoreError> = {
+          kind: InversifyCoreErrorKind.injectionDecoratorConflict,
+          message:
+            'Unexpected injection found. Multiple @inject, @multiInject or @unmanaged decorators found',
+        };
+
+        expect(result).toBeInstanceOf(InversifyCoreError);
+        expect(result).toStrictEqual(
+          expect.objectContaining(expectedErrorProperties),
+        );
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/calculations/buildClassElementMetadataFromMaybeClassElementMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildClassElementMetadataFromMaybeClassElementMetadata.ts
@@ -1,0 +1,35 @@
+import { InversifyCoreError } from '../../error/models/InversifyCoreError';
+import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
+import { ClassElementMetadata } from '../models/ClassElementMetadata';
+import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
+import { MaybeClassElementMetadataKind } from '../models/MaybeClassElementMetadataKind';
+import { MaybeManagedClassElementMetadata } from '../models/MaybeManagedClassElementMetadata';
+
+export function buildClassElementMetadataFromMaybeClassElementMetadata<
+  TParams extends unknown[],
+>(
+  buildDefaultMetadata: (...params: TParams) => ClassElementMetadata,
+  buildMetadataFromMaybeManagedMetadata: (
+    metadata: MaybeManagedClassElementMetadata,
+    ...params: TParams
+  ) => ClassElementMetadata,
+): (
+  ...params: TParams
+) => (metadata: MaybeClassElementMetadata | undefined) => ClassElementMetadata {
+  return (...params: TParams) =>
+    (metadata: MaybeClassElementMetadata | undefined): ClassElementMetadata => {
+      if (metadata === undefined) {
+        return buildDefaultMetadata(...params);
+      }
+
+      switch (metadata.kind) {
+        case MaybeClassElementMetadataKind.unknown:
+          return buildMetadataFromMaybeManagedMetadata(metadata, ...params);
+        default:
+          throw new InversifyCoreError(
+            InversifyCoreErrorKind.injectionDecoratorConflict,
+            'Unexpected injection found. Multiple @inject, @multiInject or @unmanaged decorators found',
+          );
+      }
+    };
+}

--- a/packages/container/libraries/core/src/metadata/calculations/buildDefaultUnmanagedMetadata.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildDefaultUnmanagedMetadata.spec.ts
@@ -1,0 +1,23 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { UnmanagedClassElementMetadata } from '../models/UnmanagedClassElementMetadata';
+import { buildDefaultUnmanagedMetadata } from './buildDefaultUnmanagedMetadata';
+
+describe(buildDefaultUnmanagedMetadata.name, () => {
+  describe('when called', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      result = buildDefaultUnmanagedMetadata();
+    });
+
+    it('should return UnmanagedClassElementMetadata', () => {
+      const expected: UnmanagedClassElementMetadata = {
+        kind: ClassElementMetadataKind.unmanaged,
+      };
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/calculations/buildDefaultUnmanagedMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildDefaultUnmanagedMetadata.ts
@@ -1,0 +1,8 @@
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { UnmanagedClassElementMetadata } from '../models/UnmanagedClassElementMetadata';
+
+export function buildDefaultUnmanagedMetadata(): UnmanagedClassElementMetadata {
+  return {
+    kind: ClassElementMetadataKind.unmanaged,
+  };
+}

--- a/packages/container/libraries/core/src/metadata/calculations/buildUnmanagedMetadataFromMaybeClassElementMetadata.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildUnmanagedMetadataFromMaybeClassElementMetadata.spec.ts
@@ -1,0 +1,41 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('./buildClassElementMetadataFromMaybeClassElementMetadata', () => ({
+  buildClassElementMetadataFromMaybeClassElementMetadata: jest
+    .fn()
+    .mockReturnValue(jest.fn()),
+}));
+
+import { ClassElementMetadata } from '../models/ClassElementMetadata';
+import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
+import { buildUnmanagedMetadataFromMaybeClassElementMetadata } from './buildUnmanagedMetadataFromMaybeClassElementMetadata';
+
+describe(buildUnmanagedMetadataFromMaybeClassElementMetadata.name, () => {
+  describe('when called', () => {
+    let buildClassMetadataMock: jest.Mock<
+      (metadata: MaybeClassElementMetadata | undefined) => ClassElementMetadata
+    >;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      buildClassMetadataMock = jest.fn();
+
+      (
+        buildUnmanagedMetadataFromMaybeClassElementMetadata as jest.Mock<
+          typeof buildUnmanagedMetadataFromMaybeClassElementMetadata
+        >
+      ).mockReturnValueOnce(buildClassMetadataMock);
+
+      result = buildUnmanagedMetadataFromMaybeClassElementMetadata();
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should return expected function', () => {
+      expect(result).toBe(buildClassMetadataMock);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/calculations/buildUnmanagedMetadataFromMaybeClassElementMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildUnmanagedMetadataFromMaybeClassElementMetadata.ts
@@ -1,0 +1,13 @@
+import { ClassElementMetadata } from '../models/ClassElementMetadata';
+import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
+import { buildClassElementMetadataFromMaybeClassElementMetadata } from './buildClassElementMetadataFromMaybeClassElementMetadata';
+import { buildDefaultUnmanagedMetadata } from './buildDefaultUnmanagedMetadata';
+import { buildUnmanagedMetadataFromMaybeManagedMetadata } from './buildUnmanagedMetadataFromMaybeManagedMetadata';
+
+export const buildUnmanagedMetadataFromMaybeClassElementMetadata: () => (
+  metadata: MaybeClassElementMetadata | undefined,
+) => ClassElementMetadata =
+  buildClassElementMetadataFromMaybeClassElementMetadata(
+    buildDefaultUnmanagedMetadata,
+    buildUnmanagedMetadataFromMaybeManagedMetadata,
+  );

--- a/packages/container/libraries/core/src/metadata/calculations/buildUnmanagedMetadataFromMaybeManagedMetadata.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildUnmanagedMetadataFromMaybeManagedMetadata.spec.ts
@@ -1,0 +1,139 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('./buildDefaultUnmanagedMetadata');
+
+import { InversifyCoreError } from '../../error/models/InversifyCoreError';
+import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { MaybeClassElementMetadataKind } from '../models/MaybeClassElementMetadataKind';
+import { MaybeManagedClassElementMetadata } from '../models/MaybeManagedClassElementMetadata';
+import { UnmanagedClassElementMetadata } from '../models/UnmanagedClassElementMetadata';
+import { buildDefaultUnmanagedMetadata } from './buildDefaultUnmanagedMetadata';
+import { buildUnmanagedMetadataFromMaybeManagedMetadata } from './buildUnmanagedMetadataFromMaybeManagedMetadata';
+
+describe(buildUnmanagedMetadataFromMaybeManagedMetadata.name, () => {
+  describe.each<[string, MaybeManagedClassElementMetadata]>([
+    [
+      'with name',
+      {
+        kind: MaybeClassElementMetadataKind.unknown,
+        name: 'name-fixture',
+        optional: false,
+        tags: new Map(),
+        targetName: undefined,
+      },
+    ],
+    [
+      'with optional true',
+      {
+        kind: MaybeClassElementMetadataKind.unknown,
+        name: undefined,
+        optional: true,
+        tags: new Map(),
+        targetName: undefined,
+      },
+    ],
+    [
+      'with tags',
+      {
+        kind: MaybeClassElementMetadataKind.unknown,
+        name: undefined,
+        optional: false,
+        tags: new Map([['foo', 'bar']]),
+        targetName: undefined,
+      },
+    ],
+    [
+      'with targetName',
+      {
+        kind: MaybeClassElementMetadataKind.unknown,
+        name: undefined,
+        optional: false,
+        tags: new Map(),
+        targetName: 'target-name-fixture',
+      },
+    ],
+  ])(
+    'having managed metadata %s',
+    (
+      _: string,
+      maybeManagedClassElementMetadata: MaybeManagedClassElementMetadata,
+    ) => {
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          try {
+            buildUnmanagedMetadataFromMaybeManagedMetadata(
+              maybeManagedClassElementMetadata,
+            );
+          } catch (error: unknown) {
+            result = error;
+          }
+        });
+
+        it('should throw an InversifyCoreError', () => {
+          const expectedErrorProperties: Partial<InversifyCoreError> = {
+            kind: InversifyCoreErrorKind.injectionDecoratorConflict,
+            message:
+              'Unexpected injection found. Found @unmanaged injection with additional @named, @optional, @tagged or @targetName injections',
+          };
+
+          expect(result).toBeInstanceOf(InversifyCoreError);
+          expect(result).toStrictEqual(
+            expect.objectContaining(expectedErrorProperties),
+          );
+        });
+      });
+    },
+  );
+
+  describe('having non managed metadata', () => {
+    let maybeManagedClassElementMetadata: MaybeManagedClassElementMetadata;
+
+    beforeAll(() => {
+      maybeManagedClassElementMetadata = {
+        kind: MaybeClassElementMetadataKind.unknown,
+        name: undefined,
+        optional: false,
+        tags: new Map(),
+        targetName: undefined,
+      };
+    });
+
+    describe('when called', () => {
+      let unmanagedClassElementMetadataFixture: UnmanagedClassElementMetadata;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        unmanagedClassElementMetadataFixture = {
+          kind: ClassElementMetadataKind.unmanaged,
+        };
+
+        (
+          buildDefaultUnmanagedMetadata as jest.Mock<
+            typeof buildDefaultUnmanagedMetadata
+          >
+        ).mockReturnValueOnce(unmanagedClassElementMetadataFixture);
+
+        result = buildUnmanagedMetadataFromMaybeManagedMetadata(
+          maybeManagedClassElementMetadata,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call buildDefaultUnmanagedMetadata()', () => {
+        expect(buildDefaultUnmanagedMetadata).toHaveBeenCalledTimes(1);
+        expect(buildDefaultUnmanagedMetadata).toHaveBeenCalledWith();
+      });
+
+      it('should return UnmanagedClassElementMetadata', () => {
+        expect(result).toBe(unmanagedClassElementMetadataFixture);
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/calculations/buildUnmanagedMetadataFromMaybeManagedMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildUnmanagedMetadataFromMaybeManagedMetadata.ts
@@ -1,0 +1,29 @@
+import { InversifyCoreError } from '../../error/models/InversifyCoreError';
+import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
+import { MaybeManagedClassElementMetadata } from '../models/MaybeManagedClassElementMetadata';
+import { UnmanagedClassElementMetadata } from '../models/UnmanagedClassElementMetadata';
+import { buildDefaultUnmanagedMetadata } from './buildDefaultUnmanagedMetadata';
+
+export function buildUnmanagedMetadataFromMaybeManagedMetadata(
+  metadata: MaybeManagedClassElementMetadata,
+): UnmanagedClassElementMetadata {
+  if (hasManagedMetadata(metadata)) {
+    throw new InversifyCoreError(
+      InversifyCoreErrorKind.injectionDecoratorConflict,
+      'Unexpected injection found. Found @unmanaged injection with additional @named, @optional, @tagged or @targetName injections',
+    );
+  }
+
+  return buildDefaultUnmanagedMetadata();
+}
+
+function hasManagedMetadata(
+  metadata: MaybeManagedClassElementMetadata,
+): boolean {
+  return (
+    metadata.name !== undefined ||
+    metadata.optional ||
+    metadata.tags.size > 0 ||
+    metadata.targetName !== undefined
+  );
+}

--- a/packages/container/libraries/core/src/metadata/calculations/handleInjectionError.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/handleInjectionError.spec.ts
@@ -1,0 +1,139 @@
+import { beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('../../decorator/calculations/getDecoratorInfo');
+jest.mock('../../decorator/calculations/stringifyDecoratorInfo');
+
+import { getDecoratorInfo } from '../../decorator/calculations/getDecoratorInfo';
+import { stringifyDecoratorInfo } from '../../decorator/calculations/stringifyDecoratorInfo';
+import { DecoratorInfo } from '../../decorator/models/DecoratorInfo';
+import { DecoratorInfoKind } from '../../decorator/models/DecoratorInfoKind';
+import { InversifyCoreError } from '../../error/models/InversifyCoreError';
+import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
+import { handleInjectionError } from './handleInjectionError';
+
+describe(handleInjectionError.name, () => {
+  describe('having an InversifyCoreError of kind injectionDecoratorConflict', () => {
+    let targetFixture: object;
+    let propertyKeyFixture: string | symbol | undefined;
+    let parameterIndexFixture: number | undefined;
+    let errorFixture: InversifyCoreError;
+
+    beforeAll(() => {
+      targetFixture = class {};
+      propertyKeyFixture = undefined;
+      parameterIndexFixture = 0;
+      errorFixture = new InversifyCoreError(
+        InversifyCoreErrorKind.injectionDecoratorConflict,
+        'error message fixture',
+      );
+    });
+
+    describe('when called', () => {
+      let decoratorInfoFixture: DecoratorInfo;
+      let decoratorInfoStringifiedFixture: string;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        decoratorInfoFixture = {
+          index: 0,
+          kind: DecoratorInfoKind.parameter,
+          targetClass: class {},
+        };
+
+        decoratorInfoStringifiedFixture = 'decorator-info-stringified-fixture';
+
+        (
+          getDecoratorInfo as jest.Mock<typeof getDecoratorInfo>
+        ).mockReturnValueOnce(decoratorInfoFixture);
+
+        (
+          stringifyDecoratorInfo as jest.Mock<typeof stringifyDecoratorInfo>
+        ).mockReturnValueOnce(decoratorInfoStringifiedFixture);
+
+        try {
+          handleInjectionError(
+            targetFixture,
+            propertyKeyFixture,
+            parameterIndexFixture,
+            errorFixture,
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      it('should call getDecoratorInfo()', () => {
+        expect(getDecoratorInfo).toHaveBeenCalledTimes(1);
+        expect(getDecoratorInfo).toHaveBeenCalledWith(
+          targetFixture,
+          propertyKeyFixture,
+          parameterIndexFixture,
+        );
+      });
+
+      it('should call stringifyDecoratorInfo()', () => {
+        expect(stringifyDecoratorInfo).toHaveBeenCalledTimes(1);
+        expect(stringifyDecoratorInfo).toHaveBeenCalledWith(
+          decoratorInfoFixture,
+        );
+      });
+
+      it('should throw an InversifyCoreError', () => {
+        const expectedErrorProperties: Partial<InversifyCoreError> = {
+          cause: errorFixture,
+          kind: InversifyCoreErrorKind.injectionDecoratorConflict,
+          message: `Unexpected injection error.
+
+Cause:
+
+${errorFixture.message}
+
+Details
+
+${decoratorInfoStringifiedFixture}`,
+        };
+
+        expect(result).toBeInstanceOf(InversifyCoreError);
+        expect(result).toStrictEqual(
+          expect.objectContaining(expectedErrorProperties),
+        );
+      });
+    });
+  });
+
+  describe('having a non InversifyCoreError', () => {
+    let targetFixture: object;
+    let propertyKeyFixture: string | symbol | undefined;
+    let parameterIndexFixture: number | undefined;
+    let errorFixture: Error;
+
+    beforeAll(() => {
+      targetFixture = class {};
+      propertyKeyFixture = undefined;
+      parameterIndexFixture = 0;
+      errorFixture = new Error('error message fixture');
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        try {
+          handleInjectionError(
+            targetFixture,
+            propertyKeyFixture,
+            parameterIndexFixture,
+            errorFixture,
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      it('should throw an Error', () => {
+        expect(result).toBe(errorFixture);
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/calculations/handleInjectionError.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/handleInjectionError.ts
@@ -1,0 +1,40 @@
+import { getDecoratorInfo } from '../../decorator/calculations/getDecoratorInfo';
+import { stringifyDecoratorInfo } from '../../decorator/calculations/stringifyDecoratorInfo';
+import { DecoratorInfo } from '../../decorator/models/DecoratorInfo';
+import { InversifyCoreError } from '../../error/models/InversifyCoreError';
+import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
+
+export function handleInjectionError(
+  target: object,
+  propertyKey: string | symbol | undefined,
+  parameterIndex: number | undefined,
+  error: unknown,
+): never {
+  if (
+    InversifyCoreError.isErrorOfKind(
+      error,
+      InversifyCoreErrorKind.injectionDecoratorConflict,
+    )
+  ) {
+    const info: DecoratorInfo = getDecoratorInfo(
+      target,
+      propertyKey,
+      parameterIndex,
+    );
+    throw new InversifyCoreError(
+      InversifyCoreErrorKind.injectionDecoratorConflict,
+      `Unexpected injection error.
+
+Cause:
+
+${error.message}
+
+Details
+
+${stringifyDecoratorInfo(info)}`,
+      { cause: error },
+    );
+  }
+
+  throw error;
+}

--- a/packages/container/libraries/core/src/metadata/decorators/unmanaged.int.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/unmanaged.int.spec.ts
@@ -1,0 +1,68 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import 'reflect-metadata';
+
+import { getReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+
+import { classMetadataReflectKey } from '../../reflectMetadata/data/classMetadataReflectKey';
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { ClassMetadata } from '../models/ClassMetadata';
+import { unmanaged } from './unmanaged';
+
+describe(unmanaged.name, () => {
+  describe('when called', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      class Foo {
+        @unmanaged()
+        public readonly bar!: string;
+
+        @unmanaged()
+        public readonly baz!: string;
+
+        constructor(
+          @unmanaged()
+          public firstParam: number,
+          @unmanaged()
+          public secondParam: number,
+        ) {}
+      }
+
+      result = getReflectMetadata(Foo, classMetadataReflectKey);
+    });
+
+    it('should return expected metadata', () => {
+      const expected: ClassMetadata = {
+        constructorArguments: [
+          {
+            kind: ClassElementMetadataKind.unmanaged,
+          },
+          {
+            kind: ClassElementMetadataKind.unmanaged,
+          },
+        ],
+        lifecycle: {
+          postConstructMethodName: undefined,
+          preDestroyMethodName: undefined,
+        },
+        properties: new Map([
+          [
+            'bar',
+            {
+              kind: ClassElementMetadataKind.unmanaged,
+            },
+          ],
+          [
+            'baz',
+            {
+              kind: ClassElementMetadataKind.unmanaged,
+            },
+          ],
+        ]),
+      };
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/decorators/unmanaged.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/unmanaged.spec.ts
@@ -1,0 +1,171 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock(
+  '../calculations/buildUnmanagedMetadataFromMaybeClassElementMetadata',
+);
+jest.mock('./injectBase');
+
+import { buildUnmanagedMetadataFromMaybeClassElementMetadata } from '../calculations/buildUnmanagedMetadataFromMaybeClassElementMetadata';
+import { ClassElementMetadata } from '../models/ClassElementMetadata';
+import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
+import { injectBase } from './injectBase';
+import { unmanaged } from './unmanaged';
+
+describe(unmanaged.name, () => {
+  describe('having a non undefined propertyKey and an undefined parameterIndex', () => {
+    let targetFixture: object;
+    let propertyKeyFixture: string | symbol;
+
+    beforeAll(() => {
+      targetFixture = class {};
+      propertyKeyFixture = 'property-key';
+    });
+
+    describe('when called', () => {
+      let injectBaseDecoratorMock: jest.Mock<
+        ParameterDecorator & PropertyDecorator
+      > &
+        ParameterDecorator &
+        PropertyDecorator;
+
+      let updateMetadataMock: jest.Mock<
+        (
+          classElementMetadata: MaybeClassElementMetadata | undefined,
+        ) => ClassElementMetadata
+      >;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        injectBaseDecoratorMock = jest.fn() as jest.Mock<
+          ParameterDecorator & PropertyDecorator
+        > &
+          ParameterDecorator &
+          PropertyDecorator;
+
+        updateMetadataMock = jest.fn();
+
+        (
+          buildUnmanagedMetadataFromMaybeClassElementMetadata as jest.Mock<
+            typeof buildUnmanagedMetadataFromMaybeClassElementMetadata
+          >
+        ).mockReturnValueOnce(updateMetadataMock);
+
+        (injectBase as jest.Mock<typeof injectBase>).mockReturnValueOnce(
+          injectBaseDecoratorMock,
+        );
+
+        result = unmanaged()(targetFixture, propertyKeyFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call buildUnmanagedMetadataFromMaybeClassElementMetadata()', () => {
+        expect(
+          buildUnmanagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          buildUnmanagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledWith();
+      });
+
+      it('should call injectBase()', () => {
+        expect(injectBase).toHaveBeenCalledTimes(1);
+        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+      });
+
+      it('should call injectBaseDecorator()', () => {
+        expect(injectBaseDecoratorMock).toHaveBeenCalledTimes(1);
+        expect(injectBaseDecoratorMock).toHaveBeenCalledWith(
+          targetFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a undefined propertyKey and an non undefined parameterIndex', () => {
+    let targetFixture: object;
+    let paramIndexFixture: number;
+
+    beforeAll(() => {
+      targetFixture = class {};
+      paramIndexFixture = 0;
+    });
+
+    describe('when called', () => {
+      let injectBaseDecoratorMock: jest.Mock<
+        ParameterDecorator & PropertyDecorator
+      > &
+        ParameterDecorator &
+        PropertyDecorator;
+
+      let updateMetadataMock: jest.Mock<
+        (
+          classElementMetadata: MaybeClassElementMetadata | undefined,
+        ) => ClassElementMetadata
+      >;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        injectBaseDecoratorMock = jest.fn() as jest.Mock<
+          ParameterDecorator & PropertyDecorator
+        > &
+          ParameterDecorator &
+          PropertyDecorator;
+
+        updateMetadataMock = jest.fn();
+
+        (
+          buildUnmanagedMetadataFromMaybeClassElementMetadata as jest.Mock<
+            typeof buildUnmanagedMetadataFromMaybeClassElementMetadata
+          >
+        ).mockReturnValueOnce(updateMetadataMock);
+
+        (injectBase as jest.Mock<typeof injectBase>).mockReturnValueOnce(
+          injectBaseDecoratorMock,
+        );
+
+        result = unmanaged()(targetFixture, undefined, paramIndexFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call buildUnmanagedMetadataFromMaybeClassElementMetadata()', () => {
+        expect(
+          buildUnmanagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          buildUnmanagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledWith();
+      });
+
+      it('should call injectBase()', () => {
+        expect(injectBase).toHaveBeenCalledTimes(1);
+        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+      });
+
+      it('should call injectBaseDecorator()', () => {
+        expect(injectBaseDecoratorMock).toHaveBeenCalledTimes(1);
+        expect(injectBaseDecoratorMock).toHaveBeenCalledWith(
+          targetFixture,
+          undefined,
+          paramIndexFixture,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/decorators/unmanaged.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/unmanaged.ts
@@ -1,0 +1,28 @@
+import { buildUnmanagedMetadataFromMaybeClassElementMetadata } from '../calculations/buildUnmanagedMetadataFromMaybeClassElementMetadata';
+import { handleInjectionError } from '../calculations/handleInjectionError';
+import { ClassElementMetadata } from '../models/ClassElementMetadata';
+import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
+import { injectBase } from './injectBase';
+
+export function unmanaged(): ParameterDecorator & PropertyDecorator {
+  return (
+    target: object,
+    propertyKey: string | symbol | undefined,
+    parameterIndex?: number,
+  ): void => {
+    const updateMetadata: (
+      classElementMetadata: MaybeClassElementMetadata | undefined,
+    ) => ClassElementMetadata =
+      buildUnmanagedMetadataFromMaybeClassElementMetadata();
+
+    try {
+      if (parameterIndex === undefined) {
+        injectBase(updateMetadata)(target, propertyKey as string | symbol);
+      } else {
+        injectBase(updateMetadata)(target, propertyKey, parameterIndex);
+      }
+    } catch (error: unknown) {
+      handleInjectionError(target, propertyKey, parameterIndex, error);
+    }
+  };
+}


### PR DESCRIPTION
### Added
- Added `unmanaged` decorator.
- Added `handleInjectionError`.
- Added `buildUnmanagedMetadataFromMaybeClassElementMetadata`.
- Added `buildClassElementMetadataFromMaybeClassElementMetadata`.
- Added `buildUnmanagedMetadataFromMaybeManagedMetadata`.
- Added `buildDefaultUnmanagedMetadata`.