### PR TITLE
Update updateReflectMetadata to receive a default value builder

### DIFF
--- a/.changeset/rude-pans-remain.md
+++ b/.changeset/rude-pans-remain.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/reflect-metadata-utils": major
+---
+
+Updated `updateReflectMetadata` to receive a default value builder.

--- a/.changeset/shiny-carrots-reflect.md
+++ b/.changeset/shiny-carrots-reflect.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/reflect-metadata-utils": minor
+---
+
+Added `setReflectMetadata`.

--- a/packages/container/libraries/container/src/binding/actions/getBindingId.spec.ts
+++ b/packages/container/libraries/container/src/binding/actions/getBindingId.spec.ts
@@ -4,6 +4,7 @@ jest.mock('@inversifyjs/reflect-metadata-utils');
 
 import {
   getReflectMetadata,
+  setReflectMetadata,
   updateReflectMetadata,
 } from '@inversifyjs/reflect-metadata-utils';
 
@@ -38,7 +39,7 @@ describe(getBindingId.name, () => {
       expect(updateReflectMetadata).toHaveBeenCalledWith(
         Object,
         '@inversifyjs/container/bindingId',
-        0,
+        expect.any(Function),
         expect.any(Function),
       );
     });
@@ -71,17 +72,16 @@ describe(getBindingId.name, () => {
       );
     });
 
