### PR TITLE
Add binding fluent syntax

### DIFF
--- a/packages/container/libraries/container/package.json
+++ b/packages/container/libraries/container/package.json
@@ -4,6 +4,11 @@
     "url": "https://github.com/inversify/monorepo/issues"
   },
   "description": "InversifyJs container",
+  "dependencies": {
+    "@inversifyjs/common": "workspace:*",
+    "@inversifyjs/core": "workspace:*",
+    "@inversifyjs/reflect-metadata-utils": "workspace:*"
+  },
   "devDependencies": {
     "@eslint/js": "9.17.0",
     "@jest/globals": "29.7.0",

--- a/packages/container/libraries/container/src/binding/actions/getBindingId.spec.ts
+++ b/packages/container/libraries/container/src/binding/actions/getBindingId.spec.ts
@@ -1,0 +1,88 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('@inversifyjs/reflect-metadata-utils');
+
+import {
+  getReflectMetadata,
+  updateReflectMetadata,
+} from '@inversifyjs/reflect-metadata-utils';
+
+import { getBindingId } from './getBindingId';
+
+describe(getBindingId.name, () => {
+  describe('when called, and getReflectMetadata() returns undefined', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      (
+        getReflectMetadata as jest.Mock<typeof getReflectMetadata>
+      ).mockReturnValueOnce(0);
+
+      result = getBindingId();
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call getReflectMetadata()', () => {
+      expect(getReflectMetadata).toHaveBeenCalledTimes(1);
+      expect(getReflectMetadata).toHaveBeenCalledWith(
+        Object,
+        '@inversifyjs/container/bindingId',
+      );
+    });
+
+    it('should call updateReflectMetadata()', () => {
+      expect(updateReflectMetadata).toHaveBeenCalledTimes(1);
+      expect(updateReflectMetadata).toHaveBeenCalledWith(
+        Object,
+        '@inversifyjs/container/bindingId',
+        0,
+        expect.any(Function),
+      );
+    });
+
+    it('should return default id', () => {
+      expect(result).toBe(0);
+    });
+  });
+
+  describe('when called, and getReflectMetadata() returns Number.MAX_SAFE_INTEGER', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      (
+        getReflectMetadata as jest.Mock<typeof getReflectMetadata>
+      ).mockReturnValueOnce(Number.MAX_SAFE_INTEGER);
+
+      result = getBindingId();
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call getReflectMetadata()', () => {
+      expect(getReflectMetadata).toHaveBeenCalledTimes(1);
+      expect(getReflectMetadata).toHaveBeenCalledWith(
+        Object,
+        '@inversifyjs/container/bindingId',
+      );
+    });
+
+    it('should call updateReflectMetadata()', () => {
+      expect(updateReflectMetadata).toHaveBeenCalledTimes(1);
+      expect(updateReflectMetadata).toHaveBeenCalledWith(
+        Object,
+        '@inversifyjs/container/bindingId',
+        Number.MAX_SAFE_INTEGER,
+        expect.any(Function),
+      );
+    });
+
+    it('should return default id', () => {
+      expect(result).toBe(Number.MAX_SAFE_INTEGER);
+    });
+  });
+});

--- a/packages/container/libraries/container/src/binding/actions/getBindingId.ts
+++ b/packages/container/libraries/container/src/binding/actions/getBindingId.ts
@@ -1,0 +1,29 @@
+import {
+  getReflectMetadata,
+  updateReflectMetadata,
+} from '@inversifyjs/reflect-metadata-utils';
+
+const ID_METADATA: string = '@inversifyjs/container/bindingId';
+
+export function getBindingId(): number {
+  const bindingId: number =
+    getReflectMetadata<number>(Object, ID_METADATA) ?? 0;
+
+  if (bindingId === Number.MAX_SAFE_INTEGER) {
+    updateReflectMetadata(
+      Object,
+      ID_METADATA,
+      bindingId,
+      () => Number.MIN_SAFE_INTEGER,
+    );
+  } else {
+    updateReflectMetadata(
+      Object,
+      ID_METADATA,
+      bindingId,
+      (id: number) => id + 1,
+    );
+  }
+
+  return bindingId;
+}

--- a/packages/container/libraries/container/src/common/models/Writable.ts
+++ b/packages/container/libraries/container/src/common/models/Writable.ts
@@ -1,0 +1,3 @@
+export type Writable<T> = {
+  -readonly [TKey in keyof T]: T[TKey];
+};

--- a/packages/container/libraries/container/src/container/binding/models/BindingFluentSyntax.ts
+++ b/packages/container/libraries/container/src/container/binding/models/BindingFluentSyntax.ts
@@ -1,0 +1,53 @@
+import { Newable, ServiceIdentifier } from '@inversifyjs/common';
+import {
+  BindingActivation,
+  BindingDeactivation,
+  BindingMetadata,
+  DynamicValueBuilder,
+  Factory,
+  Provider,
+  ResolutionContext,
+} from '@inversifyjs/core';
+
+export interface BindToFluentSyntax<T> {
+  to(type: Newable<T>): BindInWhenOnFluentSyntax<T>;
+  toSelf(): BindInWhenOnFluentSyntax<T>;
+  toConstantValue(value: T): BindWhenOnFluentSyntax<T>;
+  toDynamicValue(builder: DynamicValueBuilder<T>): BindInWhenOnFluentSyntax<T>;
+  toFactory(
+    factory: T extends Factory<unknown>
+      ? (context: ResolutionContext) => T
+      : never,
+  ): BindWhenOnFluentSyntax<T>;
+  toProvider(
+    provider: T extends Provider<unknown>
+      ? (context: ResolutionContext) => T
+      : never,
+  ): BindWhenOnFluentSyntax<T>;
+  toService(service: ServiceIdentifier<T>): void;
+}
+
+export interface BindInFluentSyntax<T> {
+  inSingletonScope(): BindWhenOnFluentSyntax<T>;
+  inTransientScope(): BindWhenOnFluentSyntax<T>;
+  inRequestScope(): BindWhenOnFluentSyntax<T>;
+}
+
+export interface BindInWhenOnFluentSyntax<T>
+  extends BindInFluentSyntax<T>,
+    BindWhenOnFluentSyntax<T> {}
+
+export interface BindOnFluentSyntax<T> {
+  onActivation(activation: BindingActivation<T>): BindWhenFluentSyntax<T>;
+  onDeactivation(deactivation: BindingDeactivation<T>): BindWhenFluentSyntax<T>;
+}
+
+export interface BindWhenOnFluentSyntax<T>
+  extends BindWhenFluentSyntax<T>,
+    BindOnFluentSyntax<T> {}
+
+export interface BindWhenFluentSyntax<T> {
+  when(
+    constraint: (metadata: BindingMetadata) => boolean,
+  ): BindOnFluentSyntax<T>;
+}

