### PR TITLE
Update resolution flow with binding activations

### DIFF
--- a/packages/container/libraries/core/src/binding/calculations/stringifyBinding.spec.ts
+++ b/packages/container/libraries/core/src/binding/calculations/stringifyBinding.spec.ts
@@ -47,6 +47,7 @@ describe(stringifyBinding.name, () => {
         scope: bindingScopeValues.Singleton,
         serviceIdentifier: 'service-id',
         type: bindingTypeValues.ConstantValue,
+        value: Symbol(),
       },
       `[ type: "${bindingTypeValues.ConstantValue}", serviceIdentifier: "service-id", scope: "${bindingScopeValues.Singleton}" ]`,
     ],

--- a/packages/container/libraries/core/src/binding/models/BindingActivation.ts
+++ b/packages/container/libraries/core/src/binding/models/BindingActivation.ts
@@ -1,1 +1,3 @@
-export type BindingActivation<T = unknown> = (injectable: T) => T | Promise<T>;
+import { Resolved } from '../../resolution/models/Resolved';
+
+export type BindingActivation<T = unknown> = (injectable: T) => Resolved<T>;

--- a/packages/container/libraries/core/src/binding/models/ConstantValueBinding.ts
+++ b/packages/container/libraries/core/src/binding/models/ConstantValueBinding.ts
@@ -1,9 +1,13 @@
+import { Resolved } from '../../resolution/models/Resolved';
 import { bindingScopeValues } from './BindingScope';
 import { bindingTypeValues } from './BindingType';
 import { ScopedBinding } from './ScopedBinding';
 
-export type ConstantValueBinding<TActivated> = ScopedBinding<
-  typeof bindingTypeValues.ConstantValue,
-  typeof bindingScopeValues.Singleton,
-  TActivated | Promise<TActivated>
->;
+export interface ConstantValueBinding<TActivated>
+  extends ScopedBinding<
+    typeof bindingTypeValues.ConstantValue,
+    typeof bindingScopeValues.Singleton,
+    TActivated | Promise<TActivated>
+  > {
+  readonly value: Resolved<TActivated>;
+}

--- a/packages/container/libraries/core/src/binding/services/ActivationsService.spec.ts
+++ b/packages/container/libraries/core/src/binding/services/ActivationsService.spec.ts
@@ -112,9 +112,7 @@ describe(ActivationsService.name, () => {
       beforeAll(() => {
         bindingActivationFixture = Symbol() as unknown as BindingActivation;
 
-        activationMapsMock.get.mockReturnValueOnce(
-          [bindingActivationFixture].values(),
-        );
+        activationMapsMock.get.mockReturnValueOnce([bindingActivationFixture]);
 
         result = activationsService.get(serviceIdFixture);
       });

--- a/packages/container/libraries/core/src/binding/services/ActivationsService.ts
+++ b/packages/container/libraries/core/src/binding/services/ActivationsService.ts
@@ -42,7 +42,7 @@ export class ActivationsService {
 
   public get(
     serviceIdentifier: ServiceIdentifier,
-  ): BindingActivation[] | undefined {
+  ): Iterable<BindingActivation> | undefined {
     const bindings: Iterable<BindingActivation> | undefined =
       this.#activationMaps.get(
         ActivationRelationKind.serviceId,
@@ -53,7 +53,7 @@ export class ActivationsService {
       return undefined;
     }
 
-    return [...bindings];
+    return bindings;
   }
 
   public removeAllByModuleId(moduleId: number): void {

--- a/packages/container/libraries/core/src/binding/services/BindingServiceImplementation.spec.ts
+++ b/packages/container/libraries/core/src/binding/services/BindingServiceImplementation.spec.ts
@@ -23,6 +23,7 @@ describe(BindingServiceImplementation.name, () => {
         scope: bindingScopeValues.Singleton,
         serviceIdentifier: 'service-identifier-fixture',
         type: bindingTypeValues.ConstantValue,
+        value: Symbol(),
       };
     });
 
@@ -82,6 +83,7 @@ describe(BindingServiceImplementation.name, () => {
         scope: bindingScopeValues.Singleton,
         serviceIdentifier: Symbol(),
         type: bindingTypeValues.ConstantValue,
+        value: Symbol(),
       };
     });
 
@@ -128,6 +130,7 @@ describe(BindingServiceImplementation.name, () => {
         scope: bindingScopeValues.Singleton,
         serviceIdentifier: Symbol(),
         type: bindingTypeValues.ConstantValue,
+        value: Symbol(),
       };
     });
 

--- a/packages/container/libraries/core/src/planning/calculations/checkPlanServiceRedirectionBindingNodeSingleInjectionBindings.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/checkPlanServiceRedirectionBindingNodeSingleInjectionBindings.spec.ts
@@ -87,6 +87,7 @@ describe(
                 scope: bindingScopeValues.Singleton,
                 serviceIdentifier: 'service-id',
                 type: bindingTypeValues.ConstantValue,
+                value: Symbol(),
               },
               parent: Symbol() as unknown as BindingNodeParent,
             },

