### PR TITLE
Update ManagedClassElementMetadata with optional typescript origin flag

### DIFF
--- a/.changeset/fresh-pandas-sin.md
+++ b/.changeset/fresh-pandas-sin.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": minor
+---
+
+Updated `ManagedClassElementMetadata` with `isFromTypescriptParamType`.

--- a/packages/container/libraries/core/src/metadata/calculations/assertMetadataFromTypescriptIfManaged.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/assertMetadataFromTypescriptIfManaged.spec.ts
@@ -1,0 +1,86 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { InversifyCoreError } from '../../error/models/InversifyCoreError';
+import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
+import { ManagedClassElementMetadataFixtures } from '../fixtures/ManagedClassElementMetadataFixtures';
+import { MaybeManagedClassElementMetadataFixtures } from '../fixtures/MaybeManagedClassElementMetadataFixtures';
+import { ManagedClassElementMetadata } from '../models/ManagedClassElementMetadata';
+import { MaybeManagedClassElementMetadata } from '../models/MaybeManagedClassElementMetadata';
+import { assertMetadataFromTypescriptIfManaged } from './assertMetadataFromTypescriptIfManaged';
+
+describe(assertMetadataFromTypescriptIfManaged, () => {
+  describe.each<
+    [string, MaybeManagedClassElementMetadata | ManagedClassElementMetadata]
+  >([
+    [
+      "ManagedClassElementMetadata which doesn't come from typescript",
+      ManagedClassElementMetadataFixtures.withNoIsFromTypescriptParamType,
+    ],
+  ])(
+    'having %s',
+    (
+      _: string,
+      metadataFixture:
+        | MaybeManagedClassElementMetadata
+        | ManagedClassElementMetadata,
+    ) => {
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          try {
+            assertMetadataFromTypescriptIfManaged(metadataFixture);
+          } catch (error: unknown) {
+            result = error;
+          }
+        });
+
+        it('should throw an InversifyCoreError', () => {
+          const expectedErrorProperties: Partial<InversifyCoreError> = {
+            kind: InversifyCoreErrorKind.injectionDecoratorConflict,
+            message:
+              'Unexpected injection found. Multiple @inject, @multiInject or @unmanaged decorators found',
+          };
+
+          expect(result).toBeInstanceOf(InversifyCoreError);
+          expect(result).toStrictEqual(
+            expect.objectContaining(expectedErrorProperties),
+          );
+        });
+      });
+    },
+  );
+
+  describe.each<
+    [string, MaybeManagedClassElementMetadata | ManagedClassElementMetadata]
+  >([
+    [
+      'ManagedClassElementMetadata which comes from typescript',
+      ManagedClassElementMetadataFixtures.withIsFromTypescriptParamTypeTrue,
+    ],
+    [
+      'MaybeManagedClassElementMetadata',
+      MaybeManagedClassElementMetadataFixtures.any,
+    ],
+  ])(
+    'having %s',
+    (
+      _: string,
+      metadataFixture:
+        | MaybeManagedClassElementMetadata
+        | ManagedClassElementMetadata,
+    ) => {
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = assertMetadataFromTypescriptIfManaged(metadataFixture);
+        });
+
+        it('should return undefined', () => {
+          expect(result).toBeUndefined();
+        });
+      });
+    },
+  );
+});

--- a/packages/container/libraries/core/src/metadata/calculations/assertMetadataFromTypescriptIfManaged.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/assertMetadataFromTypescriptIfManaged.ts
@@ -1,0 +1,19 @@
+import { InversifyCoreError } from '../../error/models/InversifyCoreError';
+import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
+import { ManagedClassElementMetadata } from '../models/ManagedClassElementMetadata';
+import { MaybeClassElementMetadataKind } from '../models/MaybeClassElementMetadataKind';
+import { MaybeManagedClassElementMetadata } from '../models/MaybeManagedClassElementMetadata';
+
+export function assertMetadataFromTypescriptIfManaged(
+  metadata: MaybeManagedClassElementMetadata | ManagedClassElementMetadata,
+): void {
+  if (
+    metadata.kind !== MaybeClassElementMetadataKind.unknown &&
+    metadata.isFromTypescriptParamType !== true
+  ) {
+    throw new InversifyCoreError(
+      InversifyCoreErrorKind.injectionDecoratorConflict,
+      'Unexpected injection found. Multiple @inject, @multiInject or @unmanaged decorators found',
+    );
+  }
+}

