### PR TITLE
Update decorator API docs page with additional decorators

### DIFF
--- a/packages/docs/services/inversify-site/docs/api/container-module.mdx
+++ b/packages/docs/services/inversify-site/docs/api/container-module.mdx
@@ -77,7 +77,7 @@ Consider [docs](/docs/api/container#ondeactivation) as reference.
 
 When a container module is loaded into a Container the registration callback is invoked. This is the opportunity for the container module to register bindings and handlers.  Use the Container load method for ContainerModule instances and the Container loadAsync method for AsyncContainerModule instances.
 
-When a container module is unloaded from a Container the bindings added by that container will be removed and the [deactivation process](https://github.com/inversify/InversifyJS/blob/master/wiki/deactivation_handler.md) will occur for each of them.  Container deactivation and [activation handlers](/docs/fundamentals/lifecycle/activation) will also be removed.
-Use the unloadAsync method to unload when there will be an async deactivation handler or async [pre destroy](https://github.com/inversify/InversifyJS/blob/master/wiki/pre_destroy.md) 
+When a container module is unloaded from a Container the bindings added by that container will be removed and the [deactivation process](/docs/fundamentals/lifecycle/deactivation) will occur for each of them. Container deactivation and [activation handlers](/docs/fundamentals/lifecycle/activation) will also be removed.
+Use the unloadAsync method to unload when there will be an async deactivation handler or async [preDestroy](/docs/api/decorator#predestroy) 
 
 <CodeBlock language="ts">{containerModuleApiExampleSource}</CodeBlock>

--- a/packages/docs/services/inversify-site/docs/api/decorator.mdx
+++ b/packages/docs/services/inversify-site/docs/api/decorator.mdx
@@ -7,6 +7,8 @@ import decoratorApiInjectPropertySource from '@inversifyjs/code-examples/generat
 import decoratorApiMultiInjectPropertySource from '@inversifyjs/code-examples/generated/examples/decoratorApiMultiInjectProperty.ts.txt';
 import decoratorApiNamedSource from '@inversifyjs/code-examples/generated/examples/decoratorApiNamed.ts.txt';
 import decoratorApiOptionalSource from '@inversifyjs/code-examples/generated/examples/decoratorApiOptional.ts.txt';
+import decoratorApiPostConstructSource from '@inversifyjs/code-examples/generated/examples/decoratorApiPostConstruct.ts.txt';
+import decoratorApiPreDestroySource from '@inversifyjs/code-examples/generated/examples/decoratorApiPreDestroy.ts.txt';
 import decoratorApiTaggedSource from '@inversifyjs/code-examples/generated/examples/decoratorApiTagged.ts.txt';
 import decoratorApiUnmanagedSource from '@inversifyjs/code-examples/generated/examples/decoratorApiUnmanaged.ts.txt';
 import CodeBlock from '@theme/CodeBlock';
@@ -119,6 +121,18 @@ Decorator used to establish a relation between a constructor argument or a class
 Decorator used to establish a target constructor argument or property is optional and, therefore, it shall not be resolved if no bindings are found for the associated service id.
 
 <CodeBlock language="ts">{decoratorApiOptionalSource}</CodeBlock>
+
+## postConstruct
+
+Decorator used to establish an activation handler for the target class. Consider [docs](/docs/fundamentals/lifecycle/activation) as reference.
+
+<CodeBlock language="ts">{decoratorApiPostConstructSource}</CodeBlock>
+
+## preDestroy
+
+Decorator used to establish a deactivation handler for the target class. Consider [docs](/docs/fundamentals/lifecycle/deactivation) as reference.
+
+<CodeBlock language="ts">{decoratorApiPreDestroySource}</CodeBlock>
 
 ## tagged
 

--- a/packages/docs/services/inversify-site/docs/fundamentals/lifecycle/activation.mdx
+++ b/packages/docs/services/inversify-site/docs/fundamentals/lifecycle/activation.mdx
@@ -13,6 +13,7 @@ There are multiple ways to provide an activation handler
 
 - Adding the handler to the [container](/docs/api/container#onactivation).
 - Adding the handler to the [binding](/docs/api/binding-syntax#onactivation).
+- Adding the handler to the class through the [postConstruct decorator](/docs/api/decorator#postconstruct).
 
-When multiple activation handlers are binded to a service identifier, the binding handler is called before any others. Then the container handlers are called, starting at the root container and descending the descendant containers stopping at the container with the binding.
+When multiple activation handlers are binded to a service identifier, the `postConstruct` handler is called before any others. After that, the binding handler is called. Then, container handlers are called, starting at the root container and descending the descendant containers stopping at the container with the binding.
 

--- a/packages/docs/services/inversify-site/docs/fundamentals/lifecycle/deactivation.mdx
+++ b/packages/docs/services/inversify-site/docs/fundamentals/lifecycle/deactivation.mdx
@@ -13,6 +13,6 @@ It's possible to add a deactivation handler in multiple ways
 
 - Adding the handler to the [container](/docs/api/container#ondeactivation).
 - Adding the handler to a [binding](/docs/api/binding-syntax#ondeactivation).
-- Adding the handler to the class through the [preDestroy decorator](https://github.com/inversify/InversifyJS/blob/master/wiki/pre_destroy.md).
+- Adding the handler to the class through the [preDestroy decorator](/docs/api/decorator#predestroy).
 
 Handlers added to the container are the first ones to be resolved. Any handler added to a child container is called before the ones added to their parent. Relevant bindings from the container are called next and finally the `preDestroy` method is called. In the example above, relevant bindings are those bindings bound to the unbinded "Destroyable" service identifier.

--- a/packages/docs/services/inversify-site/docusaurus.config.ts
+++ b/packages/docs/services/inversify-site/docusaurus.config.ts
@@ -129,6 +129,7 @@ const config: Config = {
     },
   } satisfies Preset.ThemeConfig,
   title: 'InversifyJS',
+  trailingSlash: true,
   url: 'https://inversify.github.io',
 };
 

--- a/packages/docs/tools/inversify-code-examples/src/examples/containerApiOnDeactivation.ts
+++ b/packages/docs/tools/inversify-code-examples/src/examples/containerApiOnDeactivation.ts
@@ -9,14 +9,10 @@ interface Weapon {
 }
 
 export class Katana implements Weapon {
-  #damage: number = 10;
+  readonly #damage: number = 10;
 
   public get damage(): number {
     return this.#damage;
-  }
-
-  public improve(): void {
-    this.#damage += 2;
   }
 }
 

--- a/packages/docs/tools/inversify-code-examples/src/examples/decoratorApiPostConstruct.int.spec.ts
+++ b/packages/docs/tools/inversify-code-examples/src/examples/decoratorApiPostConstruct.int.spec.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { katana } from './decoratorApiPostConstruct';
+
+describe('Decorator API (postConstruct)', () => {
+  it('should provide activated service', () => {
+    expect(katana.damage).toBe(12);
+  });
+});

--- a/packages/docs/tools/inversify-code-examples/src/examples/decoratorApiPostConstruct.ts
+++ b/packages/docs/tools/inversify-code-examples/src/examples/decoratorApiPostConstruct.ts
@@ -1,0 +1,29 @@
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+import { Container, postConstruct } from 'inversify';
+
+// Begin-example
+interface Weapon {
+  damage: number;
+}
+
+export class Katana implements Weapon {
+  #damage: number = 10;
+
+  public get damage(): number {
+    return this.#damage;
+  }
+
+  @postConstruct()
+  public improve(): void {
+    this.#damage += 2;
+  }
+}
+
+const container: Container = new Container();
+container.bind<Weapon>('Weapon').to(Katana);
+
+// Katana.damage is 12
+const katana: Weapon = container.get<Weapon>('Weapon');
+// End-example
+
+export { katana };

--- a/packages/docs/tools/inversify-code-examples/src/examples/decoratorApiPreDestroy.int.spec.ts
+++ b/packages/docs/tools/inversify-code-examples/src/examples/decoratorApiPreDestroy.int.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { katanaDamageSpy } from './decoratorApiPreDestroy';
+
+describe('Decorator API (preDestroy)', () => {
+  it('should provide activated service', () => {
+    expect(katanaDamageSpy).toHaveBeenCalledTimes(1);
+    expect(katanaDamageSpy).toHaveBeenCalledWith();
+  });
+});

--- a/packages/docs/tools/inversify-code-examples/src/examples/decoratorApiPreDestroy.ts
+++ b/packages/docs/tools/inversify-code-examples/src/examples/decoratorApiPreDestroy.ts
@@ -1,0 +1,39 @@
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+import { jest } from '@jest/globals';
+
+import { Container, preDestroy } from 'inversify';
+
+// Begin-example
+interface Weapon {
+  damage: number;
+}
+
+export class Katana implements Weapon {
+  readonly #damage: number = 10;
+
+  public get damage(): number {
+    return this.#damage;
+  }
+
+  @preDestroy()
+  public onDeactivation(): void {
+    console.log(`Deactivating weapon with damage ${this.damage.toString()}`);
+  }
+}
+
+const container: Container = new Container();
+
+container.bind<Weapon>('Weapon').to(Katana).inSingletonScope();
+
+container.get('Weapon');
+
+// Exclude-from-example
+export const katanaDamageSpy: jest.SpiedGetter<number> = jest.spyOn<
+  Weapon,
+  'damage',
+  number,
+  'get'
+>(container.get<Weapon>('Weapon'), 'damage', 'get');
+
+container.unbind('Weapon');
+// End-example


### PR DESCRIPTION
### Changed
- Updated decorators API docs page with `preDestroy` decorator.
- Updated decoratos API docs page with `postConstruct` decorator.
- Updated config with `trailingSlash` option enabled.