--- a/packages/container/libraries/container/src/container/binding/models/BindingFluentSyntaxImplementation.spec.ts
+++ b/packages/container/libraries/container/src/container/binding/models/BindingFluentSyntaxImplementation.spec.ts
@@ -1,0 +1,872 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('../../../binding/actions/getBindingId');
+
+import { ServiceIdentifier } from '@inversifyjs/common';
+import {
+  Binding,
+  BindingActivation,
+  BindingDeactivation,
+  BindingMetadata,
+  BindingScope,
+  bindingScopeValues,
+  BindingType,
+  bindingTypeValues,
+  ConstantValueBinding,
+  DynamicValueBuilder,
+  Factory,
+  InstanceBinding,
+  Provider,
+  ResolutionContext,
+  ScopedBinding,
+  ServiceRedirectionBinding,
+} from '@inversifyjs/core';
+
+import { getBindingId } from '../../../binding/actions/getBindingId';
+import { Writable } from '../../../common/models/Writable';
+import {
+  BindInFluentSyntaxImplementation,
+  BindInWhenOnFluentSyntaxImplementation,
+  BindOnFluentSyntaxImplementation,
+  BindToFluentSyntaxImplementation,
+  BindWhenFluentSyntaxImplementation,
+  BindWhenOnFluentSyntaxImplementation,
+} from './BindingFluentSyntaxImplementation';
+
+describe(BindInFluentSyntaxImplementation.name, () => {
+  let bindingMock: jest.Mocked<
+    ScopedBinding<BindingType, BindingScope, unknown>
+  >;
+
+  let bindingMockSetScopeMock: jest.Mock<(value: BindingScope) => void>;
+
+  let bindInFluentSyntaxImplementation: BindInFluentSyntaxImplementation<unknown>;
+
+  beforeAll(() => {
+    let bindingScope: BindingScope = bindingScopeValues.Singleton;
+
+    bindingMockSetScopeMock = jest.fn();
+
+    bindingMock = {
+      get scope(): BindingScope {
+        return bindingScope;
+      },
+      set scope(value: BindingScope) {
+        bindingMockSetScopeMock(value);
+
+        bindingScope = value;
+      },
+    } as Partial<
+      jest.Mocked<ScopedBinding<BindingType, BindingScope, unknown>>
+    > as jest.Mocked<ScopedBinding<BindingType, BindingScope, unknown>>;
+
+    bindInFluentSyntaxImplementation = new BindInFluentSyntaxImplementation(
+      bindingMock,
+    );
+  });
+
+  describe.each<
+    [
+      string,
+      (
+        bindInFluentSyntaxImplementation: BindInFluentSyntaxImplementation<unknown>,
+      ) => unknown,
+      BindingScope,
+    ]
+  >([
+    [
+      '.inRequestScope()',
+      (
+        bindInFluentSyntaxImplementation: BindInFluentSyntaxImplementation<unknown>,
+      ) => bindInFluentSyntaxImplementation.inRequestScope(),
+      bindingScopeValues.Request,
+    ],
+    [
+      '.inSingletonScope()',
+      (
+        bindInFluentSyntaxImplementation: BindInFluentSyntaxImplementation<unknown>,
+      ) => bindInFluentSyntaxImplementation.inSingletonScope(),
+      bindingScopeValues.Singleton,
+    ],
+    [
+      '.inTransientScope()',
+      (
+        bindInFluentSyntaxImplementation: BindInFluentSyntaxImplementation<unknown>,
+      ) => bindInFluentSyntaxImplementation.inTransientScope(),
+      bindingScopeValues.Transient,
+    ],
+  ])(
+    '%s',
+    (
+      _: string,
+      buildResult: (
+        bindInFluentSyntaxImplementation: BindInFluentSyntaxImplementation<unknown>,
+      ) => unknown,
+      expectedScope: BindingScope,
+    ) => {
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = buildResult(bindInFluentSyntaxImplementation);
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should set binding scope', () => {
+          expect(bindingMockSetScopeMock).toHaveBeenCalledTimes(1);
+          expect(bindingMockSetScopeMock).toHaveBeenCalledWith(expectedScope);
+        });
+
+        it('should return BindWhenOnFluentSyntax', () => {
+          expect(result).toBeInstanceOf(BindWhenOnFluentSyntaxImplementation);
+        });
+      });
+    },
+  );
+});
+
+describe(BindToFluentSyntaxImplementation.name, () => {
+  class Foo {}
+
+  let bindingIdFixture: number;
+
+  let dynamicValueBuilderfixture: DynamicValueBuilder<unknown>;
+  let factoryBuilderFixture: (context: ResolutionContext) => Factory<unknown>;
+  let providerBuilderFixture: (context: ResolutionContext) => Provider<unknown>;
+
+  let callbackMock: jest.Mock<(binding: Binding) => void>;
+  let containerModuleIdFixture: number;
+  let defaultScopeFixture: BindingScope;
+  let serviceIdentifierFixture: ServiceIdentifier;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let bindToFluentSyntaxImplementation: BindToFluentSyntaxImplementation<any>;
+
+  beforeAll(() => {
+    bindingIdFixture = 1;
+
+    dynamicValueBuilderfixture = () => Symbol.for('dynamic-value');
+    factoryBuilderFixture = () => () => Symbol.for('value-from-factory');
+    providerBuilderFixture = () => async () =>
+      Symbol.for('value-from-provider');
+
+    (getBindingId as jest.Mock<typeof getBindingId>).mockReturnValue(
+      bindingIdFixture,
+    );
+
+    callbackMock = jest.fn();
+    containerModuleIdFixture = 1;
+    defaultScopeFixture = bindingScopeValues.Singleton;
+    serviceIdentifierFixture = 'service-id';
+
+    bindToFluentSyntaxImplementation = new BindToFluentSyntaxImplementation(
+      callbackMock,
+      containerModuleIdFixture,
+      defaultScopeFixture,
+      serviceIdentifierFixture,
+    );
+  });
+
+  describe.each<
+    [
+      string,
+      (
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        bindToFluentSyntaxImplementation: BindToFluentSyntaxImplementation<any>,
+      ) => unknown,
+      () => Binding,
+      NewableFunction,
+    ]
+  >([
+    [
+      '.to()',
+      (
+        bindToFluentSyntaxImplementation: BindToFluentSyntaxImplementation<unknown>,
+      ): unknown => bindToFluentSyntaxImplementation.to(Foo),
+      (): Binding => ({
+        cache: {
+          isRight: false,
+          value: undefined,
+        },
+        id: bindingIdFixture,
+        implementationType: Foo,
+        isSatisfiedBy: expect.any(Function) as unknown as (
+          metadata: BindingMetadata,
+        ) => boolean,
+        moduleId: containerModuleIdFixture,
+        onActivation: undefined,
+        onDeactivation: undefined,
+        scope: defaultScopeFixture,
+        serviceIdentifier: serviceIdentifierFixture,
+        type: bindingTypeValues.Instance,
+      }),
+      BindWhenOnFluentSyntaxImplementation,
+    ],
+    [
+      '.toConstantValue()',
+      (
+        bindToFluentSyntaxImplementation: BindToFluentSyntaxImplementation<unknown>,
+      ): unknown =>
+        bindToFluentSyntaxImplementation.toConstantValue(
+          Symbol.for('constant-value'),
+        ),
+      (): Binding => ({
+        cache: {
+          isRight: false,
+          value: undefined,
+        },
+        id: bindingIdFixture,
+        isSatisfiedBy: expect.any(Function) as unknown as (
+          metadata: BindingMetadata,
+        ) => boolean,
+        moduleId: containerModuleIdFixture,
+        onActivation: undefined,
+        onDeactivation: undefined,
+        scope: bindingScopeValues.Singleton,
+        serviceIdentifier: serviceIdentifierFixture,
+        type: bindingTypeValues.ConstantValue,
+        value: Symbol.for('constant-value'),
+      }),
+      BindWhenOnFluentSyntaxImplementation,
+    ],
+    [
+      '.toDynamicValue()',
+      (
+        bindToFluentSyntaxImplementation: BindToFluentSyntaxImplementation<unknown>,
+      ): unknown =>
+        bindToFluentSyntaxImplementation.toDynamicValue(
+          dynamicValueBuilderfixture,
+        ),
+      (): Binding => ({
+        cache: {
+          isRight: false,
+          value: undefined,
+        },
+        id: bindingIdFixture,
+        isSatisfiedBy: expect.any(Function) as unknown as (
+          metadata: BindingMetadata,
+        ) => boolean,
+        moduleId: containerModuleIdFixture,
+        onActivation: undefined,
+        onDeactivation: undefined,
+        scope: defaultScopeFixture,
+        serviceIdentifier: serviceIdentifierFixture,
+        type: bindingTypeValues.DynamicValue,
+        value: dynamicValueBuilderfixture,
+      }),
+      BindWhenOnFluentSyntaxImplementation,
+    ],
+    [
+      '.toFactory()',
+      (
+        bindToFluentSyntaxImplementation: BindToFluentSyntaxImplementation<
+          Factory<unknown>
+        >,
+      ): unknown =>
+        bindToFluentSyntaxImplementation.toFactory(factoryBuilderFixture),
+      (): Binding => ({
+        cache: {
+          isRight: false,
+          value: undefined,
+        },
+        factory: factoryBuilderFixture,
+        id: bindingIdFixture,
+        isSatisfiedBy: expect.any(Function) as unknown as (
+          metadata: BindingMetadata,
+        ) => boolean,
+        moduleId: containerModuleIdFixture,
+        onActivation: undefined,
+        onDeactivation: undefined,
+        scope: bindingScopeValues.Singleton,
+        serviceIdentifier: serviceIdentifierFixture,
+        type: bindingTypeValues.Factory,
+      }),
+      BindWhenOnFluentSyntaxImplementation,
+    ],
+    [
+      '.toProvider()',
+      (
+        bindToFluentSyntaxImplementation: BindToFluentSyntaxImplementation<
+          Provider<unknown>
+        >,
+      ): unknown =>
+        bindToFluentSyntaxImplementation.toProvider(providerBuilderFixture),
+      (): Binding => ({
+        cache: {
+          isRight: false,
+          value: undefined,
+        },
+        id: bindingIdFixture,
+        isSatisfiedBy: expect.any(Function) as unknown as (
+          metadata: BindingMetadata,
+        ) => boolean,
+        moduleId: containerModuleIdFixture,
+        onActivation: undefined,
+        onDeactivation: undefined,
+        provider: providerBuilderFixture,
+        scope: bindingScopeValues.Singleton,
+        serviceIdentifier: serviceIdentifierFixture,
+        type: bindingTypeValues.Provider,
+      }),
+      BindWhenOnFluentSyntaxImplementation,
+    ],
+  ])(
+    '%s',
+    (
+      _: string,
+      buildResult: (
+        bindToFluentSyntaxImplementation: BindToFluentSyntaxImplementation<unknown>,
+      ) => unknown,
+      buildExpectedBinding: () => Binding,
+      expectedResultType: NewableFunction,
+    ) => {
+      describe('when called', () => {
+        let expectedBinding: Binding;
+        let result: unknown;
+
+        beforeAll(() => {
+          expectedBinding = buildExpectedBinding();
+          result = buildResult(bindToFluentSyntaxImplementation);
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call getBindingId', () => {
+          expect(getBindingId).toHaveBeenCalledTimes(1);
+          expect(getBindingId).toHaveBeenCalledWith();
+        });
+
+        it('should call callback', () => {
+          expect(callbackMock).toHaveBeenCalledTimes(1);
+          expect(callbackMock).toHaveBeenCalledWith(expectedBinding);
+        });
+
+        it('should return expected result', () => {
+          expect(result).toBeInstanceOf(expectedResultType);
+        });
+      });
+    },
+  );
+
+  describe('.toSelf', () => {
+    describe('having a non function service identifier', () => {
+      let callbackMock: jest.Mock<(binding: Binding) => void>;
+      let containerModuleIdFixture: number;
+      let defaultScopeFixture: BindingScope;
+      let serviceIdentifierFixture: ServiceIdentifier;
+
+      let bindToFluentSyntaxImplementation: BindToFluentSyntaxImplementation<unknown>;
+
+      beforeAll(() => {
+        callbackMock = jest.fn();
+        containerModuleIdFixture = 1;
+        defaultScopeFixture = bindingScopeValues.Singleton;
+        serviceIdentifierFixture = 'service-id';
+
+        bindToFluentSyntaxImplementation = new BindToFluentSyntaxImplementation(
+          callbackMock,
+          containerModuleIdFixture,
+          defaultScopeFixture,
+          serviceIdentifierFixture,
+        );
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          try {
+            bindToFluentSyntaxImplementation.toSelf();
+          } catch (error: unknown) {
+            result = error;
+          }
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should trow an Error', () => {
+          const expectedErrorProperties: Partial<Error> = {
+            message:
+              '"toSelf" function can only be applied when a newable function is used as service identifier',
+          };
+
+          expect(result).toBeInstanceOf(Error);
+          expect(result).toStrictEqual(
+            expect.objectContaining(expectedErrorProperties),
+          );
+        });
+      });
+    });
+
+    describe('having a function service identifier', () => {
+      class Foo {}
+
+      let callbackMock: jest.Mock<(binding: Binding) => void>;
+      let containerModuleIdFixture: number;
+      let defaultScopeFixture: BindingScope;
+      let serviceIdentifierFixture: ServiceIdentifier;
+
+      let bindToFluentSyntaxImplementation: BindToFluentSyntaxImplementation<unknown>;
+
+      beforeAll(() => {
+        callbackMock = jest.fn();
+        containerModuleIdFixture = 1;
+        defaultScopeFixture = bindingScopeValues.Singleton;
+        serviceIdentifierFixture = Foo;
+
+        bindToFluentSyntaxImplementation = new BindToFluentSyntaxImplementation(
+          callbackMock,
+          containerModuleIdFixture,
+          defaultScopeFixture,
+          serviceIdentifierFixture,
+        );
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = bindToFluentSyntaxImplementation.toSelf();
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call callback()', () => {
+          const expectedBinding: InstanceBinding<unknown> = {
+            cache: {
+              isRight: false,
+              value: undefined,
+            },
+            id: getBindingId(),
+            implementationType: Foo,
+            isSatisfiedBy: expect.any(Function) as unknown as (
+              metadata: BindingMetadata,
+            ) => boolean,
+            moduleId: containerModuleIdFixture,
+            onActivation: undefined,
+            onDeactivation: undefined,
+            scope: defaultScopeFixture,
+            serviceIdentifier: serviceIdentifierFixture,
+            type: bindingTypeValues.Instance,
+          };
+
+          expect(callbackMock).toHaveBeenCalledTimes(1);
+          expect(callbackMock).toHaveBeenCalledWith(expectedBinding);
+        });
+
+        it('should return expected result', () => {
+          expect(result).toBeInstanceOf(BindInWhenOnFluentSyntaxImplementation);
+        });
+      });
+    });
+  });
+
+  describe('.toService', () => {
+    describe('when called', () => {
+      let targetServiceFixture: ServiceIdentifier;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        targetServiceFixture = 'another-service-id';
+
+        result =
+          bindToFluentSyntaxImplementation.toService(targetServiceFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call callback()', () => {
+        const expectedBinding: ServiceRedirectionBinding<unknown> = {
+          id: bindingIdFixture,
+          isSatisfiedBy: expect.any(Function) as unknown as (
+            metadata: BindingMetadata,
+          ) => boolean,
+          moduleId: containerModuleIdFixture,
+          serviceIdentifier: serviceIdentifierFixture,
+          targetServiceIdentifier: targetServiceFixture,
+          type: bindingTypeValues.ServiceRedirection,
+        };
+
+        expect(callbackMock).toHaveBeenCalledTimes(1);
+        expect(callbackMock).toHaveBeenCalledWith(expectedBinding);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+});
+
+describe(BindOnFluentSyntaxImplementation.name, () => {
+  let bindingFixture: Writable<ConstantValueBinding<unknown>>;
+  let bindingActivationSetterMock: jest.Mock<
+    (value: BindingActivation | undefined) => undefined
+  >;
+  let bindingDeactivationSetterMock: jest.Mock<
+    (value: BindingDeactivation | undefined) => undefined
+  >;
+
+  let bindOnFluentSyntaxImplementation: BindOnFluentSyntaxImplementation<unknown>;
+
+  beforeAll(() => {
+    bindingActivationSetterMock = jest.fn();
+    bindingDeactivationSetterMock = jest.fn();
+
+    bindingFixture = {
+      cache: {
+        isRight: false,
+        value: undefined,
+      },
+      id: 1,
+      isSatisfiedBy: expect.any(Function) as unknown as (
+        metadata: BindingMetadata,
+      ) => boolean,
+      moduleId: undefined,
+      get onActivation(): BindingActivation<unknown> | undefined {
+        return undefined;
+      },
+      set onActivation(value: BindingActivation<unknown> | undefined) {
+        bindingActivationSetterMock(value);
+      },
+      get onDeactivation(): BindingDeactivation<unknown> | undefined {
+        return undefined;
+      },
+      set onDeactivation(value: BindingDeactivation<unknown> | undefined) {
+        bindingDeactivationSetterMock(value);
+      },
+      scope: bindingScopeValues.Singleton,
+      serviceIdentifier: 'service-id',
+      type: bindingTypeValues.ConstantValue,
+      value: Symbol.for('constant-value'),
+    };
+
+    bindOnFluentSyntaxImplementation = new BindOnFluentSyntaxImplementation(
+      bindingFixture,
+    );
+  });
+
+  describe('.onActivation', () => {
+    describe('when called', () => {
+      let activationFixture: BindingActivation<unknown>;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        activationFixture = (value: unknown) => value;
+
+        result =
+          bindOnFluentSyntaxImplementation.onActivation(activationFixture);
+      });
+
+      it('should set binding activation', () => {
+        expect(bindingActivationSetterMock).toHaveBeenCalledTimes(1);
+        expect(bindingActivationSetterMock).toHaveBeenCalledWith(
+          activationFixture,
+        );
+      });
+
+      it('should return expected result', () => {
+        expect(result).toBeInstanceOf(BindWhenFluentSyntaxImplementation);
+      });
+    });
+  });
+
+  describe('.onDeactivation', () => {
+    describe('when called', () => {
+      let deactivationFixture: BindingDeactivation<unknown>;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        deactivationFixture = () => undefined;
+
+        result =
+          bindOnFluentSyntaxImplementation.onDeactivation(deactivationFixture);
+      });
+
+      it('should set binding deactivation', () => {
+        expect(bindingDeactivationSetterMock).toHaveBeenCalledTimes(1);
+        expect(bindingDeactivationSetterMock).toHaveBeenCalledWith(
+          deactivationFixture,
+        );
+      });
+
+      it('should return expected result', () => {
+        expect(result).toBeInstanceOf(BindWhenFluentSyntaxImplementation);
+      });
+    });
+  });
+});
+
+describe(BindWhenFluentSyntaxImplementation.name, () => {
+  let bindingFixture: ConstantValueBinding<unknown>;
+
+  let isSatisfiedBySetterMock: jest.Mock<
+    (value: (metadata: BindingMetadata) => boolean) => void
+  >;
+
+  let bindWhenFluentSyntaxImplementation: BindWhenFluentSyntaxImplementation<unknown>;
+
+  beforeAll(() => {
+    isSatisfiedBySetterMock = jest.fn();
+
+    bindingFixture = {
+      cache: {
+        isRight: false,
+        value: undefined,
+      },
+      id: 1,
+      get isSatisfiedBy() {
+        return () => true;
+      },
+      set isSatisfiedBy(value: (metadata: BindingMetadata) => boolean) {
+        isSatisfiedBySetterMock(value);
+      },
+      moduleId: undefined,
+      onActivation: undefined,
+      onDeactivation: undefined,
+      scope: bindingScopeValues.Singleton,
+      serviceIdentifier: 'service-id',
+      type: bindingTypeValues.ConstantValue,
+      value: Symbol(),
+    };
+
+    bindWhenFluentSyntaxImplementation = new BindWhenFluentSyntaxImplementation(
+      bindingFixture,
+    );
+  });
+
+  describe('.when', () => {
+    let constraintFixture: (metadata: BindingMetadata) => boolean;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      constraintFixture = () => true;
+
+      result = bindWhenFluentSyntaxImplementation.when(constraintFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should set constraint', () => {
+      expect(isSatisfiedBySetterMock).toHaveBeenCalledTimes(1);
+      expect(isSatisfiedBySetterMock).toHaveBeenCalledWith(constraintFixture);
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBeInstanceOf(BindOnFluentSyntaxImplementation);
+    });
+  });
+});
+
+describe(BindWhenOnFluentSyntaxImplementation.name, () => {
+  let bindingFixture: Writable<ConstantValueBinding<unknown>>;
+  let bindingActivationSetterMock: jest.Mock<
+    (value: BindingActivation | undefined) => undefined
+  >;
+  let bindingDeactivationSetterMock: jest.Mock<
+    (value: BindingDeactivation | undefined) => undefined
+  >;
+
+  let bindWhenOnFluentSyntaxImplementation: BindWhenOnFluentSyntaxImplementation<unknown>;
+
+  beforeAll(() => {
+    bindingActivationSetterMock = jest.fn();
+    bindingDeactivationSetterMock = jest.fn();
+
+    bindingFixture = {
+      cache: {
+        isRight: false,
+        value: undefined,
+      },
+      id: 1,
+      isSatisfiedBy: expect.any(Function) as unknown as (
+        metadata: BindingMetadata,
+      ) => boolean,
+      moduleId: undefined,
+      get onActivation(): BindingActivation<unknown> | undefined {
+        return undefined;
+      },
+      set onActivation(value: BindingActivation<unknown> | undefined) {
+        bindingActivationSetterMock(value);
+      },
+      get onDeactivation(): BindingDeactivation<unknown> | undefined {
+        return undefined;
+      },
+      set onDeactivation(value: BindingDeactivation<unknown> | undefined) {
+        bindingDeactivationSetterMock(value);
+      },
+      scope: bindingScopeValues.Singleton,
+      serviceIdentifier: 'service-id',
+      type: bindingTypeValues.ConstantValue,
+      value: Symbol.for('constant-value'),
+    };
+
+    bindWhenOnFluentSyntaxImplementation =
+      new BindWhenOnFluentSyntaxImplementation(bindingFixture);
+  });
+
+  describe('.onActivation', () => {
+    describe('when called', () => {
+      let activationFixture: BindingActivation<unknown>;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        activationFixture = (value: unknown) => value;
+
+        result =
+          bindWhenOnFluentSyntaxImplementation.onActivation(activationFixture);
+      });
+
+      it('should set binding activation', () => {
+        expect(bindingActivationSetterMock).toHaveBeenCalledTimes(1);
+        expect(bindingActivationSetterMock).toHaveBeenCalledWith(
+          activationFixture,
+        );
+      });
+
+      it('should return expected result', () => {
+        expect(result).toBeInstanceOf(BindWhenFluentSyntaxImplementation);
+      });
+    });
+  });
+
+  describe('.onDeactivation', () => {
+    describe('when called', () => {
+      let deactivationFixture: BindingDeactivation<unknown>;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        deactivationFixture = () => undefined;
+
+        result =
+          bindWhenOnFluentSyntaxImplementation.onDeactivation(
+            deactivationFixture,
+          );
+      });
+
+      it('should set binding deactivation', () => {
+        expect(bindingDeactivationSetterMock).toHaveBeenCalledTimes(1);
+        expect(bindingDeactivationSetterMock).toHaveBeenCalledWith(
+          deactivationFixture,
+        );
+      });
+
+      it('should return expected result', () => {
+        expect(result).toBeInstanceOf(BindWhenFluentSyntaxImplementation);
+      });
+    });
+  });
+});
+
+describe(BindInWhenOnFluentSyntaxImplementation.name, () => {
+  let bindingMock: jest.Mocked<
+    ScopedBinding<BindingType, BindingScope, unknown>
+  >;
+
+  let bindingMockSetScopeMock: jest.Mock<(value: BindingScope) => void>;
+
+  let bindInWhenOnFluentSyntaxImplementation: BindInWhenOnFluentSyntaxImplementation<unknown>;
+
+  beforeAll(() => {
+    let bindingScope: BindingScope = bindingScopeValues.Singleton;
+
+    bindingMockSetScopeMock = jest.fn();
+
+    bindingMock = {
+      get scope(): BindingScope {
+        return bindingScope;
+      },
+      set scope(value: BindingScope) {
+        bindingMockSetScopeMock(value);
+
+        bindingScope = value;
+      },
+    } as Partial<
+      jest.Mocked<ScopedBinding<BindingType, BindingScope, unknown>>
+    > as jest.Mocked<ScopedBinding<BindingType, BindingScope, unknown>>;
+
+    bindInWhenOnFluentSyntaxImplementation =
+      new BindInWhenOnFluentSyntaxImplementation(bindingMock);
+  });
+
+  describe.each<
+    [
+      string,
+      (
+        bindInFluentSyntaxImplementation: BindInWhenOnFluentSyntaxImplementation<unknown>,
+      ) => unknown,
+      BindingScope,
+    ]
+  >([
+    [
+      '.inRequestScope()',
+      (
+        bindInFluentSyntaxImplementation: BindInWhenOnFluentSyntaxImplementation<unknown>,
+      ) => bindInFluentSyntaxImplementation.inRequestScope(),
+      bindingScopeValues.Request,
+    ],
+    [
+      '.inSingletonScope()',
+      (
+        bindInFluentSyntaxImplementation: BindInWhenOnFluentSyntaxImplementation<unknown>,
+      ) => bindInFluentSyntaxImplementation.inSingletonScope(),
+      bindingScopeValues.Singleton,
+    ],
+    [
+      '.inTransientScope()',
+      (
+        bindInFluentSyntaxImplementation: BindInWhenOnFluentSyntaxImplementation<unknown>,
+      ) => bindInFluentSyntaxImplementation.inTransientScope(),
+      bindingScopeValues.Transient,
+    ],
+  ])(
+    '%s',
+    (
+      _: string,
+      buildResult: (
+        bindInFluentSyntaxImplementation: BindInWhenOnFluentSyntaxImplementation<unknown>,
+      ) => unknown,
+      expectedScope: BindingScope,
+    ) => {
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = buildResult(bindInWhenOnFluentSyntaxImplementation);
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should set binding scope', () => {
+          expect(bindingMockSetScopeMock).toHaveBeenCalledTimes(1);
+          expect(bindingMockSetScopeMock).toHaveBeenCalledWith(expectedScope);
+        });
+
+        it('should return BindWhenOnFluentSyntax', () => {
+          expect(result).toBeInstanceOf(BindWhenOnFluentSyntaxImplementation);
+        });
+      });
+    },
+  );
+});