--- a/packages/container/libraries/core/src/planning/calculations/plan.int.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/plan.int.spec.ts
@@ -220,6 +220,7 @@ describe(plan.name, () => {
       scope: bindingScopeValues.Singleton,
       serviceIdentifier: ServiceIds.constantValue,
       type: bindingTypeValues.ConstantValue,
+      value: Symbol(),
     };
 
     dynamicValueBinding = {

--- a/packages/container/libraries/core/src/planning/calculations/plan.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/plan.spec.ts
@@ -64,6 +64,7 @@ describe(plan.name, () => {
           scope: bindingScopeValues.Singleton,
           serviceIdentifier: planParamsMock.rootConstraints.serviceIdentifier,
           type: bindingTypeValues.ConstantValue,
+          value: Symbol(),
         };
 
         planParamsMock.getBindings.mockReturnValueOnce([constantValueBinding]);
@@ -191,6 +192,7 @@ describe(plan.name, () => {
           scope: bindingScopeValues.Singleton,
           serviceIdentifier: planParamsMock.rootConstraints.serviceIdentifier,
           type: bindingTypeValues.ConstantValue,
+          value: Symbol(),
         };
 
         planParamsMock.getBindings.mockReturnValueOnce([constantValueBinding]);
@@ -361,6 +363,7 @@ describe(plan.name, () => {
           scope: bindingScopeValues.Singleton,
           serviceIdentifier: planParamsMock.rootConstraints.serviceIdentifier,
           type: bindingTypeValues.ConstantValue,
+          value: Symbol(),
         };
         constructorArgumentMetadata = {
           kind: ClassElementMetadataKind.multipleInjection,
@@ -536,6 +539,7 @@ describe(plan.name, () => {
           scope: bindingScopeValues.Singleton,
           serviceIdentifier: planParamsMock.rootConstraints.serviceIdentifier,
           type: bindingTypeValues.ConstantValue,
+          value: Symbol(),
         };
         constructorArgumentMetadata = {
           kind: ClassElementMetadataKind.multipleInjection,
@@ -715,6 +719,7 @@ describe(plan.name, () => {
           scope: bindingScopeValues.Singleton,
           serviceIdentifier: planParamsMock.rootConstraints.serviceIdentifier,
           type: bindingTypeValues.ConstantValue,
+          value: Symbol(),
         };
         constructorArgumentMetadata = {
           kind: ClassElementMetadataKind.singleInjection,
@@ -1108,6 +1113,7 @@ describe(plan.name, () => {
           scope: bindingScopeValues.Singleton,
           serviceIdentifier: serviceRedirectionBinding.targetServiceIdentifier,
           type: bindingTypeValues.ConstantValue,
+          value: Symbol(),
         };
 
         planParamsMock.getBindings

--- a/packages/container/libraries/core/src/planning/calculations/throwErrorWhenUnexpectedBindingsAmountFound.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/throwErrorWhenUnexpectedBindingsAmountFound.spec.ts
@@ -113,6 +113,7 @@ Trying to resolve bindings for "${stringifiedServiceIdentifier} (Root service)".
           scope: bindingScopeValues.Singleton,
           serviceIdentifier: 'target-service-id',
           type: bindingTypeValues.ConstantValue,
+          value: Symbol(),
         },
         parent: parentNode,
       };
@@ -369,6 +370,7 @@ Trying to resolve bindings for "${stringifiedServiceIdentifier} (Root service)".
             scope: bindingScopeValues.Singleton,
             serviceIdentifier: 'target-service-id',
             type: bindingTypeValues.ConstantValue,
+            value: Symbol(),
           },
           parent: parentNode,
         },
@@ -386,6 +388,7 @@ Trying to resolve bindings for "${stringifiedServiceIdentifier} (Root service)".
             scope: bindingScopeValues.Singleton,
             serviceIdentifier: 'target-service-id',
             type: bindingTypeValues.ConstantValue,
+            value: Symbol(),
           },
           parent: parentNode,
         },

--- a/packages/container/libraries/core/src/resolution/actions/resolve.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolve.spec.ts
@@ -164,6 +164,7 @@ describe(resolve.name, () => {
         scope: bindingScopeValues.Singleton,
         serviceIdentifier: 'service-id',
         type: bindingTypeValues.ConstantValue,
+        value: Symbol(),
       };
 
       const bindingNode: PlanBindingNode = {
@@ -241,6 +242,7 @@ describe(resolve.name, () => {
         scope: bindingScopeValues.Singleton,
         serviceIdentifier: 'service-id',
         type: bindingTypeValues.ConstantValue,
+        value: Symbol(),
       };
 
       const bindingNode: PlanBindingNode = {

--- a/packages/container/libraries/core/src/resolution/actions/resolveBindingActivations.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveBindingActivations.ts
@@ -1,0 +1,77 @@
+import { ServiceIdentifier } from '@inversifyjs/common';
+
+import { BindingActivation } from '../../binding/models/BindingActivation';
+import { isPromise } from '../../common/calculations/isPromise';
+import { ResolutionParams } from '../models/ResolutionParams';
+import { Resolved } from '../models/Resolved';
+
+export function resolveBindingActivations<TActivated>(
+  params: ResolutionParams,
+  serviceIdentifier: ServiceIdentifier<TActivated>,
+  value: Resolved<TActivated>,
+): Resolved<TActivated> {
+  const activations: Iterable<BindingActivation<TActivated>> | undefined =
+    params.getActivations(serviceIdentifier);
+
+  if (activations !== undefined) {
+    if (isPromise(value)) {
+      return resolveBindingActivationsFromIteratorAsync(
+        value,
+        activations[Symbol.iterator](),
+      );
+    } else {
+      return resolveBindingActivationsFromIterator(
+        value,
+        activations[Symbol.iterator](),
+      );
+    }
+  }
+
+  return value;
+}
+
+function resolveBindingActivationsFromIterator<TActivated>(
+  value: Awaited<TActivated>,
+  activationsIterator: Iterator<BindingActivation<TActivated>>,
+): Resolved<TActivated> {
+  let activatedValue: Awaited<TActivated> = value;
+
+  let activationIteratorResult: IteratorResult<BindingActivation<TActivated>> =
+    activationsIterator.next();
+
+  while (activationIteratorResult.done !== true) {
+    const nextActivatedValue: Resolved<TActivated> =
+      activationIteratorResult.value(activatedValue);
+
+    if (isPromise(nextActivatedValue)) {
+      return resolveBindingActivationsFromIteratorAsync(
+        nextActivatedValue,
+        activationsIterator,
+      );
+    } else {
+      activatedValue = nextActivatedValue;
+    }
+
+    activationIteratorResult = activationsIterator.next();
+  }
+
+  return activatedValue;
+}
+
+async function resolveBindingActivationsFromIteratorAsync<TActivated>(
+  value: Promise<TActivated>,
+  activationsIterator: Iterator<BindingActivation<TActivated>>,
+): Promise<Awaited<TActivated>> {
+  let activatedValue: Awaited<TActivated> = await value;
+
+  let activationIteratorResult: IteratorResult<BindingActivation<TActivated>> =
+    activationsIterator.next();
+
+  while (activationIteratorResult.done !== true) {
+    activatedValue = await activationIteratorResult.value(activatedValue);
+
+    activationIteratorResult = activationsIterator.next();
+  }
+
+  return activatedValue;
+}

--- a/packages/container/libraries/core/src/resolution/actions/resolveScoped.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveScoped.spec.ts
@@ -2,6 +2,8 @@ import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 import { Right } from '@inversifyjs/common';
 
+jest.mock('./resolveBindingActivations');
+
 import {
   BindingScope,
   bindingScopeValues,
@@ -12,6 +14,7 @@ import {
 } from '../../binding/models/BindingType';
 import { ScopedBinding } from '../../binding/models/ScopedBinding';
 import { ResolutionParams } from '../models/ResolutionParams';
+import { resolveBindingActivations } from './resolveBindingActivations';
 import { resolveScoped } from './resolveScoped';
 
 describe(resolveScoped.name, () => {
@@ -100,6 +103,7 @@ describe(resolveScoped.name, () => {
     >;
 
     let resolveResult: unknown;
+    let activatedResolveResult: unknown;
 
     let result: unknown;
 
@@ -120,10 +124,14 @@ describe(resolveScoped.name, () => {
       };
 
       resolveResult = Symbol();
+      activatedResolveResult = Symbol();
 
       getBindingMock.mockReturnValueOnce(bindingFixture);
 
       resolveMock.mockReturnValueOnce(resolveResult);
+      (
+        resolveBindingActivations as jest.Mock<typeof resolveBindingActivations>
+      ).mockReturnValueOnce(activatedResolveResult);
 
       result = resolveScoped(getBindingMock, resolveMock)(
         paramsMock,
@@ -145,17 +153,26 @@ describe(resolveScoped.name, () => {
       expect(resolveMock).toHaveBeenCalledWith(paramsMock, argFixture);
     });
 
+    it('should call resolveBindingActivations()', () => {
+      expect(resolveBindingActivations).toHaveBeenCalledTimes(1);
+      expect(resolveBindingActivations).toHaveBeenCalledWith(
+        paramsMock,
+        bindingFixture.serviceIdentifier,
+        resolveResult,
+      );
+    });
+
     it('should cache value', () => {
       const expectedCache: Right<unknown> = {
         isRight: true,
-        value: resolveResult,
+        value: activatedResolveResult,
       };
 
       expect(bindingFixture.cache).toStrictEqual(expectedCache);
     });
 
     it('should return expected result', () => {
-      expect(result).toBe(resolveResult);
+      expect(result).toBe(activatedResolveResult);
     });
   });
 
@@ -235,6 +252,7 @@ describe(resolveScoped.name, () => {
     >;
 
     let resolveResult: unknown;
+    let activatedResolveResult: unknown;
 
     let result: unknown;
 
@@ -255,10 +273,14 @@ describe(resolveScoped.name, () => {
       };
 
       resolveResult = Symbol();
+      activatedResolveResult = Symbol();
 
       getBindingMock.mockReturnValueOnce(bindingFixture);
 
       resolveMock.mockReturnValueOnce(resolveResult);
+      (
+        resolveBindingActivations as jest.Mock<typeof resolveBindingActivations>
+      ).mockReturnValueOnce(activatedResolveResult);
 
       paramsMock.requestScopeCache.has.mockReturnValueOnce(false);
 
@@ -289,16 +311,25 @@ describe(resolveScoped.name, () => {
       expect(resolveMock).toHaveBeenCalledWith(paramsMock, argFixture);
     });
 
-    it('should call params.requestScopeCache.set()', () => {
-      expect(paramsMock.requestScopeCache.set).toHaveBeenCalledTimes(1);
-      expect(paramsMock.requestScopeCache.set).toHaveBeenCalledWith(
-        bindingFixture.id,
+    it('should call resolveBindingActivations()', () => {
+      expect(resolveBindingActivations).toHaveBeenCalledTimes(1);
+      expect(resolveBindingActivations).toHaveBeenCalledWith(
+        paramsMock,
+        bindingFixture.serviceIdentifier,
         resolveResult,
       );
     });
 
+    it('should call params.requestScopeCache.set()', () => {
+      expect(paramsMock.requestScopeCache.set).toHaveBeenCalledTimes(1);
+      expect(paramsMock.requestScopeCache.set).toHaveBeenCalledWith(
+        bindingFixture.id,
+        activatedResolveResult,
+      );
+    });
+
     it('should return expected result', () => {
-      expect(result).toBe(resolveResult);
+      expect(result).toBe(activatedResolveResult);
     });
   });
 
@@ -310,6 +341,7 @@ describe(resolveScoped.name, () => {
     >;
 
     let resolveResult: unknown;
+    let activatedResolveResult: unknown;
 
     let result: unknown;
 
@@ -330,10 +362,14 @@ describe(resolveScoped.name, () => {
       };
 
       resolveResult = Symbol();
+      activatedResolveResult = Symbol();
 
       getBindingMock.mockReturnValueOnce(bindingFixture);
 
       resolveMock.mockReturnValueOnce(resolveResult);
+      (
+        resolveBindingActivations as jest.Mock<typeof resolveBindingActivations>
+      ).mockReturnValueOnce(activatedResolveResult);
 
       result = resolveScoped(getBindingMock, resolveMock)(
         paramsMock,
@@ -355,8 +391,17 @@ describe(resolveScoped.name, () => {
       expect(resolveMock).toHaveBeenCalledWith(paramsMock, argFixture);
     });
 
+    it('should call resolveBindingActivations()', () => {
+      expect(resolveBindingActivations).toHaveBeenCalledTimes(1);
+      expect(resolveBindingActivations).toHaveBeenCalledWith(
+        paramsMock,
+        bindingFixture.serviceIdentifier,
+        resolveResult,
+      );
+    });
+
     it('should return expected result', () => {
-      expect(result).toBe(resolveResult);
+      expect(result).toBe(activatedResolveResult);
     });
   });
 });

--- a/packages/container/libraries/core/src/resolution/actions/resolveServiceRedirectionBindingNode.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveServiceRedirectionBindingNode.spec.ts
@@ -65,6 +65,7 @@ describe(resolveServiceRedirectionBindingNode.name, () => {
           scope: bindingScopeValues.Singleton,
           serviceIdentifier: 'service-id',
           type: bindingTypeValues.ConstantValue,
+          value: Symbol(),
         },
         parent: nodeRedirectionFixture,
       };

--- a/packages/container/libraries/core/src/resolution/actions/resolveSingletonScopedBinding.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveSingletonScopedBinding.ts
@@ -3,6 +3,7 @@ import { BindingType } from '../../binding/models/BindingType';
 import { ScopedBinding } from '../../binding/models/ScopedBinding';
 import { ResolutionParams } from '../models/ResolutionParams';
 import { Resolved } from '../models/Resolved';
+import { resolveBindingActivations } from './resolveBindingActivations';
 
 export function resolveSingletonScopedBinding<
   TActivated,
@@ -26,7 +27,11 @@ export function resolveSingletonScopedBinding<
       return binding.cache.value;
     }
 
-    const resolvedValue: Resolved<TActivated> = resolve(params, binding);
+    const resolvedValue: Resolved<TActivated> = resolveBindingActivations(
+      params,
+      binding.serviceIdentifier,
+      resolve(params, binding),
+    );
 
     binding.cache = {
       isRight: true,

--- a/packages/container/libraries/core/src/resolution/calculations/resolveConstantValueBindingCallback.spec.ts
+++ b/packages/container/libraries/core/src/resolution/calculations/resolveConstantValueBindingCallback.spec.ts
@@ -1,31 +1,49 @@
 import { beforeAll, describe, expect, it } from '@jest/globals';
 
-import { InversifyCoreError } from '../../error/models/InversifyCoreError';
-import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
+import { bindingScopeValues } from '../../binding/models/BindingScope';
+import { bindingTypeValues } from '../../binding/models/BindingType';
+import { ConstantValueBinding } from '../../binding/models/ConstantValueBinding';
+import { ResolutionParams } from '../models/ResolutionParams';
 import { resolveConstantValueBindingCallback } from './resolveConstantValueBindingCallback';
 
 describe(resolveConstantValueBindingCallback.name, () => {
+  let resolutionParamsFixture: ResolutionParams;
+  let constantValueBindingFixture: ConstantValueBinding<unknown>;
+
+  beforeAll(() => {
+    resolutionParamsFixture = {
+      context: Symbol() as unknown,
+    } as Partial<ResolutionParams> as ResolutionParams;
+
+    constantValueBindingFixture = {
+      cache: {
+        isRight: false,
+        value: undefined,
+      },
+      id: 1,
+      isSatisfiedBy: () => true,
+      moduleId: undefined,
+      onActivation: undefined,
+      onDeactivation: undefined,
+      scope: bindingScopeValues.Singleton,
+      serviceIdentifier: 'service-id',
+      type: bindingTypeValues.ConstantValue,
+      value: Symbol(),
+    };
+  });
+
   describe('when called', () => {
     let result: unknown;
 
     beforeAll(() => {
-      try {
-        resolveConstantValueBindingCallback();
-      } catch (error: unknown) {
-        result = error;
-      }
+      result = resolveConstantValueBindingCallback(
+        resolutionParamsFixture,
+        constantValueBindingFixture,
+      );
     });
 
-    it('should throw an InversifyCoreError', () => {
-      const expectedErrorProperties: Partial<InversifyCoreError> = {
-        kind: InversifyCoreErrorKind.unknown,
-        message: 'Expected constant value binding with value, none found',
-      };
-
-      expect(result).toBeInstanceOf(InversifyCoreError);
-      expect(result).toStrictEqual(
-        expect.objectContaining(expectedErrorProperties),
-      );
+    it('should return expected value', () => {
+      expect(result).toBe(constantValueBindingFixture.value);
     });
   });
 });

--- a/packages/container/libraries/core/src/resolution/calculations/resolveConstantValueBindingCallback.ts
+++ b/packages/container/libraries/core/src/resolution/calculations/resolveConstantValueBindingCallback.ts
@@ -1,9 +1,10 @@
-import { InversifyCoreError } from '../../error/models/InversifyCoreError';
-import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
+import { ConstantValueBinding } from '../../binding/models/ConstantValueBinding';
+import { ResolutionParams } from '../models/ResolutionParams';
+import { Resolved } from '../models/Resolved';
 
-export function resolveConstantValueBindingCallback(): never {
-  throw new InversifyCoreError(
-    InversifyCoreErrorKind.unknown,
-    'Expected constant value binding with value, none found',
-  );
+export function resolveConstantValueBindingCallback<TActivated>(
+  _params: ResolutionParams,
+  binding: ConstantValueBinding<TActivated>,
+): Resolved<TActivated> {
+  return binding.value;
 }

--- a/packages/container/libraries/core/src/resolution/models/ResolutionParams.ts
+++ b/packages/container/libraries/core/src/resolution/models/ResolutionParams.ts
@@ -8,7 +8,7 @@ export interface ResolutionParams {
   context: ResolutionContext;
   getActivations: <TActivated>(
     serviceIdentifier: ServiceIdentifier<TActivated>,
-  ) => BindingActivation<TActivated>[] | undefined;
+  ) => Iterable<BindingActivation<TActivated>> | undefined;
   planResult: PlanResult;
   requestScopeCache: Map<number, unknown>;
 }


### PR DESCRIPTION
### Added
- Added `resolveBindingActivations`.

### Changed
- Updated `ConstantValueBinding` with `value`.
- Updated `resolveScoped` to rely on `resolveBindingActivations`.
- Updated `resolveSingletonScopedBinding` to rely on `resolveBindingActivations`.