-    it('should call updateReflectMetadata()', () => {
-      expect(updateReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(updateReflectMetadata).toHaveBeenCalledWith(
+    it('should call setReflectMetadata()', () => {
+      expect(setReflectMetadata).toHaveBeenCalledTimes(1);
+      expect(setReflectMetadata).toHaveBeenCalledWith(
         Object,
         '@inversifyjs/container/bindingId',
-        Number.MAX_SAFE_INTEGER,
-        expect.any(Function),
+        Number.MIN_SAFE_INTEGER,
       );
     });
 
-    it('should return default id', () => {
+    it('should return expected result', () => {
       expect(result).toBe(Number.MAX_SAFE_INTEGER);
     });
   });

--- a/packages/container/libraries/container/src/binding/actions/getBindingId.ts
+++ b/packages/container/libraries/container/src/binding/actions/getBindingId.ts
@@ -1,5 +1,6 @@
 import {
   getReflectMetadata,
+  setReflectMetadata,
   updateReflectMetadata,
 } from '@inversifyjs/reflect-metadata-utils';
 
@@ -10,17 +11,12 @@ export function getBindingId(): number {
     getReflectMetadata<number>(Object, ID_METADATA) ?? 0;
 
   if (bindingId === Number.MAX_SAFE_INTEGER) {
-    updateReflectMetadata(
-      Object,
-      ID_METADATA,
-      bindingId,
-      () => Number.MIN_SAFE_INTEGER,
-    );
+    setReflectMetadata(Object, ID_METADATA, Number.MIN_SAFE_INTEGER);
   } else {
     updateReflectMetadata(
       Object,
       ID_METADATA,
-      bindingId,
+      () => bindingId,
       (id: number) => id + 1,
     );
   }

--- a/packages/container/libraries/core/src/index.ts
+++ b/packages/container/libraries/core/src/index.ts
@@ -56,6 +56,8 @@ import { PlanServiceNodeParent } from './planning/models/PlanServiceNodeParent';
 import { PlanServiceRedirectionBindingNode } from './planning/models/PlanServiceRedirectionBindingNode';
 import { PlanTree } from './planning/models/PlanTree';
 import { resolve } from './resolution/actions/resolve';
+import { GetOptions } from './resolution/models/GetOptions';
+import { GetOptionsTagConstraint } from './resolution/models/GetOptionsTagConstraint';
 import { ResolutionContext } from './resolution/models/ResolutionContext';
 import { ResolutionParams } from './resolution/models/ResolutionParams';
 import { Resolved } from './resolution/models/Resolved';
@@ -80,6 +82,8 @@ export type {
   DynamicValueBuilder,
   Factory,
   FactoryBinding,
+  GetOptions,
+  GetOptionsTagConstraint,
   InstanceBinding,
   LeafBindingNode,
   LegacyMetadata,

--- a/packages/container/libraries/core/src/legacyTarget/calculations/getTargetId.spec.ts
+++ b/packages/container/libraries/core/src/legacyTarget/calculations/getTargetId.spec.ts
@@ -4,6 +4,7 @@ jest.mock('@inversifyjs/reflect-metadata-utils');
 
 import {
   getReflectMetadata,
+  setReflectMetadata,
   updateReflectMetadata,
 } from '@inversifyjs/reflect-metadata-utils';
 
@@ -38,7 +39,7 @@ describe(getTargetId.name, () => {
       expect(updateReflectMetadata).toHaveBeenCalledWith(
         Object,
         '@inversifyjs/core/targetId',
-        0,
+        expect.any(Function),
         expect.any(Function),
       );
     });
@@ -71,13 +72,12 @@ describe(getTargetId.name, () => {
       );
     });
 
-    it('should call updateReflectMetadata()', () => {
-      expect(updateReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(updateReflectMetadata).toHaveBeenCalledWith(
+    it('should call setReflectMetadata()', () => {
+      expect(setReflectMetadata).toHaveBeenCalledTimes(1);
+      expect(setReflectMetadata).toHaveBeenCalledWith(
         Object,
         '@inversifyjs/core/targetId',
-        Number.MAX_SAFE_INTEGER,
-        expect.any(Function),
+        Number.MIN_SAFE_INTEGER,
       );
     });
 

--- a/packages/container/libraries/core/src/legacyTarget/calculations/getTargetId.ts
+++ b/packages/container/libraries/core/src/legacyTarget/calculations/getTargetId.ts
@@ -1,5 +1,6 @@
 import {
   getReflectMetadata,
+  setReflectMetadata,
   updateReflectMetadata,
 } from '@inversifyjs/reflect-metadata-utils';
 
@@ -9,17 +10,12 @@ export function getTargetId(): number {
   const targetId: number = getReflectMetadata<number>(Object, ID_METADATA) ?? 0;
 
   if (targetId === Number.MAX_SAFE_INTEGER) {
-    updateReflectMetadata(
-      Object,
-      ID_METADATA,
-      targetId,
-      () => Number.MIN_SAFE_INTEGER,
-    );
+    setReflectMetadata(Object, ID_METADATA, Number.MIN_SAFE_INTEGER);
   } else {
     updateReflectMetadata(
       Object,
       ID_METADATA,
-      targetId,
+      () => targetId,
       (id: number) => id + 1,
     );
   }

--- a/packages/container/libraries/core/src/metadata/decorators/injectBase.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/injectBase.spec.ts
@@ -12,8 +12,6 @@ jest.mock('../actions/updateMaybeClassMetadataProperty', () => ({
   updateMaybeClassMetadataProperty: jest.fn(),
 }));
 
-jest.mock('../calculations/getDefaultClassMetadata');
-
 import { Newable } from '@inversifyjs/common';
 import { updateReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
 
@@ -21,7 +19,6 @@ import { classMetadataReflectKey } from '../../reflectMetadata/data/classMetadat
 import { updateMaybeClassMetadataConstructorArgument } from '../actions/updateMaybeClassMetadataConstructorArgument';
 import { updateMaybeClassMetadataProperty } from '../actions/updateMaybeClassMetadataProperty';
 import { getDefaultClassMetadata } from '../calculations/getDefaultClassMetadata';
-import { ClassMetadata } from '../models/ClassMetadata';
 import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
 import { MaybeClassMetadata } from '../models/MaybeClassMetadata';
 import { injectBase } from './injectBase';
@@ -43,22 +40,13 @@ describe(injectBase.name, () => {
   });
 
   describe('when called, as property decorator', () => {
-    let defaultClassMetadataFixture: ClassMetadata;
     let targetFixture: Newable;
     let updateMaybeClassMetadataPropertyResult: jest.Mock<
       (classMetadata: MaybeClassMetadata) => MaybeClassMetadata
     >;
 
     beforeAll(() => {
-      defaultClassMetadataFixture = {
-        [Symbol()]: Symbol(),
-      } as unknown as ClassMetadata;
-
       updateMaybeClassMetadataPropertyResult = jest.fn();
-
-      (
-        getDefaultClassMetadata as jest.Mock<typeof getDefaultClassMetadata>
-      ).mockReturnValueOnce(defaultClassMetadataFixture);
 
       (
         updateMaybeClassMetadataProperty as jest.Mock<
@@ -83,29 +71,20 @@ describe(injectBase.name, () => {
       expect(updateReflectMetadata).toHaveBeenCalledWith(
         targetFixture,
         classMetadataReflectKey,
-        defaultClassMetadataFixture,
+        getDefaultClassMetadata,
         updateMaybeClassMetadataPropertyResult,
       );
     });
   });
 
   describe('when called, as constructor parameter decorator', () => {
-    let defaultClassMetadataFixture: ClassMetadata;
     let targetFixture: Newable;
     let updateMaybeClassMetadataConstructorArgumentsResult: jest.Mock<
       (classMetadata: MaybeClassMetadata) => MaybeClassMetadata
     >;
 
     beforeAll(() => {
-      defaultClassMetadataFixture = {
-        [Symbol()]: Symbol(),
-      } as unknown as ClassMetadata;
-
       updateMaybeClassMetadataConstructorArgumentsResult = jest.fn();
-
-      (
-        getDefaultClassMetadata as jest.Mock<typeof getDefaultClassMetadata>
-      ).mockReturnValueOnce(defaultClassMetadataFixture);
 
       (
         updateMaybeClassMetadataConstructorArgument as jest.Mock<
@@ -132,7 +111,7 @@ describe(injectBase.name, () => {
       expect(updateReflectMetadata).toHaveBeenCalledWith(
         targetFixture,
         classMetadataReflectKey,
-        expect.anything(),
+        getDefaultClassMetadata,
         updateMaybeClassMetadataConstructorArgumentsResult,
       );
     });

--- a/packages/container/libraries/core/src/metadata/decorators/injectBase.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/injectBase.ts
@@ -40,7 +40,7 @@ function injectParameter(
       updateReflectMetadata(
         target,
         classMetadataReflectKey,
-        getDefaultClassMetadata(),
+        getDefaultClassMetadata,
         updateMaybeClassMetadataConstructorArgument(
           updateMetadata,
           parameterIndex,
@@ -66,7 +66,7 @@ function injectProperty(
     updateReflectMetadata(
       target.constructor,
       classMetadataReflectKey,
-      getDefaultClassMetadata(),
+      getDefaultClassMetadata,
       updateMaybeClassMetadataProperty(updateMetadata, propertyKey),
     );
   };

--- a/packages/container/libraries/core/src/metadata/decorators/postConstruct.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/postConstruct.spec.ts
@@ -5,14 +5,12 @@ jest.mock('@inversifyjs/reflect-metadata-utils');
 import { updateReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
 
 jest.mock('../actions/updateMaybeClassMetadataPostConstructor');
-jest.mock('../calculations/getDefaultClassMetadata');
 jest.mock('../calculations/handleInjectionError');
 
 import { classMetadataReflectKey } from '../../reflectMetadata/data/classMetadataReflectKey';
 import { updateMaybeClassMetadataPostConstructor } from '../actions/updateMaybeClassMetadataPostConstructor';
 import { getDefaultClassMetadata } from '../calculations/getDefaultClassMetadata';
 import { handleInjectionError } from '../calculations/handleInjectionError';
-import { ClassMetadata } from '../models/ClassMetadata';
 import { MaybeClassMetadata } from '../models/MaybeClassMetadata';
 import { postConstruct } from './postConstruct';
 
@@ -28,8 +26,6 @@ describe(postConstruct.name, () => {
   });
 
   describe('when caled', () => {
-    let classMetadataFixture: ClassMetadata;
-
     let updateMaybeClassMetadataPostConstructorResult: jest.Mock<
       (metadata: MaybeClassMetadata) => MaybeClassMetadata
     >;
@@ -37,20 +33,7 @@ describe(postConstruct.name, () => {
     let result: unknown;
 
     beforeAll(() => {
-      classMetadataFixture = {
-        constructorArguments: [],
-        lifecycle: {
-          postConstructMethodName: undefined,
-          preDestroyMethodName: undefined,
-        },
-        properties: new Map(),
-      };
-
       updateMaybeClassMetadataPostConstructorResult = jest.fn();
-
-      (
-        getDefaultClassMetadata as jest.Mock<typeof getDefaultClassMetadata>
-      ).mockReturnValueOnce(classMetadataFixture);
 
       (
         updateMaybeClassMetadataPostConstructor as jest.Mock<
@@ -69,11 +52,6 @@ describe(postConstruct.name, () => {
       jest.clearAllMocks();
     });
 
-    it('should call getDefaultClassMetadata()', () => {
-      expect(getDefaultClassMetadata).toHaveBeenCalledTimes(1);
-      expect(getDefaultClassMetadata).toHaveBeenCalledWith();
-    });
-
     it('should call updateMaybeClassMetadataPostConstructor()', () => {
       expect(updateMaybeClassMetadataPostConstructor).toHaveBeenCalledTimes(1);
       expect(updateMaybeClassMetadataPostConstructor).toHaveBeenCalledWith(
@@ -86,7 +64,7 @@ describe(postConstruct.name, () => {
       expect(updateReflectMetadata).toHaveBeenCalledWith(
         targetFixture.constructor,
         classMetadataReflectKey,
-        classMetadataFixture,
+        getDefaultClassMetadata,
         updateMaybeClassMetadataPostConstructorResult,
       );
     });
@@ -97,7 +75,6 @@ describe(postConstruct.name, () => {
   });
 
   describe('when caled, and updateReflectMetadata throws an Error', () => {
-    let classMetadataFixture: ClassMetadata;
     let errorFixture: Error;
 
     let updateMaybeClassMetadataPostConstructorResult: jest.Mock<
@@ -107,22 +84,9 @@ describe(postConstruct.name, () => {
     let result: unknown;
 
     beforeAll(() => {
-      classMetadataFixture = {
-        constructorArguments: [],
-        lifecycle: {
-          postConstructMethodName: undefined,
-          preDestroyMethodName: undefined,
-        },
-        properties: new Map(),
-      };
-
       errorFixture = new Error('error-fixture');
 
       updateMaybeClassMetadataPostConstructorResult = jest.fn();
-
-      (
-        getDefaultClassMetadata as jest.Mock<typeof getDefaultClassMetadata>
-      ).mockReturnValueOnce(classMetadataFixture);
 
       (
         updateMaybeClassMetadataPostConstructor as jest.Mock<
@@ -147,11 +111,6 @@ describe(postConstruct.name, () => {
       jest.clearAllMocks();
     });
 
-    it('should call getDefaultClassMetadata()', () => {
-      expect(getDefaultClassMetadata).toHaveBeenCalledTimes(1);
-      expect(getDefaultClassMetadata).toHaveBeenCalledWith();
-    });
-
     it('should call updateMaybeClassMetadataPostConstructor()', () => {
       expect(updateMaybeClassMetadataPostConstructor).toHaveBeenCalledTimes(1);
       expect(updateMaybeClassMetadataPostConstructor).toHaveBeenCalledWith(
@@ -164,7 +123,7 @@ describe(postConstruct.name, () => {
       expect(updateReflectMetadata).toHaveBeenCalledWith(
         targetFixture.constructor,
         classMetadataReflectKey,
-        classMetadataFixture,
+        getDefaultClassMetadata,
         updateMaybeClassMetadataPostConstructorResult,
       );
     });

--- a/packages/container/libraries/core/src/metadata/decorators/postConstruct.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/postConstruct.ts
@@ -15,7 +15,7 @@ export function postConstruct(): MethodDecorator {
       updateReflectMetadata(
         target.constructor,
         classMetadataReflectKey,
-        getDefaultClassMetadata(),
+        getDefaultClassMetadata,
         updateMaybeClassMetadataPostConstructor(propertyKey),
       );
     } catch (error: unknown) {

--- a/packages/container/libraries/core/src/metadata/decorators/preDestroy.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/preDestroy.spec.ts
@@ -5,14 +5,12 @@ jest.mock('@inversifyjs/reflect-metadata-utils');
 import { updateReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
 
 jest.mock('../actions/updateMaybeClassMetadataPreDestroy');
-jest.mock('../calculations/getDefaultClassMetadata');
 jest.mock('../calculations/handleInjectionError');
 
 import { classMetadataReflectKey } from '../../reflectMetadata/data/classMetadataReflectKey';
 import { updateMaybeClassMetadataPreDestroy } from '../actions/updateMaybeClassMetadataPreDestroy';
 import { getDefaultClassMetadata } from '../calculations/getDefaultClassMetadata';
 import { handleInjectionError } from '../calculations/handleInjectionError';
-import { ClassMetadata } from '../models/ClassMetadata';
 import { MaybeClassMetadata } from '../models/MaybeClassMetadata';
 import { preDestroy } from './preDestroy';
 
@@ -28,8 +26,6 @@ describe(preDestroy.name, () => {
   });
 
   describe('when caled', () => {
-    let classMetadataFixture: ClassMetadata;
-
     let updateMaybeClassMetadataPostConstructorResult: jest.Mock<
       (metadata: MaybeClassMetadata) => MaybeClassMetadata
     >;
@@ -37,20 +33,7 @@ describe(preDestroy.name, () => {
     let result: unknown;
 
     beforeAll(() => {
-      classMetadataFixture = {
-        constructorArguments: [],
-        lifecycle: {
-          postConstructMethodName: undefined,
-          preDestroyMethodName: undefined,
-        },
-        properties: new Map(),
-      };
-
       updateMaybeClassMetadataPostConstructorResult = jest.fn();
-
-      (
-        getDefaultClassMetadata as jest.Mock<typeof getDefaultClassMetadata>
-      ).mockReturnValueOnce(classMetadataFixture);
 
       (
         updateMaybeClassMetadataPreDestroy as jest.Mock<
@@ -69,11 +52,6 @@ describe(preDestroy.name, () => {
       jest.clearAllMocks();
     });
 
-    it('should call getDefaultClassMetadata()', () => {
-      expect(getDefaultClassMetadata).toHaveBeenCalledTimes(1);
-      expect(getDefaultClassMetadata).toHaveBeenCalledWith();
-    });
-
     it('should call updateMaybeClassMetadataPreDestroy()', () => {
       expect(updateMaybeClassMetadataPreDestroy).toHaveBeenCalledTimes(1);
       expect(updateMaybeClassMetadataPreDestroy).toHaveBeenCalledWith(
@@ -86,7 +64,7 @@ describe(preDestroy.name, () => {
       expect(updateReflectMetadata).toHaveBeenCalledWith(
         targetFixture.constructor,
         classMetadataReflectKey,
-        classMetadataFixture,
+        getDefaultClassMetadata,
         updateMaybeClassMetadataPostConstructorResult,
       );
     });
@@ -97,7 +75,6 @@ describe(preDestroy.name, () => {
   });
 
   describe('when caled, and updateReflectMetadata throws an Error', () => {
-    let classMetadataFixture: ClassMetadata;
     let errorFixture: Error;
 
     let updateMaybeClassMetadataPostConstructorResult: jest.Mock<
@@ -107,22 +84,9 @@ describe(preDestroy.name, () => {
     let result: unknown;
 
     beforeAll(() => {
-      classMetadataFixture = {
-        constructorArguments: [],
-        lifecycle: {
-          postConstructMethodName: undefined,
-          preDestroyMethodName: undefined,
-        },
-        properties: new Map(),
-      };
-
       errorFixture = new Error('error-fixture');
 
       updateMaybeClassMetadataPostConstructorResult = jest.fn();
-
-      (
-        getDefaultClassMetadata as jest.Mock<typeof getDefaultClassMetadata>
-      ).mockReturnValueOnce(classMetadataFixture);
 
       (
         updateMaybeClassMetadataPreDestroy as jest.Mock<
@@ -147,11 +111,6 @@ describe(preDestroy.name, () => {
       jest.clearAllMocks();
     });
 
-    it('should call getDefaultClassMetadata()', () => {
-      expect(getDefaultClassMetadata).toHaveBeenCalledTimes(1);
-      expect(getDefaultClassMetadata).toHaveBeenCalledWith();
-    });
-
     it('should call updateMaybeClassMetadataPreDestroy()', () => {
       expect(updateMaybeClassMetadataPreDestroy).toHaveBeenCalledTimes(1);
       expect(updateMaybeClassMetadataPreDestroy).toHaveBeenCalledWith(
@@ -164,7 +123,7 @@ describe(preDestroy.name, () => {
       expect(updateReflectMetadata).toHaveBeenCalledWith(
         targetFixture.constructor,
         classMetadataReflectKey,
-        classMetadataFixture,
+        getDefaultClassMetadata,
         updateMaybeClassMetadataPostConstructorResult,
       );
     });

--- a/packages/container/libraries/core/src/metadata/decorators/preDestroy.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/preDestroy.ts
@@ -15,7 +15,7 @@ export function preDestroy(): MethodDecorator {
       updateReflectMetadata(
         target.constructor,
         classMetadataReflectKey,
-        getDefaultClassMetadata(),
+        getDefaultClassMetadata,
         updateMaybeClassMetadataPreDestroy(propertyKey),
       );
     } catch (error: unknown) {

--- a/packages/foundation/libraries/reflect-metadata-utils/src/index.ts
+++ b/packages/foundation/libraries/reflect-metadata-utils/src/index.ts
@@ -1,4 +1,5 @@
 import { getReflectMetadata } from './reflectMetadata/utils/getReflectMetadata';
+import { setReflectMetadata } from './reflectMetadata/utils/setReflectMetadata';
 import { updateReflectMetadata } from './reflectMetadata/utils/updateReflectMetadata';
 
-export { getReflectMetadata, updateReflectMetadata };
+export { getReflectMetadata, setReflectMetadata, updateReflectMetadata };

--- a/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/setReflectMetadata.spec.ts
+++ b/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/setReflectMetadata.spec.ts
@@ -1,0 +1,45 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import 'reflect-metadata';
+
+import { setReflectMetadata } from './setReflectMetadata';
+
+describe(setReflectMetadata.name, () => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  let targetFixture: Function;
+  let metadataKeyFixture: unknown;
+  let metadataFixture: unknown;
+
+  beforeAll(() => {
+    targetFixture = class {};
+    metadataKeyFixture = 'sample-key';
+    metadataFixture = 'metadata';
+  });
+
+  describe('when called', () => {
+    let reflectMetadata: unknown;
+    let result: unknown;
+
+    beforeAll(() => {
+      metadataFixture = 'metadata';
+      result = setReflectMetadata(
+        targetFixture,
+        metadataKeyFixture,
+        metadataFixture,
+      );
+
+      reflectMetadata = Reflect.getOwnMetadata(
+        metadataKeyFixture,
+        targetFixture,
+      );
+    });
+
+    it('should set metadata', () => {
+      expect(reflectMetadata).toBe(metadataFixture);
+    });
+
+    it('should return undefined', () => {
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/setReflectMetadata.ts
+++ b/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/setReflectMetadata.ts
@@ -1,0 +1,7 @@
+export function setReflectMetadata(
+  target: object,
+  metadataKey: unknown,
+  metadata: unknown,
+): void {
+  Reflect.defineMetadata(metadataKey, metadata, target);
+}

--- a/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/updateReflectMetadata.spec.ts
+++ b/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/updateReflectMetadata.spec.ts
@@ -12,14 +12,16 @@ describe(updateReflectMetadata.name, () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
     let targetFixture: Function;
     let metadataKeyFixture: unknown;
+    let buildDefaultValueMock: jest.Mock<() => unknown>;
     let defaultValueFixture: unknown;
     let callbackMock: jest.Mock<(value: unknown) => unknown>;
     let reflectMetadata: unknown;
 
     beforeAll(() => {
       targetFixture = class {};
-      metadataKeyFixture = 'sample-key';
       defaultValueFixture = 'default-value';
+      metadataKeyFixture = 'sample-key';
+      buildDefaultValueMock = jest.fn(() => defaultValueFixture);
       callbackMock = jest
         .fn<(value: unknown) => unknown>()
         .mockImplementationOnce((value: unknown) => value);
@@ -31,7 +33,7 @@ describe(updateReflectMetadata.name, () => {
       updateReflectMetadata(
         targetFixture,
         metadataKeyFixture,
-        defaultValueFixture,
+        buildDefaultValueMock,
         callbackMock,
       );
 
@@ -51,6 +53,11 @@ describe(updateReflectMetadata.name, () => {
         targetFixture,
         metadataKeyFixture,
       );
+    });
+
+    it('should call buildDefaultValue', () => {
+      expect(buildDefaultValueMock).toHaveBeenCalledTimes(1);
+      expect(buildDefaultValueMock).toHaveBeenCalledWith();
     });
 
     it('should call callback()', () => {
@@ -68,7 +75,7 @@ describe(updateReflectMetadata.name, () => {
     let targetFixture: Function;
     let metadataFixture: unknown;
     let metadataKeyFixture: unknown;
-    let defaultValueFixture: unknown;
+    let buildDefaultValueMock: jest.Mock<() => unknown>;
     let callbackMock: jest.Mock<(value: unknown) => unknown>;
     let reflectMetadata: unknown;
 
@@ -76,7 +83,7 @@ describe(updateReflectMetadata.name, () => {
       targetFixture = class {};
       metadataFixture = 'metadata';
       metadataKeyFixture = 'sample-key';
-      defaultValueFixture = 'default-value';
+      buildDefaultValueMock = jest.fn();
       callbackMock = jest
         .fn<(value: unknown) => unknown>()
         .mockImplementationOnce((value: unknown) => value);
@@ -88,7 +95,7 @@ describe(updateReflectMetadata.name, () => {
       updateReflectMetadata(
         targetFixture,
         metadataKeyFixture,
-        defaultValueFixture,
+        buildDefaultValueMock,
         callbackMock,
       );
 
@@ -108,6 +115,10 @@ describe(updateReflectMetadata.name, () => {
         targetFixture,
         metadataKeyFixture,
       );
+    });
+
+    it('should not call buildDefaultValue()', () => {
+      expect(buildDefaultValueMock).not.toHaveBeenCalled();
     });
 
     it('should call callback()', () => {

--- a/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/updateReflectMetadata.ts
+++ b/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/updateReflectMetadata.ts
@@ -3,11 +3,11 @@ import { getReflectMetadata } from './getReflectMetadata';
 export function updateReflectMetadata<TMetadata>(
   target: object,
   metadataKey: unknown,
-  defaultValue: TMetadata,
+  buildDefaultValue: () => TMetadata,
   callback: (metadata: TMetadata) => TMetadata,
 ): void {
   const metadata: TMetadata =
-    getReflectMetadata(target, metadataKey) ?? defaultValue;
+    getReflectMetadata(target, metadataKey) ?? buildDefaultValue();
 
   const updatedMetadata: TMetadata = callback(metadata);
 


### PR DESCRIPTION
### Added
- Added `setReflectMetadata`.

### Changed
- Updated `updateReflectMetadata` to receive a default value builder.
- Updated core modules to rely on latest `updateReflectMetadata` and  `setReflectMetadata`.
