### PR TITLE
Add binding to syntax factory code examples

### DIFF
--- a/packages/docs/services/inversify-site/docs/api/binding-syntax.mdx
+++ b/packages/docs/services/inversify-site/docs/api/binding-syntax.mdx
@@ -3,6 +3,8 @@ sidebar_position: 2
 title: Binding Syntax
 ---
 import bindingToSyntaxApiToSource from '@inversifyjs/code-examples/generated/examples/bindingToSyntaxApiTo.ts.txt';
+import bindingToSyntaxApiToAutoFactorySource from '@inversifyjs/code-examples/generated/examples/bindingToSyntaxApiToAutoFactory.ts.txt';
+import bindingToSyntaxApiToAutoNamedFactorySource from '@inversifyjs/code-examples/generated/examples/bindingToSyntaxApiToAutoNamedFactory.ts.txt';
 import bindingToSyntaxApiToConstantValueSource from '@inversifyjs/code-examples/generated/examples/bindingToSyntaxApiToConstantValue.ts.txt';
 import bindingToSyntaxApiToConstructorSource from '@inversifyjs/code-examples/generated/examples/bindingToSyntaxApiToConstructor.ts.txt';
 import bindingToSyntaxApiToDynamicValueSource from '@inversifyjs/code-examples/generated/examples/bindingToSyntaxApiToDynamicValue.ts.txt';
@@ -106,6 +108,8 @@ toAutoFactory<T2>(serviceIdentifier: interfaces.ServiceIdentifier<T2>): interfac
 
 Binds a factory of services asociated a target service identifier to the given service identifier.
 
+<CodeBlock language="ts">{bindingToSyntaxApiToAutoFactorySource}</CodeBlock>
+
 ### toAutoNamedFactory
 
 ```ts
@@ -113,6 +117,8 @@ toAutoNamedFactory<T2>(serviceIdentifier: interfaces.ServiceIdentifier<T2>): Bin
 ```
 
 Binds a factory of services asociated a target service identifier and a name to the given service identifier.
+
+<CodeBlock language="ts">{bindingToSyntaxApiToAutoNamedFactorySource}</CodeBlock>
 
 ### toProvider
 

--- a/packages/docs/tools/inversify-code-examples/src/examples/bindingToSyntaxApiToAutoFactory.int.spec.ts
+++ b/packages/docs/tools/inversify-code-examples/src/examples/bindingToSyntaxApiToAutoFactory.int.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { container, Ninja } from './bindingToSyntaxApiToAutoFactory';
+
+describe('BindingToSyntax API (toAutoFactory)', () => {
+  it('should provide ninja', () => {
+    const ninja: Ninja = container.get(Ninja);
+
+    expect(ninja.fight()).toBe('hit!');
+    expect(ninja.sneak()).toBe('throw!');
+  });
+});

--- a/packages/docs/tools/inversify-code-examples/src/examples/bindingToSyntaxApiToAutoFactory.ts
+++ b/packages/docs/tools/inversify-code-examples/src/examples/bindingToSyntaxApiToAutoFactory.ts
@@ -1,0 +1,59 @@
+import { Container, inject, injectable, interfaces } from 'inversify';
+
+interface Weapon {
+  damage: number;
+}
+
+export class Katana implements Weapon {
+  public readonly damage: number = 10;
+
+  public hit(): unknown {
+    return 'hit!';
+  }
+}
+
+export class Shuriken implements Weapon {
+  public readonly damage: number = 5;
+
+  public throw(): unknown {
+    return 'throw!';
+  }
+}
+
+// Begin-example
+@injectable()
+class Ninja implements Ninja {
+  readonly #katana: Katana;
+  readonly #shuriken: Shuriken;
+
+  constructor(
+    @inject('Factory<Katana>') katanaFactory: interfaces.AutoFactory<Katana>,
+    @inject('Shuriken') shuriken: Shuriken,
+  ) {
+    this.#katana = katanaFactory();
+    this.#shuriken = shuriken;
+  }
+
+  public fight() {
+    return this.#katana.hit();
+  }
+
+  public sneak() {
+    return this.#shuriken.throw();
+  }
+}
+
+// Exclude-from-example
+const container: Container = new Container();
+
+container.bind('Katana').to(Katana);
+container.bind('Shuriken').to(Shuriken);
+
+container
+  .bind<interfaces.Factory<Katana>>('Factory<Katana>')
+  .toAutoFactory<Katana>('Katana');
+
+container.bind(Ninja).toSelf();
+// End-example
+
+export { container, Ninja };

--- a/packages/docs/tools/inversify-code-examples/src/examples/bindingToSyntaxApiToAutoNamedFactory.int.spec.ts
+++ b/packages/docs/tools/inversify-code-examples/src/examples/bindingToSyntaxApiToAutoNamedFactory.int.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { container, Ninja } from './bindingToSyntaxApiToAutoNamedFactory';
+
+describe('BindingToSyntax API (toAutoNamedFactory)', () => {
+  it('should provide ninja', () => {
+    const ninja: Ninja = container.get(Ninja);
+
+    expect(ninja.fight()).toBe('hit!');
+    expect(ninja.sneak()).toBe('throw!');
+  });
+});

--- a/packages/docs/tools/inversify-code-examples/src/examples/bindingToSyntaxApiToAutoNamedFactory.ts
+++ b/packages/docs/tools/inversify-code-examples/src/examples/bindingToSyntaxApiToAutoNamedFactory.ts
@@ -1,0 +1,58 @@
+import { Container, inject, injectable, interfaces } from 'inversify';
+
+interface Weapon {
+  damage: number;
+}
+
+export class Katana implements Weapon {
+  public readonly damage: number = 10;
+
+  public hit(): unknown {
+    return 'hit!';
+  }
+}
+
+export class Shuriken implements Weapon {
+  public readonly damage: number = 5;
+
+  public throw(): unknown {
+    return 'throw!';
+  }
+}
+
+// Begin-example
+@injectable()
+class Ninja implements Ninja {
+  readonly #katana: Katana;
+  readonly #shuriken: Shuriken;
+
+  constructor(
+    @inject('Factory<Weapon>')
+    katanaFactory: interfaces.AutoNamedFactory<Weapon>,
+  ) {
+    this.#katana = katanaFactory('katana') as Katana;
+    this.#shuriken = katanaFactory('shuriken') as Shuriken;
+  }
+
+  public fight() {
+    return this.#katana.hit();
+  }
+
+  public sneak() {
+    return this.#shuriken.throw();
+  }
+}
+
+// Exclude-from-example
+const container: Container = new Container();
+
+container.bind<Weapon>('Weapon').to(Katana).whenTargetNamed('katana');
+container.bind<Weapon>('Weapon').to(Shuriken).whenTargetNamed('shuriken');
+container
+  .bind<interfaces.AutoNamedFactory<Weapon>>('Factory<Weapon>')
+  .toAutoNamedFactory<Weapon>('Weapon');
+
+container.bind(Ninja).toSelf();
+// End-example
+
+export { container, Ninja };


### PR DESCRIPTION
### Changed
- Updated `BindingSyntax` API docs page with additional examples.