### PR TITLE
Add inject decorators

### DIFF
--- a/packages/container/libraries/core/src/metadata/calculations/buildDefaultManagedMetadata.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildDefaultManagedMetadata.spec.ts
@@ -1,0 +1,41 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { ServiceIdentifier } from '@inversifyjs/common';
+
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { ManagedClassElementMetadata } from '../models/ManagedClassElementMetadata';
+import { buildDefaultManagedMetadata } from './buildDefaultManagedMetadata';
+
+describe(buildDefaultManagedMetadata.name, () => {
+  let metadataKindFixture: ClassElementMetadataKind.singleInjection;
+  let serviceIdentifierFixture: ServiceIdentifier;
+
+  beforeAll(() => {
+    metadataKindFixture = ClassElementMetadataKind.singleInjection;
+    serviceIdentifierFixture = 'service-id';
+  });
+
+  describe('when called', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      result = buildDefaultManagedMetadata(
+        metadataKindFixture,
+        serviceIdentifierFixture,
+      );
+    });
+
+    it('should return ManagedClassElementMetadata', () => {
+      const expected: ManagedClassElementMetadata = {
+        kind: metadataKindFixture,
+        name: undefined,
+        optional: false,
+        tags: new Map(),
+        targetName: undefined,
+        value: serviceIdentifierFixture,
+      };
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/calculations/buildDefaultManagedMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildDefaultManagedMetadata.ts
@@ -1,0 +1,20 @@
+import { LazyServiceIdentifier, ServiceIdentifier } from '@inversifyjs/common';
+
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { ManagedClassElementMetadata } from '../models/ManagedClassElementMetadata';
+
+export function buildDefaultManagedMetadata(
+  kind:
+    | ClassElementMetadataKind.singleInjection
+    | ClassElementMetadataKind.multipleInjection,
+  serviceIdentifier: ServiceIdentifier | LazyServiceIdentifier,
+): ManagedClassElementMetadata {
+  return {
+    kind,
+    name: undefined,
+    optional: false,
+    tags: new Map(),
+    targetName: undefined,
+    value: serviceIdentifier,
+  };
+}

--- a/packages/container/libraries/core/src/metadata/calculations/buildManagedMetadataFromMaybeClassElementMetadata.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildManagedMetadataFromMaybeClassElementMetadata.spec.ts
@@ -1,0 +1,57 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { LazyServiceIdentifier, ServiceIdentifier } from '@inversifyjs/common';
+
+jest.mock('./buildClassElementMetadataFromMaybeClassElementMetadata', () => ({
+  buildClassElementMetadataFromMaybeClassElementMetadata: jest
+    .fn()
+    .mockReturnValue(jest.fn()),
+}));
+
+import { ClassElementMetadata } from '../models/ClassElementMetadata';
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
+import { buildManagedMetadataFromMaybeClassElementMetadata } from './buildManagedMetadataFromMaybeClassElementMetadata';
+
+describe(buildManagedMetadataFromMaybeClassElementMetadata.name, () => {
+  let kindFixture:
+    | ClassElementMetadataKind.multipleInjection
+    | ClassElementMetadataKind.singleInjection;
+  let serviceIdentifierFixture: ServiceIdentifier | LazyServiceIdentifier;
+
+  beforeAll(() => {
+    kindFixture = ClassElementMetadataKind.multipleInjection;
+    serviceIdentifierFixture = 'service-id';
+  });
+
+  describe('when called', () => {
+    let buildClassMetadataMock: jest.Mock<
+      (metadata: MaybeClassElementMetadata | undefined) => ClassElementMetadata
+    >;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      buildClassMetadataMock = jest.fn();
+
+      (
+        buildManagedMetadataFromMaybeClassElementMetadata as jest.Mock<
+          typeof buildManagedMetadataFromMaybeClassElementMetadata
+        >
+      ).mockReturnValueOnce(buildClassMetadataMock);
+
+      result = buildManagedMetadataFromMaybeClassElementMetadata(
+        kindFixture,
+        serviceIdentifierFixture,
+      );
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should return expected function', () => {
+      expect(result).toBe(buildClassMetadataMock);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/calculations/buildManagedMetadataFromMaybeClassElementMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildManagedMetadataFromMaybeClassElementMetadata.ts
@@ -1,0 +1,19 @@
+import { LazyServiceIdentifier, ServiceIdentifier } from '@inversifyjs/common';
+
+import { ClassElementMetadata } from '../models/ClassElementMetadata';
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
+import { buildClassElementMetadataFromMaybeClassElementMetadata } from './buildClassElementMetadataFromMaybeClassElementMetadata';
+import { buildDefaultManagedMetadata } from './buildDefaultManagedMetadata';
+import { buildManagedMetadataFromMaybeManagedMetadata } from './buildManagedMetadataFromMaybeManagedMetadata';
+
+export const buildManagedMetadataFromMaybeClassElementMetadata: (
+  kind:
+    | ClassElementMetadataKind.multipleInjection
+    | ClassElementMetadataKind.singleInjection,
+  serviceIdentifier: ServiceIdentifier | LazyServiceIdentifier,
+) => (metadata: MaybeClassElementMetadata | undefined) => ClassElementMetadata =
+  buildClassElementMetadataFromMaybeClassElementMetadata(
+    buildDefaultManagedMetadata,
+    buildManagedMetadataFromMaybeManagedMetadata,
+  );

--- a/packages/container/libraries/core/src/metadata/calculations/buildManagedMetadataFromMaybeManagedMetadata.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildManagedMetadataFromMaybeManagedMetadata.spec.ts
@@ -1,0 +1,50 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { LazyServiceIdentifier, ServiceIdentifier } from '@inversifyjs/common';
+
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { ManagedClassElementMetadata } from '../models/ManagedClassElementMetadata';
+import { MaybeClassElementMetadataKind } from '../models/MaybeClassElementMetadataKind';
+import { MaybeManagedClassElementMetadata } from '../models/MaybeManagedClassElementMetadata';
+import { buildManagedMetadataFromMaybeManagedMetadata } from './buildManagedMetadataFromMaybeManagedMetadata';
+
+describe(buildManagedMetadataFromMaybeManagedMetadata.name, () => {
+  describe('when called', () => {
+    let metadataFixture: MaybeManagedClassElementMetadata;
+    let kindFixture:
+      | ClassElementMetadataKind.singleInjection
+      | ClassElementMetadataKind.multipleInjection;
+    let serviceIdentifierFixture: ServiceIdentifier | LazyServiceIdentifier;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      metadataFixture = {
+        kind: MaybeClassElementMetadataKind.unknown,
+        name: 'name-fixture',
+        optional: true,
+        tags: new Map(),
+        targetName: 'target-name-fixture',
+      };
+
+      result = buildManagedMetadataFromMaybeManagedMetadata(
+        metadataFixture,
+        kindFixture,
+        serviceIdentifierFixture,
+      );
+    });
+
+    it('should return ManagedClassElementMetadata', () => {
+      const expected: ManagedClassElementMetadata = {
+        kind: kindFixture,
+        name: metadataFixture.name,
+        optional: metadataFixture.optional,
+        tags: metadataFixture.tags,
+        targetName: metadataFixture.targetName,
+        value: serviceIdentifierFixture,
+      };
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/calculations/buildManagedMetadataFromMaybeManagedMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildManagedMetadataFromMaybeManagedMetadata.ts
@@ -1,0 +1,19 @@
+import { LazyServiceIdentifier, ServiceIdentifier } from '@inversifyjs/common';
+
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { ManagedClassElementMetadata } from '../models/ManagedClassElementMetadata';
+import { MaybeManagedClassElementMetadata } from '../models/MaybeManagedClassElementMetadata';
+
+export function buildManagedMetadataFromMaybeManagedMetadata(
+  metadata: MaybeManagedClassElementMetadata,
+  kind:
+    | ClassElementMetadataKind.singleInjection
+    | ClassElementMetadataKind.multipleInjection,
+  serviceIdentifier: ServiceIdentifier | LazyServiceIdentifier,
+): ManagedClassElementMetadata {
+  return {
+    ...metadata,
+    kind,
+    value: serviceIdentifier,
+  };
+}

--- a/packages/container/libraries/core/src/metadata/decorators/inject.int.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/inject.int.spec.ts
@@ -1,0 +1,88 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import 'reflect-metadata';
+
+import { getReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+
+import { classMetadataReflectKey } from '../../reflectMetadata/data/classMetadataReflectKey';
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { ClassMetadata } from '../models/ClassMetadata';
+import { inject } from './inject';
+
+describe(inject.name, () => {
+  describe('when called', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      class Foo {
+        @inject('bar')
+        public readonly bar!: string;
+
+        @inject('baz')
+        public readonly baz!: string;
+
+        constructor(
+          @inject('firstParam')
+          public firstParam: number,
+          @inject('secondParam')
+          public secondParam: number,
+        ) {}
+      }
+
+      result = getReflectMetadata(Foo, classMetadataReflectKey);
+    });
+
+    it('should return expected metadata', () => {
+      const expected: ClassMetadata = {
+        constructorArguments: [
+          {
+            kind: ClassElementMetadataKind.singleInjection,
+            name: undefined,
+            optional: false,
+            tags: new Map(),
+            targetName: undefined,
+            value: 'firstParam',
+          },
+          {
+            kind: ClassElementMetadataKind.singleInjection,
+            name: undefined,
+            optional: false,
+            tags: new Map(),
+            targetName: undefined,
+            value: 'secondParam',
+          },
+        ],
+        lifecycle: {
+          postConstructMethodName: undefined,
+          preDestroyMethodName: undefined,
+        },
+        properties: new Map([
+          [
+            'bar',
+            {
+              kind: ClassElementMetadataKind.singleInjection,
+              name: undefined,
+              optional: false,
+              tags: new Map(),
+              targetName: undefined,
+              value: 'bar',
+            },
+          ],
+          [
+            'baz',
+            {
+              kind: ClassElementMetadataKind.singleInjection,
+              name: undefined,
+              optional: false,
+              tags: new Map(),
+              targetName: undefined,
+              value: 'baz',
+            },
+          ],
+        ]),
+      };
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/decorators/inject.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/inject.spec.ts
@@ -1,0 +1,359 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { ServiceIdentifier } from '@inversifyjs/common';
+
+jest.mock('../calculations/buildManagedMetadataFromMaybeClassElementMetadata');
+jest.mock('../calculations/handleInjectionError');
+jest.mock('./injectBase');
+
+import { buildManagedMetadataFromMaybeClassElementMetadata } from '../calculations/buildManagedMetadataFromMaybeClassElementMetadata';
+import { handleInjectionError } from '../calculations/handleInjectionError';
+import { ClassElementMetadata } from '../models/ClassElementMetadata';
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
+import { inject } from './inject';
+import { injectBase } from './injectBase';
+
+describe(inject.name, () => {
+  describe('having a non undefined propertyKey and an undefined parameterIndex', () => {
+    let serviceIdentifierFixture: ServiceIdentifier;
+    let targetFixture: object;
+    let propertyKeyFixture: string | symbol;
+
+    beforeAll(() => {
+      serviceIdentifierFixture = 'service-id-fixture';
+      targetFixture = class {};
+      propertyKeyFixture = 'property-key';
+    });
+
+    describe('when called', () => {
+      let injectBaseDecoratorMock: jest.Mock<
+        ParameterDecorator & PropertyDecorator
+      > &
+        ParameterDecorator &
+        PropertyDecorator;
+
+      let updateMetadataMock: jest.Mock<
+        (
+          classElementMetadata: MaybeClassElementMetadata | undefined,
+        ) => ClassElementMetadata
+      >;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        injectBaseDecoratorMock = jest.fn() as jest.Mock<
+          ParameterDecorator & PropertyDecorator
+        > &
+          ParameterDecorator &
+          PropertyDecorator;
+
+        updateMetadataMock = jest.fn();
+
+        (
+          buildManagedMetadataFromMaybeClassElementMetadata as jest.Mock<
+            typeof buildManagedMetadataFromMaybeClassElementMetadata
+          >
+        ).mockReturnValueOnce(updateMetadataMock);
+
+        (injectBase as jest.Mock<typeof injectBase>).mockReturnValueOnce(
+          injectBaseDecoratorMock,
+        );
+
+        result = inject(serviceIdentifierFixture)(
+          targetFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call buildManagedMetadataFromMaybeClassElementMetadata()', () => {
+        expect(
+          buildManagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          buildManagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledWith(
+          ClassElementMetadataKind.singleInjection,
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should call injectBase()', () => {
+        expect(injectBase).toHaveBeenCalledTimes(1);
+        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+      });
+
+      it('should call injectBaseDecorator()', () => {
+        expect(injectBaseDecoratorMock).toHaveBeenCalledTimes(1);
+        expect(injectBaseDecoratorMock).toHaveBeenCalledWith(
+          targetFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when called, and injectBase throws an Error', () => {
+      let errorFixture: Error;
+      let updateMetadataMock: jest.Mock<
+        (
+          classElementMetadata: MaybeClassElementMetadata | undefined,
+        ) => ClassElementMetadata
+      >;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        errorFixture = new Error('message-error-fixture');
+        updateMetadataMock = jest.fn();
+
+        (
+          buildManagedMetadataFromMaybeClassElementMetadata as jest.Mock<
+            typeof buildManagedMetadataFromMaybeClassElementMetadata
+          >
+        ).mockReturnValueOnce(updateMetadataMock);
+
+        (injectBase as jest.Mock<typeof injectBase>).mockImplementation(
+          (): never => {
+            throw errorFixture;
+          },
+        );
+
+        (
+          handleInjectionError as jest.Mock<typeof handleInjectionError>
+        ).mockImplementation(
+          (
+            _target: object,
+            _propertyKey: string | symbol | undefined,
+            _parameterIndex: number | undefined,
+            error: unknown,
+          ): never => {
+            throw error;
+          },
+        );
+
+        try {
+          inject(serviceIdentifierFixture)(targetFixture, propertyKeyFixture);
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call buildManagedMetadataFromMaybeClassElementMetadata()', () => {
+        expect(
+          buildManagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          buildManagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledWith(
+          ClassElementMetadataKind.singleInjection,
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should call injectBase()', () => {
+        expect(injectBase).toHaveBeenCalledTimes(1);
+        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+      });
+
+      it('should throw handleInjectionError()', () => {
+        expect(handleInjectionError).toHaveBeenCalledTimes(1);
+        expect(handleInjectionError).toHaveBeenCalledWith(
+          targetFixture,
+          propertyKeyFixture,
+          undefined,
+          errorFixture,
+        );
+      });
+
+      it('should throw an Error', () => {
+        expect(result).toBe(errorFixture);
+      });
+    });
+  });
+
+  describe('having a undefined propertyKey and an non undefined parameterIndex', () => {
+    let serviceIdentifierFixture: ServiceIdentifier;
+    let targetFixture: object;
+    let paramIndexFixture: number;
+
+    beforeAll(() => {
+      serviceIdentifierFixture = 'service-id-fixture';
+      targetFixture = class {};
+      paramIndexFixture = 0;
+    });
+
+    describe('when called', () => {
+      let injectBaseDecoratorMock: jest.Mock<
+        ParameterDecorator & PropertyDecorator
+      > &
+        ParameterDecorator &
+        PropertyDecorator;
+
+      let updateMetadataMock: jest.Mock<
+        (
+          classElementMetadata: MaybeClassElementMetadata | undefined,
+        ) => ClassElementMetadata
+      >;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        injectBaseDecoratorMock = jest.fn() as jest.Mock<
+          ParameterDecorator & PropertyDecorator
+        > &
+          ParameterDecorator &
+          PropertyDecorator;
+
+        updateMetadataMock = jest.fn();
+
+        (
+          buildManagedMetadataFromMaybeClassElementMetadata as jest.Mock<
+            typeof buildManagedMetadataFromMaybeClassElementMetadata
+          >
+        ).mockReturnValueOnce(updateMetadataMock);
+
+        (injectBase as jest.Mock<typeof injectBase>).mockReturnValueOnce(
+          injectBaseDecoratorMock,
+        );
+
+        result = inject(serviceIdentifierFixture)(
+          targetFixture,
+          undefined,
+          paramIndexFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call buildManagedMetadataFromMaybeClassElementMetadata()', () => {
+        expect(
+          buildManagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          buildManagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledWith(
+          ClassElementMetadataKind.singleInjection,
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should call injectBase()', () => {
+        expect(injectBase).toHaveBeenCalledTimes(1);
+        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+      });
+
+      it('should call injectBaseDecorator()', () => {
+        expect(injectBaseDecoratorMock).toHaveBeenCalledTimes(1);
+        expect(injectBaseDecoratorMock).toHaveBeenCalledWith(
+          targetFixture,
+          undefined,
+          paramIndexFixture,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when called, and injectBase throws an Error', () => {
+      let errorFixture: Error;
+      let updateMetadataMock: jest.Mock<
+        (
+          classElementMetadata: MaybeClassElementMetadata | undefined,
+        ) => ClassElementMetadata
+      >;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        errorFixture = new Error('message-error-fixture');
+        updateMetadataMock = jest.fn();
+
+        (
+          buildManagedMetadataFromMaybeClassElementMetadata as jest.Mock<
+            typeof buildManagedMetadataFromMaybeClassElementMetadata
+          >
+        ).mockReturnValueOnce(updateMetadataMock);
+
+        (injectBase as jest.Mock<typeof injectBase>).mockImplementation(
+          (): never => {
+            throw errorFixture;
+          },
+        );
+
+        (
+          handleInjectionError as jest.Mock<typeof handleInjectionError>
+        ).mockImplementation(
+          (
+            _target: object,
+            _propertyKey: string | symbol | undefined,
+            _parameterIndex: number | undefined,
+            error: unknown,
+          ): never => {
+            throw error;
+          },
+        );
+
+        try {
+          inject(serviceIdentifierFixture)(
+            targetFixture,
+            undefined,
+            paramIndexFixture,
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call buildManagedMetadataFromMaybeClassElementMetadata()', () => {
+        expect(
+          buildManagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          buildManagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledWith(
+          ClassElementMetadataKind.singleInjection,
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should call injectBase()', () => {
+        expect(injectBase).toHaveBeenCalledTimes(1);
+        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+      });
+
+      it('should throw handleInjectionError()', () => {
+        expect(handleInjectionError).toHaveBeenCalledTimes(1);
+        expect(handleInjectionError).toHaveBeenCalledWith(
+          targetFixture,
+          undefined,
+          paramIndexFixture,
+          errorFixture,
+        );
+      });
+
+      it('should throw an Error', () => {
+        expect(result).toBe(errorFixture);
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/decorators/inject.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/inject.ts
@@ -1,0 +1,36 @@
+import { LazyServiceIdentifier, ServiceIdentifier } from '@inversifyjs/common';
+
+import { buildManagedMetadataFromMaybeClassElementMetadata } from '../calculations/buildManagedMetadataFromMaybeClassElementMetadata';
+import { handleInjectionError } from '../calculations/handleInjectionError';
+import { ClassElementMetadata } from '../models/ClassElementMetadata';
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
+import { injectBase } from './injectBase';
+
+export function inject(
+  serviceIdentifier: ServiceIdentifier | LazyServiceIdentifier,
+): ParameterDecorator & PropertyDecorator {
+  return (
+    target: object,
+    propertyKey: string | symbol | undefined,
+    parameterIndex?: number,
+  ): void => {
+    const updateMetadata: (
+      classElementMetadata: MaybeClassElementMetadata | undefined,
+    ) => ClassElementMetadata =
+      buildManagedMetadataFromMaybeClassElementMetadata(
+        ClassElementMetadataKind.singleInjection,
+        serviceIdentifier,
+      );
+
+    try {
+      if (parameterIndex === undefined) {
+        injectBase(updateMetadata)(target, propertyKey as string | symbol);
+      } else {
+        injectBase(updateMetadata)(target, propertyKey, parameterIndex);
+      }
+    } catch (error: unknown) {
+      handleInjectionError(target, propertyKey, parameterIndex, error);
+    }
+  };
+}

--- a/packages/container/libraries/core/src/metadata/decorators/multiInject.int.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/multiInject.int.spec.ts
@@ -1,0 +1,88 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import 'reflect-metadata';
+
+import { getReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+
+import { classMetadataReflectKey } from '../../reflectMetadata/data/classMetadataReflectKey';
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { ClassMetadata } from '../models/ClassMetadata';
+import { multiInject } from './multiInject';
+
+describe(multiInject.name, () => {
+  describe('when called', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      class Foo {
+        @multiInject('bar')
+        public readonly bar!: string;
+
+        @multiInject('baz')
+        public readonly baz!: string;
+
+        constructor(
+          @multiInject('firstParam')
+          public firstParam: number,
+          @multiInject('secondParam')
+          public secondParam: number,
+        ) {}
+      }
+
+      result = getReflectMetadata(Foo, classMetadataReflectKey);
+    });
+
+    it('should return expected metadata', () => {
+      const expected: ClassMetadata = {
+        constructorArguments: [
+          {
+            kind: ClassElementMetadataKind.multipleInjection,
+            name: undefined,
+            optional: false,
+            tags: new Map(),
+            targetName: undefined,
+            value: 'firstParam',
+          },
+          {
+            kind: ClassElementMetadataKind.multipleInjection,
+            name: undefined,
+            optional: false,
+            tags: new Map(),
+            targetName: undefined,
+            value: 'secondParam',
+          },
+        ],
+        lifecycle: {
+          postConstructMethodName: undefined,
+          preDestroyMethodName: undefined,
+        },
+        properties: new Map([
+          [
+            'bar',
+            {
+              kind: ClassElementMetadataKind.multipleInjection,
+              name: undefined,
+              optional: false,
+              tags: new Map(),
+              targetName: undefined,
+              value: 'bar',
+            },
+          ],
+          [
+            'baz',
+            {
+              kind: ClassElementMetadataKind.multipleInjection,
+              name: undefined,
+              optional: false,
+              tags: new Map(),
+              targetName: undefined,
+              value: 'baz',
+            },
+          ],
+        ]),
+      };
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/decorators/multiInject.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/multiInject.spec.ts
@@ -1,0 +1,362 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { ServiceIdentifier } from '@inversifyjs/common';
+
+jest.mock('../calculations/buildManagedMetadataFromMaybeClassElementMetadata');
+jest.mock('../calculations/handleInjectionError');
+jest.mock('./injectBase');
+
+import { buildManagedMetadataFromMaybeClassElementMetadata } from '../calculations/buildManagedMetadataFromMaybeClassElementMetadata';
+import { handleInjectionError } from '../calculations/handleInjectionError';
+import { ClassElementMetadata } from '../models/ClassElementMetadata';
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
+import { injectBase } from './injectBase';
+import { multiInject } from './multiInject';
+
+describe(multiInject.name, () => {
+  describe('having a non undefined propertyKey and an undefined parameterIndex', () => {
+    let serviceIdentifierFixture: ServiceIdentifier;
+    let targetFixture: object;
+    let propertyKeyFixture: string | symbol;
+
+    beforeAll(() => {
+      serviceIdentifierFixture = 'service-id-fixture';
+      targetFixture = class {};
+      propertyKeyFixture = 'property-key';
+    });
+
+    describe('when called', () => {
+      let injectBaseDecoratorMock: jest.Mock<
+        ParameterDecorator & PropertyDecorator
+      > &
+        ParameterDecorator &
+        PropertyDecorator;
+
+      let updateMetadataMock: jest.Mock<
+        (
+          classElementMetadata: MaybeClassElementMetadata | undefined,
+        ) => ClassElementMetadata
+      >;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        injectBaseDecoratorMock = jest.fn() as jest.Mock<
+          ParameterDecorator & PropertyDecorator
+        > &
+          ParameterDecorator &
+          PropertyDecorator;
+
+        updateMetadataMock = jest.fn();
+
+        (
+          buildManagedMetadataFromMaybeClassElementMetadata as jest.Mock<
+            typeof buildManagedMetadataFromMaybeClassElementMetadata
+          >
+        ).mockReturnValueOnce(updateMetadataMock);
+
+        (injectBase as jest.Mock<typeof injectBase>).mockReturnValueOnce(
+          injectBaseDecoratorMock,
+        );
+
+        result = multiInject(serviceIdentifierFixture)(
+          targetFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call buildManagedMetadataFromMaybeClassElementMetadata()', () => {
+        expect(
+          buildManagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          buildManagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledWith(
+          ClassElementMetadataKind.multipleInjection,
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should call injectBase()', () => {
+        expect(injectBase).toHaveBeenCalledTimes(1);
+        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+      });
+
+      it('should call injectBaseDecorator()', () => {
+        expect(injectBaseDecoratorMock).toHaveBeenCalledTimes(1);
+        expect(injectBaseDecoratorMock).toHaveBeenCalledWith(
+          targetFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when called, and injectBase throws an Error', () => {
+      let errorFixture: Error;
+      let updateMetadataMock: jest.Mock<
+        (
+          classElementMetadata: MaybeClassElementMetadata | undefined,
+        ) => ClassElementMetadata
+      >;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        errorFixture = new Error('message-error-fixture');
+        updateMetadataMock = jest.fn();
+
+        (
+          buildManagedMetadataFromMaybeClassElementMetadata as jest.Mock<
+            typeof buildManagedMetadataFromMaybeClassElementMetadata
+          >
+        ).mockReturnValueOnce(updateMetadataMock);
+
+        (injectBase as jest.Mock<typeof injectBase>).mockImplementation(
+          (): never => {
+            throw errorFixture;
+          },
+        );
+
+        (
+          handleInjectionError as jest.Mock<typeof handleInjectionError>
+        ).mockImplementation(
+          (
+            _target: object,
+            _propertyKey: string | symbol | undefined,
+            _parameterIndex: number | undefined,
+            error: unknown,
+          ): never => {
+            throw error;
+          },
+        );
+
+        try {
+          multiInject(serviceIdentifierFixture)(
+            targetFixture,
+            propertyKeyFixture,
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call buildManagedMetadataFromMaybeClassElementMetadata()', () => {
+        expect(
+          buildManagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          buildManagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledWith(
+          ClassElementMetadataKind.multipleInjection,
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should call injectBase()', () => {
+        expect(injectBase).toHaveBeenCalledTimes(1);
+        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+      });
+
+      it('should throw handleInjectionError()', () => {
+        expect(handleInjectionError).toHaveBeenCalledTimes(1);
+        expect(handleInjectionError).toHaveBeenCalledWith(
+          targetFixture,
+          propertyKeyFixture,
+          undefined,
+          errorFixture,
+        );
+      });
+
+      it('should throw an Error', () => {
+        expect(result).toBe(errorFixture);
+      });
+    });
+  });
+
+  describe('having a undefined propertyKey and an non undefined parameterIndex', () => {
+    let serviceIdentifierFixture: ServiceIdentifier;
+    let targetFixture: object;
+    let paramIndexFixture: number;
+
+    beforeAll(() => {
+      serviceIdentifierFixture = 'service-id-fixture';
+      targetFixture = class {};
+      paramIndexFixture = 0;
+    });
+
+    describe('when called', () => {
+      let injectBaseDecoratorMock: jest.Mock<
+        ParameterDecorator & PropertyDecorator
+      > &
+        ParameterDecorator &
+        PropertyDecorator;
+
+      let updateMetadataMock: jest.Mock<
+        (
+          classElementMetadata: MaybeClassElementMetadata | undefined,
+        ) => ClassElementMetadata
+      >;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        injectBaseDecoratorMock = jest.fn() as jest.Mock<
+          ParameterDecorator & PropertyDecorator
+        > &
+          ParameterDecorator &
+          PropertyDecorator;
+
+        updateMetadataMock = jest.fn();
+
+        (
+          buildManagedMetadataFromMaybeClassElementMetadata as jest.Mock<
+            typeof buildManagedMetadataFromMaybeClassElementMetadata
+          >
+        ).mockReturnValueOnce(updateMetadataMock);
+
+        (injectBase as jest.Mock<typeof injectBase>).mockReturnValueOnce(
+          injectBaseDecoratorMock,
+        );
+
+        result = multiInject(serviceIdentifierFixture)(
+          targetFixture,
+          undefined,
+          paramIndexFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call buildManagedMetadataFromMaybeClassElementMetadata()', () => {
+        expect(
+          buildManagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          buildManagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledWith(
+          ClassElementMetadataKind.multipleInjection,
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should call injectBase()', () => {
+        expect(injectBase).toHaveBeenCalledTimes(1);
+        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+      });
+
+      it('should call injectBaseDecorator()', () => {
+        expect(injectBaseDecoratorMock).toHaveBeenCalledTimes(1);
+        expect(injectBaseDecoratorMock).toHaveBeenCalledWith(
+          targetFixture,
+          undefined,
+          paramIndexFixture,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when called, and injectBase throws an Error', () => {
+      let errorFixture: Error;
+      let updateMetadataMock: jest.Mock<
+        (
+          classElementMetadata: MaybeClassElementMetadata | undefined,
+        ) => ClassElementMetadata
+      >;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        errorFixture = new Error('message-error-fixture');
+        updateMetadataMock = jest.fn();
+
+        (
+          buildManagedMetadataFromMaybeClassElementMetadata as jest.Mock<
+            typeof buildManagedMetadataFromMaybeClassElementMetadata
+          >
+        ).mockReturnValueOnce(updateMetadataMock);
+
+        (injectBase as jest.Mock<typeof injectBase>).mockImplementation(
+          (): never => {
+            throw errorFixture;
+          },
+        );
+
+        (
+          handleInjectionError as jest.Mock<typeof handleInjectionError>
+        ).mockImplementation(
+          (
+            _target: object,
+            _propertyKey: string | symbol | undefined,
+            _parameterIndex: number | undefined,
+            error: unknown,
+          ): never => {
+            throw error;
+          },
+        );
+
+        try {
+          multiInject(serviceIdentifierFixture)(
+            targetFixture,
+            undefined,
+            paramIndexFixture,
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call buildManagedMetadataFromMaybeClassElementMetadata()', () => {
+        expect(
+          buildManagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          buildManagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledWith(
+          ClassElementMetadataKind.multipleInjection,
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should call injectBase()', () => {
+        expect(injectBase).toHaveBeenCalledTimes(1);
+        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+      });
+
+      it('should throw handleInjectionError()', () => {
+        expect(handleInjectionError).toHaveBeenCalledTimes(1);
+        expect(handleInjectionError).toHaveBeenCalledWith(
+          targetFixture,
+          undefined,
+          paramIndexFixture,
+          errorFixture,
+        );
+      });
+
+      it('should throw an Error', () => {
+        expect(result).toBe(errorFixture);
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/decorators/multiInject.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/multiInject.ts
@@ -1,0 +1,36 @@
+import { LazyServiceIdentifier, ServiceIdentifier } from '@inversifyjs/common';
+
+import { buildManagedMetadataFromMaybeClassElementMetadata } from '../calculations/buildManagedMetadataFromMaybeClassElementMetadata';
+import { handleInjectionError } from '../calculations/handleInjectionError';
+import { ClassElementMetadata } from '../models/ClassElementMetadata';
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
+import { injectBase } from './injectBase';
+
+export function multiInject(
+  serviceIdentifier: ServiceIdentifier | LazyServiceIdentifier,
+): ParameterDecorator & PropertyDecorator {
+  return (
+    target: object,
+    propertyKey: string | symbol | undefined,
+    parameterIndex?: number,
+  ): void => {
+    const updateMetadata: (
+      classElementMetadata: MaybeClassElementMetadata | undefined,
+    ) => ClassElementMetadata =
+      buildManagedMetadataFromMaybeClassElementMetadata(
+        ClassElementMetadataKind.multipleInjection,
+        serviceIdentifier,
+      );
+
+    try {
+      if (parameterIndex === undefined) {
+        injectBase(updateMetadata)(target, propertyKey as string | symbol);
+      } else {
+        injectBase(updateMetadata)(target, propertyKey, parameterIndex);
+      }
+    } catch (error: unknown) {
+      handleInjectionError(target, propertyKey, parameterIndex, error);
+    }
+  };
+}

--- a/packages/container/libraries/core/src/metadata/decorators/unmanaged.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/unmanaged.spec.ts
@@ -3,9 +3,11 @@ import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 jest.mock(
   '../calculations/buildUnmanagedMetadataFromMaybeClassElementMetadata',
 );
+jest.mock('../calculations/handleInjectionError');
 jest.mock('./injectBase');
 
 import { buildUnmanagedMetadataFromMaybeClassElementMetadata } from '../calculations/buildUnmanagedMetadataFromMaybeClassElementMetadata';
+import { handleInjectionError } from '../calculations/handleInjectionError';
 import { ClassElementMetadata } from '../models/ClassElementMetadata';
 import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
 import { injectBase } from './injectBase';
@@ -88,9 +90,88 @@ describe(unmanaged.name, () => {
         expect(result).toBeUndefined();
       });
     });
+
+    describe('when called, and injectBase throws an Error', () => {
+      let errorFixture: Error;
+      let updateMetadataMock: jest.Mock<
+        (
+          classElementMetadata: MaybeClassElementMetadata | undefined,
+        ) => ClassElementMetadata
+      >;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        errorFixture = new Error('message-error-fixture');
+        updateMetadataMock = jest.fn();
+
+        (
+          buildUnmanagedMetadataFromMaybeClassElementMetadata as jest.Mock<
+            typeof buildUnmanagedMetadataFromMaybeClassElementMetadata
+          >
+        ).mockReturnValueOnce(updateMetadataMock);
+
+        (injectBase as jest.Mock<typeof injectBase>).mockImplementation(
+          (): never => {
+            throw errorFixture;
+          },
+        );
+
+        (
+          handleInjectionError as jest.Mock<typeof handleInjectionError>
+        ).mockImplementation(
+          (
+            _target: object,
+            _propertyKey: string | symbol | undefined,
+            _parameterIndex: number | undefined,
+            error: unknown,
+          ): never => {
+            throw error;
+          },
+        );
+
+        try {
+          unmanaged()(targetFixture, propertyKeyFixture);
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call buildUnmanagedMetadataFromMaybeClassElementMetadata()', () => {
+        expect(
+          buildUnmanagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          buildUnmanagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledWith();
+      });
+
+      it('should call injectBase()', () => {
+        expect(injectBase).toHaveBeenCalledTimes(1);
+        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+      });
+
+      it('should throw handleInjectionError()', () => {
+        expect(handleInjectionError).toHaveBeenCalledTimes(1);
+        expect(handleInjectionError).toHaveBeenCalledWith(
+          targetFixture,
+          propertyKeyFixture,
+          undefined,
+          errorFixture,
+        );
+      });
+
+      it('should throw an Error', () => {
+        expect(result).toBe(errorFixture);
+      });
+    });
   });
 
-  describe('having a undefined propertyKey and an non undefined parameterIndex', () => {
+  describe('having an undefined propertyKey and an non undefined parameterIndex', () => {
     let targetFixture: object;
     let paramIndexFixture: number;
 
@@ -165,6 +246,85 @@ describe(unmanaged.name, () => {
 
       it('should return undefined', () => {
         expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when called, and injectBase throws an Error', () => {
+      let errorFixture: Error;
+      let updateMetadataMock: jest.Mock<
+        (
+          classElementMetadata: MaybeClassElementMetadata | undefined,
+        ) => ClassElementMetadata
+      >;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        errorFixture = new Error('message-error-fixture');
+        updateMetadataMock = jest.fn();
+
+        (
+          buildUnmanagedMetadataFromMaybeClassElementMetadata as jest.Mock<
+            typeof buildUnmanagedMetadataFromMaybeClassElementMetadata
+          >
+        ).mockReturnValueOnce(updateMetadataMock);
+
+        (injectBase as jest.Mock<typeof injectBase>).mockImplementation(
+          (): never => {
+            throw errorFixture;
+          },
+        );
+
+        (
+          handleInjectionError as jest.Mock<typeof handleInjectionError>
+        ).mockImplementation(
+          (
+            _target: object,
+            _propertyKey: string | symbol | undefined,
+            _parameterIndex: number | undefined,
+            error: unknown,
+          ): never => {
+            throw error;
+          },
+        );
+
+        try {
+          unmanaged()(targetFixture, undefined, paramIndexFixture);
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call buildUnmanagedMetadataFromMaybeClassElementMetadata()', () => {
+        expect(
+          buildUnmanagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          buildUnmanagedMetadataFromMaybeClassElementMetadata,
+        ).toHaveBeenCalledWith();
+      });
+
+      it('should call injectBase()', () => {
+        expect(injectBase).toHaveBeenCalledTimes(1);
+        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+      });
+
+      it('should throw handleInjectionError()', () => {
+        expect(handleInjectionError).toHaveBeenCalledTimes(1);
+        expect(handleInjectionError).toHaveBeenCalledWith(
+          targetFixture,
+          undefined,
+          paramIndexFixture,
+          errorFixture,
+        );
+      });
+
+      it('should throw an Error', () => {
+        expect(result).toBe(errorFixture);
       });
     });
   });


### PR DESCRIPTION
### Added
- Added `multiInject` decorator.
- Added `inject` decorator.
- Added `buildManagedMetadataFromMaybeClassElementMetadata`.
- Added `buildManagedMetadataFromMaybeManagedMetadata`.
- Added `buildDefaultManagedMetadata`.