### PR TITLE
Add resolve binding utils

### DIFF
--- a/packages/container/libraries/core/src/resolution/actions/resolveScoped.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveScoped.spec.ts
@@ -1,0 +1,362 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { Right } from '@inversifyjs/common';
+
+import {
+  BindingScope,
+  bindingScopeValues,
+} from '../../binding/models/BindingScope';
+import {
+  BindingType,
+  bindingTypeValues,
+} from '../../binding/models/BindingType';
+import { ScopedBinding } from '../../binding/models/ScopedBinding';
+import { ResolutionParams } from '../models/ResolutionParams';
+import { resolveScoped } from './resolveScoped';
+
+describe(resolveScoped.name, () => {
+  let getBindingMock: jest.Mock<
+    (arg: unknown) => ScopedBinding<BindingType, BindingScope, unknown>
+  >;
+
+  let paramsMock: jest.Mocked<ResolutionParams>;
+  let argFixture: unknown;
+  let resolveMock: jest.Mock<
+    (params: ResolutionParams, arg: unknown) => unknown
+  >;
+
+  beforeAll(() => {
+    getBindingMock = jest.fn();
+
+    paramsMock = {
+      requestScopeCache: {
+        get: jest.fn(),
+        has: jest.fn(),
+        set: jest.fn() as unknown,
+      } as Partial<jest.Mocked<Map<number, unknown>>> as jest.Mocked<
+        Map<number, unknown>
+      >,
+    } as Partial<
+      jest.Mocked<ResolutionParams>
+    > as jest.Mocked<ResolutionParams>;
+
+    argFixture = Symbol();
+
+    resolveMock = jest.fn();
+  });
+
+  describe('when called, and getBinding() returns singleton scoped binding with cache', () => {
+    let bindingFixture: ScopedBinding<
+      BindingType,
+      typeof bindingScopeValues.Singleton,
+      unknown
+    >;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      bindingFixture = bindingFixture = {
+        cache: {
+          isRight: true,
+          value: Symbol(),
+        },
+        id: 1,
+        isSatisfiedBy: () => true,
+        moduleId: undefined,
+        onActivation: undefined,
+        onDeactivation: undefined,
+        scope: bindingScopeValues.Singleton,
+        serviceIdentifier: 'service-id',
+        type: bindingTypeValues.ConstantValue,
+      };
+
+      getBindingMock.mockReturnValueOnce(bindingFixture);
+
+      result = resolveScoped(getBindingMock, resolveMock)(
+        paramsMock,
+        argFixture,
+      );
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call getBinding()', () => {
+      expect(getBindingMock).toHaveBeenCalledTimes(1);
+      expect(getBindingMock).toHaveBeenCalledWith(argFixture);
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe((bindingFixture.cache as Right<unknown>).value);
+    });
+  });
+
+  describe('when called, and getBinding() returns singleton scoped binding with no cache', () => {
+    let bindingFixture: ScopedBinding<
+      BindingType,
+      typeof bindingScopeValues.Singleton,
+      unknown
+    >;
+
+    let resolveResult: unknown;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      bindingFixture = bindingFixture = {
+        cache: {
+          isRight: false,
+          value: undefined,
+        },
+        id: 1,
+        isSatisfiedBy: () => true,
+        moduleId: undefined,
+        onActivation: undefined,
+        onDeactivation: undefined,
+        scope: bindingScopeValues.Singleton,
+        serviceIdentifier: 'service-id',
+        type: bindingTypeValues.ConstantValue,
+      };
+
+      resolveResult = Symbol();
+
+      getBindingMock.mockReturnValueOnce(bindingFixture);
+
+      resolveMock.mockReturnValueOnce(resolveResult);
+
+      result = resolveScoped(getBindingMock, resolveMock)(
+        paramsMock,
+        argFixture,
+      );
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call getBinding()', () => {
+      expect(getBindingMock).toHaveBeenCalledTimes(1);
+      expect(getBindingMock).toHaveBeenCalledWith(argFixture);
+    });
+
+    it('should call resolve()', () => {
+      expect(resolveMock).toHaveBeenCalledTimes(1);
+      expect(resolveMock).toHaveBeenCalledWith(paramsMock, argFixture);
+    });
+
+    it('should cache value', () => {
+      const expectedCache: Right<unknown> = {
+        isRight: true,
+        value: resolveResult,
+      };
+
+      expect(bindingFixture.cache).toStrictEqual(expectedCache);
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(resolveResult);
+    });
+  });
+
+  describe('when called, and getBinding() returns request scoped binding, and requestScopeCache.has() returns true', () => {
+    let bindingFixture: ScopedBinding<
+      BindingType,
+      typeof bindingScopeValues.Request,
+      unknown
+    >;
+
+    let resolveResult: unknown;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      bindingFixture = bindingFixture = {
+        cache: {
+          isRight: false,
+          value: undefined,
+        },
+        id: 1,
+        isSatisfiedBy: () => true,
+        moduleId: undefined,
+        onActivation: undefined,
+        onDeactivation: undefined,
+        scope: bindingScopeValues.Request,
+        serviceIdentifier: 'service-id',
+        type: bindingTypeValues.ConstantValue,
+      };
+
+      resolveResult = Symbol();
+
+      getBindingMock.mockReturnValueOnce(bindingFixture);
+
+      paramsMock.requestScopeCache.has.mockReturnValueOnce(true);
+      paramsMock.requestScopeCache.get.mockReturnValueOnce(resolveResult);
+
+      result = resolveScoped(getBindingMock, resolveMock)(
+        paramsMock,
+        argFixture,
+      );
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call getBinding()', () => {
+      expect(getBindingMock).toHaveBeenCalledTimes(1);
+      expect(getBindingMock).toHaveBeenCalledWith(argFixture);
+    });
+
+    it('should call params.requestScopeCache.has()', () => {
+      expect(paramsMock.requestScopeCache.has).toHaveBeenCalledTimes(1);
+      expect(paramsMock.requestScopeCache.has).toHaveBeenCalledWith(
+        bindingFixture.id,
+      );
+    });
+
+    it('should call params.requestScopeCache.get()', () => {
+      expect(paramsMock.requestScopeCache.get).toHaveBeenCalledTimes(1);
+      expect(paramsMock.requestScopeCache.get).toHaveBeenCalledWith(
+        bindingFixture.id,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(resolveResult);
+    });
+  });
+
+  describe('when called, and getBinding() returns request scoped binding, and requestScopeCache.has() returns false', () => {
+    let bindingFixture: ScopedBinding<
+      BindingType,
+      typeof bindingScopeValues.Request,
+      unknown
+    >;
+
+    let resolveResult: unknown;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      bindingFixture = bindingFixture = {
+        cache: {
+          isRight: false,
+          value: undefined,
+        },
+        id: 1,
+        isSatisfiedBy: () => true,
+        moduleId: undefined,
+        onActivation: undefined,
+        onDeactivation: undefined,
+        scope: bindingScopeValues.Request,
+        serviceIdentifier: 'service-id',
+        type: bindingTypeValues.ConstantValue,
+      };
+
+      resolveResult = Symbol();
+
+      getBindingMock.mockReturnValueOnce(bindingFixture);
+
+      resolveMock.mockReturnValueOnce(resolveResult);
+
+      paramsMock.requestScopeCache.has.mockReturnValueOnce(false);
+
+      result = resolveScoped(getBindingMock, resolveMock)(
+        paramsMock,
+        argFixture,
+      );
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call getBinding()', () => {
+      expect(getBindingMock).toHaveBeenCalledTimes(1);
+      expect(getBindingMock).toHaveBeenCalledWith(argFixture);
+    });
+
+    it('should call params.requestScopeCache.has()', () => {
+      expect(paramsMock.requestScopeCache.has).toHaveBeenCalledTimes(1);
+      expect(paramsMock.requestScopeCache.has).toHaveBeenCalledWith(
+        bindingFixture.id,
+      );
+    });
+
+    it('should call resolve()', () => {
+      expect(resolveMock).toHaveBeenCalledTimes(1);
+      expect(resolveMock).toHaveBeenCalledWith(paramsMock, argFixture);
+    });
+
+    it('should call params.requestScopeCache.set()', () => {
+      expect(paramsMock.requestScopeCache.set).toHaveBeenCalledTimes(1);
+      expect(paramsMock.requestScopeCache.set).toHaveBeenCalledWith(
+        bindingFixture.id,
+        resolveResult,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(resolveResult);
+    });
+  });
+
+  describe('when called, and getBinding() returns transient scoped binding', () => {
+    let bindingFixture: ScopedBinding<
+      BindingType,
+      typeof bindingScopeValues.Transient,
+      unknown
+    >;
+
+    let resolveResult: unknown;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      bindingFixture = bindingFixture = {
+        cache: {
+          isRight: false,
+          value: undefined,
+        },
+        id: 1,
+        isSatisfiedBy: () => true,
+        moduleId: undefined,
+        onActivation: undefined,
+        onDeactivation: undefined,
+        scope: bindingScopeValues.Transient,
+        serviceIdentifier: 'service-id',
+        type: bindingTypeValues.ConstantValue,
+      };
+
+      resolveResult = Symbol();
+
+      getBindingMock.mockReturnValueOnce(bindingFixture);
+
+      resolveMock.mockReturnValueOnce(resolveResult);
+
+      result = resolveScoped(getBindingMock, resolveMock)(
+        paramsMock,
+        argFixture,
+      );
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call getBinding()', () => {
+      expect(getBindingMock).toHaveBeenCalledTimes(1);
+      expect(getBindingMock).toHaveBeenCalledWith(argFixture);
+    });
+
+    it('should call resolve()', () => {
+      expect(resolveMock).toHaveBeenCalledTimes(1);
+      expect(resolveMock).toHaveBeenCalledWith(paramsMock, argFixture);
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(resolveResult);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/resolution/actions/resolveScoped.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveScoped.ts
@@ -1,0 +1,52 @@
+import {
+  BindingScope,
+  bindingScopeValues,
+} from '../../binding/models/BindingScope';
+import { BindingType } from '../../binding/models/BindingType';
+import { ScopedBinding } from '../../binding/models/ScopedBinding';
+import { ResolutionParams } from '../models/ResolutionParams';
+
+export function resolveScoped<
+  TActivated,
+  TArg,
+  TType extends BindingType,
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
+  TBinding extends ScopedBinding<TType, BindingScope, TActivated>,
+>(
+  getBinding: (arg: TArg) => TBinding,
+  resolve: (params: ResolutionParams, arg: TArg) => TActivated,
+): (params: ResolutionParams, arg: TArg) => TActivated {
+  return (params: ResolutionParams, arg: TArg): TActivated => {
+    const binding: TBinding = getBinding(arg);
+
+    switch (binding.scope) {
+      case bindingScopeValues.Singleton: {
+        if (binding.cache.isRight) {
+          return binding.cache.value;
+        }
+
+        const resolvedValue: TActivated = resolve(params, arg);
+
+        binding.cache = {
+          isRight: true,
+          value: resolvedValue,
+        };
+
+        return resolvedValue;
+      }
+      case bindingScopeValues.Request: {
+        if (params.requestScopeCache.has(binding.id)) {
+          return params.requestScopeCache.get(binding.id) as TActivated;
+        }
+
+        const resolvedValue: TActivated = resolve(params, arg);
+
+        params.requestScopeCache.set(binding.id, resolvedValue);
+
+        return resolvedValue;
+      }
+      case bindingScopeValues.Transient:
+        return resolve(params, arg);
+    }
+  };
+}

--- a/packages/container/libraries/core/src/resolution/actions/resolveScopedBinding.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveScopedBinding.ts
@@ -1,0 +1,20 @@
+import { BindingScope } from '../../binding/models/BindingScope';
+import { BindingType } from '../../binding/models/BindingType';
+import { ScopedBinding } from '../../binding/models/ScopedBinding';
+import { getSelf } from '../../common/calculations/getSelf';
+import { ResolutionParams } from '../models/ResolutionParams';
+import { resolveScoped } from './resolveScoped';
+
+export const resolveScopedBinding: <
+  TActivated,
+  TType extends BindingType,
+  TBinding extends ScopedBinding<TType, BindingScope, TActivated>,
+>(
+  resolve: (params: ResolutionParams, binding: TBinding) => TActivated,
+) => (params: ResolutionParams, binding: TBinding) => TActivated = <
+  TActivated,
+  TType extends BindingType,
+  TBinding extends ScopedBinding<TType, BindingScope, TActivated>,
+>(
+  resolve: (params: ResolutionParams, binding: TBinding) => TActivated,
+) => resolveScoped(getSelf, resolve);

--- a/packages/container/libraries/core/src/resolution/actions/resolveScopedInstanceBindingNode.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveScopedInstanceBindingNode.ts
@@ -1,0 +1,20 @@
+import { InstanceBinding } from '../../binding/models/InstanceBinding';
+import { InstanceBindingNode } from '../../planning/models/InstanceBindingNode';
+import { getInstanceNodeBinding } from '../calculations/getInstanceNodeBinding';
+import { ResolutionParams } from '../models/ResolutionParams';
+import { resolveScoped } from './resolveScoped';
+
+export const resolveScopedInstanceBindingNode: <TActivated>(
+  resolve: (
+    params: ResolutionParams,
+    node: InstanceBindingNode<InstanceBinding<TActivated>>,
+  ) => TActivated,
+) => (
+  params: ResolutionParams,
+  node: InstanceBindingNode<InstanceBinding<TActivated>>,
+) => TActivated = <TActivated>(
+  resolve: (
+    params: ResolutionParams,
+    node: InstanceBindingNode<InstanceBinding<TActivated>>,
+  ) => TActivated,
+) => resolveScoped(getInstanceNodeBinding, resolve);

--- a/packages/container/libraries/core/src/resolution/actions/resolveSingletonScopedBinding.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveSingletonScopedBinding.spec.ts
@@ -1,0 +1,147 @@
+import { beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { Right } from '@inversifyjs/common';
+
+import { bindingScopeValues } from '../../binding/models/BindingScope';
+import {
+  BindingType,
+  bindingTypeValues,
+} from '../../binding/models/BindingType';
+import { ScopedBinding } from '../../binding/models/ScopedBinding';
+import { ResolutionParams } from '../models/ResolutionParams';
+import { resolveSingletonScopedBinding } from './resolveSingletonScopedBinding';
+
+describe(resolveSingletonScopedBinding.name, () => {
+  describe('having a binding with cache.isRight equals to true', () => {
+    let resolutionParamsFixture: ResolutionParams;
+    let bindingFixture: ScopedBinding<
+      BindingType,
+      typeof bindingScopeValues.Singleton,
+      unknown
+    >;
+
+    let resolveMock: jest.Mock<
+      (
+        params: ResolutionParams,
+        binding: ScopedBinding<
+          BindingType,
+          typeof bindingScopeValues.Singleton,
+          unknown
+        >,
+      ) => unknown
+    >;
+
+    beforeAll(() => {
+      resolutionParamsFixture = Symbol() as unknown as ResolutionParams;
+      bindingFixture = {
+        cache: {
+          isRight: true,
+          value: Symbol(),
+        },
+        id: 1,
+        isSatisfiedBy: () => true,
+        moduleId: undefined,
+        onActivation: undefined,
+        onDeactivation: undefined,
+        scope: bindingScopeValues.Singleton,
+        serviceIdentifier: 'service-id',
+        type: bindingTypeValues.ConstantValue,
+      };
+
+      resolveMock = jest.fn();
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = resolveSingletonScopedBinding(resolveMock)(
+          resolutionParamsFixture,
+          bindingFixture,
+        );
+      });
+
+      it('should return cached value', () => {
+        expect(result).toBe((bindingFixture.cache as Right<unknown>).value);
+      });
+    });
+  });
+
+  describe('having a binding with cache.isRight equals to false', () => {
+    let resolutionParamsFixture: ResolutionParams;
+    let bindingFixture: ScopedBinding<
+      BindingType,
+      typeof bindingScopeValues.Singleton,
+      unknown
+    >;
+
+    let resolveMock: jest.Mock<
+      (
+        params: ResolutionParams,
+        binding: ScopedBinding<
+          BindingType,
+          typeof bindingScopeValues.Singleton,
+          unknown
+        >,
+      ) => unknown
+    >;
+
+    beforeAll(() => {
+      resolutionParamsFixture = Symbol() as unknown as ResolutionParams;
+      bindingFixture = {
+        cache: {
+          isRight: false,
+          value: undefined,
+        },
+        id: 1,
+        isSatisfiedBy: () => true,
+        moduleId: undefined,
+        onActivation: undefined,
+        onDeactivation: undefined,
+        scope: bindingScopeValues.Singleton,
+        serviceIdentifier: 'service-id',
+        type: bindingTypeValues.ConstantValue,
+      };
+
+      resolveMock = jest.fn();
+    });
+
+    describe('when called', () => {
+      let resolveResult: unknown;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        resolveResult = Symbol();
+
+        resolveMock.mockReturnValueOnce(resolveResult);
+
+        result = resolveSingletonScopedBinding(resolveMock)(
+          resolutionParamsFixture,
+          bindingFixture,
+        );
+      });
+
+      it('should call resolve()', () => {
+        expect(resolveMock).toHaveBeenCalledTimes(1);
+        expect(resolveMock).toHaveBeenCalledWith(
+          resolutionParamsFixture,
+          bindingFixture,
+        );
+      });
+
+      it('should cache value', () => {
+        const expectedCache: Right<unknown> = {
+          isRight: true,
+          value: resolveResult,
+        };
+
+        expect(bindingFixture.cache).toStrictEqual(expectedCache);
+      });
+
+      it('should return cached value', () => {
+        expect(result).toBe(resolveResult);
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/resolution/actions/resolveSingletonScopedBinding.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveSingletonScopedBinding.ts
@@ -1,0 +1,31 @@
+import { bindingScopeValues } from '../../binding/models/BindingScope';
+import { BindingType } from '../../binding/models/BindingType';
+import { ScopedBinding } from '../../binding/models/ScopedBinding';
+import { ResolutionParams } from '../models/ResolutionParams';
+
+export function resolveSingletonScopedBinding<
+  TActivated,
+  TType extends BindingType,
+  TBinding extends ScopedBinding<
+    TType,
+    typeof bindingScopeValues.Singleton,
+    TActivated
+  >,
+>(
+  resolve: (params: ResolutionParams, binding: TBinding) => TActivated,
+): (params: ResolutionParams, binding: TBinding) => TActivated {
+  return (params: ResolutionParams, binding: TBinding): TActivated => {
+    if (binding.cache.isRight) {
+      return binding.cache.value;
+    }
+
+    const resolvedValue: TActivated = resolve(params, binding);
+
+    binding.cache = {
+      isRight: true,
+      value: resolvedValue,
+    };
+
+    return resolvedValue;
+  };
+}

--- a/packages/container/libraries/core/src/resolution/calculations/resolveConstantValueBindingCallback.spec.ts
+++ b/packages/container/libraries/core/src/resolution/calculations/resolveConstantValueBindingCallback.spec.ts
@@ -1,0 +1,31 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { InversifyCoreError } from '../../error/models/InversifyCoreError';
+import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
+import { resolveConstantValueBindingCallback } from './resolveConstantValueBindingCallback';
+
+describe(resolveConstantValueBindingCallback.name, () => {
+  describe('when called', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      try {
+        resolveConstantValueBindingCallback();
+      } catch (error: unknown) {
+        result = error;
+      }
+    });
+
+    it('should throw an InversifyCoreError', () => {
+      const expectedErrorProperties: Partial<InversifyCoreError> = {
+        kind: InversifyCoreErrorKind.unknown,
+        message: 'Expected constant value binding with value, none found',
+      };
+
+      expect(result).toBeInstanceOf(InversifyCoreError);
+      expect(result).toStrictEqual(
+        expect.objectContaining(expectedErrorProperties),
+      );
+    });
+  });
+});

--- a/packages/container/libraries/core/src/resolution/calculations/resolveConstantValueBindingCallback.ts
+++ b/packages/container/libraries/core/src/resolution/calculations/resolveConstantValueBindingCallback.ts
@@ -1,0 +1,9 @@
+import { InversifyCoreError } from '../../error/models/InversifyCoreError';
+import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
+
+export function resolveConstantValueBindingCallback(): never {
+  throw new InversifyCoreError(
+    InversifyCoreErrorKind.unknown,
+    'Expected constant value binding with value, none found',
+  );
+}

--- a/packages/container/libraries/core/src/resolution/calculations/resolveDynamicValueBindingCallback.spec.ts
+++ b/packages/container/libraries/core/src/resolution/calculations/resolveDynamicValueBindingCallback.spec.ts
@@ -1,0 +1,63 @@
+import { beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { bindingScopeValues } from '../../binding/models/BindingScope';
+import { bindingTypeValues } from '../../binding/models/BindingType';
+import { DynamicValueBinding } from '../../binding/models/DynamicValueBinding';
+import { ResolutionParams } from '../models/ResolutionParams';
+import { resolveDynamicValueBindingCallback } from './resolveDynamicValueBindingCallback';
+
+describe(resolveDynamicValueBindingCallback.name, () => {
+  let resolutionParamsFixture: ResolutionParams;
+
+  let dynamicValueBindingMock: jest.Mocked<DynamicValueBinding<unknown>>;
+
+  beforeAll(() => {
+    resolutionParamsFixture = {
+      context: Symbol() as unknown,
+    } as Partial<ResolutionParams> as ResolutionParams;
+
+    dynamicValueBindingMock = {
+      cache: {
+        isRight: false,
+        value: undefined,
+      },
+      id: 1,
+      isSatisfiedBy: jest.fn(),
+      moduleId: undefined,
+      onActivation: undefined,
+      onDeactivation: undefined,
+      scope: bindingScopeValues.Singleton,
+      serviceIdentifier: 'service-id',
+      type: bindingTypeValues.DynamicValue,
+      value: jest.fn(),
+    };
+  });
+
+  describe('when called', () => {
+    let dynamicValueFixture: unknown;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      dynamicValueFixture = Symbol();
+
+      dynamicValueBindingMock.value.mockReturnValueOnce(dynamicValueFixture);
+
+      result = resolveDynamicValueBindingCallback(
+        resolutionParamsFixture,
+        dynamicValueBindingMock,
+      );
+    });
+
+    it('should call dynamicValueBinding.value()', () => {
+      expect(dynamicValueBindingMock.value).toHaveBeenCalledTimes(1);
+      expect(dynamicValueBindingMock.value).toHaveBeenCalledWith(
+        resolutionParamsFixture.context,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(dynamicValueFixture);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/resolution/calculations/resolveDynamicValueBindingCallback.ts
+++ b/packages/container/libraries/core/src/resolution/calculations/resolveDynamicValueBindingCallback.ts
@@ -1,0 +1,9 @@
+import { DynamicValueBinding } from '../../binding/models/DynamicValueBinding';
+import { ResolutionParams } from '../models/ResolutionParams';
+
+export function resolveDynamicValueBindingCallback<TActivated>(
+  params: ResolutionParams,
+  binding: DynamicValueBinding<TActivated>,
+): TActivated | Promise<TActivated> {
+  return binding.value(params.context);
+}

--- a/packages/container/libraries/core/src/resolution/calculations/resolveFactoryBindingCallback.spec.ts
+++ b/packages/container/libraries/core/src/resolution/calculations/resolveFactoryBindingCallback.spec.ts
@@ -1,0 +1,63 @@
+import { beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { bindingScopeValues } from '../../binding/models/BindingScope';
+import { bindingTypeValues } from '../../binding/models/BindingType';
+import { FactoryBinding } from '../../binding/models/FactoryBinding';
+import { ResolutionParams } from '../models/ResolutionParams';
+import { resolveFactoryBindingCallback } from './resolveFactoryBindingCallback';
+
+describe(resolveFactoryBindingCallback.name, () => {
+  let resolutionParamsFixture: ResolutionParams;
+
+  let factoryValueBindingMock: jest.Mocked<FactoryBinding<unknown>>;
+
+  beforeAll(() => {
+    resolutionParamsFixture = {
+      context: Symbol() as unknown,
+    } as Partial<ResolutionParams> as ResolutionParams;
+
+    factoryValueBindingMock = {
+      cache: {
+        isRight: false,
+        value: undefined,
+      },
+      factory: jest.fn(),
+      id: 1,
+      isSatisfiedBy: jest.fn(),
+      moduleId: undefined,
+      onActivation: undefined,
+      onDeactivation: undefined,
+      scope: bindingScopeValues.Singleton,
+      serviceIdentifier: 'service-id',
+      type: bindingTypeValues.Factory,
+    };
+  });
+
+  describe('when called', () => {
+    let factoryFixture: () => unknown;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      factoryFixture = () => Symbol();
+
+      factoryValueBindingMock.factory.mockReturnValueOnce(factoryFixture);
+
+      result = resolveFactoryBindingCallback(
+        resolutionParamsFixture,
+        factoryValueBindingMock,
+      );
+    });
+
+    it('should call factoryValueBinding.factory()', () => {
+      expect(factoryValueBindingMock.factory).toHaveBeenCalledTimes(1);
+      expect(factoryValueBindingMock.factory).toHaveBeenCalledWith(
+        resolutionParamsFixture.context,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(factoryFixture);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/resolution/calculations/resolveFactoryBindingCallback.ts
+++ b/packages/container/libraries/core/src/resolution/calculations/resolveFactoryBindingCallback.ts
@@ -1,0 +1,10 @@
+import { Factory } from '../../binding/models/Factory';
+import { FactoryBinding } from '../../binding/models/FactoryBinding';
+import { ResolutionParams } from '../models/ResolutionParams';
+
+export function resolveFactoryBindingCallback(
+  params: ResolutionParams,
+  binding: FactoryBinding<unknown>,
+): Factory<unknown> {
+  return binding.factory(params.context);
+}

--- a/packages/container/libraries/core/src/resolution/calculations/resolveProviderBindingCallback.spec.ts
+++ b/packages/container/libraries/core/src/resolution/calculations/resolveProviderBindingCallback.spec.ts
@@ -1,0 +1,64 @@
+import { beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { bindingScopeValues } from '../../binding/models/BindingScope';
+import { bindingTypeValues } from '../../binding/models/BindingType';
+import { Provider } from '../../binding/models/Provider';
+import { ProviderBinding } from '../../binding/models/ProviderBinding';
+import { ResolutionParams } from '../models/ResolutionParams';
+import { resolveProviderBindingCallback } from './resolveProviderBindingCallback';
+
+describe(resolveProviderBindingCallback.name, () => {
+  let resolutionParamsFixture: ResolutionParams;
+
+  let providerBindingMock: jest.Mocked<ProviderBinding<unknown>>;
+
+  beforeAll(() => {
+    resolutionParamsFixture = {
+      context: Symbol() as unknown,
+    } as Partial<ResolutionParams> as ResolutionParams;
+
+    providerBindingMock = {
+      cache: {
+        isRight: false,
+        value: undefined,
+      },
+      id: 1,
+      isSatisfiedBy: jest.fn(),
+      moduleId: undefined,
+      onActivation: undefined,
+      onDeactivation: undefined,
+      provider: jest.fn(),
+      scope: bindingScopeValues.Singleton,
+      serviceIdentifier: 'service-id',
+      type: bindingTypeValues.Provider,
+    };
+  });
+
+  describe('when called', () => {
+    let providerFixture: Provider<unknown>;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      providerFixture = async () => undefined;
+
+      providerBindingMock.provider.mockReturnValueOnce(providerFixture);
+
+      result = resolveProviderBindingCallback(
+        resolutionParamsFixture,
+        providerBindingMock,
+      );
+    });
+
+    it('should call binding.provider()', () => {
+      expect(providerBindingMock.provider).toHaveBeenCalledTimes(1);
+      expect(providerBindingMock.provider).toHaveBeenCalledWith(
+        resolutionParamsFixture.context,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(providerFixture);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/resolution/calculations/resolveProviderBindingCallback.ts
+++ b/packages/container/libraries/core/src/resolution/calculations/resolveProviderBindingCallback.ts
@@ -1,0 +1,10 @@
+import { Provider } from '../../binding/models/Provider';
+import { ProviderBinding } from '../../binding/models/ProviderBinding';
+import { ResolutionParams } from '../models/ResolutionParams';
+
+export function resolveProviderBindingCallback<TActivated>(
+  params: ResolutionParams,
+  binding: ProviderBinding<TActivated>,
+): Provider<TActivated> {
+  return binding.provider(params.context);
+}


### PR DESCRIPTION
### Added
- Added `resolveScopedBinding`.
- Added `resolveScopedInstanceBindingNode`.
- Added `resolveScoped`.
- Added `resolveSingletonScopedBinding`.
- Added `resolveConstantValueBindingCallback`.
- Added `resolveDynamicValueBindingCallback`.
- Added `resolveFactoryBindingCallback`.
- Added `resolveProviderBindingCallback`.