### PR TITLE
Update service deactivation to invoke missing handlers

### DIFF
--- a/packages/container/libraries/core/src/binding/fixtures/ConstantValueBindingFixtures.ts
+++ b/packages/container/libraries/core/src/binding/fixtures/ConstantValueBindingFixtures.ts
@@ -41,6 +41,27 @@ export class ConstantValueBindingFixtures {
     };
   }
 
+  public static get withOnDeactivationAsync(): ConstantValueBinding<unknown> {
+    return {
+      ...ConstantValueBindingFixtures.any,
+      onDeactivation: async (): Promise<void> => undefined,
+    };
+  }
+
+  public static get withOnDeactivationSync(): ConstantValueBinding<unknown> {
+    return {
+      ...ConstantValueBindingFixtures.any,
+      onDeactivation: (): void => undefined,
+    };
+  }
+
+  public static get withOnDeactivationUndefined(): ConstantValueBinding<unknown> {
+    return {
+      ...ConstantValueBindingFixtures.any,
+      onDeactivation: undefined,
+    };
+  }
+
   public static get withModuleIdUndefined(): ConstantValueBinding<unknown> {
     return {
       ...ConstantValueBindingFixtures.any,

--- a/packages/container/libraries/core/src/resolution/actions/resolveBindingDeactivations.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveBindingDeactivations.spec.ts
@@ -1,16 +1,18 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
-import { ServiceIdentifier } from '@inversifyjs/common';
+jest.mock('./resolveBindingServiceDeactivations');
 
-import { BindingDeactivation } from '../../binding/models/BindingDeactivation';
+import { ConstantValueBindingFixtures } from '../../binding/fixtures/ConstantValueBindingFixtures';
+import { ConstantValueBinding } from '../../binding/models/ConstantValueBinding';
 import { DeactivationParams } from '../models/DeactivationParams';
 import { resolveBindingDeactivations } from './resolveBindingDeactivations';
+import { resolveBindingServiceDeactivations } from './resolveBindingServiceDeactivations';
 
 describe(resolveBindingDeactivations.name, () => {
-  describe('having a non promise value', () => {
+  describe('having a binding with no deactivation', () => {
     let paramsMock: jest.Mocked<DeactivationParams>;
-    let serviceIdentifierFixture: ServiceIdentifier;
-    let valueFixture: unknown;
+    let bindingFixture: ConstantValueBinding<unknown>;
+    let resolvedValue: unknown;
 
     beforeAll(() => {
       paramsMock = {
@@ -19,18 +21,18 @@ describe(resolveBindingDeactivations.name, () => {
       } as Partial<
         jest.Mocked<DeactivationParams>
       > as jest.Mocked<DeactivationParams>;
-      serviceIdentifierFixture = 'service-id';
-      valueFixture = Symbol();
+      bindingFixture = ConstantValueBindingFixtures.withOnDeactivationUndefined;
+      resolvedValue = Symbol();
     });
 
-    describe('when called, and params.getActivations() returns undefined', () => {
+    describe('when called', () => {
       let result: unknown;
 
       beforeAll(() => {
         result = resolveBindingDeactivations(
           paramsMock,
-          serviceIdentifierFixture,
-          valueFixture,
+          bindingFixture,
+          resolvedValue,
         );
       });
 
@@ -38,89 +40,13 @@ describe(resolveBindingDeactivations.name, () => {
         jest.clearAllMocks();
       });
 
-      it('should call params.getActivations', () => {
-        expect(paramsMock.getDeactivations).toHaveBeenCalledTimes(1);
-        expect(paramsMock.getDeactivations).toHaveBeenCalledWith(
-          serviceIdentifierFixture,
-        );
-      });
-
-      it('should return undefined', () => {
-        expect(result).toBeUndefined();
-      });
-    });
-
-    describe('when called, and params.getActivations() returns sync activations', () => {
-      let deactivationMock: jest.Mock<BindingDeactivation>;
-
-      let result: unknown;
-
-      beforeAll(() => {
-        deactivationMock = jest.fn();
-        deactivationMock.mockReturnValueOnce(undefined);
-
-        paramsMock.getDeactivations.mockReturnValueOnce([deactivationMock]);
-
-        result = resolveBindingDeactivations(
+      it('should call resolveBindingServiceDeactivations()', () => {
+        expect(resolveBindingServiceDeactivations).toHaveBeenCalledTimes(1);
+        expect(resolveBindingServiceDeactivations).toHaveBeenCalledWith(
           paramsMock,
-          serviceIdentifierFixture,
-          valueFixture,
+          bindingFixture.serviceIdentifier,
+          bindingFixture.cache.value,
         );
-      });
-
-      afterAll(() => {
-        jest.clearAllMocks();
-      });
-
-      it('should call params.getActivations', () => {
-        expect(paramsMock.getDeactivations).toHaveBeenCalledTimes(1);
-        expect(paramsMock.getDeactivations).toHaveBeenCalledWith(
-          serviceIdentifierFixture,
-        );
-      });
-
-      it('should call activation', () => {
-        expect(deactivationMock).toHaveBeenCalledTimes(1);
-        expect(deactivationMock).toHaveBeenCalledWith(valueFixture);
-      });
-
-      it('should return undefined', () => {
-        expect(result).toBeUndefined();
-      });
-    });
-
-    describe('when called, and params.getActivations() returns async activations', () => {
-      let deactivationMock: jest.Mock<BindingDeactivation>;
-
-      let result: unknown;
-
-      beforeAll(async () => {
-        deactivationMock = jest.fn();
-        deactivationMock.mockReturnValueOnce(Promise.resolve(undefined));
-
-        paramsMock.getDeactivations.mockReturnValueOnce([deactivationMock]);
-
-        result = await resolveBindingDeactivations(
-          paramsMock,
-          serviceIdentifierFixture,
-          valueFixture,
-        );
-      });
-
-      afterAll(() => {
-        jest.clearAllMocks();
-      });
-
-      it('should call params.getActivations', () => {
-        expect(paramsMock.getDeactivations).toHaveBeenCalledTimes(1);
-        expect(paramsMock.getDeactivations).toHaveBeenCalledWith(
-          serviceIdentifierFixture,
-        );
-      });
-
-      it('should call activation', () => {
-        expect(deactivationMock).toHaveBeenCalledTimes(1);
-        expect(deactivationMock).toHaveBeenCalledWith(valueFixture);
       });
 
       it('should return undefined', () => {
@@ -129,10 +55,10 @@ describe(resolveBindingDeactivations.name, () => {
     });
   });
 
-  describe('having a promise value', () => {
+  describe('having a binding with sync deactivation', () => {
     let paramsMock: jest.Mocked<DeactivationParams>;
-    let serviceIdentifierFixture: ServiceIdentifier;
-    let valueFixture: unknown;
+    let bindingFixture: ConstantValueBinding<unknown>;
+    let resolvedValue: unknown;
 
     beforeAll(() => {
       paramsMock = {
@@ -141,18 +67,18 @@ describe(resolveBindingDeactivations.name, () => {
       } as Partial<
         jest.Mocked<DeactivationParams>
       > as jest.Mocked<DeactivationParams>;
-      serviceIdentifierFixture = 'service-id';
-      valueFixture = Symbol();
+      bindingFixture = ConstantValueBindingFixtures.withOnDeactivationSync;
+      resolvedValue = Symbol();
     });
 
-    describe('when called, and params.getActivations() returns undefined', () => {
+    describe('when called', () => {
       let result: unknown;
 
-      beforeAll(async () => {
-        result = await resolveBindingDeactivations(
+      beforeAll(() => {
+        result = resolveBindingDeactivations(
           paramsMock,
-          serviceIdentifierFixture,
-          Promise.resolve(valueFixture),
+          bindingFixture,
+          resolvedValue,
         );
       });
 
@@ -160,10 +86,12 @@ describe(resolveBindingDeactivations.name, () => {
         jest.clearAllMocks();
       });
 
-      it('should call params.getActivations', () => {
-        expect(paramsMock.getDeactivations).toHaveBeenCalledTimes(1);
-        expect(paramsMock.getDeactivations).toHaveBeenCalledWith(
-          serviceIdentifierFixture,
+      it('should call resolveBindingServiceDeactivations()', () => {
+        expect(resolveBindingServiceDeactivations).toHaveBeenCalledTimes(1);
+        expect(resolveBindingServiceDeactivations).toHaveBeenCalledWith(
+          paramsMock,
+          bindingFixture.serviceIdentifier,
+          bindingFixture.cache.value,
         );
       });
 
@@ -171,61 +99,32 @@ describe(resolveBindingDeactivations.name, () => {
         expect(result).toBeUndefined();
       });
     });
+  });
 
-    describe('when called, and params.getActivations() returns sync activations', () => {
-      let deactivationMock: jest.Mock<BindingDeactivation>;
+  describe('having a binding with async deactivation', () => {
+    let paramsMock: jest.Mocked<DeactivationParams>;
+    let bindingFixture: ConstantValueBinding<unknown>;
+    let resolvedValue: unknown;
 
-      let result: unknown;
-
-      beforeAll(async () => {
-        deactivationMock = jest.fn();
-        deactivationMock.mockReturnValueOnce(undefined);
-
-        paramsMock.getDeactivations.mockReturnValueOnce([deactivationMock]);
-
-        result = await resolveBindingDeactivations(
-          paramsMock,
-          serviceIdentifierFixture,
-          Promise.resolve(valueFixture),
-        );
-      });
-
-      afterAll(() => {
-        jest.clearAllMocks();
-      });
-
-      it('should call params.getActivations', () => {
-        expect(paramsMock.getDeactivations).toHaveBeenCalledTimes(1);
-        expect(paramsMock.getDeactivations).toHaveBeenCalledWith(
-          serviceIdentifierFixture,
-        );
-      });
-
-      it('should call activation', () => {
-        expect(deactivationMock).toHaveBeenCalledTimes(1);
-        expect(deactivationMock).toHaveBeenCalledWith(valueFixture);
-      });
-
-      it('should return undefined', () => {
-        expect(result).toBeUndefined();
-      });
+    beforeAll(() => {
+      paramsMock = {
+        getBindings: jest.fn(),
+        getDeactivations: jest.fn(),
+      } as Partial<
+        jest.Mocked<DeactivationParams>
+      > as jest.Mocked<DeactivationParams>;
+      bindingFixture = ConstantValueBindingFixtures.withOnDeactivationAsync;
+      resolvedValue = Symbol();
     });
 
-    describe('when called, and params.getActivations() returns async activations', () => {
-      let deactivationMock: jest.Mock<BindingDeactivation>;
-
+    describe('when called', () => {
       let result: unknown;
 
-      beforeAll(async () => {
-        deactivationMock = jest.fn();
-        deactivationMock.mockReturnValueOnce(Promise.resolve(undefined));
-
-        paramsMock.getDeactivations.mockReturnValueOnce([deactivationMock]);
-
-        result = await resolveBindingDeactivations(
+      beforeAll(() => {
+        result = resolveBindingDeactivations(
           paramsMock,
-          serviceIdentifierFixture,
-          Promise.resolve(valueFixture),
+          bindingFixture,
+          resolvedValue,
         );
       });
 
@@ -233,20 +132,17 @@ describe(resolveBindingDeactivations.name, () => {
         jest.clearAllMocks();
       });
 
-      it('should call params.getActivations', () => {
-        expect(paramsMock.getDeactivations).toHaveBeenCalledTimes(1);
-        expect(paramsMock.getDeactivations).toHaveBeenCalledWith(
-          serviceIdentifierFixture,
+      it('should call resolveBindingServiceDeactivations()', () => {
+        expect(resolveBindingServiceDeactivations).toHaveBeenCalledTimes(1);
+        expect(resolveBindingServiceDeactivations).toHaveBeenCalledWith(
+          paramsMock,
+          bindingFixture.serviceIdentifier,
+          bindingFixture.cache.value,
         );
       });
 
-      it('should call activation', () => {
-        expect(deactivationMock).toHaveBeenCalledTimes(1);
-        expect(deactivationMock).toHaveBeenCalledWith(valueFixture);
-      });
-
-      it('should return undefined', () => {
-        expect(result).toBeUndefined();
+      it('should return Promise', () => {
+        expect(result).toStrictEqual(Promise.resolve(undefined));
       });
     });
   });

--- a/packages/container/libraries/core/src/resolution/actions/resolveBindingServiceDeactivations.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveBindingServiceDeactivations.spec.ts
@@ -1,0 +1,253 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { ServiceIdentifier } from '@inversifyjs/common';
+
+import { BindingDeactivation } from '../../binding/models/BindingDeactivation';
+import { DeactivationParams } from '../models/DeactivationParams';
+import { resolveBindingServiceDeactivations } from './resolveBindingServiceDeactivations';
+
+describe(resolveBindingServiceDeactivations.name, () => {
+  describe('having a non promise value', () => {
+    let paramsMock: jest.Mocked<DeactivationParams>;
+    let serviceIdentifierFixture: ServiceIdentifier;
+    let valueFixture: unknown;
+
+    beforeAll(() => {
+      paramsMock = {
+        getBindings: jest.fn(),
+        getDeactivations: jest.fn(),
+      } as Partial<
+        jest.Mocked<DeactivationParams>
+      > as jest.Mocked<DeactivationParams>;
+      serviceIdentifierFixture = 'service-id';
+      valueFixture = Symbol();
+    });
+
+    describe('when called, and params.getActivations() returns undefined', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = resolveBindingServiceDeactivations(
+          paramsMock,
+          serviceIdentifierFixture,
+          valueFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call params.getActivations', () => {
+        expect(paramsMock.getDeactivations).toHaveBeenCalledTimes(1);
+        expect(paramsMock.getDeactivations).toHaveBeenCalledWith(
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when called, and params.getActivations() returns sync activations', () => {
+      let deactivationMock: jest.Mock<BindingDeactivation>;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        deactivationMock = jest.fn();
+        deactivationMock.mockReturnValueOnce(undefined);
+
+        paramsMock.getDeactivations.mockReturnValueOnce([deactivationMock]);
+
+        result = resolveBindingServiceDeactivations(
+          paramsMock,
+          serviceIdentifierFixture,
+          valueFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call params.getActivations', () => {
+        expect(paramsMock.getDeactivations).toHaveBeenCalledTimes(1);
+        expect(paramsMock.getDeactivations).toHaveBeenCalledWith(
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should call activation', () => {
+        expect(deactivationMock).toHaveBeenCalledTimes(1);
+        expect(deactivationMock).toHaveBeenCalledWith(valueFixture);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when called, and params.getActivations() returns async activations', () => {
+      let deactivationMock: jest.Mock<BindingDeactivation>;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        deactivationMock = jest.fn();
+        deactivationMock.mockReturnValueOnce(Promise.resolve(undefined));
+
+        paramsMock.getDeactivations.mockReturnValueOnce([deactivationMock]);
+
+        result = await resolveBindingServiceDeactivations(
+          paramsMock,
+          serviceIdentifierFixture,
+          valueFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call params.getActivations', () => {
+        expect(paramsMock.getDeactivations).toHaveBeenCalledTimes(1);
+        expect(paramsMock.getDeactivations).toHaveBeenCalledWith(
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should call activation', () => {
+        expect(deactivationMock).toHaveBeenCalledTimes(1);
+        expect(deactivationMock).toHaveBeenCalledWith(valueFixture);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a promise value', () => {
+    let paramsMock: jest.Mocked<DeactivationParams>;
+    let serviceIdentifierFixture: ServiceIdentifier;
+    let valueFixture: unknown;
+
+    beforeAll(() => {
+      paramsMock = {
+        getBindings: jest.fn(),
+        getDeactivations: jest.fn(),
+      } as Partial<
+        jest.Mocked<DeactivationParams>
+      > as jest.Mocked<DeactivationParams>;
+      serviceIdentifierFixture = 'service-id';
+      valueFixture = Symbol();
+    });
+
+    describe('when called, and params.getActivations() returns undefined', () => {
+      let result: unknown;
+
+      beforeAll(async () => {
+        result = await resolveBindingServiceDeactivations(
+          paramsMock,
+          serviceIdentifierFixture,
+          Promise.resolve(valueFixture),
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call params.getActivations', () => {
+        expect(paramsMock.getDeactivations).toHaveBeenCalledTimes(1);
+        expect(paramsMock.getDeactivations).toHaveBeenCalledWith(
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when called, and params.getActivations() returns sync activations', () => {
+      let deactivationMock: jest.Mock<BindingDeactivation>;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        deactivationMock = jest.fn();
+        deactivationMock.mockReturnValueOnce(undefined);
+
+        paramsMock.getDeactivations.mockReturnValueOnce([deactivationMock]);
+
+        result = await resolveBindingServiceDeactivations(
+          paramsMock,
+          serviceIdentifierFixture,
+          Promise.resolve(valueFixture),
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call params.getActivations', () => {
+        expect(paramsMock.getDeactivations).toHaveBeenCalledTimes(1);
+        expect(paramsMock.getDeactivations).toHaveBeenCalledWith(
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should call activation', () => {
+        expect(deactivationMock).toHaveBeenCalledTimes(1);
+        expect(deactivationMock).toHaveBeenCalledWith(valueFixture);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when called, and params.getActivations() returns async activations', () => {
+      let deactivationMock: jest.Mock<BindingDeactivation>;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        deactivationMock = jest.fn();
+        deactivationMock.mockReturnValueOnce(Promise.resolve(undefined));
+
+        paramsMock.getDeactivations.mockReturnValueOnce([deactivationMock]);
+
+        result = await resolveBindingServiceDeactivations(
+          paramsMock,
+          serviceIdentifierFixture,
+          Promise.resolve(valueFixture),
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call params.getActivations', () => {
+        expect(paramsMock.getDeactivations).toHaveBeenCalledTimes(1);
+        expect(paramsMock.getDeactivations).toHaveBeenCalledWith(
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should call activation', () => {
+        expect(deactivationMock).toHaveBeenCalledTimes(1);
+        expect(deactivationMock).toHaveBeenCalledWith(valueFixture);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/resolution/actions/resolveBindingServiceDeactivations.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveBindingServiceDeactivations.ts
@@ -1,0 +1,70 @@
+import { isPromise, ServiceIdentifier } from '@inversifyjs/common';
+
+import { BindingDeactivation } from '../../binding/models/BindingDeactivation';
+import { DeactivationParams } from '../models/DeactivationParams';
+import { Resolved, SyncResolved } from '../models/Resolved';
+
+export function resolveBindingServiceDeactivations<TActivated>(
+  params: DeactivationParams,
+  serviceIdentifier: ServiceIdentifier<TActivated>,
+  value: Resolved<TActivated>,
+): void | Promise<void> {
+  const deactivations: Iterable<BindingDeactivation<TActivated>> | undefined =
+    params.getDeactivations(serviceIdentifier);
+
+  if (deactivations === undefined) {
+    return undefined;
+  }
+
+  if (isPromise(value)) {
+    return resolveBindingDeactivationsFromIteratorAsync(
+      value,
+      deactivations[Symbol.iterator](),
+    );
+  }
+
+  return resolveBindingDeactivationsFromIterator(
+    value,
+    deactivations[Symbol.iterator](),
+  );
+}
+
+function resolveBindingDeactivationsFromIterator<TActivated>(
+  value: SyncResolved<TActivated>,
+  deactivationsIterator: Iterator<BindingDeactivation<TActivated>>,
+): void | Promise<void> {
+  let deactivationIteratorResult: IteratorResult<
+    BindingDeactivation<TActivated>
+  > = deactivationsIterator.next();
+
+  while (deactivationIteratorResult.done !== true) {
+    const nextDeactivationValue: void | Promise<void> =
+      deactivationIteratorResult.value(value);
+
+    if (isPromise(nextDeactivationValue)) {
+      return resolveBindingDeactivationsFromIteratorAsync(
+        value,
+        deactivationsIterator,
+      );
+    }
+
+    deactivationIteratorResult = deactivationsIterator.next();
+  }
+}
+
+async function resolveBindingDeactivationsFromIteratorAsync<TActivated>(
+  value: Resolved<TActivated>,
+  deactivationsIterator: Iterator<BindingDeactivation<TActivated>>,
+): Promise<void> {
+  const resolvedValue: SyncResolved<TActivated> = await value;
+
+  let deactivationIteratorResult: IteratorResult<
+    BindingDeactivation<TActivated>
+  > = deactivationsIterator.next();
+
+  while (deactivationIteratorResult.done !== true) {
+    await deactivationIteratorResult.value(resolvedValue);
+
+    deactivationIteratorResult = deactivationsIterator.next();
+  }
+}

--- a/packages/container/libraries/core/src/resolution/actions/resolveServiceDeactivations.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveServiceDeactivations.spec.ts
@@ -116,7 +116,7 @@ describe(resolveServiceDeactivations.name, () => {
       expect(resolveBindingDeactivations).toHaveBeenCalledTimes(1);
       expect(resolveBindingDeactivations).toHaveBeenCalledWith(
         paramsMock,
-        serviceIdentifierFixture,
+        bindingFixture,
         bindingFixture.cache.value,
       );
     });
@@ -177,7 +177,7 @@ describe(resolveServiceDeactivations.name, () => {
       expect(resolveBindingDeactivations).toHaveBeenCalledTimes(1);
       expect(resolveBindingDeactivations).toHaveBeenCalledWith(
         paramsMock,
-        serviceIdentifierFixture,
+        bindingFixture,
         bindingFixture.cache.value,
       );
     });
@@ -239,7 +239,7 @@ describe(resolveServiceDeactivations.name, () => {
       expect(resolveBindingDeactivations).toHaveBeenCalledTimes(1);
       expect(resolveBindingDeactivations).toHaveBeenCalledWith(
         paramsMock,
-        serviceIdentifierFixture,
+        bindingFixture,
         bindingFixture.cache.value,
       );
     });

--- a/packages/container/libraries/core/src/resolution/actions/resolveServiceDeactivations.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveServiceDeactivations.ts
@@ -43,16 +43,12 @@ export function resolveServiceDeactivations(
       if (preDestroyResult === undefined) {
         deactivationResult = resolveBindingDeactivations(
           params,
-          serviceIdentifier,
+          binding,
           binding.cache.value,
         );
       } else {
         deactivationResult = preDestroyResult.then((): void | Promise<void> =>
-          resolveBindingDeactivations(
-            params,
-            serviceIdentifier,
-            binding.cache.value,
-          ),
+          resolveBindingDeactivations(params, binding, binding.cache.value),
         );
       }
 


### PR DESCRIPTION
### Changed
- Updated `ConstantValueBindingFixtures` with additional ones.
- Updated `DeactivationService.get` to return ancestor `deactivations`.
- Updated `resolveServiceDeactivations` to invoke binding deactivations.