--- a/packages/container/libraries/container/src/container/binding/models/BindingFluentSyntaxImplementation.ts
+++ b/packages/container/libraries/container/src/container/binding/models/BindingFluentSyntaxImplementation.ts
@@ -1,0 +1,343 @@
+import { Newable, ServiceIdentifier } from '@inversifyjs/common';
+import {
+  Binding,
+  BindingActivation,
+  BindingDeactivation,
+  BindingMetadata,
+  BindingScope,
+  bindingScopeValues,
+  BindingType,
+  bindingTypeValues,
+  ConstantValueBinding,
+  DynamicValueBinding,
+  DynamicValueBuilder,
+  Factory,
+  FactoryBinding,
+  InstanceBinding,
+  Provider,
+  ProviderBinding,
+  ResolutionContext,
+  Resolved,
+  ScopedBinding,
+  ServiceRedirectionBinding,
+} from '@inversifyjs/core';
+
+import { getBindingId } from '../../../binding/actions/getBindingId';
+import { Writable } from '../../../common/models/Writable';
+import { BindingConstraintUtils } from '../utils/BindingConstraintUtils';
+import {
+  BindInFluentSyntax,
+  BindInWhenOnFluentSyntax,
+  BindOnFluentSyntax,
+  BindToFluentSyntax,
+  BindWhenFluentSyntax,
+  BindWhenOnFluentSyntax,
+} from './BindingFluentSyntax';
+
+export class BindInFluentSyntaxImplementation<T>
+  implements BindInFluentSyntax<T>
+{
+  readonly #binding: Writable<ScopedBinding<BindingType, BindingScope, T>>;
+
+  constructor(binding: Writable<ScopedBinding<BindingType, BindingScope, T>>) {
+    this.#binding = binding;
+  }
+
+  public inRequestScope(): BindWhenOnFluentSyntax<T> {
+    this.#binding.scope = bindingScopeValues.Request;
+
+    return new BindWhenOnFluentSyntaxImplementation(this.#binding);
+  }
+
+  public inSingletonScope(): BindWhenOnFluentSyntax<T> {
+    this.#binding.scope = bindingScopeValues.Singleton;
+
+    return new BindWhenOnFluentSyntaxImplementation(this.#binding);
+  }
+
+  public inTransientScope(): BindWhenOnFluentSyntax<T> {
+    this.#binding.scope = bindingScopeValues.Transient;
+
+    return new BindWhenOnFluentSyntaxImplementation(this.#binding);
+  }
+}
+
+export class BindToFluentSyntaxImplementation<T>
+  implements BindToFluentSyntax<T>
+{
+  readonly #callback: (binding: Binding<T>) => void;
+  readonly #containerModuleId: number | undefined;
+  readonly #defaultScope: BindingScope;
+  readonly #serviceIdentifier: ServiceIdentifier<T>;
+
+  constructor(
+    callback: (binding: Binding<T>) => void,
+    containerModuleId: number | undefined,
+    defaultScope: BindingScope,
+    serviceIdentifier: ServiceIdentifier<T>,
+  ) {
+    this.#callback = callback;
+    this.#containerModuleId = containerModuleId;
+    this.#defaultScope = defaultScope;
+    this.#serviceIdentifier = serviceIdentifier;
+  }
+
+  public to(type: Newable<T>): BindInWhenOnFluentSyntax<T> {
+    const binding: InstanceBinding<T> = {
+      cache: {
+        isRight: false,
+        value: undefined,
+      },
+      id: getBindingId(),
+      implementationType: type,
+      isSatisfiedBy: BindingConstraintUtils.always,
+      moduleId: this.#containerModuleId,
+      onActivation: undefined,
+      onDeactivation: undefined,
+      scope: this.#defaultScope,
+      serviceIdentifier: this.#serviceIdentifier,
+      type: bindingTypeValues.Instance,
+    };
+
+    this.#callback(binding);
+
+    return new BindInWhenOnFluentSyntaxImplementation<T>(binding);
+  }
+
+  public toSelf(): BindInWhenOnFluentSyntax<T> {
+    if (typeof this.#serviceIdentifier !== 'function') {
+      throw new Error(
+        '"toSelf" function can only be applied when a newable function is used as service identifier',
+      );
+    }
+
+    const binding: InstanceBinding<T> = {
+      cache: {
+        isRight: false,
+        value: undefined,
+      },
+      id: getBindingId(),
+      implementationType: this.#serviceIdentifier as Newable<T>,
+      isSatisfiedBy: BindingConstraintUtils.always,
+      moduleId: this.#containerModuleId,
+      onActivation: undefined,
+      onDeactivation: undefined,
+      scope: this.#defaultScope,
+      serviceIdentifier: this.#serviceIdentifier,
+      type: bindingTypeValues.Instance,
+    };
+
+    this.#callback(binding);
+
+    return new BindInWhenOnFluentSyntaxImplementation<T>(binding);
+  }
+
+  public toConstantValue(value: T): BindWhenOnFluentSyntax<T> {
+    const binding: ConstantValueBinding<T> = {
+      cache: {
+        isRight: false,
+        value: undefined,
+      },
+      id: getBindingId(),
+      isSatisfiedBy: BindingConstraintUtils.always,
+      moduleId: this.#containerModuleId,
+      onActivation: undefined,
+      onDeactivation: undefined,
+      scope: bindingScopeValues.Singleton,
+      serviceIdentifier: this.#serviceIdentifier,
+      type: bindingTypeValues.ConstantValue,
+      value: value as Resolved<T>,
+    };
+
+    this.#callback(binding);
+
+    return new BindWhenOnFluentSyntaxImplementation<T>(binding);
+  }
+
+  public toDynamicValue(
+    builder: DynamicValueBuilder<T>,
+  ): BindInWhenOnFluentSyntax<T> {
+    const binding: DynamicValueBinding<T> = {
+      cache: {
+        isRight: false,
+        value: undefined,
+      },
+      id: getBindingId(),
+      isSatisfiedBy: BindingConstraintUtils.always,
+      moduleId: this.#containerModuleId,
+      onActivation: undefined,
+      onDeactivation: undefined,
+      scope: bindingScopeValues.Singleton,
+      serviceIdentifier: this.#serviceIdentifier,
+      type: bindingTypeValues.DynamicValue,
+      value: builder,
+    };
+
+    this.#callback(binding);
+
+    return new BindInWhenOnFluentSyntaxImplementation(binding);
+  }
+
+  public toFactory(
+    builder: T extends Factory<unknown>
+      ? (context: ResolutionContext) => T
+      : never,
+  ): BindWhenOnFluentSyntax<T> {
+    const binding: FactoryBinding<Factory<unknown>> = {
+      cache: {
+        isRight: false,
+        value: undefined,
+      },
+      factory: builder,
+      id: getBindingId(),
+      isSatisfiedBy: BindingConstraintUtils.always,
+      moduleId: this.#containerModuleId,
+      onActivation: undefined,
+      onDeactivation: undefined,
+      scope: bindingScopeValues.Singleton,
+      serviceIdentifier: this.#serviceIdentifier,
+      type: bindingTypeValues.Factory,
+    };
+
+    this.#callback(binding as Binding as Binding<T>);
+
+    return new BindWhenOnFluentSyntaxImplementation<T>(
+      binding as Writable<ScopedBinding<BindingType, BindingScope, T>>,
+    );
+  }
+
+  public toProvider(
+    provider: T extends Provider<unknown>
+      ? (context: ResolutionContext) => T
+      : never,
+  ): BindWhenOnFluentSyntax<T> {
+    const binding: ProviderBinding<Provider<unknown>> = {
+      cache: {
+        isRight: false,
+        value: undefined,
+      },
+      id: getBindingId(),
+      isSatisfiedBy: BindingConstraintUtils.always,
+      moduleId: this.#containerModuleId,
+      onActivation: undefined,
+      onDeactivation: undefined,
+      provider,
+      scope: bindingScopeValues.Singleton,
+      serviceIdentifier: this.#serviceIdentifier,
+      type: bindingTypeValues.Provider,
+    };
+
+    this.#callback(binding as Binding as Binding<T>);
+
+    return new BindWhenOnFluentSyntaxImplementation<T>(
+      binding as Writable<ScopedBinding<BindingType, BindingScope, T>>,
+    );
+  }
+
+  public toService(service: ServiceIdentifier<T>): void {
+    const binding: ServiceRedirectionBinding<T> = {
+      id: getBindingId(),
+      isSatisfiedBy: BindingConstraintUtils.always,
+      moduleId: this.#containerModuleId,
+      serviceIdentifier: this.#serviceIdentifier,
+      targetServiceIdentifier: service,
+      type: bindingTypeValues.ServiceRedirection,
+    };
+
+    this.#callback(binding);
+  }
+}
+
+export class BindOnFluentSyntaxImplementation<T>
+  implements BindOnFluentSyntax<T>
+{
+  readonly #binding: Writable<ScopedBinding<BindingType, BindingScope, T>>;
+
+  constructor(binding: Writable<ScopedBinding<BindingType, BindingScope, T>>) {
+    this.#binding = binding;
+  }
+
+  public onActivation(
+    activation: BindingActivation<T>,
+  ): BindWhenFluentSyntax<T> {
+    this.#binding.onActivation = activation;
+
+    return new BindWhenFluentSyntaxImplementation(this.#binding);
+  }
+
+  public onDeactivation(
+    deactivation: BindingDeactivation<T>,
+  ): BindWhenFluentSyntax<T> {
+    this.#binding.onDeactivation = deactivation;
+
+    return new BindWhenFluentSyntaxImplementation(this.#binding);
+  }
+}
+
+export class BindWhenFluentSyntaxImplementation<T>
+  implements BindWhenFluentSyntax<T>
+{
+  readonly #binding: Writable<ScopedBinding<BindingType, BindingScope, T>>;
+
+  constructor(binding: Writable<ScopedBinding<BindingType, BindingScope, T>>) {
+    this.#binding = binding;
+  }
+
+  public when(
+    constraint: (metadata: BindingMetadata) => boolean,
+  ): BindOnFluentSyntax<T> {
+    this.#binding.isSatisfiedBy = constraint;
+
+    return new BindOnFluentSyntaxImplementation(this.#binding);
+  }
+}
+
+export class BindWhenOnFluentSyntaxImplementation<T>
+  extends BindWhenFluentSyntaxImplementation<T>
+  implements BindWhenOnFluentSyntax<T>
+{
+  readonly #bindOnFluentSyntax: BindOnFluentSyntax<T>;
+
+  constructor(binding: Writable<ScopedBinding<BindingType, BindingScope, T>>) {
+    super(binding);
+
+    this.#bindOnFluentSyntax = new BindOnFluentSyntaxImplementation(binding);
+  }
+
+  public onActivation(
+    activation: BindingActivation<T>,
+  ): BindWhenFluentSyntax<T> {
+    return this.#bindOnFluentSyntax.onActivation(activation);
+  }
+
+  public onDeactivation(
+    deactivation: BindingDeactivation<T>,
+  ): BindWhenFluentSyntax<T> {
+    return this.#bindOnFluentSyntax.onDeactivation(deactivation);
+  }
+}
+
+export class BindInWhenOnFluentSyntaxImplementation<T>
+  extends BindWhenOnFluentSyntaxImplementation<T>
+  implements BindInWhenOnFluentSyntax<T>
+{
+  readonly #bindInFluentSyntax: BindInFluentSyntax<T>;
+
+  constructor(binding: Writable<ScopedBinding<BindingType, BindingScope, T>>) {
+    super(binding);
+
+    this.#bindInFluentSyntax = new BindInFluentSyntaxImplementation(binding);
+  }
+
+  public inRequestScope(): BindWhenOnFluentSyntax<T> {
+    return this.#bindInFluentSyntax.inRequestScope();
+  }
+
+  public inSingletonScope(): BindWhenOnFluentSyntax<T> {
+    return this.#bindInFluentSyntax.inSingletonScope();
+  }
+
+  public inTransientScope(): BindWhenOnFluentSyntax<T> {
+    return this.#bindInFluentSyntax.inTransientScope();
+  }
+}

--- a/packages/container/libraries/container/src/container/binding/utils/BindingConstraintUtils.spec.ts
+++ b/packages/container/libraries/container/src/container/binding/utils/BindingConstraintUtils.spec.ts
@@ -1,0 +1,23 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { BindingMetadata } from '@inversifyjs/core';
+
+import { BindingConstraintUtils } from './BindingConstraintUtils';
+
+describe(BindingConstraintUtils.name, () => {
+  describe('.allways', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = BindingConstraintUtils.always(
+          Symbol() as unknown as BindingMetadata,
+        );
+      });
+
+      it('should return true', () => {
+        expect(result).toBe(true);
+      });
+    });
+  });
+});

--- a/packages/container/libraries/container/src/container/binding/utils/BindingConstraintUtils.ts
+++ b/packages/container/libraries/container/src/container/binding/utils/BindingConstraintUtils.ts
@@ -1,0 +1,8 @@
+import { BindingMetadata } from '@inversifyjs/core';
+
+export class BindingConstraintUtils {
+  public static readonly always: (bindingMetadata: BindingMetadata) => boolean =
+    (_bindingMetadata: BindingMetadata): boolean => {
+      return true;
+    };
+}


### PR DESCRIPTION
### Added
- Added `BindInFluentSyntaxImplementation`.
- Added `BindingConstraintUtils`.
- Added `BindingFluentSyntax`.
- Added `Writable` model.
- Added `getBindingId`.