### PR TITLE
Add pending class metadata actions

### DIFF
--- a/packages/container/libraries/core/src/metadata/actions/decrementPendingClassMetadataCount.spec.ts
+++ b/packages/container/libraries/core/src/metadata/actions/decrementPendingClassMetadataCount.spec.ts
@@ -1,0 +1,121 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('@inversifyjs/reflect-metadata-utils');
+
+import { updateReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+
+import { pendingClassMetadataCountReflectKey } from '../../reflectMetadata/data/pendingClassMetadataCountReflectKey';
+import { getDefaultPendingClassMetadataCount } from '../calculations/getDefaultPendingClassMetadataCount';
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
+import { MaybeClassElementMetadataKind } from '../models/MaybeClassElementMetadataKind';
+import { decrementPendingClassMetadataCount } from './decrementPendingClassMetadataCount';
+
+describe(decrementPendingClassMetadataCount.name, () => {
+  let typeFixture: object;
+
+  beforeAll(() => {
+    typeFixture = class {};
+  });
+
+  describe('with unknown metadata', () => {
+    let metadataFixture: MaybeClassElementMetadata;
+
+    beforeAll(() => {
+      metadataFixture = {
+        kind: MaybeClassElementMetadataKind.unknown,
+        name: undefined,
+        optional: false,
+        tags: new Map(),
+        targetName: undefined,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result =
+          decrementPendingClassMetadataCount(typeFixture)(metadataFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call updateReflectMetadata', () => {
+        expect(updateReflectMetadata).toHaveBeenCalledTimes(1);
+        expect(updateReflectMetadata).toHaveBeenCalledWith(
+          typeFixture,
+          pendingClassMetadataCountReflectKey,
+          getDefaultPendingClassMetadataCount,
+          expect.any(Function),
+        );
+      });
+
+      it('should return expected value', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('with undefined metadata', () => {
+    let metadataFixture: undefined;
+
+    beforeAll(() => {
+      metadataFixture = undefined;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result =
+          decrementPendingClassMetadataCount(typeFixture)(metadataFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should not call updateReflectMetadata', () => {
+        expect(updateReflectMetadata).not.toHaveBeenCalled();
+      });
+
+      it('should return expected value', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('with non uknown metadata', () => {
+    let metadataFixture: MaybeClassElementMetadata;
+
+    beforeAll(() => {
+      metadataFixture = {
+        kind: ClassElementMetadataKind.unmanaged,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result =
+          decrementPendingClassMetadataCount(typeFixture)(metadataFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should not call updateReflectMetadata', () => {
+        expect(updateReflectMetadata).not.toHaveBeenCalled();
+      });
+
+      it('should return expected value', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/actions/decrementPendingClassMetadataCount.ts
+++ b/packages/container/libraries/core/src/metadata/actions/decrementPendingClassMetadataCount.ts
@@ -1,0 +1,24 @@
+import { updateReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+
+import { pendingClassMetadataCountReflectKey } from '../../reflectMetadata/data/pendingClassMetadataCountReflectKey';
+import { getDefaultPendingClassMetadataCount } from '../calculations/getDefaultPendingClassMetadataCount';
+import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
+import { MaybeClassElementMetadataKind } from '../models/MaybeClassElementMetadataKind';
+
+export function decrementPendingClassMetadataCount(
+  type: object,
+): (metadata: MaybeClassElementMetadata | undefined) => void {
+  return (metadata: MaybeClassElementMetadata | undefined): void => {
+    if (
+      metadata !== undefined &&
+      metadata.kind === MaybeClassElementMetadataKind.unknown
+    ) {
+      updateReflectMetadata(
+        type,
+        pendingClassMetadataCountReflectKey,
+        getDefaultPendingClassMetadataCount,
+        (count: number) => count - 1,
+      );
+    }
+  };
+}

--- a/packages/container/libraries/core/src/metadata/actions/incrementPendingClassMetadataCount.spec.ts
+++ b/packages/container/libraries/core/src/metadata/actions/incrementPendingClassMetadataCount.spec.ts
@@ -1,0 +1,85 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('@inversifyjs/reflect-metadata-utils');
+
+import { updateReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+
+import { pendingClassMetadataCountReflectKey } from '../../reflectMetadata/data/pendingClassMetadataCountReflectKey';
+import { getDefaultPendingClassMetadataCount } from '../calculations/getDefaultPendingClassMetadataCount';
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
+import { incrementPendingClassMetadataCount } from './incrementPendingClassMetadataCount';
+
+describe(incrementPendingClassMetadataCount.name, () => {
+  let typeFixture: object;
+
+  beforeAll(() => {
+    typeFixture = class {};
+  });
+
+  describe('with non undefined metadata', () => {
+    let metadataFixture: MaybeClassElementMetadata;
+
+    beforeAll(() => {
+      metadataFixture = {
+        kind: ClassElementMetadataKind.unmanaged,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result =
+          incrementPendingClassMetadataCount(typeFixture)(metadataFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should not call updateReflectMetadata', () => {
+        expect(updateReflectMetadata).not.toHaveBeenCalled();
+      });
+
+      it('should return expected value', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('with undefined metadata', () => {
+    let metadataFixture: undefined;
+
+    beforeAll(() => {
+      metadataFixture = undefined;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result =
+          incrementPendingClassMetadataCount(typeFixture)(metadataFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call updateReflectMetadata', () => {
+        expect(updateReflectMetadata).toHaveBeenCalledTimes(1);
+        expect(updateReflectMetadata).toHaveBeenCalledWith(
+          typeFixture,
+          pendingClassMetadataCountReflectKey,
+          getDefaultPendingClassMetadataCount,
+          expect.any(Function),
+        );
+      });
+
+      it('should return expected value', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/actions/incrementPendingClassMetadataCount.ts
+++ b/packages/container/libraries/core/src/metadata/actions/incrementPendingClassMetadataCount.ts
@@ -1,0 +1,20 @@
+import { updateReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+
+import { pendingClassMetadataCountReflectKey } from '../../reflectMetadata/data/pendingClassMetadataCountReflectKey';
+import { getDefaultPendingClassMetadataCount } from '../calculations/getDefaultPendingClassMetadataCount';
+import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
+
+export function incrementPendingClassMetadataCount(
+  type: object,
+): (metadata: MaybeClassElementMetadata | undefined) => void {
+  return (metadata: MaybeClassElementMetadata | undefined): void => {
+    if (metadata === undefined) {
+      updateReflectMetadata(
+        type,
+        pendingClassMetadataCountReflectKey,
+        getDefaultPendingClassMetadataCount,
+        (count: number) => count + 1,
+      );
+    }
+  };
+}

--- a/packages/container/libraries/core/src/metadata/calculations/getDefaultPendingClassMetadataCount.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/getDefaultPendingClassMetadataCount.spec.ts
@@ -1,0 +1,17 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { getDefaultPendingClassMetadataCount } from './getDefaultPendingClassMetadataCount';
+
+describe(getDefaultPendingClassMetadataCount.name, () => {
+  describe('when called', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      result = getDefaultPendingClassMetadataCount();
+    });
+
+    it('should return expected value', () => {
+      expect(result).toBe(0);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/calculations/getDefaultPendingClassMetadataCount.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/getDefaultPendingClassMetadataCount.ts
@@ -1,0 +1,3 @@
+export function getDefaultPendingClassMetadataCount(): number {
+  return 0;
+}

--- a/packages/container/libraries/core/src/metadata/calculations/isPendingClassMetadata.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/isPendingClassMetadata.spec.ts
@@ -1,0 +1,58 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import 'reflect-metadata';
+
+import { pendingClassMetadataCountReflectKey } from '../../reflectMetadata/data/pendingClassMetadataCountReflectKey';
+import { isPendingClassMetadata } from './isPendingClassMetadata';
+
+describe(isPendingClassMetadata.name, () => {
+  describe('having no metadata', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = isPendingClassMetadata(class {});
+      });
+
+      it('should return false', () => {
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('having non zero number as metadata', () => {
+    describe('when called', () => {
+      class Foo {}
+
+      let result: unknown;
+
+      beforeAll(() => {
+        Reflect.defineMetadata(pendingClassMetadataCountReflectKey, 1, Foo);
+
+        result = isPendingClassMetadata(Foo);
+      });
+
+      it('should return true', () => {
+        expect(result).toBe(true);
+      });
+    });
+  });
+
+  describe('having zero number as metadata', () => {
+    describe('when called', () => {
+      class Foo {}
+
+      let result: unknown;
+
+      beforeAll(() => {
+        Reflect.defineMetadata(pendingClassMetadataCountReflectKey, 0, Foo);
+
+        result = isPendingClassMetadata(Foo);
+      });
+
+      it('should return false', () => {
+        expect(result).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/calculations/isPendingClassMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/isPendingClassMetadata.ts
@@ -1,0 +1,15 @@
+import { Newable } from '@inversifyjs/common';
+import { getReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+
+import { pendingClassMetadataCountReflectKey } from '../../reflectMetadata/data/pendingClassMetadataCountReflectKey';
+
+export function isPendingClassMetadata(type: Newable): boolean {
+  const pendingClassMetadataCount: number | undefined = getReflectMetadata(
+    type,
+    pendingClassMetadataCountReflectKey,
+  );
+
+  return (
+    pendingClassMetadataCount !== undefined && pendingClassMetadataCount !== 0
+  );
+}

--- a/packages/container/libraries/core/src/reflectMetadata/data/pendingClassMetadataCountReflectKey.ts
+++ b/packages/container/libraries/core/src/reflectMetadata/data/pendingClassMetadataCountReflectKey.ts
@@ -1,0 +1,2 @@
+export const pendingClassMetadataCountReflectKey: string =
+  '@inversifyjs/core/pendingClassMetadataCountReflectKey';


### PR DESCRIPTION
### Added
- Added `isPendingClassMetadata`.
- Added `decrementPendingClassMetadataCount`.
- Added `incrementPendingClassMetadataCount`.
- Added `getDefaultPendingClassMetadataCount`.
- Added `pendingClassMetadataCountReflectKey`.