### PR TITLE
Update service activation to invoke missing handlers

### DIFF
--- a/.changeset/sixty-bugs-yell.md
+++ b/.changeset/sixty-bugs-yell.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": patch
+---
+
+Updated `ActivationService.get` to provide missing parent activations

--- a/packages/container/libraries/core/src/binding/fixtures/ConstantValueBindingFixtures.ts
+++ b/packages/container/libraries/core/src/binding/fixtures/ConstantValueBindingFixtures.ts
@@ -41,6 +41,13 @@ export class ConstantValueBindingFixtures {
     };
   }
 
+  public static get withOnActivationUndefined(): ConstantValueBinding<unknown> {
+    return {
+      ...ConstantValueBindingFixtures.any,
+      onActivation: undefined,
+    };
+  }
+
   public static get withOnDeactivationAsync(): ConstantValueBinding<unknown> {
     return {
       ...ConstantValueBindingFixtures.any,

--- a/packages/container/libraries/core/src/resolution/actions/resolveBindingDeactivations.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveBindingDeactivations.spec.ts
@@ -12,7 +12,7 @@ describe(resolveBindingDeactivations.name, () => {
   describe('having a binding with no deactivation', () => {
     let paramsMock: jest.Mocked<DeactivationParams>;
     let bindingFixture: ConstantValueBinding<unknown>;
-    let resolvedValue: unknown;
+    let resolvedValueFixture: unknown;
 
     beforeAll(() => {
       paramsMock = {
@@ -22,7 +22,7 @@ describe(resolveBindingDeactivations.name, () => {
         jest.Mocked<DeactivationParams>
       > as jest.Mocked<DeactivationParams>;
       bindingFixture = ConstantValueBindingFixtures.withOnDeactivationUndefined;
-      resolvedValue = Symbol();
+      resolvedValueFixture = Symbol();
     });
 
     describe('when called', () => {
@@ -32,7 +32,7 @@ describe(resolveBindingDeactivations.name, () => {
         result = resolveBindingDeactivations(
           paramsMock,
           bindingFixture,
-          resolvedValue,
+          resolvedValueFixture,
         );
       });
 
@@ -45,7 +45,7 @@ describe(resolveBindingDeactivations.name, () => {
         expect(resolveBindingServiceDeactivations).toHaveBeenCalledWith(
           paramsMock,
           bindingFixture.serviceIdentifier,
-          bindingFixture.cache.value,
+          resolvedValueFixture,
         );
       });
 
@@ -58,7 +58,7 @@ describe(resolveBindingDeactivations.name, () => {
   describe('having a binding with sync deactivation', () => {
     let paramsMock: jest.Mocked<DeactivationParams>;
     let bindingFixture: ConstantValueBinding<unknown>;
-    let resolvedValue: unknown;
+    let resolvedValueFixture: unknown;
 
     beforeAll(() => {
       paramsMock = {
@@ -68,7 +68,7 @@ describe(resolveBindingDeactivations.name, () => {
         jest.Mocked<DeactivationParams>
       > as jest.Mocked<DeactivationParams>;
       bindingFixture = ConstantValueBindingFixtures.withOnDeactivationSync;
-      resolvedValue = Symbol();
+      resolvedValueFixture = Symbol();
     });
 
     describe('when called', () => {
@@ -78,7 +78,7 @@ describe(resolveBindingDeactivations.name, () => {
         result = resolveBindingDeactivations(
           paramsMock,
           bindingFixture,
-          resolvedValue,
+          resolvedValueFixture,
         );
       });
 
@@ -91,7 +91,7 @@ describe(resolveBindingDeactivations.name, () => {
         expect(resolveBindingServiceDeactivations).toHaveBeenCalledWith(
           paramsMock,
           bindingFixture.serviceIdentifier,
-          bindingFixture.cache.value,
+          resolvedValueFixture,
         );
       });
 
@@ -104,7 +104,7 @@ describe(resolveBindingDeactivations.name, () => {
   describe('having a binding with async deactivation', () => {
     let paramsMock: jest.Mocked<DeactivationParams>;
     let bindingFixture: ConstantValueBinding<unknown>;
-    let resolvedValue: unknown;
+    let resolvedValueFixture: unknown;
 
     beforeAll(() => {
       paramsMock = {
@@ -114,7 +114,7 @@ describe(resolveBindingDeactivations.name, () => {
         jest.Mocked<DeactivationParams>
       > as jest.Mocked<DeactivationParams>;
       bindingFixture = ConstantValueBindingFixtures.withOnDeactivationAsync;
-      resolvedValue = Symbol();
+      resolvedValueFixture = Symbol();
     });
 
     describe('when called', () => {
@@ -124,7 +124,7 @@ describe(resolveBindingDeactivations.name, () => {
         result = resolveBindingDeactivations(
           paramsMock,
           bindingFixture,
-          resolvedValue,
+          resolvedValueFixture,
         );
       });
 
@@ -137,7 +137,7 @@ describe(resolveBindingDeactivations.name, () => {
         expect(resolveBindingServiceDeactivations).toHaveBeenCalledWith(
           paramsMock,
           bindingFixture.serviceIdentifier,
-          bindingFixture.cache.value,
+          resolvedValueFixture,
         );
       });
 

--- a/packages/container/libraries/core/src/resolution/actions/resolveBindingDeactivations.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveBindingDeactivations.ts
@@ -23,14 +23,14 @@ export function resolveBindingDeactivations<TResolved>(
     return resolveBindingServiceDeactivations(
       params,
       binding.serviceIdentifier,
-      binding.cache.value,
+      resolvedValue,
     );
   } else {
     return deactivationResult.then((): void | Promise<void> =>
       resolveBindingServiceDeactivations(
         params,
         binding.serviceIdentifier,
-        binding.cache.value,
+        resolvedValue,
       ),
     );
   }

--- a/packages/container/libraries/core/src/resolution/actions/resolveBindingServiceActivations.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveBindingServiceActivations.spec.ts
@@ -1,0 +1,263 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { ServiceIdentifier } from '@inversifyjs/common';
+
+import { BindingActivation } from '../../binding/models/BindingActivation';
+import { ResolutionParams } from '../models/ResolutionParams';
+import { resolveBindingServiceActivations } from './resolveBindingServiceActivations';
+
+describe(resolveBindingServiceActivations.name, () => {
+  describe('having a non promise value', () => {
+    let paramsMock: jest.Mocked<ResolutionParams>;
+    let serviceIdentifierFixture: ServiceIdentifier;
+    let valueFixture: unknown;
+
+    beforeAll(() => {
+      paramsMock = {
+        getActivations: jest.fn(),
+      } as Partial<
+        jest.Mocked<ResolutionParams>
+      > as jest.Mocked<ResolutionParams>;
+      serviceIdentifierFixture = 'service-id';
+      valueFixture = Symbol();
+    });
+
+    describe('when called, and params.getActivations() returns undefined', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = resolveBindingServiceActivations(
+          paramsMock,
+          serviceIdentifierFixture,
+          valueFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call params.getActivations', () => {
+        expect(paramsMock.getActivations).toHaveBeenCalledTimes(1);
+        expect(paramsMock.getActivations).toHaveBeenCalledWith(
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should return value', () => {
+        expect(result).toBe(valueFixture);
+      });
+    });
+
+    describe('when called, and params.getActivations() returns sync activations', () => {
+      let activationMock: jest.Mock<BindingActivation>;
+      let activationResult: unknown;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        activationResult = Symbol('activation-result');
+
+        activationMock = jest.fn().mockReturnValueOnce(activationResult);
+
+        paramsMock.getActivations.mockReturnValueOnce([activationMock]);
+
+        result = resolveBindingServiceActivations(
+          paramsMock,
+          serviceIdentifierFixture,
+          valueFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call params.getActivations', () => {
+        expect(paramsMock.getActivations).toHaveBeenCalledTimes(1);
+        expect(paramsMock.getActivations).toHaveBeenCalledWith(
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should call activation', () => {
+        expect(activationMock).toHaveBeenCalledTimes(1);
+        expect(activationMock).toHaveBeenCalledWith(valueFixture);
+      });
+
+      it('should return value', () => {
+        expect(result).toBe(activationResult);
+      });
+    });
+
+    describe('when called, and params.getActivations() returns async activations', () => {
+      let activationMock: jest.Mock<BindingActivation>;
+      let activationResult: unknown;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        activationResult = Symbol('activation-result');
+
+        activationMock = jest
+          .fn()
+          .mockReturnValueOnce(Promise.resolve(activationResult));
+
+        paramsMock.getActivations.mockReturnValueOnce([activationMock]);
+
+        result = await resolveBindingServiceActivations(
+          paramsMock,
+          serviceIdentifierFixture,
+          valueFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call params.getActivations', () => {
+        expect(paramsMock.getActivations).toHaveBeenCalledTimes(1);
+        expect(paramsMock.getActivations).toHaveBeenCalledWith(
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should call activation', () => {
+        expect(activationMock).toHaveBeenCalledTimes(1);
+        expect(activationMock).toHaveBeenCalledWith(valueFixture);
+      });
+
+      it('should return value', () => {
+        expect(result).toBe(activationResult);
+      });
+    });
+  });
+
+  describe('having a promise value', () => {
+    let paramsMock: jest.Mocked<ResolutionParams>;
+    let serviceIdentifierFixture: ServiceIdentifier;
+    let valueFixture: unknown;
+
+    beforeAll(() => {
+      paramsMock = {
+        getActivations: jest.fn(),
+      } as Partial<
+        jest.Mocked<ResolutionParams>
+      > as jest.Mocked<ResolutionParams>;
+      serviceIdentifierFixture = 'service-id';
+      valueFixture = Symbol();
+    });
+
+    describe('when called, and params.getActivations() returns undefined', () => {
+      let result: unknown;
+
+      beforeAll(async () => {
+        result = await resolveBindingServiceActivations(
+          paramsMock,
+          serviceIdentifierFixture,
+          Promise.resolve(valueFixture),
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call params.getActivations', () => {
+        expect(paramsMock.getActivations).toHaveBeenCalledTimes(1);
+        expect(paramsMock.getActivations).toHaveBeenCalledWith(
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should return value', () => {
+        expect(result).toBe(valueFixture);
+      });
+    });
+
+    describe('when called, and params.getActivations() returns sync activations', () => {
+      let activationMock: jest.Mock<BindingActivation>;
+      let activationResult: unknown;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        activationResult = Symbol('activation-result');
+
+        activationMock = jest.fn().mockReturnValueOnce(activationResult);
+
+        paramsMock.getActivations.mockReturnValueOnce([activationMock]);
+
+        result = await resolveBindingServiceActivations(
+          paramsMock,
+          serviceIdentifierFixture,
+          Promise.resolve(valueFixture),
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call params.getActivations', () => {
+        expect(paramsMock.getActivations).toHaveBeenCalledTimes(1);
+        expect(paramsMock.getActivations).toHaveBeenCalledWith(
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should call activation', () => {
+        expect(activationMock).toHaveBeenCalledTimes(1);
+        expect(activationMock).toHaveBeenCalledWith(valueFixture);
+      });
+
+      it('should return value', () => {
+        expect(result).toBe(activationResult);
+      });
+    });
+
+    describe('when called, and params.getActivations() returns async activations', () => {
+      let activationMock: jest.Mock<BindingActivation>;
+      let activationResult: unknown;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        activationResult = Symbol('activation-result');
+
+        activationMock = jest
+          .fn()
+          .mockReturnValueOnce(Promise.resolve(activationResult));
+
+        paramsMock.getActivations.mockReturnValueOnce([activationMock]);
+
+        result = await resolveBindingServiceActivations(
+          paramsMock,
+          serviceIdentifierFixture,
+          Promise.resolve(valueFixture),
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call params.getActivations', () => {
+        expect(paramsMock.getActivations).toHaveBeenCalledTimes(1);
+        expect(paramsMock.getActivations).toHaveBeenCalledWith(
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should call activation', () => {
+        expect(activationMock).toHaveBeenCalledTimes(1);
+        expect(activationMock).toHaveBeenCalledWith(valueFixture);
+      });
+
+      it('should return value', () => {
+        expect(result).toBe(activationResult);
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/resolution/actions/resolveBindingServiceActivations.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveBindingServiceActivations.ts
@@ -1,0 +1,76 @@
+import { isPromise, ServiceIdentifier } from '@inversifyjs/common';
+
+import { BindingActivation } from '../../binding/models/BindingActivation';
+import { ResolutionParams } from '../models/ResolutionParams';
+import { Resolved, SyncResolved } from '../models/Resolved';
+
+export function resolveBindingServiceActivations<TActivated>(
+  params: ResolutionParams,
+  serviceIdentifier: ServiceIdentifier<TActivated>,
+  value: Resolved<TActivated>,
+): Resolved<TActivated> {
+  const activations: Iterable<BindingActivation<TActivated>> | undefined =
+    params.getActivations(serviceIdentifier);
+
+  if (activations === undefined) {
+    return value;
+  }
+
+  if (isPromise(value)) {
+    return resolveBindingActivationsFromIteratorAsync(
+      value,
+      activations[Symbol.iterator](),
+    );
+  }
+
+  return resolveBindingActivationsFromIterator(
+    value,
+    activations[Symbol.iterator](),
+  );
+}
+
+function resolveBindingActivationsFromIterator<TActivated>(
+  value: SyncResolved<TActivated>,
+  activationsIterator: Iterator<BindingActivation<TActivated>>,
+): Resolved<TActivated> {
+  let activatedValue: SyncResolved<TActivated> = value;
+
+  let activationIteratorResult: IteratorResult<BindingActivation<TActivated>> =
+    activationsIterator.next();
+
+  while (activationIteratorResult.done !== true) {
+    const nextActivatedValue: Resolved<TActivated> =
+      activationIteratorResult.value(activatedValue);
+
+    if (isPromise(nextActivatedValue)) {
+      return resolveBindingActivationsFromIteratorAsync(
+        nextActivatedValue,
+        activationsIterator,
+      );
+    } else {
+      activatedValue = nextActivatedValue;
+    }
+
+    activationIteratorResult = activationsIterator.next();
+  }
+
+  return activatedValue;
+}
+
+async function resolveBindingActivationsFromIteratorAsync<TActivated>(
+  value: Promise<TActivated>,
+  activationsIterator: Iterator<BindingActivation<TActivated>>,
+): Promise<SyncResolved<TActivated>> {
+  let activatedValue: SyncResolved<TActivated> = await value;
+
+  let activationIteratorResult: IteratorResult<BindingActivation<TActivated>> =
+    activationsIterator.next();
+
+  while (activationIteratorResult.done !== true) {
+    activatedValue = await activationIteratorResult.value(activatedValue);
+
+    activationIteratorResult = activationsIterator.next();
+  }
+
+  return activatedValue;
+}

--- a/packages/container/libraries/core/src/resolution/actions/resolveScoped.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveScoped.spec.ts
@@ -157,7 +157,7 @@ describe(resolveScoped.name, () => {
       expect(resolveBindingActivations).toHaveBeenCalledTimes(1);
       expect(resolveBindingActivations).toHaveBeenCalledWith(
         paramsMock,
-        bindingFixture.serviceIdentifier,
+        bindingFixture,
         resolveResult,
       );
     });
@@ -315,7 +315,7 @@ describe(resolveScoped.name, () => {
       expect(resolveBindingActivations).toHaveBeenCalledTimes(1);
       expect(resolveBindingActivations).toHaveBeenCalledWith(
         paramsMock,
-        bindingFixture.serviceIdentifier,
+        bindingFixture,
         resolveResult,
       );
     });
@@ -395,7 +395,7 @@ describe(resolveScoped.name, () => {
       expect(resolveBindingActivations).toHaveBeenCalledTimes(1);
       expect(resolveBindingActivations).toHaveBeenCalledWith(
         paramsMock,
-        bindingFixture.serviceIdentifier,
+        bindingFixture,
         resolveResult,
       );
     });

--- a/packages/container/libraries/core/src/resolution/actions/resolveScoped.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveScoped.ts
@@ -1,5 +1,3 @@
-import { ServiceIdentifier } from '@inversifyjs/common';
-
 import {
   BindingScope,
   bindingScopeValues,
@@ -32,7 +30,7 @@ export function resolveScoped<
         const resolvedValue: Resolved<TActivated> = resolveAndActivate(
           params,
           arg,
-          binding.serviceIdentifier,
+          binding,
           resolve,
         );
 
@@ -53,7 +51,7 @@ export function resolveScoped<
         const resolvedValue: Resolved<TActivated> = resolveAndActivate(
           params,
           arg,
-          binding.serviceIdentifier,
+          binding,
           resolve,
         );
 
@@ -62,12 +60,7 @@ export function resolveScoped<
         return resolvedValue;
       }
       case bindingScopeValues.Transient:
-        return resolveAndActivate(
-          params,
-          arg,
-          binding.serviceIdentifier,
-          resolve,
-        );
+        return resolveAndActivate(params, arg, binding, resolve);
     }
   };
 }
@@ -75,12 +68,12 @@ export function resolveScoped<
 function resolveAndActivate<TActivated, TArg>(
   params: ResolutionParams,
   arg: TArg,
-  serviceIdentifier: ServiceIdentifier,
+  binding: ScopedBinding<BindingType, BindingScope, TActivated>,
   resolve: (params: ResolutionParams, arg: TArg) => Resolved<TActivated>,
 ): Resolved<TActivated> {
   return resolveBindingActivations<TActivated>(
     params,
-    serviceIdentifier,
+    binding,
     resolve(params, arg),
   );
 }

--- a/packages/container/libraries/core/src/resolution/actions/resolveSingletonScopedBinding.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveSingletonScopedBinding.spec.ts
@@ -144,7 +144,7 @@ describe(resolveSingletonScopedBinding.name, () => {
         expect(resolveBindingActivations).toHaveBeenCalledTimes(1);
         expect(resolveBindingActivations).toHaveBeenCalledWith(
           resolutionParamsFixture,
-          bindingFixture.serviceIdentifier,
+          bindingFixture,
           resolveResult,
         );
       });

--- a/packages/container/libraries/core/src/resolution/actions/resolveSingletonScopedBinding.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveSingletonScopedBinding.ts
@@ -29,7 +29,7 @@ export function resolveSingletonScopedBinding<
 
     const resolvedValue: Resolved<TActivated> = resolveBindingActivations(
       params,
-      binding.serviceIdentifier,
+      binding,
       resolve(params, binding),
     );
 


### PR DESCRIPTION
### Changed
- Updated `BindingService` to provide missing parent handlers.
- Updated service activation flow to invoke missing handlers.