### PR TITLE
🏷️ fix(strongly-typed) allow use of generic helpers

### DIFF
--- a/.changeset/hot-lobsters-allow.md
+++ b/.changeset/hot-lobsters-allow.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/strongly-typed": patch
+---
+
+Fixed types to allow use of generic helper functions

--- a/packages/container/libraries/strongly-typed/src/container.spec.ts
+++ b/packages/container/libraries/strongly-typed/src/container.spec.ts
@@ -120,10 +120,13 @@ describe('interfaces', () => {
         });
 
         it('gets a promise', async () => {
-          // @ts-expect-error :: can't call get() to get Promise
-          expect(() => container.get('asyncNumber')).toThrow(
-            'it has asynchronous dependencies',
-          );
+          expect(() => {
+            const num = container.get('asyncNumber');
+            /* eslint-disable @typescript-eslint/no-unused-expressions */
+            // @ts-expect-error :: num is never
+            num.then;
+            /* eslint-enable @typescript-eslint/no-unused-expressions */
+          }).toThrow('it has asynchronous dependencies');
           const n: Promise<number> = container.getAsync('asyncNumber');
           expect(await n).toBe(1);
         });
@@ -199,6 +202,29 @@ describe('interfaces', () => {
           container.bind('foo').to(Foo);
           // @ts-expect-error :: can't bind Bar to Foo
           container.bind('foo').to(Bar);
+        });
+      });
+
+      describe('generics', () => {
+        beforeEach(() => {
+          container.bind('foo').to(Foo);
+        });
+
+        it('can be used in a generic function', () => {
+          function test<T extends BindingMap>(
+            container: TypedContainer<T>,
+          ): void {
+            const foo: Foo = container.get('foo');
+            // @ts-expect-error :: can't assign Foo to Bar
+            const bar: Bar = container.get('foo');
+
+            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+            foo;
+            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+            bar;
+          }
+
+          test(container);
         });
       });
     });

--- a/packages/container/libraries/strongly-typed/src/container.ts
+++ b/packages/container/libraries/strongly-typed/src/container.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unnecessary-type-parameters */
+
 import { Container, type interfaces } from 'inversify';
 
 type IfAny<T, TYes, TNo> = 0 extends 1 & T ? TYes : TNo;
@@ -23,11 +23,7 @@ type ContainerBinding<
       ? any
       : never;
 
-type Synchronous<T extends BindingMap> = IfAny<
-  T,
-  any,
-  { [K in keyof T as T[K] extends Promise<any> ? never : K]: T[K] }
->;
+type NeverPromise<T> = T extends Promise<any> ? never : T;
 
 type First<T extends any[]> = T extends [infer TFirst, ...any[]]
   ? TFirst
@@ -44,47 +40,47 @@ interface ContainerOverrides<
   parent: ContainerOverrides<First<TAncestors>, AllButFirst<TAncestors>> | null;
   bind: Bind<T>;
   get: <
-    TBound extends ContainerBinding<Synchronous<T>, TKey>,
-    TKey extends MappedServiceIdentifier<Synchronous<T>> = any,
+    TBound extends ContainerBinding<T, TKey>,
+    TKey extends MappedServiceIdentifier<T> = any,
   >(
     serviceIdentifier: TKey,
-  ) => TBound;
+  ) => NeverPromise<TBound>;
   getNamed: <
-    TBound extends ContainerBinding<Synchronous<T>, TKey>,
-    TKey extends MappedServiceIdentifier<Synchronous<T>> = any,
+    TBound extends ContainerBinding<T, TKey>,
+    TKey extends MappedServiceIdentifier<T> = any,
   >(
     serviceIdentifier: TKey,
     named: PropertyKey,
-  ) => TBound;
+  ) => NeverPromise<TBound>;
   getTagged: <
-    TBound extends ContainerBinding<Synchronous<T>, TKey>,
-    TKey extends MappedServiceIdentifier<Synchronous<T>> = any,
+    TBound extends ContainerBinding<T, TKey>,
+    TKey extends MappedServiceIdentifier<T> = any,
   >(
     serviceIdentifier: TKey,
     key: PropertyKey,
     value: unknown,
-  ) => TBound;
+  ) => NeverPromise<TBound>;
   getAll: <
-    TBound extends ContainerBinding<Synchronous<T>, TKey>,
-    TKey extends MappedServiceIdentifier<Synchronous<T>> = any,
+    TBound extends ContainerBinding<T, TKey>,
+    TKey extends MappedServiceIdentifier<T> = any,
   >(
     serviceIdentifier: TKey,
-  ) => TBound[];
+  ) => NeverPromise<TBound[]>;
   getAllTagged: <
-    TBound extends ContainerBinding<Synchronous<T>, TKey>,
-    TKey extends MappedServiceIdentifier<Synchronous<T>> = any,
+    TBound extends ContainerBinding<T, TKey>,
+    TKey extends MappedServiceIdentifier<T> = any,
   >(
     serviceIdentifier: TKey,
     key: PropertyKey,
     value: unknown,
-  ) => TBound[];
+  ) => NeverPromise<TBound[]>;
   getAllNamed: <
-    TBound extends ContainerBinding<Synchronous<T>, TKey>,
-    TKey extends MappedServiceIdentifier<Synchronous<T>> = any,
+    TBound extends ContainerBinding<T, TKey>,
+    TKey extends MappedServiceIdentifier<T> = any,
   >(
     serviceIdentifier: TKey,
     named: PropertyKey,
-  ) => TBound[];
+  ) => NeverPromise<TBound[]>;
   getAsync: <
     TBound extends ContainerBinding<T, TKey>,
     TKey extends MappedServiceIdentifier<T> = any,


### PR DESCRIPTION
Fixes https://github.com/inversify/monorepo/issues/170

At the moment it's impossible to create generic helper functions to deal with `TypedContainer`:

```ts
interface MyMap {
  foo: string;
}

function fn<T extends MyMap>(container: TypedContainer<T>) {
  container.get('foo') // error
}
```

This is because of the `Synchronous` type that guards against calling `.get()` on `Promise` bindings. Under the hood, this type is a mapped type, which [doesn't work well with generics][1] (by design).

Rather than drop this guard all together, this change aims to strike a balance by removing the `Synchronous` mapped type, and instead changing the return type of synchronous `get()` methods to be `never` if the binding is a `Promise`.

This won't error as obviously or as immediately as before, but will still at least flag to the developer semantically that this binding will never return a value (since it will throw), and should cause compilation errors if consumers try to do anything with the returned value.

In return, we gain the ability to use generic helper functions.

[1]: https://github.com/microsoft/TypeScript/issues/35647