### PR TITLE
Update factory bindings with resolution context param

### DIFF
--- a/packages/container/libraries/core/src/binding/models/DynamicValue.ts
+++ b/packages/container/libraries/core/src/binding/models/DynamicValue.ts
@@ -1,1 +1,0 @@
-export type DynamicValue<T> = () => T | Promise<T>;

--- a/packages/container/libraries/core/src/binding/models/DynamicValueBinding.ts
+++ b/packages/container/libraries/core/src/binding/models/DynamicValueBinding.ts
@@ -1,6 +1,6 @@
 import { BindingScope } from './BindingScope';
 import { bindingTypeValues } from './BindingType';
-import { DynamicValue } from './DynamicValue';
+import { DynamicValueBuilder } from './DynamicValueBuilder';
 import { ScopedBinding } from './ScopedBinding';
 
 export interface DynamicValueBinding<TActivated>
@@ -9,5 +9,5 @@ export interface DynamicValueBinding<TActivated>
     BindingScope,
     TActivated | Promise<TActivated>
   > {
-  readonly value: DynamicValue<TActivated>;
+  readonly value: DynamicValueBuilder<TActivated>;
 }

--- a/packages/container/libraries/core/src/binding/models/DynamicValueBuilder.ts
+++ b/packages/container/libraries/core/src/binding/models/DynamicValueBuilder.ts
@@ -1,0 +1,5 @@
+import { ResolutionContext } from '../../resolution/models/ResolutionContext';
+
+export type DynamicValueBuilder<T> = (
+  context: ResolutionContext,
+) => T | Promise<T>;

--- a/packages/container/libraries/core/src/binding/models/FactoryBinding.ts
+++ b/packages/container/libraries/core/src/binding/models/FactoryBinding.ts
@@ -1,3 +1,4 @@
+import { ResolutionContext } from '../../resolution/models/ResolutionContext';
 import { bindingScopeValues } from './BindingScope';
 import { bindingTypeValues } from './BindingType';
 import { Factory } from './Factory';
@@ -9,5 +10,5 @@ export interface FactoryBinding<TActivated>
     typeof bindingScopeValues.Singleton,
     Factory<TActivated>
   > {
-  readonly factory: () => Factory<TActivated>;
+  readonly factory: (context: ResolutionContext) => Factory<TActivated>;
 }

--- a/packages/container/libraries/core/src/binding/models/ProviderBinding.ts
+++ b/packages/container/libraries/core/src/binding/models/ProviderBinding.ts
@@ -1,3 +1,4 @@
+import { ResolutionContext } from '../../resolution/models/ResolutionContext';
 import { bindingScopeValues } from './BindingScope';
 import { bindingTypeValues } from './BindingType';
 import { Provider } from './Provider';
@@ -9,5 +10,5 @@ export interface ProviderBinding<TActivated>
     typeof bindingScopeValues.Singleton,
     Provider<TActivated>
   > {
-  readonly provider: () => Provider<TActivated>;
+  readonly provider: (context: ResolutionContext) => Provider<TActivated>;
 }

