### PR TITLE
Update BindingService

### DIFF
--- a/.changeset/nice-fireants-add.md
+++ b/.changeset/nice-fireants-add.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": major
+---
+
+Renamed `BindingService.remove` to `removeAllByServiceId`.

--- a/.changeset/red-ads-raise.md
+++ b/.changeset/red-ads-raise.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": major
+---
+
+Renamed `BindingService.removeByModule` to `removeAllByModuleId`.

--- a/packages/container/libraries/container/src/container/services/Container.spec.ts
+++ b/packages/container/libraries/container/src/container/services/Container.spec.ts
@@ -55,7 +55,7 @@ describe(Container.name, () => {
     > as jest.Mocked<ActivationsService>;
     bindingServiceMock = {
       get: jest.fn(),
-      remove: jest.fn(),
+      removeAllByServiceId: jest.fn(),
       set: jest.fn(),
     } as Partial<jest.Mocked<BindingService>> as jest.Mocked<BindingService>;
     deactivationServiceMock = {
@@ -996,9 +996,11 @@ describe(Container.name, () => {
         );
       });
 
-      it('should call bindingService.remove()', () => {
-        expect(bindingServiceMock.remove).toHaveBeenCalledTimes(1);
-        expect(bindingServiceMock.remove).toHaveBeenCalledWith(
+      it('should call bindingService.removeAllByServiceId()', () => {
+        expect(bindingServiceMock.removeAllByServiceId).toHaveBeenCalledTimes(
+          1,
+        );
+        expect(bindingServiceMock.removeAllByServiceId).toHaveBeenCalledWith(
           serviceIdentifierFixture,
         );
       });

--- a/packages/container/libraries/core/src/binding/fixtures/ConstantValueBindingFixtures.ts
+++ b/packages/container/libraries/core/src/binding/fixtures/ConstantValueBindingFixtures.ts
@@ -40,4 +40,18 @@ export class ConstantValueBindingFixtures {
       },
     };
   }
+
+  public static get withModuleIdUndefined(): ConstantValueBinding<unknown> {
+    return {
+      ...ConstantValueBindingFixtures.any,
+      moduleId: undefined,
+    };
+  }
+
+  public static get withModuleId(): ConstantValueBinding<unknown> {
+    return {
+      ...ConstantValueBindingFixtures.any,
+      moduleId: 1,
+    };
+  }
 }

--- a/packages/container/libraries/core/src/binding/services/ActivationsService.spec.ts
+++ b/packages/container/libraries/core/src/binding/services/ActivationsService.spec.ts
@@ -152,7 +152,7 @@ describe(ActivationsService.name, () => {
     });
   });
 
-  describe('.removeAllByModule', () => {
+  describe('.removeAllByModuleId', () => {
     let moduleIdFixture: number;
 
     beforeAll(() => {

--- a/packages/container/libraries/core/src/planning/calculations/buildFilteredServiceBindings.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildFilteredServiceBindings.ts
@@ -23,8 +23,9 @@ export function buildFilteredServiceBindings(
   const serviceIdentifier: ServiceIdentifier =
     options?.customServiceIdentifier ?? bindingMetadata.serviceIdentifier;
 
-  const serviceBindings: Binding<unknown>[] =
-    params.getBindings(serviceIdentifier) ?? [];
+  const serviceBindings: Binding<unknown>[] = [
+    ...(params.getBindings(serviceIdentifier) ?? []),
+  ];
 
   return serviceBindings.filter((binding: Binding<unknown>): boolean =>
     binding.isSatisfiedBy(bindingMetadata),

--- a/packages/container/libraries/core/src/planning/models/BasePlanParams.ts
+++ b/packages/container/libraries/core/src/planning/models/BasePlanParams.ts
@@ -6,7 +6,7 @@ import { ClassMetadata } from '../../metadata/models/ClassMetadata';
 export interface BasePlanParams {
   getBindings: <TInstance>(
     serviceIdentifier: ServiceIdentifier<TInstance>,
-  ) => Binding<TInstance>[] | undefined;
+  ) => Iterable<Binding<TInstance>> | undefined;
   getClassMetadata: (type: Newable) => ClassMetadata;
   servicesBranch: Set<ServiceIdentifier>;
 }

--- a/packages/container/libraries/core/src/resolution/actions/resolveBindingDeactivations.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveBindingDeactivations.ts
@@ -9,23 +9,23 @@ export function resolveBindingDeactivations<TActivated>(
   serviceIdentifier: ServiceIdentifier<TActivated>,
   value: Resolved<TActivated>,
 ): void | Promise<void> {
-  const activations: Iterable<BindingDeactivation<TActivated>> | undefined =
+  const deactivations: Iterable<BindingDeactivation<TActivated>> | undefined =
     params.getDeactivations(serviceIdentifier);
 
-  if (activations === undefined) {
+  if (deactivations === undefined) {
     return undefined;
   }
 
   if (isPromise(value)) {
     return resolveBindingDeactivationsFromIteratorAsync(
       value,
-      activations[Symbol.iterator](),
+      deactivations[Symbol.iterator](),
     );
   }
 
   return resolveBindingDeactivationsFromIterator(
     value,
-    activations[Symbol.iterator](),
+    deactivations[Symbol.iterator](),
   );
 }
 

--- a/packages/container/libraries/core/src/resolution/actions/resolveServiceDeactivations.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveServiceDeactivations.ts
@@ -19,7 +19,8 @@ export function resolveServiceDeactivations(
   params: DeactivationParams,
   serviceIdentifier: ServiceIdentifier,
 ): void | Promise<void> {
-  const bindings: Binding[] | undefined = params.getBindings(serviceIdentifier);
+  const bindings: Iterable<Binding> | undefined =
+    params.getBindings(serviceIdentifier);
 
   if (bindings === undefined) {
     return;
@@ -67,13 +68,20 @@ export function resolveServiceDeactivations(
 }
 
 function filterSinglentonScopedBindings(
-  bindings: Binding[],
+  bindings: Iterable<Binding>,
 ): SingletonScopedBinding[] {
-  return bindings.filter(
-    (binding: Binding): binding is SingletonScopedBinding =>
+  const filteredBindings: SingletonScopedBinding[] = [];
+
+  for (const binding of bindings) {
+    if (
       isScopedBinding(binding) &&
-      binding.scope === bindingScopeValues.Singleton,
-  );
+      binding.scope === bindingScopeValues.Singleton
+    ) {
+      filteredBindings.push(binding as SingletonScopedBinding);
+    }
+  }
+
+  return filteredBindings;
 }
 
 function resolveBindingPreDestroy(

--- a/packages/container/libraries/core/src/resolution/models/DeactivationParams.ts
+++ b/packages/container/libraries/core/src/resolution/models/DeactivationParams.ts
@@ -7,7 +7,7 @@ import { ClassMetadata } from '../../metadata/models/ClassMetadata';
 export interface DeactivationParams {
   getBindings: <TInstance>(
     serviceIdentifier: ServiceIdentifier<TInstance>,
-  ) => Binding<TInstance>[] | undefined;
+  ) => Iterable<Binding<TInstance>> | undefined;
   getClassMetadata: (type: Newable) => ClassMetadata;
   getDeactivations: <TActivated>(
     serviceIdentifier: ServiceIdentifier<TActivated>,


### PR DESCRIPTION
### Changed
- Renamed `BindingService.remove` to `removeAllByServiceId`.
- Renamed `BindingService.removeByModule` to `removeAllByModuleId`.
- Updated `BindingService` to rely on `OneToManyMapStar` data structure.