### PR TITLE
Update plan service node to allow single binding

### DIFF
--- a/packages/container/libraries/core/src/common/models/Writable.ts
+++ b/packages/container/libraries/core/src/common/models/Writable.ts
@@ -1,0 +1,3 @@
+export type Writable<T> = {
+  -readonly [TKey in keyof T]: T[TKey];
+};

--- a/packages/container/libraries/core/src/planning/calculations/checkServiceNodeSingleInjectionBindings.ts
+++ b/packages/container/libraries/core/src/planning/calculations/checkServiceNodeSingleInjectionBindings.ts
@@ -10,19 +10,21 @@ export function checkServiceNodeSingleInjectionBindings(
   serviceNode: PlanServiceNode,
   isOptional: boolean,
 ): void {
-  if (serviceNode.bindings.length === SINGLE_INJECTION_BINDINGS) {
-    const [planBindingNode]: [PlanBindingNode] = serviceNode.bindings as [
-      PlanBindingNode,
-    ];
+  if (Array.isArray(serviceNode.bindings)) {
+    if (serviceNode.bindings.length === SINGLE_INJECTION_BINDINGS) {
+      const [planBindingNode]: [PlanBindingNode] = serviceNode.bindings as [
+        PlanBindingNode,
+      ];
 
-    if (isPlanServiceRedirectionBindingNode(planBindingNode)) {
-      checkPlanServiceRedirectionBindingNodeSingleInjectionBindings(
-        planBindingNode,
-        isOptional,
-      );
+      if (isPlanServiceRedirectionBindingNode(planBindingNode)) {
+        checkPlanServiceRedirectionBindingNodeSingleInjectionBindings(
+          planBindingNode,
+          isOptional,
+        );
+      }
+
+      return;
     }
-
-    return;
   }
 
   throwErrorWhenUnexpectedBindingsAmountFound(

--- a/packages/container/libraries/core/src/planning/calculations/plan.int.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/plan.int.spec.ts
@@ -15,6 +15,7 @@ import { ProviderBinding } from '../../binding/models/ProviderBinding';
 import { ServiceRedirectionBinding } from '../../binding/models/ServiceRedirectionBinding';
 import { BindingService } from '../../binding/services/BindingService';
 import { BindingServiceImplementation } from '../../binding/services/BindingServiceImplementation';
+import { Writable } from '../../common/models/Writable';
 import { InversifyCoreError } from '../../error/models/InversifyCoreError';
 import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
 import { getDefaultClassMetadata } from '../../metadata/calculations/getDefaultClassMetadata';
@@ -68,10 +69,10 @@ function buildLeafBindingPlanResult(
     },
   };
 
-  planServiceNode.bindings.push({
+  (planServiceNode as Writable<PlanServiceNode>).bindings = {
     binding: binding,
     parent: planServiceNode,
-  });
+  };
 
   return planResult;
 }
@@ -113,10 +114,10 @@ function buildSimpleInstancePlanResult(
     serviceIdentifier: constructorParameterBinding.serviceIdentifier,
   };
 
-  constructorParamServiceNode.bindings.push({
+  (constructorParamServiceNode as Writable<PlanServiceNode>).bindings = {
     binding: constructorParameterBinding,
     parent: constructorParamServiceNode,
-  });
+  };
 
   instanceBindingNode.constructorParams.push(constructorParamServiceNode);
 
@@ -136,14 +137,14 @@ function buildSimpleInstancePlanResult(
     serviceIdentifier: propertyKeyBinding.serviceIdentifier,
   };
 
-  propertyServiceNode.bindings.push({
+  (propertyServiceNode as Writable<PlanServiceNode>).bindings = {
     binding: propertyKeyBinding,
     parent: propertyServiceNode,
-  });
+  };
 
   instanceBindingNode.propertyParams.set(propertyKey, propertyServiceNode);
 
-  planServiceNode.bindings.push(instanceBindingNode);
+  (planServiceNode as Writable<PlanServiceNode>).bindings = instanceBindingNode;
 
   const planResult: PlanResult = {
     tree: {
@@ -185,7 +186,8 @@ function buildServiceRedirectionToLeafBindingPlanResult(
     parent: serviceRedirectionBindingNode,
   });
 
-  planServiceNode.bindings.push(serviceRedirectionBindingNode);
+  (planServiceNode as Writable<PlanServiceNode>).bindings =
+    serviceRedirectionBindingNode;
 
   return planResult;
 }

--- a/packages/container/libraries/core/src/planning/calculations/plan.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/plan.spec.ts
@@ -10,6 +10,7 @@ import { bindingTypeValues } from '../../binding/models/BindingType';
 import { ConstantValueBinding } from '../../binding/models/ConstantValueBinding';
 import { InstanceBinding } from '../../binding/models/InstanceBinding';
 import { ServiceRedirectionBinding } from '../../binding/models/ServiceRedirectionBinding';
+import { Writable } from '../../common/models/Writable';
 import { ClassElementMetadataKind } from '../../metadata/models/ClassElementMetadataKind';
 import { ClassMetadata } from '../../metadata/models/ClassMetadata';
 import { ManagedClassElementMetadata } from '../../metadata/models/ManagedClassElementMetadata';
@@ -105,8 +106,10 @@ describe(plan.name, () => {
       });
 
       it('should return expected PlanResult', () => {
+        const planServiceNodeBindings: PlanBindingNode[] = [];
+
         const planServiceNode: PlanServiceNode = {
-          bindings: [],
+          bindings: planServiceNodeBindings,
           parent: undefined,
           serviceIdentifier: planParamsMock.rootConstraints.serviceIdentifier,
         };
@@ -117,7 +120,7 @@ describe(plan.name, () => {
           },
         };
 
-        planServiceNode.bindings.push({
+        planServiceNodeBindings.push({
           binding: constantValueBinding,
           parent: planServiceNode,
         });
@@ -231,8 +234,10 @@ describe(plan.name, () => {
       });
 
       it('should return expected PlanResult', () => {
+        const planServiceNodeBindings: PlanBindingNode[] = [];
+
         const planServiceNode: PlanServiceNode = {
-          bindings: [],
+          bindings: planServiceNodeBindings,
           parent: undefined,
           serviceIdentifier: planParamsMock.rootConstraints.serviceIdentifier,
         };
@@ -243,7 +248,7 @@ describe(plan.name, () => {
           },
         };
 
-        planServiceNode.bindings.push({
+        planServiceNodeBindings.push({
           binding: constantValueBinding,
           parent: planServiceNode,
         });
@@ -323,8 +328,10 @@ describe(plan.name, () => {
       });
 
       it('should return expected PlanResult', () => {
+        const planServiceNodeBindings: PlanBindingNode[] = [];
+
         const planServiceNode: PlanServiceNode = {
-          bindings: [],
+          bindings: planServiceNodeBindings,
           parent: undefined,
           serviceIdentifier: planParamsMock.rootConstraints.serviceIdentifier,
         };
@@ -343,7 +350,7 @@ describe(plan.name, () => {
           propertyParams: new Map(),
         };
 
-        planServiceNode.bindings.push(instanceBindingNode);
+        planServiceNodeBindings.push(instanceBindingNode);
 
         expect(result).toStrictEqual(expected);
       });
@@ -471,8 +478,10 @@ describe(plan.name, () => {
       });
 
       it('should return expected PlanResult', () => {
+        const planServiceNodeBindings: PlanBindingNode[] = [];
+
         const planServiceNode: PlanServiceNode = {
-          bindings: [],
+          bindings: planServiceNodeBindings,
           parent: undefined,
           serviceIdentifier: planParamsMock.rootConstraints.serviceIdentifier,
         };
@@ -491,26 +500,30 @@ describe(plan.name, () => {
           propertyParams: new Map(),
         };
 
+        const constructorParamsPlanServiceNodeBindings: PlanBindingNode[] = [];
+
         const constructorParamsPlanServiceNode: PlanServiceNode = {
-          bindings: [],
+          bindings: constructorParamsPlanServiceNodeBindings,
           parent: instanceBindingNode,
           serviceIdentifier:
             constructorArgumentMetadata.value as ServiceIdentifier,
         };
 
-        constructorParamsPlanServiceNode.bindings.push({
+        constructorParamsPlanServiceNodeBindings.push({
           binding: constantValueBinding,
           parent: constructorParamsPlanServiceNode,
         });
 
+        const propertyParamsPlanServiceNodeBindings: PlanBindingNode[] = [];
+
         const propertyParamsPlanServiceNode: PlanServiceNode = {
-          bindings: [],
+          bindings: propertyParamsPlanServiceNodeBindings,
           parent: instanceBindingNode,
           serviceIdentifier:
             propertyArgumentMetadata.value as ServiceIdentifier,
         };
 
-        propertyParamsPlanServiceNode.bindings.push({
+        propertyParamsPlanServiceNodeBindings.push({
           binding: constantValueBinding,
           parent: propertyParamsPlanServiceNode,
         });
@@ -524,7 +537,7 @@ describe(plan.name, () => {
           propertyParamsPlanServiceNode,
         );
 
-        planServiceNode.bindings.push(instanceBindingNode);
+        planServiceNodeBindings.push(instanceBindingNode);
 
         expect(result).toStrictEqual(expected);
       });
@@ -654,8 +667,10 @@ describe(plan.name, () => {
       });
 
       it('should return expected PlanResult', () => {
+        const planServiceNodeBindings: PlanBindingNode[] = [];
+
         const planServiceNode: PlanServiceNode = {
-          bindings: [],
+          bindings: planServiceNodeBindings,
           parent: undefined,
           serviceIdentifier: planParamsMock.rootConstraints.serviceIdentifier,
         };
@@ -674,28 +689,32 @@ describe(plan.name, () => {
           propertyParams: new Map(),
         };
 
+        const constructorParamsPlanServiceNodeBindings: PlanBindingNode[] = [];
+
         const constructorParamsPlanServiceNode: PlanServiceNode = {
-          bindings: [],
+          bindings: constructorParamsPlanServiceNodeBindings,
           parent: instanceBindingNode,
           serviceIdentifier: (
             constructorArgumentMetadata.value as LazyServiceIdentifier
           ).unwrap(),
         };
 
-        constructorParamsPlanServiceNode.bindings.push({
+        constructorParamsPlanServiceNodeBindings.push({
           binding: constantValueBinding,
           parent: constructorParamsPlanServiceNode,
         });
 
+        const propertyParamsPlanServiceNodeBindings: PlanBindingNode[] = [];
+
         const propertyParamsPlanServiceNode: PlanServiceNode = {
-          bindings: [],
+          bindings: propertyParamsPlanServiceNodeBindings,
           parent: instanceBindingNode,
           serviceIdentifier: (
             propertyArgumentMetadata.value as LazyServiceIdentifier
           ).unwrap(),
         };
 
-        propertyParamsPlanServiceNode.bindings.push({
+        propertyParamsPlanServiceNodeBindings.push({
           binding: constantValueBinding,
           parent: propertyParamsPlanServiceNode,
         });
@@ -709,7 +728,7 @@ describe(plan.name, () => {
           propertyParamsPlanServiceNode,
         );
 
-        planServiceNode.bindings.push(instanceBindingNode);
+        planServiceNodeBindings.push(instanceBindingNode);
 
         expect(result).toStrictEqual(expected);
       });
@@ -826,14 +845,14 @@ describe(plan.name, () => {
 
       it('should call checkServiceNodeSingleInjectionBindings()', () => {
         const constructorParamsPlanServiceNode: PlanServiceNode = {
-          bindings: expect.any(Array) as unknown as PlanBindingNode[],
+          bindings: expect.any(Object) as unknown as PlanBindingNode,
           parent: expect.any(Object) as unknown as PlanServiceNodeParent,
           serviceIdentifier:
             constructorArgumentMetadata.value as ServiceIdentifier,
         };
 
         const propertyParamsPlanServiceNode: PlanServiceNode = {
-          bindings: expect.any(Array) as unknown as PlanBindingNode[],
+          bindings: expect.any(Object) as unknown as PlanBindingNode,
           parent: expect.any(Object) as unknown as PlanServiceNodeParent,
           serviceIdentifier:
             propertyArgumentMetadata.value as ServiceIdentifier,
@@ -867,8 +886,10 @@ describe(plan.name, () => {
       });
 
       it('should return expected PlanResult', () => {
+        const planServiceNodeBindings: PlanBindingNode[] = [];
+
         const planServiceNode: PlanServiceNode = {
-          bindings: [],
+          bindings: planServiceNodeBindings,
           parent: undefined,
           serviceIdentifier: planParamsMock.rootConstraints.serviceIdentifier,
         };
@@ -888,28 +909,31 @@ describe(plan.name, () => {
         };
 
         const constructorParamsPlanServiceNode: PlanServiceNode = {
-          bindings: [],
+          bindings: undefined,
           parent: instanceBindingNode,
           serviceIdentifier:
             constructorArgumentMetadata.value as ServiceIdentifier,
         };
 
-        constructorParamsPlanServiceNode.bindings.push({
+        (
+          constructorParamsPlanServiceNode as Writable<PlanServiceNode>
+        ).bindings = {
           binding: constantValueBinding,
           parent: constructorParamsPlanServiceNode,
-        });
+        };
 
         const propertyParamsPlanServiceNode: PlanServiceNode = {
-          bindings: [],
+          bindings: undefined,
           parent: instanceBindingNode,
           serviceIdentifier:
             propertyArgumentMetadata.value as ServiceIdentifier,
         };
 
-        propertyParamsPlanServiceNode.bindings.push({
-          binding: constantValueBinding,
-          parent: propertyParamsPlanServiceNode,
-        });
+        (propertyParamsPlanServiceNode as Writable<PlanServiceNode>).bindings =
+          {
+            binding: constantValueBinding,
+            parent: propertyParamsPlanServiceNode,
+          };
 
         instanceBindingNode.constructorParams.push(
           constructorParamsPlanServiceNode,
@@ -920,7 +944,7 @@ describe(plan.name, () => {
           propertyParamsPlanServiceNode,
         );
 
-        planServiceNode.bindings.push(instanceBindingNode);
+        planServiceNodeBindings.push(instanceBindingNode);
 
         expect(result).toStrictEqual(expected);
       });
@@ -1007,8 +1031,10 @@ describe(plan.name, () => {
       });
 
       it('should return expected PlanResult', () => {
+        const planServiceNodeBindings: PlanBindingNode[] = [];
+
         const planServiceNode: PlanServiceNode = {
-          bindings: [],
+          bindings: planServiceNodeBindings,
           parent: undefined,
           serviceIdentifier: planParamsMock.rootConstraints.serviceIdentifier,
         };
@@ -1027,7 +1053,7 @@ describe(plan.name, () => {
           propertyParams: new Map(),
         };
 
-        planServiceNode.bindings.push(instanceBindingNode);
+        planServiceNodeBindings.push(instanceBindingNode);
 
         expect(result).toStrictEqual(expected);
       });
@@ -1085,8 +1111,10 @@ describe(plan.name, () => {
       });
 
       it('should return expected PlanResult', () => {
+        const planServiceNodeBindings: PlanBindingNode[] = [];
+
         const planServiceNode: PlanServiceNode = {
-          bindings: [],
+          bindings: planServiceNodeBindings,
           parent: undefined,
           serviceIdentifier: planParamsMock.rootConstraints.serviceIdentifier,
         };
@@ -1106,7 +1134,7 @@ describe(plan.name, () => {
 
         serviceRedirectionBindingNode.redirections.push();
 
-        planServiceNode.bindings.push(serviceRedirectionBindingNode);
+        planServiceNodeBindings.push(serviceRedirectionBindingNode);
 
         expect(result).toStrictEqual(expected);
       });
@@ -1198,8 +1226,10 @@ describe(plan.name, () => {
       });
 
       it('should return expected PlanResult', () => {
+        const planServiceNodeBindings: PlanBindingNode[] = [];
+
         const planServiceNode: PlanServiceNode = {
-          bindings: [],
+          bindings: planServiceNodeBindings,
           parent: undefined,
           serviceIdentifier: planParamsMock.rootConstraints.serviceIdentifier,
         };
@@ -1222,7 +1252,7 @@ describe(plan.name, () => {
           parent: serviceRedirectionBindingNode,
         });
 
-        planServiceNode.bindings.push(serviceRedirectionBindingNode);
+        planServiceNodeBindings.push(serviceRedirectionBindingNode);
 
         expect(result).toStrictEqual(expected);
       });
@@ -1264,7 +1294,7 @@ describe(plan.name, () => {
 
       it('should call checkServiceNodeSingleInjectionBindings()', () => {
         const expectedServiceNode: PlanServiceNode = {
-          bindings: [],
+          bindings: undefined,
           parent: undefined,
           serviceIdentifier: planParamsMock.rootConstraints.serviceIdentifier,
         };
@@ -1282,7 +1312,7 @@ describe(plan.name, () => {
         const expected: PlanResult = {
           tree: {
             root: {
-              bindings: [],
+              bindings: undefined,
               parent: undefined,
               serviceIdentifier:
                 planParamsMock.rootConstraints.serviceIdentifier,

--- a/packages/container/libraries/core/src/planning/calculations/plan.ts
+++ b/packages/container/libraries/core/src/planning/calculations/plan.ts
@@ -5,6 +5,7 @@ import { BindingMetadata } from '../../binding/models/BindingMetadata';
 import { bindingTypeValues } from '../../binding/models/BindingType';
 import { InstanceBinding } from '../../binding/models/InstanceBinding';
 import { ServiceRedirectionBinding } from '../../binding/models/ServiceRedirectionBinding';
+import { Writable } from '../../common/models/Writable';
 import { ClassElementMetadata } from '../../metadata/models/ClassElementMetadata';
 import { ClassElementMetadataKind } from '../../metadata/models/ClassElementMetadataKind';
 import { ClassMetadata } from '../../metadata/models/ClassMetadata';
@@ -42,13 +43,15 @@ export function plan(params: PlanParams): PlanResult {
       binding.isSatisfiedBy(bindingMetadata),
   );
 
+  const serviceNodeBindings: PlanBindingNode[] = [];
+
   const serviceNode: PlanServiceNode = {
-    bindings: [],
+    bindings: serviceNodeBindings,
     parent: undefined,
     serviceIdentifier: params.rootConstraints.serviceIdentifier,
   };
 
-  serviceNode.bindings.push(
+  serviceNodeBindings.push(
     ...buildServiceNodeBindings(
       params,
       bindingMetadata,
@@ -59,6 +62,10 @@ export function plan(params: PlanParams): PlanResult {
 
   if (!params.rootConstraints.isMultiple) {
     checkServiceNodeSingleInjectionBindings(serviceNode, false);
+
+    const [planBindingNode]: PlanBindingNode[] = serviceNodeBindings;
+
+    (serviceNode as Writable<PlanServiceNode>).bindings = planBindingNode;
   }
 
   return {
@@ -122,13 +129,15 @@ function buildPlanServiceNodeFromClassElementMetadata(
       binding.isSatisfiedBy(bindingMetadata),
   );
 
+  const serviceNodeBindings: PlanBindingNode[] = [];
+
   const serviceNode: PlanServiceNode = {
-    bindings: [],
+    bindings: serviceNodeBindings,
     parent: params.node,
     serviceIdentifier,
   };
 
-  serviceNode.bindings.push(
+  serviceNodeBindings.push(
     ...buildServiceNodeBindings(
       params,
       bindingMetadata,
@@ -142,6 +151,10 @@ function buildPlanServiceNodeFromClassElementMetadata(
       serviceNode,
       elementMetadata.optional,
     );
+
+    const [planBindingNode]: PlanBindingNode[] = serviceNodeBindings;
+
+    (serviceNode as Writable<PlanServiceNode>).bindings = planBindingNode;
   }
 
   return serviceNode;

--- a/packages/container/libraries/core/src/planning/calculations/throwErrorWhenUnexpectedBindingsAmountFound.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/throwErrorWhenUnexpectedBindingsAmountFound.spec.ts
@@ -19,7 +19,149 @@ import { isPlanServiceRedirectionBindingNode } from './isPlanServiceRedirectionB
 import { throwErrorWhenUnexpectedBindingsAmountFound } from './throwErrorWhenUnexpectedBindingsAmountFound';
 
 describe(throwErrorWhenUnexpectedBindingsAmountFound.name, () => {
-  describe('having bindings empty and isOptional false and node PlanServiceRedirectionBindingNode', () => {
+  describe('having undefined bindings and isOptional false and node PlanServiceNode', () => {
+    let bindingsFixture: undefined;
+    let isOptionalFixture: false;
+    let nodeFixture: PlanServiceNode;
+
+    beforeAll(() => {
+      bindingsFixture = undefined;
+      isOptionalFixture = false;
+      nodeFixture = {
+        bindings: [],
+        parent: undefined,
+        serviceIdentifier: 'service-identifier',
+      };
+    });
+
+    describe('when called, and isPlanServiceRedirectionBindingNode() returns true', () => {
+      let stringifiedServiceIdentifier: string;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        stringifiedServiceIdentifier = 'stringified-service-id';
+
+        (
+          isPlanServiceRedirectionBindingNode as unknown as jest.Mock<
+            typeof isPlanServiceRedirectionBindingNode
+          >
+        ).mockReturnValueOnce(false);
+
+        (
+          stringifyServiceIdentifier as jest.Mock<
+            typeof stringifyServiceIdentifier
+          >
+        )
+          .mockReturnValueOnce(stringifiedServiceIdentifier)
+          .mockReturnValueOnce(stringifiedServiceIdentifier);
+
+        try {
+          throwErrorWhenUnexpectedBindingsAmountFound(
+            bindingsFixture,
+            isOptionalFixture,
+            nodeFixture,
+          );
+        } catch (error) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should throw InversifyCoreError', () => {
+        const expectedErrorProperties: Partial<InversifyCoreError> = {
+          kind: InversifyCoreErrorKind.planning,
+          message: `No bindings found for service: "${stringifiedServiceIdentifier}".
+
+Trying to resolve bindings for "${stringifiedServiceIdentifier} (Root service)".`,
+        };
+
+        expect(result).toBeInstanceOf(InversifyCoreError);
+        expect(result).toStrictEqual(
+          expect.objectContaining(expectedErrorProperties),
+        );
+      });
+    });
+  });
+
+  describe('having single binding and isOptional false and node PlanServiceNode', () => {
+    let bindingsFixture: PlanBindingNode;
+    let isOptionalFixture: false;
+    let nodeFixture: PlanServiceNode;
+
+    beforeAll(() => {
+      const parentNode: PlanServiceNode = {
+        bindings: [],
+        parent: undefined,
+        serviceIdentifier: 'target-service-id',
+      };
+
+      bindingsFixture = {
+        binding: {
+          cache: {
+            isRight: true,
+            value: Symbol(),
+          },
+          id: 0,
+          isSatisfiedBy: () => true,
+          moduleId: undefined,
+          onActivation: {
+            isRight: false,
+            value: undefined,
+          },
+          onDeactivation: {
+            isRight: false,
+            value: undefined,
+          },
+          scope: bindingScopeValues.Singleton,
+          serviceIdentifier: 'target-service-id',
+          type: bindingTypeValues.ConstantValue,
+        },
+        parent: parentNode,
+      };
+      isOptionalFixture = false;
+      nodeFixture = {
+        bindings: [],
+        parent: undefined,
+        serviceIdentifier: 'service-identifier',
+      };
+    });
+
+    describe('when called, and isPlanServiceRedirectionBindingNode() returns false', () => {
+      let stringifiedServiceIdentifier: string;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        stringifiedServiceIdentifier = 'stringified-service-id';
+
+        (
+          isPlanServiceRedirectionBindingNode as unknown as jest.Mock<
+            typeof isPlanServiceRedirectionBindingNode
+          >
+        ).mockReturnValueOnce(false);
+
+        result = throwErrorWhenUnexpectedBindingsAmountFound(
+          bindingsFixture,
+          isOptionalFixture,
+          nodeFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having bindings empty array and isOptional false and node PlanServiceRedirectionBindingNode', () => {
     let bindingsFixture: [];
     let isOptionalFixture: false;
     let nodeFixture: PlanServiceRedirectionBindingNode;
@@ -66,8 +208,8 @@ describe(throwErrorWhenUnexpectedBindingsAmountFound.name, () => {
             typeof stringifyServiceIdentifier
           >
         )
-          .mockReturnValueOnce(stringifiedServiceIdentifier)
-          .mockReturnValueOnce(stringifiedTargetServiceIdentifier);
+          .mockReturnValueOnce(stringifiedTargetServiceIdentifier)
+          .mockReturnValueOnce(stringifiedServiceIdentifier);
 
         try {
           result = throwErrorWhenUnexpectedBindingsAmountFound(
@@ -100,7 +242,7 @@ Trying to resolve bindings for "${stringifiedServiceIdentifier}".`,
     });
   });
 
-  describe('having bindings empty and isOptional false and node PlanServiceNode', () => {
+  describe('having bindings empty array and isOptional false and node PlanServiceNode', () => {
     let bindingsFixture: [];
     let isOptionalFixture: false;
     let nodeFixture: PlanServiceNode;
@@ -168,7 +310,7 @@ Trying to resolve bindings for "${stringifiedServiceIdentifier} (Root service)".
     });
   });
 
-  describe('having bindings empty and isOptional true and node PlanServiceNode', () => {
+  describe('having bindings empty array and isOptional true and node PlanServiceNode', () => {
     let bindingsFixture: [];
     let isOptionalFixture: true;
     let nodeFixture: PlanServiceNode;
@@ -315,8 +457,8 @@ Trying to resolve bindings for "${stringifiedServiceIdentifier} (Root service)".
             typeof stringifyServiceIdentifier
           >
         )
-          .mockReturnValueOnce(stringifiedServiceIdentifierFixture)
-          .mockReturnValueOnce(stringifiedTargetServiceIdentifierFixture);
+          .mockReturnValueOnce(stringifiedTargetServiceIdentifierFixture)
+          .mockReturnValueOnce(stringifiedServiceIdentifierFixture);
 
         (stringifyBinding as jest.Mock<typeof stringifyBinding>)
           .mockReturnValueOnce(stringifiedBindingFixture)

--- a/packages/container/libraries/core/src/planning/models/PlanServiceNode.ts
+++ b/packages/container/libraries/core/src/planning/models/PlanServiceNode.ts
@@ -4,7 +4,7 @@ import { PlanBindingNode } from './PlanBindingNode';
 import { PlanServiceNodeParent } from './PlanServiceNodeParent';
 
 export interface PlanServiceNode {
-  readonly bindings: PlanBindingNode[];
+  readonly bindings: PlanBindingNode | PlanBindingNode[] | undefined;
   readonly parent: PlanServiceNodeParent | undefined;
   readonly serviceIdentifier: ServiceIdentifier;
 }


### PR DESCRIPTION
### Added
- Added `Writable`.

### Changed
- Updated `PlanServiceNode` to allow non array binding.
- Updated `throwErrorWhenUnexpectedBindingsAmountFound` to allow non array bindings.