### PR TITLE
Update decorators to handle pending class metadata count

### DIFF
--- a/packages/container/libraries/core/src/metadata/decorators/inject.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/inject.spec.ts
@@ -6,6 +6,7 @@ jest.mock('../calculations/buildManagedMetadataFromMaybeClassElementMetadata');
 jest.mock('../calculations/handleInjectionError');
 jest.mock('./injectBase');
 
+import { decrementPendingClassMetadataCount } from '../actions/decrementPendingClassMetadataCount';
 import { buildManagedMetadataFromMaybeClassElementMetadata } from '../calculations/buildManagedMetadataFromMaybeClassElementMetadata';
 import { handleInjectionError } from '../calculations/handleInjectionError';
 import { ClassElementMetadata } from '../models/ClassElementMetadata';
@@ -84,7 +85,10 @@ describe(inject.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          decrementPendingClassMetadataCount,
+        );
       });
 
       it('should call injectBaseDecorator()', () => {
@@ -164,7 +168,10 @@ describe(inject.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          decrementPendingClassMetadataCount,
+        );
       });
 
       it('should throw handleInjectionError()', () => {
@@ -253,7 +260,10 @@ describe(inject.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          decrementPendingClassMetadataCount,
+        );
       });
 
       it('should call injectBaseDecorator()', () => {
@@ -338,7 +348,10 @@ describe(inject.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          decrementPendingClassMetadataCount,
+        );
       });
 
       it('should throw handleInjectionError()', () => {

--- a/packages/container/libraries/core/src/metadata/decorators/inject.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/inject.ts
@@ -1,5 +1,6 @@
 import { LazyServiceIdentifier, ServiceIdentifier } from '@inversifyjs/common';
 
+import { decrementPendingClassMetadataCount } from '../actions/decrementPendingClassMetadataCount';
 import { buildManagedMetadataFromMaybeClassElementMetadata } from '../calculations/buildManagedMetadataFromMaybeClassElementMetadata';
 import { handleInjectionError } from '../calculations/handleInjectionError';
 import { ClassElementMetadata } from '../models/ClassElementMetadata';
@@ -24,9 +25,16 @@ export function inject(
   ): void => {
     try {
       if (parameterIndex === undefined) {
-        injectBase(updateMetadata)(target, propertyKey as string | symbol);
+        injectBase(updateMetadata, decrementPendingClassMetadataCount)(
+          target,
+          propertyKey as string | symbol,
+        );
       } else {
-        injectBase(updateMetadata)(target, propertyKey, parameterIndex);
+        injectBase(updateMetadata, decrementPendingClassMetadataCount)(
+          target,
+          propertyKey,
+          parameterIndex,
+        );
       }
     } catch (error: unknown) {
       handleInjectionError(target, propertyKey, parameterIndex, error);

--- a/packages/container/libraries/core/src/metadata/decorators/injectBase.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/injectBase.spec.ts
@@ -29,6 +29,11 @@ describe(injectBase.name, () => {
       metadata: MaybeClassElementMetadata | undefined,
     ) => MaybeClassElementMetadata
   >;
+  let updatePendingClassMetadataCountMock: jest.Mock<
+    (
+      target: object,
+    ) => (metadata: MaybeClassElementMetadata | undefined) => void
+  >;
 
   beforeAll(() => {
     updateMetadataMock =
@@ -37,6 +42,7 @@ describe(injectBase.name, () => {
           metadata: MaybeClassElementMetadata | undefined,
         ) => MaybeClassElementMetadata
       >();
+    updatePendingClassMetadataCountMock = jest.fn();
   });
 
   describe('when called, as property decorator', () => {
@@ -55,7 +61,7 @@ describe(injectBase.name, () => {
       ).mockReturnValueOnce(updateMaybeClassMetadataPropertyResult);
 
       class TargetFixture {
-        @injectBase(updateMetadataMock)
+        @injectBase(updateMetadataMock, updatePendingClassMetadataCountMock)
         public foo: string | undefined;
       }
 
@@ -94,7 +100,7 @@ describe(injectBase.name, () => {
 
       class TargetFixture {
         constructor(
-          @injectBase(updateMetadataMock)
+          @injectBase(updateMetadataMock, updatePendingClassMetadataCountMock)
           public foo: string | undefined,
         ) {}
       }
@@ -125,7 +131,7 @@ describe(injectBase.name, () => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         class TargetFixture {
           public doSomethingWithFoo(
-            @injectBase(updateMetadataMock)
+            @injectBase(updateMetadataMock, updatePendingClassMetadataCountMock)
             foo: string | undefined,
           ) {
             console.log(foo ?? '?');

--- a/packages/container/libraries/core/src/metadata/decorators/multiInject.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/multiInject.spec.ts
@@ -6,6 +6,7 @@ jest.mock('../calculations/buildManagedMetadataFromMaybeClassElementMetadata');
 jest.mock('../calculations/handleInjectionError');
 jest.mock('./injectBase');
 
+import { decrementPendingClassMetadataCount } from '../actions/decrementPendingClassMetadataCount';
 import { buildManagedMetadataFromMaybeClassElementMetadata } from '../calculations/buildManagedMetadataFromMaybeClassElementMetadata';
 import { handleInjectionError } from '../calculations/handleInjectionError';
 import { ClassElementMetadata } from '../models/ClassElementMetadata';
@@ -84,7 +85,10 @@ describe(multiInject.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          decrementPendingClassMetadataCount,
+        );
       });
 
       it('should call injectBaseDecorator()', () => {
@@ -167,7 +171,10 @@ describe(multiInject.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          decrementPendingClassMetadataCount,
+        );
       });
 
       it('should throw handleInjectionError()', () => {
@@ -256,7 +263,10 @@ describe(multiInject.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          decrementPendingClassMetadataCount,
+        );
       });
 
       it('should call injectBaseDecorator()', () => {
@@ -341,7 +351,10 @@ describe(multiInject.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          decrementPendingClassMetadataCount,
+        );
       });
 
       it('should throw handleInjectionError()', () => {

--- a/packages/container/libraries/core/src/metadata/decorators/multiInject.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/multiInject.ts
@@ -1,5 +1,6 @@
 import { LazyServiceIdentifier, ServiceIdentifier } from '@inversifyjs/common';
 
+import { decrementPendingClassMetadataCount } from '../actions/decrementPendingClassMetadataCount';
 import { buildManagedMetadataFromMaybeClassElementMetadata } from '../calculations/buildManagedMetadataFromMaybeClassElementMetadata';
 import { handleInjectionError } from '../calculations/handleInjectionError';
 import { ClassElementMetadata } from '../models/ClassElementMetadata';
@@ -24,9 +25,16 @@ export function multiInject(
   ): void => {
     try {
       if (parameterIndex === undefined) {
-        injectBase(updateMetadata)(target, propertyKey as string | symbol);
+        injectBase(updateMetadata, decrementPendingClassMetadataCount)(
+          target,
+          propertyKey as string | symbol,
+        );
       } else {
-        injectBase(updateMetadata)(target, propertyKey, parameterIndex);
+        injectBase(updateMetadata, decrementPendingClassMetadataCount)(
+          target,
+          propertyKey,
+          parameterIndex,
+        );
       }
     } catch (error: unknown) {
       handleInjectionError(target, propertyKey, parameterIndex, error);

--- a/packages/container/libraries/core/src/metadata/decorators/named.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/named.spec.ts
@@ -7,6 +7,7 @@ jest.mock(
 jest.mock('../calculations/handleInjectionError');
 jest.mock('./injectBase');
 
+import { incrementPendingClassMetadataCount } from '../actions/incrementPendingClassMetadataCount';
 import { updateMetadataName } from '../actions/updateMetadataName';
 import { buildMaybeClassElementMetadataFromMaybeClassElementMetadata } from '../calculations/buildMaybeClassElementMetadataFromMaybeClassElementMetadata';
 import { handleInjectionError } from '../calculations/handleInjectionError';
@@ -94,7 +95,10 @@ describe(named.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          incrementPendingClassMetadataCount,
+        );
       });
 
       it('should call injectBaseDecorator()', () => {
@@ -173,7 +177,10 @@ describe(named.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          incrementPendingClassMetadataCount,
+        );
       });
 
       it('should throw handleInjectionError()', () => {
@@ -259,7 +266,10 @@ describe(named.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          incrementPendingClassMetadataCount,
+        );
       });
 
       it('should call injectBaseDecorator()', () => {
@@ -339,7 +349,10 @@ describe(named.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          incrementPendingClassMetadataCount,
+        );
       });
 
       it('should throw handleInjectionError()', () => {

--- a/packages/container/libraries/core/src/metadata/decorators/named.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/named.ts
@@ -1,3 +1,4 @@
+import { incrementPendingClassMetadataCount } from '../actions/incrementPendingClassMetadataCount';
 import { updateMetadataName } from '../actions/updateMetadataName';
 import { buildMaybeClassElementMetadataFromMaybeClassElementMetadata } from '../calculations/buildMaybeClassElementMetadataFromMaybeClassElementMetadata';
 import { handleInjectionError } from '../calculations/handleInjectionError';
@@ -24,9 +25,16 @@ export function named(
   ): void => {
     try {
       if (parameterIndex === undefined) {
-        injectBase(updateMetadata)(target, propertyKey as string | symbol);
+        injectBase(updateMetadata, incrementPendingClassMetadataCount)(
+          target,
+          propertyKey as string | symbol,
+        );
       } else {
-        injectBase(updateMetadata)(target, propertyKey, parameterIndex);
+        injectBase(updateMetadata, incrementPendingClassMetadataCount)(
+          target,
+          propertyKey,
+          parameterIndex,
+        );
       }
     } catch (error: unknown) {
       handleInjectionError(target, propertyKey, parameterIndex, error);

--- a/packages/container/libraries/core/src/metadata/decorators/optional.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/optional.spec.ts
@@ -7,6 +7,7 @@ jest.mock(
 jest.mock('../calculations/handleInjectionError');
 jest.mock('./injectBase');
 
+import { incrementPendingClassMetadataCount } from '../actions/incrementPendingClassMetadataCount';
 import { updateMetadataOptional } from '../actions/updateMetadataOptional';
 import { buildMaybeClassElementMetadataFromMaybeClassElementMetadata } from '../calculations/buildMaybeClassElementMetadataFromMaybeClassElementMetadata';
 import { handleInjectionError } from '../calculations/handleInjectionError';
@@ -78,7 +79,10 @@ describe(optional.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          incrementPendingClassMetadataCount,
+        );
       });
 
       it('should call injectBaseDecorator()', () => {
@@ -155,7 +159,10 @@ describe(optional.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          incrementPendingClassMetadataCount,
+        );
       });
 
       it('should throw handleInjectionError()', () => {
@@ -235,7 +242,10 @@ describe(optional.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          incrementPendingClassMetadataCount,
+        );
       });
 
       it('should call injectBaseDecorator()', () => {
@@ -313,7 +323,10 @@ describe(optional.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          incrementPendingClassMetadataCount,
+        );
       });
 
       it('should throw handleInjectionError()', () => {

--- a/packages/container/libraries/core/src/metadata/decorators/optional.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/optional.ts
@@ -1,3 +1,4 @@
+import { incrementPendingClassMetadataCount } from '../actions/incrementPendingClassMetadataCount';
 import { updateMetadataOptional } from '../actions/updateMetadataOptional';
 import { buildMaybeClassElementMetadataFromMaybeClassElementMetadata } from '../calculations/buildMaybeClassElementMetadataFromMaybeClassElementMetadata';
 import { handleInjectionError } from '../calculations/handleInjectionError';
@@ -21,9 +22,16 @@ export function optional(): ParameterDecorator & PropertyDecorator {
   ): void => {
     try {
       if (parameterIndex === undefined) {
-        injectBase(updateMetadata)(target, propertyKey as string | symbol);
+        injectBase(updateMetadata, incrementPendingClassMetadataCount)(
+          target,
+          propertyKey as string | symbol,
+        );
       } else {
-        injectBase(updateMetadata)(target, propertyKey, parameterIndex);
+        injectBase(updateMetadata, incrementPendingClassMetadataCount)(
+          target,
+          propertyKey,
+          parameterIndex,
+        );
       }
     } catch (error: unknown) {
       handleInjectionError(target, propertyKey, parameterIndex, error);

--- a/packages/container/libraries/core/src/metadata/decorators/tagged.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/tagged.spec.ts
@@ -7,6 +7,7 @@ jest.mock(
 jest.mock('../calculations/handleInjectionError');
 jest.mock('./injectBase');
 
+import { incrementPendingClassMetadataCount } from '../actions/incrementPendingClassMetadataCount';
 import { updateMetadataName } from '../actions/updateMetadataName';
 import { buildMaybeClassElementMetadataFromMaybeClassElementMetadata } from '../calculations/buildMaybeClassElementMetadataFromMaybeClassElementMetadata';
 import { handleInjectionError } from '../calculations/handleInjectionError';
@@ -100,7 +101,10 @@ describe(tagged.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          incrementPendingClassMetadataCount,
+        );
       });
 
       it('should call injectBaseDecorator()', () => {
@@ -181,7 +185,10 @@ describe(tagged.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          incrementPendingClassMetadataCount,
+        );
       });
 
       it('should throw handleInjectionError()', () => {
@@ -269,7 +276,10 @@ describe(tagged.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          incrementPendingClassMetadataCount,
+        );
       });
 
       it('should call injectBaseDecorator()', () => {
@@ -355,7 +365,10 @@ describe(tagged.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          incrementPendingClassMetadataCount,
+        );
       });
 
       it('should throw handleInjectionError()', () => {

--- a/packages/container/libraries/core/src/metadata/decorators/tagged.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/tagged.ts
@@ -1,3 +1,4 @@
+import { incrementPendingClassMetadataCount } from '../actions/incrementPendingClassMetadataCount';
 import { updateMetadataTag } from '../actions/updateMetadataTag';
 import { buildMaybeClassElementMetadataFromMaybeClassElementMetadata } from '../calculations/buildMaybeClassElementMetadataFromMaybeClassElementMetadata';
 import { handleInjectionError } from '../calculations/handleInjectionError';
@@ -25,9 +26,16 @@ export function tagged(
   ): void => {
     try {
       if (parameterIndex === undefined) {
-        injectBase(updateMetadata)(target, propertyKey as string | symbol);
+        injectBase(updateMetadata, incrementPendingClassMetadataCount)(
+          target,
+          propertyKey as string | symbol,
+        );
       } else {
-        injectBase(updateMetadata)(target, propertyKey, parameterIndex);
+        injectBase(updateMetadata, incrementPendingClassMetadataCount)(
+          target,
+          propertyKey,
+          parameterIndex,
+        );
       }
     } catch (error: unknown) {
       handleInjectionError(target, propertyKey, parameterIndex, error);

--- a/packages/container/libraries/core/src/metadata/decorators/targetName.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/targetName.spec.ts
@@ -7,6 +7,7 @@ jest.mock(
 jest.mock('../calculations/handleInjectionError');
 jest.mock('./injectBase');
 
+import { incrementPendingClassMetadataCount } from '../actions/incrementPendingClassMetadataCount';
 import { updateMetadataTargetName } from '../actions/updateMetadataTargetName';
 import { buildMaybeClassElementMetadataFromMaybeClassElementMetadata } from '../calculations/buildMaybeClassElementMetadataFromMaybeClassElementMetadata';
 import { handleInjectionError } from '../calculations/handleInjectionError';
@@ -94,7 +95,10 @@ describe(targetName.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          incrementPendingClassMetadataCount,
+        );
       });
 
       it('should call injectBaseDecorator()', () => {
@@ -173,7 +177,10 @@ describe(targetName.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          incrementPendingClassMetadataCount,
+        );
       });
 
       it('should throw handleInjectionError()', () => {
@@ -259,7 +266,10 @@ describe(targetName.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          incrementPendingClassMetadataCount,
+        );
       });
 
       it('should call injectBaseDecorator()', () => {
@@ -339,7 +349,10 @@ describe(targetName.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          incrementPendingClassMetadataCount,
+        );
       });
 
       it('should throw handleInjectionError()', () => {

--- a/packages/container/libraries/core/src/metadata/decorators/targetName.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/targetName.ts
@@ -1,3 +1,4 @@
+import { incrementPendingClassMetadataCount } from '../actions/incrementPendingClassMetadataCount';
 import { updateMetadataTargetName } from '../actions/updateMetadataTargetName';
 import { buildMaybeClassElementMetadataFromMaybeClassElementMetadata } from '../calculations/buildMaybeClassElementMetadataFromMaybeClassElementMetadata';
 import { handleInjectionError } from '../calculations/handleInjectionError';
@@ -24,9 +25,16 @@ export function targetName(
   ): void => {
     try {
       if (parameterIndex === undefined) {
-        injectBase(updateMetadata)(target, propertyKey as string | symbol);
+        injectBase(updateMetadata, incrementPendingClassMetadataCount)(
+          target,
+          propertyKey as string | symbol,
+        );
       } else {
-        injectBase(updateMetadata)(target, propertyKey, parameterIndex);
+        injectBase(updateMetadata, incrementPendingClassMetadataCount)(
+          target,
+          propertyKey,
+          parameterIndex,
+        );
       }
     } catch (error: unknown) {
       handleInjectionError(target, propertyKey, parameterIndex, error);

--- a/packages/container/libraries/core/src/metadata/decorators/unmanaged.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/unmanaged.spec.ts
@@ -6,6 +6,7 @@ jest.mock(
 jest.mock('../calculations/handleInjectionError');
 jest.mock('./injectBase');
 
+import { decrementPendingClassMetadataCount } from '../actions/decrementPendingClassMetadataCount';
 import { buildUnmanagedMetadataFromMaybeClassElementMetadata } from '../calculations/buildUnmanagedMetadataFromMaybeClassElementMetadata';
 import { handleInjectionError } from '../calculations/handleInjectionError';
 import { ClassElementMetadata } from '../models/ClassElementMetadata';
@@ -75,7 +76,10 @@ describe(unmanaged.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          decrementPendingClassMetadataCount,
+        );
       });
 
       it('should call injectBaseDecorator()', () => {
@@ -152,7 +156,10 @@ describe(unmanaged.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          decrementPendingClassMetadataCount,
+        );
       });
 
       it('should throw handleInjectionError()', () => {
@@ -232,7 +239,10 @@ describe(unmanaged.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          decrementPendingClassMetadataCount,
+        );
       });
 
       it('should call injectBaseDecorator()', () => {
@@ -310,7 +320,10 @@ describe(unmanaged.name, () => {
 
       it('should call injectBase()', () => {
         expect(injectBase).toHaveBeenCalledTimes(1);
-        expect(injectBase).toHaveBeenCalledWith(updateMetadataMock);
+        expect(injectBase).toHaveBeenCalledWith(
+          updateMetadataMock,
+          decrementPendingClassMetadataCount,
+        );
       });
 
       it('should throw handleInjectionError()', () => {

--- a/packages/container/libraries/core/src/metadata/decorators/unmanaged.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/unmanaged.ts
@@ -1,3 +1,4 @@
+import { decrementPendingClassMetadataCount } from '../actions/decrementPendingClassMetadataCount';
 import { buildUnmanagedMetadataFromMaybeClassElementMetadata } from '../calculations/buildUnmanagedMetadataFromMaybeClassElementMetadata';
 import { handleInjectionError } from '../calculations/handleInjectionError';
 import { ClassElementMetadata } from '../models/ClassElementMetadata';
@@ -17,9 +18,16 @@ export function unmanaged(): ParameterDecorator & PropertyDecorator {
   ): void => {
     try {
       if (parameterIndex === undefined) {
-        injectBase(updateMetadata)(target, propertyKey as string | symbol);
+        injectBase(updateMetadata, decrementPendingClassMetadataCount)(
+          target,
+          propertyKey as string | symbol,
+        );
       } else {
-        injectBase(updateMetadata)(target, propertyKey, parameterIndex);
+        injectBase(updateMetadata, decrementPendingClassMetadataCount)(
+          target,
+          propertyKey,
+          parameterIndex,
+        );
       }
     } catch (error: unknown) {
       handleInjectionError(target, propertyKey, parameterIndex, error);


### PR DESCRIPTION
### Changed
- Updated `injectBase` with `updatePendingClassMetadataCount`.
- Updated decorators to handle pending class metadata count.