--- a/packages/container/libraries/core/src/metadata/calculations/buildClassElementMetadataFromMaybeClassElementMetadata.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildClassElementMetadataFromMaybeClassElementMetadata.spec.ts
@@ -4,6 +4,7 @@ import { InversifyCoreError } from '../../error/models/InversifyCoreError';
 import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
 import { ClassElementMetadata } from '../models/ClassElementMetadata';
 import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { ManagedClassElementMetadata } from '../models/ManagedClassElementMetadata';
 import { MaybeClassElementMetadataKind } from '../models/MaybeClassElementMetadataKind';
 import { MaybeManagedClassElementMetadata } from '../models/MaybeManagedClassElementMetadata';
 import { UnmanagedClassElementMetadata } from '../models/UnmanagedClassElementMetadata';
@@ -16,7 +17,9 @@ describe(buildClassElementMetadataFromMaybeClassElementMetadata.name, () => {
     >;
     let buildMetadataFromMaybeManagedMetadataMock: jest.Mock<
       (
-        metadata: MaybeManagedClassElementMetadata,
+        metadata:
+          | MaybeManagedClassElementMetadata
+          | ManagedClassElementMetadata,
         ...params: unknown[]
       ) => ClassElementMetadata
     >;
@@ -72,7 +75,9 @@ describe(buildClassElementMetadataFromMaybeClassElementMetadata.name, () => {
     >;
     let buildMetadataFromMaybeManagedMetadataMock: jest.Mock<
       (
-        metadata: MaybeManagedClassElementMetadata,
+        metadata:
+          | MaybeManagedClassElementMetadata
+          | ManagedClassElementMetadata,
         ...params: unknown[]
       ) => ClassElementMetadata
     >;
@@ -139,7 +144,9 @@ describe(buildClassElementMetadataFromMaybeClassElementMetadata.name, () => {
     >;
     let buildMetadataFromMaybeManagedMetadataMock: jest.Mock<
       (
-        metadata: MaybeManagedClassElementMetadata,
+        metadata:
+          | MaybeManagedClassElementMetadata
+          | ManagedClassElementMetadata,
         ...params: unknown[]
       ) => ClassElementMetadata
     >;

--- a/packages/container/libraries/core/src/metadata/calculations/buildClassElementMetadataFromMaybeClassElementMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildClassElementMetadataFromMaybeClassElementMetadata.ts
@@ -1,8 +1,9 @@
 import { InversifyCoreError } from '../../error/models/InversifyCoreError';
 import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
 import { ClassElementMetadata } from '../models/ClassElementMetadata';
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { ManagedClassElementMetadata } from '../models/ManagedClassElementMetadata';
 import { MaybeClassElementMetadata } from '../models/MaybeClassElementMetadata';
-import { MaybeClassElementMetadataKind } from '../models/MaybeClassElementMetadataKind';
 import { MaybeManagedClassElementMetadata } from '../models/MaybeManagedClassElementMetadata';
 
 export function buildClassElementMetadataFromMaybeClassElementMetadata<
@@ -10,7 +11,7 @@ export function buildClassElementMetadataFromMaybeClassElementMetadata<
 >(
   buildDefaultMetadata: (...params: TParams) => ClassElementMetadata,
   buildMetadataFromMaybeManagedMetadata: (
-    metadata: MaybeManagedClassElementMetadata,
+    metadata: MaybeManagedClassElementMetadata | ManagedClassElementMetadata,
     ...params: TParams
   ) => ClassElementMetadata,
 ): (
@@ -22,14 +23,13 @@ export function buildClassElementMetadataFromMaybeClassElementMetadata<
         return buildDefaultMetadata(...params);
       }
 
-      switch (metadata.kind) {
-        case MaybeClassElementMetadataKind.unknown:
-          return buildMetadataFromMaybeManagedMetadata(metadata, ...params);
-        default:
-          throw new InversifyCoreError(
-            InversifyCoreErrorKind.injectionDecoratorConflict,
-            'Unexpected injection found. Multiple @inject, @multiInject or @unmanaged decorators found',
-          );
+      if (metadata.kind === ClassElementMetadataKind.unmanaged) {
+        throw new InversifyCoreError(
+          InversifyCoreErrorKind.injectionDecoratorConflict,
+          'Unexpected injection found. Multiple @inject, @multiInject or @unmanaged decorators found',
+        );
       }
+
+      return buildMetadataFromMaybeManagedMetadata(metadata, ...params);
     };
 }

--- a/packages/container/libraries/core/src/metadata/calculations/buildClassElementMetadataFromTypescriptParameterType.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildClassElementMetadataFromTypescriptParameterType.spec.ts
@@ -1,0 +1,36 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { Newable } from '@inversifyjs/common';
+
+import { ClassElementMetadata } from '../models/ClassElementMetadata';
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { buildClassElementMetadataFromTypescriptParameterType } from './buildClassElementMetadataFromTypescriptParameterType';
+
+describe(buildClassElementMetadataFromTypescriptParameterType.name, () => {
+  describe('when called', () => {
+    let typeFixture: Newable;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      typeFixture = class {};
+
+      result =
+        buildClassElementMetadataFromTypescriptParameterType(typeFixture);
+    });
+
+    it('should return ClassElementMetadata', () => {
+      const expected: ClassElementMetadata = {
+        isFromTypescriptParamType: true,
+        kind: ClassElementMetadataKind.singleInjection,
+        name: undefined,
+        optional: false,
+        tags: new Map(),
+        targetName: undefined,
+        value: typeFixture,
+      };
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/calculations/buildClassElementMetadataFromTypescriptParameterType.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildClassElementMetadataFromTypescriptParameterType.ts
@@ -1,0 +1,18 @@
+import { Newable } from '@inversifyjs/common';
+
+import { ClassElementMetadata } from '../models/ClassElementMetadata';
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+
+export function buildClassElementMetadataFromTypescriptParameterType(
+  type: Newable,
+): ClassElementMetadata {
+  return {
+    isFromTypescriptParamType: true,
+    kind: ClassElementMetadataKind.singleInjection,
+    name: undefined,
+    optional: false,
+    tags: new Map(),
+    targetName: undefined,
+    value: type,
+  };
+}

--- a/packages/container/libraries/core/src/metadata/calculations/buildManagedMetadataFromMaybeManagedMetadata.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildManagedMetadataFromMaybeManagedMetadata.spec.ts
@@ -1,11 +1,14 @@
-import { beforeAll, describe, expect, it } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 import { LazyServiceIdentifier, ServiceIdentifier } from '@inversifyjs/common';
+
+jest.mock('./assertMetadataFromTypescriptIfManaged');
 
 import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
 import { ManagedClassElementMetadata } from '../models/ManagedClassElementMetadata';
 import { MaybeClassElementMetadataKind } from '../models/MaybeClassElementMetadataKind';
 import { MaybeManagedClassElementMetadata } from '../models/MaybeManagedClassElementMetadata';
+import { assertMetadataFromTypescriptIfManaged } from './assertMetadataFromTypescriptIfManaged';
 import { buildManagedMetadataFromMaybeManagedMetadata } from './buildManagedMetadataFromMaybeManagedMetadata';
 
 describe(buildManagedMetadataFromMaybeManagedMetadata.name, () => {
@@ -34,6 +37,17 @@ describe(buildManagedMetadataFromMaybeManagedMetadata.name, () => {
         metadataFixture,
         kindFixture,
         serviceIdentifierFixture,
+      );
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call assertMetadataFromTypescriptIfManaged()', () => {
+      expect(assertMetadataFromTypescriptIfManaged).toHaveBeenCalledTimes(1);
+      expect(assertMetadataFromTypescriptIfManaged).toHaveBeenCalledWith(
+        metadataFixture,
       );
     });
 

--- a/packages/container/libraries/core/src/metadata/calculations/buildManagedMetadataFromMaybeManagedMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildManagedMetadataFromMaybeManagedMetadata.ts
@@ -3,14 +3,17 @@ import { LazyServiceIdentifier, ServiceIdentifier } from '@inversifyjs/common';
 import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
 import { ManagedClassElementMetadata } from '../models/ManagedClassElementMetadata';
 import { MaybeManagedClassElementMetadata } from '../models/MaybeManagedClassElementMetadata';
+import { assertMetadataFromTypescriptIfManaged } from './assertMetadataFromTypescriptIfManaged';
 
 export function buildManagedMetadataFromMaybeManagedMetadata(
-  metadata: MaybeManagedClassElementMetadata,
+  metadata: MaybeManagedClassElementMetadata | ManagedClassElementMetadata,
   kind:
     | ClassElementMetadataKind.singleInjection
     | ClassElementMetadataKind.multipleInjection,
   serviceIdentifier: ServiceIdentifier | LazyServiceIdentifier,
 ): ManagedClassElementMetadata {
+  assertMetadataFromTypescriptIfManaged(metadata);
+
   return {
     ...metadata,
     kind,

--- a/packages/container/libraries/core/src/metadata/calculations/buildUnmanagedMetadataFromMaybeManagedMetadata.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildUnmanagedMetadataFromMaybeManagedMetadata.spec.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
+jest.mock('./assertMetadataFromTypescriptIfManaged');
 jest.mock('./buildDefaultUnmanagedMetadata');
 
 import { InversifyCoreError } from '../../error/models/InversifyCoreError';
@@ -8,6 +9,7 @@ import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
 import { MaybeClassElementMetadataKind } from '../models/MaybeClassElementMetadataKind';
 import { MaybeManagedClassElementMetadata } from '../models/MaybeManagedClassElementMetadata';
 import { UnmanagedClassElementMetadata } from '../models/UnmanagedClassElementMetadata';
+import { assertMetadataFromTypescriptIfManaged } from './assertMetadataFromTypescriptIfManaged';
 import { buildDefaultUnmanagedMetadata } from './buildDefaultUnmanagedMetadata';
 import { buildUnmanagedMetadataFromMaybeManagedMetadata } from './buildUnmanagedMetadataFromMaybeManagedMetadata';
 
@@ -72,6 +74,19 @@ describe(buildUnmanagedMetadataFromMaybeManagedMetadata.name, () => {
           }
         });
 
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call assertMetadataFromTypescriptIfManaged()', () => {
+          expect(assertMetadataFromTypescriptIfManaged).toHaveBeenCalledTimes(
+            1,
+          );
+          expect(assertMetadataFromTypescriptIfManaged).toHaveBeenCalledWith(
+            maybeManagedClassElementMetadata,
+          );
+        });
+
         it('should throw an InversifyCoreError', () => {
           const expectedErrorProperties: Partial<InversifyCoreError> = {
             kind: InversifyCoreErrorKind.injectionDecoratorConflict,
@@ -124,6 +139,13 @@ describe(buildUnmanagedMetadataFromMaybeManagedMetadata.name, () => {
 
       afterAll(() => {
         jest.clearAllMocks();
+      });
+
+      it('should call assertMetadataFromTypescriptIfManaged()', () => {
+        expect(assertMetadataFromTypescriptIfManaged).toHaveBeenCalledTimes(1);
+        expect(assertMetadataFromTypescriptIfManaged).toHaveBeenCalledWith(
+          maybeManagedClassElementMetadata,
+        );
       });
 
       it('should call buildDefaultUnmanagedMetadata()', () => {

--- a/packages/container/libraries/core/src/metadata/calculations/buildUnmanagedMetadataFromMaybeManagedMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildUnmanagedMetadataFromMaybeManagedMetadata.ts
@@ -1,12 +1,16 @@
 import { InversifyCoreError } from '../../error/models/InversifyCoreError';
 import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
+import { ManagedClassElementMetadata } from '../models/ManagedClassElementMetadata';
 import { MaybeManagedClassElementMetadata } from '../models/MaybeManagedClassElementMetadata';
 import { UnmanagedClassElementMetadata } from '../models/UnmanagedClassElementMetadata';
+import { assertMetadataFromTypescriptIfManaged } from './assertMetadataFromTypescriptIfManaged';
 import { buildDefaultUnmanagedMetadata } from './buildDefaultUnmanagedMetadata';
 
 export function buildUnmanagedMetadataFromMaybeManagedMetadata(
-  metadata: MaybeManagedClassElementMetadata,
+  metadata: MaybeManagedClassElementMetadata | ManagedClassElementMetadata,
 ): UnmanagedClassElementMetadata {
+  assertMetadataFromTypescriptIfManaged(metadata);
+
   if (hasManagedMetadata(metadata)) {
     throw new InversifyCoreError(
       InversifyCoreErrorKind.injectionDecoratorConflict,
@@ -18,7 +22,7 @@ export function buildUnmanagedMetadataFromMaybeManagedMetadata(
 }
 
 function hasManagedMetadata(
-  metadata: MaybeManagedClassElementMetadata,
+  metadata: MaybeManagedClassElementMetadata | ManagedClassElementMetadata,
 ): boolean {
   return (
     metadata.name !== undefined ||

--- a/packages/container/libraries/core/src/metadata/fixtures/ManagedClassElementMetadataFixtures.ts
+++ b/packages/container/libraries/core/src/metadata/fixtures/ManagedClassElementMetadataFixtures.ts
@@ -1,0 +1,31 @@
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { ManagedClassElementMetadata } from '../models/ManagedClassElementMetadata';
+
+export class ManagedClassElementMetadataFixtures {
+  public static get any(): ManagedClassElementMetadata {
+    return {
+      kind: ClassElementMetadataKind.singleInjection,
+      name: undefined,
+      optional: false,
+      tags: new Map(),
+      targetName: undefined,
+      value: Symbol(),
+    };
+  }
+
+  public static get withIsFromTypescriptParamTypeTrue(): ManagedClassElementMetadata {
+    return {
+      ...ManagedClassElementMetadataFixtures.any,
+      isFromTypescriptParamType: true,
+    };
+  }
+
+  public static get withNoIsFromTypescriptParamType(): ManagedClassElementMetadata {
+    const fixture: ManagedClassElementMetadata =
+      ManagedClassElementMetadataFixtures.any;
+
+    delete fixture.isFromTypescriptParamType;
+
+    return fixture;
+  }
+}

--- a/packages/container/libraries/core/src/metadata/fixtures/MaybeManagedClassElementMetadataFixtures.ts
+++ b/packages/container/libraries/core/src/metadata/fixtures/MaybeManagedClassElementMetadataFixtures.ts
@@ -1,0 +1,14 @@
+import { MaybeClassElementMetadataKind } from '../models/MaybeClassElementMetadataKind';
+import { MaybeManagedClassElementMetadata } from '../models/MaybeManagedClassElementMetadata';
+
+export class MaybeManagedClassElementMetadataFixtures {
+  public static get any(): MaybeManagedClassElementMetadata {
+    return {
+      kind: MaybeClassElementMetadataKind.unknown,
+      name: undefined,
+      optional: false,
+      tags: new Map(),
+      targetName: undefined,
+    };
+  }
+}

--- a/packages/container/libraries/core/src/metadata/models/ManagedClassElementMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/models/ManagedClassElementMetadata.ts
@@ -11,6 +11,7 @@ export interface ManagedClassElementMetadata
     | ClassElementMetadataKind.singleInjection
     | ClassElementMetadataKind.multipleInjection
   > {
+  isFromTypescriptParamType?: true;
   name: MetadataName | undefined;
   optional: boolean;
   tags: Map<MetadataTag, unknown>;

--- a/packages/container/libraries/core/src/reflectMetadata/data/typescriptDesignParameterTypesReflectKey.ts
+++ b/packages/container/libraries/core/src/reflectMetadata/data/typescriptDesignParameterTypesReflectKey.ts
@@ -1,0 +1,1 @@
+export const typescriptParameterTypesReflectKey: string = 'design:paramtypes';


### PR DESCRIPTION
### Added
- Added `buildClassElementMetadataFromTypescriptParameterType`.
- Added `assertMetadataFromTypescriptIfManaged`.
- Added `typescriptParameterTypesReflectKey`.

### Changed
- Updated `buildClassElementMetadataFromMaybeClassElementMetadata`.
- Updated `buildUnmanagedMetadataFromMaybeManagedMetadata` and `buildManagedMetadataFromMaybeManagedMetadata` to handle `ManagedClassElementMetadata`.
- Updated `ManagedClassElementMetadata` with `isFromTypescriptParamType`.