### PR TITLE
Update BindWhenFluentSyntax with additional constraints

### DIFF
--- a/packages/container/libraries/container/src/binding/calculations/isBindingMetadataWithName.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isBindingMetadataWithName.spec.ts
@@ -1,0 +1,59 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { BindingMetadata, MetadataName } from '@inversifyjs/core';
+
+import { isBindingMetadataWithName } from './isBindingMetadataWithName';
+
+describe(isBindingMetadataWithName.name, () => {
+  describe('having a BindingMetadata with same name as name', () => {
+    let nameFixture: MetadataName;
+
+    let bindingMetadataFixture: BindingMetadata;
+
+    beforeAll(() => {
+      nameFixture = 'name-fixture';
+
+      bindingMetadataFixture = {
+        name: nameFixture,
+      } as Partial<BindingMetadata> as BindingMetadata;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = isBindingMetadataWithName(nameFixture)(bindingMetadataFixture);
+      });
+
+      it('should return true', () => {
+        expect(result).toBe(true);
+      });
+    });
+  });
+
+  describe('having a BindingMetadata with different name than name', () => {
+    let nameFixture: MetadataName;
+
+    let bindingMetadataFixture: BindingMetadata;
+
+    beforeAll(() => {
+      nameFixture = 'name-fixture';
+
+      bindingMetadataFixture = {
+        name: 'another-name-fixture',
+      } as Partial<BindingMetadata> as BindingMetadata;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = isBindingMetadataWithName(nameFixture)(bindingMetadataFixture);
+      });
+
+      it('should return false', () => {
+        expect(result).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/container/libraries/container/src/binding/calculations/isBindingMetadataWithName.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isBindingMetadataWithName.ts
@@ -1,0 +1,7 @@
+import { BindingMetadata, MetadataName } from '@inversifyjs/core';
+
+export function isBindingMetadataWithName(
+  name: MetadataName,
+): (metadata: BindingMetadata) => boolean {
+  return (metadata: BindingMetadata): boolean => metadata.name === name;
+}

--- a/packages/container/libraries/container/src/binding/calculations/isBindingMetadataWithRightParent.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isBindingMetadataWithRightParent.spec.ts
@@ -1,0 +1,78 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { BindingMetadata } from '@inversifyjs/core';
+
+import { isBindingMetadataWithRightParent } from './isBindingMetadataWithRightParent';
+
+describe(isBindingMetadataWithRightParent.name, () => {
+  let constraintMock: jest.Mock<(metadata: BindingMetadata) => boolean>;
+  let metadataMock: jest.Mocked<BindingMetadata>;
+
+  beforeAll(() => {
+    constraintMock = jest.fn();
+    metadataMock = {
+      getAncestor: jest.fn(),
+    } as Partial<jest.Mocked<BindingMetadata>> as jest.Mocked<BindingMetadata>;
+  });
+
+  describe('when called, and metadata.getAncestor() returns undefined', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      metadataMock.getAncestor.mockReturnValueOnce(undefined);
+
+      result = isBindingMetadataWithRightParent(constraintMock)(metadataMock);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call metadata.getAncestor()', () => {
+      expect(metadataMock.getAncestor).toHaveBeenCalledTimes(1);
+      expect(metadataMock.getAncestor).toHaveBeenCalledWith();
+    });
+
+    it('should not call constraint()', () => {
+      expect(constraintMock).not.toHaveBeenCalled();
+    });
+
+    it('should return false', () => {
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('when called, and metadata.getAncestor() returns BindingMetadata', () => {
+    let constraintResultFixture: boolean;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      constraintResultFixture = true;
+
+      metadataMock.getAncestor.mockReturnValueOnce(metadataMock);
+
+      constraintMock.mockReturnValueOnce(constraintResultFixture);
+
+      result = isBindingMetadataWithRightParent(constraintMock)(metadataMock);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call metadata.getAncestor()', () => {
+      expect(metadataMock.getAncestor).toHaveBeenCalledTimes(1);
+      expect(metadataMock.getAncestor).toHaveBeenCalledWith();
+    });
+
+    it('should call constraint()', () => {
+      expect(constraintMock).toHaveBeenCalledTimes(1);
+      expect(constraintMock).toHaveBeenCalledWith(metadataMock);
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(constraintResultFixture);
+    });
+  });
+});

--- a/packages/container/libraries/container/src/binding/calculations/isBindingMetadataWithRightParent.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isBindingMetadataWithRightParent.ts
@@ -1,0 +1,12 @@
+import { BindingMetadata } from '@inversifyjs/core';
+
+export function isBindingMetadataWithRightParent(
+  constraint: (metadata: BindingMetadata) => boolean,
+): (metadata: BindingMetadata) => boolean {
+  return (metadata: BindingMetadata): boolean => {
+    const ancestorMetadata: BindingMetadata | undefined =
+      metadata.getAncestor();
+
+    return ancestorMetadata !== undefined && constraint(ancestorMetadata);
+  };
+}

--- a/packages/container/libraries/container/src/binding/calculations/isBindingMetadataWithTag.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isBindingMetadataWithTag.spec.ts
@@ -1,0 +1,100 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { BindingMetadata, MetadataName } from '@inversifyjs/core';
+
+import { isBindingMetadataWithTag } from './isBindingMetadataWithTag';
+
+describe(isBindingMetadataWithTag.name, () => {
+  describe('having a BindingMetadata with same tag and tag value', () => {
+    let tagFixture: MetadataName;
+    let tagValueFixture: unknown;
+
+    let bindingMetadataFixture: BindingMetadata;
+
+    beforeAll(() => {
+      tagFixture = 'name-fixture';
+      tagValueFixture = Symbol();
+
+      bindingMetadataFixture = {
+        tags: new Map([[tagFixture, tagValueFixture]]),
+      } as Partial<BindingMetadata> as BindingMetadata;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = isBindingMetadataWithTag(
+          tagFixture,
+          tagValueFixture,
+        )(bindingMetadataFixture);
+      });
+
+      it('should return true', () => {
+        expect(result).toBe(true);
+      });
+    });
+  });
+
+  describe('having a BindingMetadata with same tag but different tag value', () => {
+    let tagFixture: MetadataName;
+    let tagValueFixture: unknown;
+
+    let bindingMetadataFixture: BindingMetadata;
+
+    beforeAll(() => {
+      tagFixture = 'name-fixture';
+      tagValueFixture = Symbol();
+
+      bindingMetadataFixture = {
+        tags: new Map([[tagFixture, Symbol()]]),
+      } as Partial<BindingMetadata> as BindingMetadata;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = isBindingMetadataWithTag(
+          tagFixture,
+          tagValueFixture,
+        )(bindingMetadataFixture);
+      });
+
+      it('should return false', () => {
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('having a BindingMetadata with no different tag', () => {
+    let tagFixture: MetadataName;
+    let tagValueFixture: unknown;
+
+    let bindingMetadataFixture: BindingMetadata;
+
+    beforeAll(() => {
+      tagFixture = 'name-fixture';
+      tagValueFixture = Symbol();
+
+      bindingMetadataFixture = {
+        tags: new Map(),
+      } as Partial<BindingMetadata> as BindingMetadata;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = isBindingMetadataWithTag(
+          tagFixture,
+          tagValueFixture,
+        )(bindingMetadataFixture);
+      });
+
+      it('should return false', () => {
+        expect(result).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/container/libraries/container/src/binding/calculations/isBindingMetadataWithTag.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isBindingMetadataWithTag.ts
@@ -1,0 +1,9 @@
+import { BindingMetadata, MetadataTag } from '@inversifyjs/core';
+
+export function isBindingMetadataWithTag(
+  tag: MetadataTag,
+  value: unknown,
+): (metadata: BindingMetadata) => boolean {
+  return (metadata: BindingMetadata): boolean =>
+    metadata.tags.has(tag) && metadata.tags.get(tag) === value;
+}

--- a/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadataWithName.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadataWithName.spec.ts
@@ -1,0 +1,66 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { BindingMetadata, MetadataName } from '@inversifyjs/core';
+
+jest.mock('./isBindingMetadataWithName');
+jest.mock('./isBindingMetadataWithRightParent');
+
+import { isBindingMetadataWithName } from './isBindingMetadataWithName';
+import { isBindingMetadataWithRightParent } from './isBindingMetadataWithRightParent';
+import { isParentBindingMetadataWithName } from './isParentBindingMetadataWithName';
+
+describe(isParentBindingMetadataWithName.name, () => {
+  let nameFixture: MetadataName;
+
+  beforeAll(() => {
+    nameFixture = 'name-fixture';
+  });
+
+  describe('when called', () => {
+    let isBindingMetadataWithNameResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+    let isBindingMetadataWithRightParentResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      isBindingMetadataWithNameResultMock = jest.fn();
+      isBindingMetadataWithRightParentResultMock = jest.fn();
+
+      (
+        isBindingMetadataWithName as jest.Mock<typeof isBindingMetadataWithName>
+      ).mockReturnValueOnce(isBindingMetadataWithNameResultMock);
+
+      (
+        isBindingMetadataWithRightParent as jest.Mock<
+          typeof isBindingMetadataWithRightParent
+        >
+      ).mockReturnValueOnce(isBindingMetadataWithRightParentResultMock);
+
+      result = isParentBindingMetadataWithName(nameFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isBindingMetadataWithName()', () => {
+      expect(isBindingMetadataWithName).toHaveBeenCalledTimes(1);
+      expect(isBindingMetadataWithName).toHaveBeenCalledWith(nameFixture);
+    });
+
+    it('should call isBindingMetadataWithRightParent()', () => {
+      expect(isBindingMetadataWithRightParent).toHaveBeenCalledTimes(1);
+      expect(isBindingMetadataWithRightParent).toHaveBeenCalledWith(
+        isBindingMetadataWithNameResultMock,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(isBindingMetadataWithRightParentResultMock);
+    });
+  });
+});

--- a/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadataWithName.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadataWithName.ts
@@ -1,0 +1,10 @@
+import { BindingMetadata, MetadataName } from '@inversifyjs/core';
+
+import { isBindingMetadataWithName } from './isBindingMetadataWithName';
+import { isBindingMetadataWithRightParent } from './isBindingMetadataWithRightParent';
+
+export function isParentBindingMetadataWithName(
+  name: MetadataName,
+): (metadata: BindingMetadata) => boolean {
+  return isBindingMetadataWithRightParent(isBindingMetadataWithName(name));
+}

--- a/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadataWithTag.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadataWithTag.spec.ts
@@ -1,0 +1,71 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { BindingMetadata, MetadataTag } from '@inversifyjs/core';
+
+jest.mock('./isBindingMetadataWithTag');
+jest.mock('./isBindingMetadataWithRightParent');
+
+import { isBindingMetadataWithRightParent } from './isBindingMetadataWithRightParent';
+import { isBindingMetadataWithTag } from './isBindingMetadataWithTag';
+import { isParentBindingMetadataWithTag } from './isParentBindingMetadataWithTag';
+
+describe(isParentBindingMetadataWithTag.name, () => {
+  let tagFixture: MetadataTag;
+  let tagValueFixture: unknown;
+
+  beforeAll(() => {
+    tagFixture = 'name-fixture';
+    tagValueFixture = Symbol();
+  });
+
+  describe('when called', () => {
+    let isBindingMetadataWithNameResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+    let isBindingMetadataWithRightParentResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      isBindingMetadataWithNameResultMock = jest.fn();
+      isBindingMetadataWithRightParentResultMock = jest.fn();
+
+      (
+        isBindingMetadataWithTag as jest.Mock<typeof isBindingMetadataWithTag>
+      ).mockReturnValueOnce(isBindingMetadataWithNameResultMock);
+
+      (
+        isBindingMetadataWithRightParent as jest.Mock<
+          typeof isBindingMetadataWithRightParent
+        >
+      ).mockReturnValueOnce(isBindingMetadataWithRightParentResultMock);
+
+      result = isParentBindingMetadataWithTag(tagFixture, tagValueFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isBindingMetadataWithTag()', () => {
+      expect(isBindingMetadataWithTag).toHaveBeenCalledTimes(1);
+      expect(isBindingMetadataWithTag).toHaveBeenCalledWith(
+        tagFixture,
+        tagValueFixture,
+      );
+    });
+
+    it('should call isBindingMetadataWithRightParent()', () => {
+      expect(isBindingMetadataWithRightParent).toHaveBeenCalledTimes(1);
+      expect(isBindingMetadataWithRightParent).toHaveBeenCalledWith(
+        isBindingMetadataWithNameResultMock,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(isBindingMetadataWithRightParentResultMock);
+    });
+  });
+});

--- a/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadataWithTag.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadataWithTag.ts
@@ -1,0 +1,11 @@
+import { BindingMetadata, MetadataTag } from '@inversifyjs/core';
+
+import { isBindingMetadataWithRightParent } from './isBindingMetadataWithRightParent';
+import { isBindingMetadataWithTag } from './isBindingMetadataWithTag';
+
+export function isParentBindingMetadataWithTag(
+  tag: MetadataTag,
+  value: unknown,
+): (metadata: BindingMetadata) => boolean {
+  return isBindingMetadataWithRightParent(isBindingMetadataWithTag(tag, value));
+}

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntax.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntax.ts
@@ -5,6 +5,8 @@ import {
   BindingMetadata,
   DynamicValueBuilder,
   Factory,
+  MetadataName,
+  MetadataTag,
   Provider,
   ResolutionContext,
 } from '@inversifyjs/core';
@@ -50,4 +52,8 @@ export interface BindWhenFluentSyntax<T> {
   when(
     constraint: (metadata: BindingMetadata) => boolean,
   ): BindOnFluentSyntax<T>;
+  whenNamed(name: MetadataName): BindOnFluentSyntax<T>;
+  whenParentNamed(name: MetadataName): BindOnFluentSyntax<T>;
+  whenParentTagged(tag: MetadataTag, tagValue: unknown): BindOnFluentSyntax<T>;
+  whenTagged(tag: MetadataTag, tagValue: unknown): BindOnFluentSyntax<T>;
 }

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.spec.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.spec.ts
@@ -1,6 +1,10 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 jest.mock('../actions/getBindingId');
+jest.mock('../calculations/isBindingMetadataWithName');
+jest.mock('../calculations/isBindingMetadataWithTag');
+jest.mock('../calculations/isParentBindingMetadataWithName');
+jest.mock('../calculations/isParentBindingMetadataWithTag');
 
 import { ServiceIdentifier } from '@inversifyjs/common';
 import {
@@ -16,6 +20,8 @@ import {
   DynamicValueBuilder,
   Factory,
   InstanceBinding,
+  MetadataName,
+  MetadataTag,
   Provider,
   ResolutionContext,
   ScopedBinding,
@@ -24,6 +30,10 @@ import {
 
 import { Writable } from '../../common/models/Writable';
 import { getBindingId } from '../actions/getBindingId';
+import { isBindingMetadataWithName } from '../calculations/isBindingMetadataWithName';
+import { isBindingMetadataWithTag } from '../calculations/isBindingMetadataWithTag';
+import { isParentBindingMetadataWithName } from '../calculations/isParentBindingMetadataWithName';
+import { isParentBindingMetadataWithTag } from '../calculations/isParentBindingMetadataWithTag';
 import {
   BindInFluentSyntaxImplementation,
   BindInWhenOnFluentSyntaxImplementation,
@@ -667,6 +677,122 @@ describe(BindWhenFluentSyntaxImplementation.name, () => {
     it('should set constraint', () => {
       expect(isSatisfiedBySetterMock).toHaveBeenCalledTimes(1);
       expect(isSatisfiedBySetterMock).toHaveBeenCalledWith(constraintFixture);
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBeInstanceOf(BindOnFluentSyntaxImplementation);
+    });
+  });
+
+  describe('.whenNamed', () => {
+    let nameFixture: MetadataName;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      nameFixture = 'name-fixture';
+
+      result = bindWhenFluentSyntaxImplementation.whenNamed(nameFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isBindingMetadataWithName', () => {
+      expect(isBindingMetadataWithName).toHaveBeenCalledTimes(1);
+      expect(isBindingMetadataWithName).toHaveBeenCalledWith(nameFixture);
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBeInstanceOf(BindOnFluentSyntaxImplementation);
+    });
+  });
+
+  describe('.whenParentNamed', () => {
+    let nameFixture: MetadataName;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      nameFixture = 'name-fixture';
+
+      result = bindWhenFluentSyntaxImplementation.whenParentNamed(nameFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isParentBindingMetadataWithName', () => {
+      expect(isParentBindingMetadataWithName).toHaveBeenCalledTimes(1);
+      expect(isParentBindingMetadataWithName).toHaveBeenCalledWith(nameFixture);
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBeInstanceOf(BindOnFluentSyntaxImplementation);
+    });
+  });
+
+  describe('.whenParentTagged', () => {
+    let tagFixture: MetadataTag;
+    let tagValueFixture: unknown;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      tagFixture = 'tag-fixture';
+      tagValueFixture = Symbol();
+
+      result = bindWhenFluentSyntaxImplementation.whenParentTagged(
+        tagFixture,
+        tagValueFixture,
+      );
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isParentBindingMetadataWithTag', () => {
+      expect(isParentBindingMetadataWithTag).toHaveBeenCalledTimes(1);
+      expect(isParentBindingMetadataWithTag).toHaveBeenCalledWith(
+        tagFixture,
+        tagValueFixture,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBeInstanceOf(BindOnFluentSyntaxImplementation);
+    });
+  });
+
+  describe('.whenTagged', () => {
+    let tagFixture: MetadataTag;
+    let tagValueFixture: unknown;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      tagFixture = 'tag-fixture';
+      tagValueFixture = Symbol();
+
+      result = bindWhenFluentSyntaxImplementation.whenTagged(
+        tagFixture,
+        tagValueFixture,
+      );
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isBindingMetadataWithTag', () => {
+      expect(isBindingMetadataWithTag).toHaveBeenCalledTimes(1);
+      expect(isBindingMetadataWithTag).toHaveBeenCalledWith(
+        tagFixture,
+        tagValueFixture,
+      );
     });
 
     it('should return expected result', () => {

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.ts
@@ -14,6 +14,8 @@ import {
   Factory,
   FactoryBinding,
   InstanceBinding,
+  MetadataName,
+  MetadataTag,
   Provider,
   ProviderBinding,
   ResolutionContext,
@@ -25,6 +27,10 @@ import {
 import { Writable } from '../../common/models/Writable';
 import { BindingConstraintUtils } from '../../container/binding/utils/BindingConstraintUtils';
 import { getBindingId } from '../actions/getBindingId';
+import { isBindingMetadataWithName } from '../calculations/isBindingMetadataWithName';
+import { isBindingMetadataWithTag } from '../calculations/isBindingMetadataWithTag';
+import { isParentBindingMetadataWithName } from '../calculations/isParentBindingMetadataWithName';
+import { isParentBindingMetadataWithTag } from '../calculations/isParentBindingMetadataWithTag';
 import {
   BindInFluentSyntax,
   BindInWhenOnFluentSyntax,
@@ -289,6 +295,28 @@ export class BindWhenFluentSyntaxImplementation<T>
     this.#binding.isSatisfiedBy = constraint;
 
     return new BindOnFluentSyntaxImplementation(this.#binding);
+  }
+
+  public whenNamed(name: MetadataName): BindOnFluentSyntax<T> {
+    return this.when(isBindingMetadataWithName(name));
+  }
+
+  public whenParentNamed(name: MetadataName): BindOnFluentSyntax<T> {
+    return this.when(isParentBindingMetadataWithName(name));
+  }
+
+  public whenParentTagged(
+    tag: MetadataTag,
+    tagValue: unknown,
+  ): BindOnFluentSyntax<T> {
+    return this.when(isParentBindingMetadataWithTag(tag, tagValue));
+  }
+
+  public whenTagged(
+    tag: MetadataTag,
+    tagValue: unknown,
+  ): BindOnFluentSyntax<T> {
+    return this.when(isBindingMetadataWithTag(tag, tagValue));
   }
 }
 


### PR DESCRIPTION
### Added
- Added `isParentBindingMetadataWithTag`.
- Added `isParentBindingMetadataWithName`.
- Added `isBindingMetadataWithRightParent`.
- Added `isBindingMetadataWithTag`.
- Added `isBindingMetadataWithName`.

### Changed
- Updated `BindWhenFluentSyntax` with additional constraints.