--- a/packages/container/libraries/core/src/resolution/calculations/getInstanceNodeBinding.spec.ts
+++ b/packages/container/libraries/core/src/resolution/calculations/getInstanceNodeBinding.spec.ts
@@ -1,0 +1,29 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { InstanceBinding } from '../../binding/models/InstanceBinding';
+import { InstanceBindingNode } from '../../planning/models/InstanceBindingNode';
+import { getInstanceNodeBinding } from './getInstanceNodeBinding';
+
+describe(getInstanceNodeBinding.name, () => {
+  let nodeFixture: InstanceBindingNode<InstanceBinding<unknown>>;
+
+  beforeAll(() => {
+    nodeFixture = {
+      binding: Symbol() as unknown as InstanceBinding<unknown>,
+    } as Partial<
+      InstanceBindingNode<InstanceBinding<unknown>>
+    > as InstanceBindingNode<InstanceBinding<unknown>>;
+  });
+
+  describe('when called', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      result = getInstanceNodeBinding(nodeFixture);
+    });
+
+    it('should return expected value', () => {
+      expect(result).toBe(nodeFixture.binding);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/resolution/calculations/getInstanceNodeBinding.ts
+++ b/packages/container/libraries/core/src/resolution/calculations/getInstanceNodeBinding.ts
@@ -1,0 +1,8 @@
+import { InstanceBinding } from '../../binding/models/InstanceBinding';
+import { InstanceBindingNode } from '../../planning/models/InstanceBindingNode';
+
+export function getInstanceNodeBinding<TActivated>(
+  node: InstanceBindingNode<InstanceBinding<TActivated>>,
+): InstanceBinding<TActivated> {
+  return node.binding;
+}

--- a/packages/container/libraries/core/src/resolution/models/GetOptions.ts
+++ b/packages/container/libraries/core/src/resolution/models/GetOptions.ts
@@ -1,0 +1,8 @@
+import { MetadataName } from '../../metadata/models/MetadataName';
+import { GetOptionsTagConstraint } from './GetOptionsTagConstraint';
+
+export interface GetOptions {
+  name?: MetadataName;
+  optional?: boolean;
+  tag?: GetOptionsTagConstraint;
+}

--- a/packages/container/libraries/core/src/resolution/models/GetOptionsTagConstraint.ts
+++ b/packages/container/libraries/core/src/resolution/models/GetOptionsTagConstraint.ts
@@ -1,0 +1,6 @@
+import { MetadataTag } from '../../metadata/models/MetadataTag';
+
+export interface GetOptionsTagConstraint {
+  key: MetadataTag;
+  value: unknown;
+}

--- a/packages/container/libraries/core/src/resolution/models/OptionalGetOptions.ts
+++ b/packages/container/libraries/core/src/resolution/models/OptionalGetOptions.ts
@@ -1,0 +1,5 @@
+import { GetOptions } from './GetOptions';
+
+export interface OptionalGetOptions extends GetOptions {
+  optional: true;
+}

--- a/packages/container/libraries/core/src/resolution/models/ResolutionContext.ts
+++ b/packages/container/libraries/core/src/resolution/models/ResolutionContext.ts
@@ -1,0 +1,34 @@
+import { ServiceIdentifier } from '@inversifyjs/common';
+
+import { GetOptions } from './GetOptions';
+import { OptionalGetOptions } from './OptionalGetOptions';
+
+export interface ResolutionContext {
+  get<TActivated>(
+    serviceIdentifier: ServiceIdentifier<TActivated>,
+    options: OptionalGetOptions,
+  ): TActivated | undefined;
+  get<TActivated>(
+    serviceIdentifier: ServiceIdentifier<TActivated>,
+    options?: GetOptions,
+  ): TActivated;
+
+  getAll<TActivated>(
+    serviceIdentifier: ServiceIdentifier<TActivated>,
+    options?: GetOptions,
+  ): TActivated[];
+
+  getAllAsync<TActivated>(
+    serviceIdentifier: ServiceIdentifier<TActivated>,
+    options?: GetOptions,
+  ): Promise<TActivated[]>;
+
+  getAsync<TActivated>(
+    serviceIdentifier: ServiceIdentifier<TActivated>,
+    options: OptionalGetOptions,
+  ): Promise<TActivated> | undefined;
+  getAsync<TActivated>(
+    serviceIdentifier: ServiceIdentifier<TActivated>,
+    options?: GetOptions,
+  ): Promise<TActivated>;
+}

--- a/packages/container/libraries/core/src/resolution/models/ResolutionParams.ts
+++ b/packages/container/libraries/core/src/resolution/models/ResolutionParams.ts
@@ -1,0 +1,8 @@
+import { PlanResult } from '../../planning/models/PlanResult';
+import { ResolutionContext } from './ResolutionContext';
+
+export interface ResolutionParams {
+  context: ResolutionContext;
+  planResult: PlanResult;
+  requestScopeCache: Map<number, unknown>;
+}


### PR DESCRIPTION
### Added
- Added `ResolutionContext`.
- Added `ResolutionParams`.

### Changed
- Updated `FactoryBinding.factory` to receive a `ResolutionContext` param.
- Updated `ProviderBinding.provider` to receive a `ResolutionContext` param.