### PR TITLE
Update binding fluent syntax with additional constraints

### DIFF
--- a/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingMetadata.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingMetadata.spec.ts
@@ -1,0 +1,107 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { BindingMetadata } from '@inversifyjs/core';
+
+import { isAnyAncestorBindingMetadata } from './isAnyAncestorBindingMetadata';
+
+describe(isAnyAncestorBindingMetadata.name, () => {
+  let constraintMock: jest.Mock<(metadata: BindingMetadata) => boolean>;
+  let metadataMock: jest.Mocked<BindingMetadata>;
+
+  beforeAll(() => {
+    constraintMock = jest.fn();
+    metadataMock = {
+      getAncestor: jest.fn(),
+    } as Partial<jest.Mocked<BindingMetadata>> as jest.Mocked<BindingMetadata>;
+  });
+
+  describe('when called, and metadata.getAncestor() returns undefined', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      metadataMock.getAncestor.mockReturnValueOnce(undefined);
+
+      result = isAnyAncestorBindingMetadata(constraintMock)(metadataMock);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call metadata.getAncestor()', () => {
+      expect(metadataMock.getAncestor).toHaveBeenCalledTimes(1);
+      expect(metadataMock.getAncestor).toHaveBeenCalledWith();
+    });
+
+    it('should not call constraint()', () => {
+      expect(constraintMock).not.toHaveBeenCalled();
+    });
+
+    it('should return false', () => {
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('when called, and metadata.getAncestor() returns BindingMetadata and then undefined and constraint() returns false', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      metadataMock.getAncestor
+        .mockReturnValueOnce(metadataMock)
+        .mockReturnValueOnce(undefined);
+
+      constraintMock.mockReturnValueOnce(false);
+
+      result = isAnyAncestorBindingMetadata(constraintMock)(metadataMock);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call metadata.getAncestor()', () => {
+      expect(metadataMock.getAncestor).toHaveBeenCalledTimes(2);
+      expect(metadataMock.getAncestor).toHaveBeenNthCalledWith(1);
+      expect(metadataMock.getAncestor).toHaveBeenNthCalledWith(2);
+    });
+
+    it('should call constraint()', () => {
+      expect(constraintMock).toHaveBeenCalledTimes(1);
+      expect(constraintMock).toHaveBeenCalledWith(metadataMock);
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('when called, and metadata.getAncestor() returns BindingMetadata and constraint() returns true', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      metadataMock.getAncestor.mockReturnValueOnce(metadataMock);
+
+      constraintMock.mockReturnValueOnce(true);
+
+      result = isAnyAncestorBindingMetadata(constraintMock)(metadataMock);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call metadata.getAncestor()', () => {
+      expect(metadataMock.getAncestor).toHaveBeenCalledTimes(1);
+      expect(metadataMock.getAncestor).toHaveBeenCalledWith();
+    });
+
+    it('should call constraint()', () => {
+      expect(constraintMock).toHaveBeenCalledTimes(1);
+      expect(constraintMock).toHaveBeenCalledWith(metadataMock);
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingMetadata.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingMetadata.ts
@@ -1,0 +1,20 @@
+import { BindingMetadata } from '@inversifyjs/core';
+
+export function isAnyAncestorBindingMetadata(
+  constraint: (metadata: BindingMetadata) => boolean,
+): (metadata: BindingMetadata) => boolean {
+  return (metadata: BindingMetadata): boolean => {
+    for (
+      let ancestorMetadata: BindingMetadata | undefined =
+        metadata.getAncestor();
+      ancestorMetadata !== undefined;
+      ancestorMetadata = ancestorMetadata.getAncestor()
+    ) {
+      if (constraint(ancestorMetadata)) {
+        return true;
+      }
+    }
+
+    return false;
+  };
+}

--- a/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingMetadataWithName.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingMetadataWithName.spec.ts
@@ -1,0 +1,66 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { BindingMetadata, MetadataName } from '@inversifyjs/core';
+
+jest.mock('./isBindingMetadataWithName');
+jest.mock('./isAnyAncestorBindingMetadata');
+
+import { isAnyAncestorBindingMetadata } from './isAnyAncestorBindingMetadata';
+import { isAnyAncestorBindingMetadataWithName } from './isAnyAncestorBindingMetadataWithName';
+import { isBindingMetadataWithName } from './isBindingMetadataWithName';
+
+describe(isAnyAncestorBindingMetadataWithName.name, () => {
+  let nameFixture: MetadataName;
+
+  beforeAll(() => {
+    nameFixture = 'name-fixture';
+  });
+
+  describe('when called', () => {
+    let isBindingMetadataWithNameResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+    let isAnyAncestorBindingMetadataResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      isBindingMetadataWithNameResultMock = jest.fn();
+      isAnyAncestorBindingMetadataResultMock = jest.fn();
+
+      (
+        isBindingMetadataWithName as jest.Mock<typeof isBindingMetadataWithName>
+      ).mockReturnValueOnce(isBindingMetadataWithNameResultMock);
+
+      (
+        isAnyAncestorBindingMetadata as jest.Mock<
+          typeof isAnyAncestorBindingMetadata
+        >
+      ).mockReturnValueOnce(isAnyAncestorBindingMetadataResultMock);
+
+      result = isAnyAncestorBindingMetadataWithName(nameFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isBindingMetadataWithName()', () => {
+      expect(isBindingMetadataWithName).toHaveBeenCalledTimes(1);
+      expect(isBindingMetadataWithName).toHaveBeenCalledWith(nameFixture);
+    });
+
+    it('should call isAnyAncestorBindingMetadata()', () => {
+      expect(isAnyAncestorBindingMetadata).toHaveBeenCalledTimes(1);
+      expect(isAnyAncestorBindingMetadata).toHaveBeenCalledWith(
+        isBindingMetadataWithNameResultMock,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(isAnyAncestorBindingMetadataResultMock);
+    });
+  });
+});

--- a/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingMetadataWithName.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingMetadataWithName.ts
@@ -1,0 +1,10 @@
+import { BindingMetadata, MetadataName } from '@inversifyjs/core';
+
+import { isAnyAncestorBindingMetadata } from './isAnyAncestorBindingMetadata';
+import { isBindingMetadataWithName } from './isBindingMetadataWithName';
+
+export function isAnyAncestorBindingMetadataWithName(
+  name: MetadataName,
+): (metadata: BindingMetadata) => boolean {
+  return isAnyAncestorBindingMetadata(isBindingMetadataWithName(name));
+}

--- a/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingMetadataWithServiceId.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingMetadataWithServiceId.spec.ts
@@ -1,0 +1,72 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { BindingMetadata } from '@inversifyjs/core';
+
+jest.mock('./isBindingMetadataWithServiceId');
+jest.mock('./isAnyAncestorBindingMetadata');
+
+import { ServiceIdentifier } from '@inversifyjs/common';
+
+import { isAnyAncestorBindingMetadata } from './isAnyAncestorBindingMetadata';
+import { isAnyAncestorBindingMetadataWithServiceId } from './isAnyAncestorBindingMetadataWithServiceId';
+import { isBindingMetadataWithServiceId } from './isBindingMetadataWithServiceId';
+
+describe(isAnyAncestorBindingMetadataWithServiceId.name, () => {
+  let serviceIdFixture: ServiceIdentifier;
+
+  beforeAll(() => {
+    serviceIdFixture = 'name-fixture';
+  });
+
+  describe('when called', () => {
+    let isBindingMetadataWithNameResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+    let isAnyAncestorBindingMetadataResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      isBindingMetadataWithNameResultMock = jest.fn();
+      isAnyAncestorBindingMetadataResultMock = jest.fn();
+
+      (
+        isBindingMetadataWithServiceId as jest.Mock<
+          typeof isBindingMetadataWithServiceId
+        >
+      ).mockReturnValueOnce(isBindingMetadataWithNameResultMock);
+
+      (
+        isAnyAncestorBindingMetadata as jest.Mock<
+          typeof isAnyAncestorBindingMetadata
+        >
+      ).mockReturnValueOnce(isAnyAncestorBindingMetadataResultMock);
+
+      result = isAnyAncestorBindingMetadataWithServiceId(serviceIdFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isBindingMetadataWithServiceId()', () => {
+      expect(isBindingMetadataWithServiceId).toHaveBeenCalledTimes(1);
+      expect(isBindingMetadataWithServiceId).toHaveBeenCalledWith(
+        serviceIdFixture,
+      );
+    });
+
+    it('should call isAnyAncestorBindingMetadata()', () => {
+      expect(isAnyAncestorBindingMetadata).toHaveBeenCalledTimes(1);
+      expect(isAnyAncestorBindingMetadata).toHaveBeenCalledWith(
+        isBindingMetadataWithNameResultMock,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(isAnyAncestorBindingMetadataResultMock);
+    });
+  });
+});

--- a/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingMetadataWithServiceId.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingMetadataWithServiceId.ts
@@ -1,0 +1,13 @@
+import { ServiceIdentifier } from '@inversifyjs/common';
+import { BindingMetadata } from '@inversifyjs/core';
+
+import { isAnyAncestorBindingMetadata } from './isAnyAncestorBindingMetadata';
+import { isBindingMetadataWithServiceId } from './isBindingMetadataWithServiceId';
+
+export function isAnyAncestorBindingMetadataWithServiceId(
+  serviceId: ServiceIdentifier,
+): (metadata: BindingMetadata) => boolean {
+  return isAnyAncestorBindingMetadata(
+    isBindingMetadataWithServiceId(serviceId),
+  );
+}

--- a/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingMetadataWithTag.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingMetadataWithTag.spec.ts
@@ -1,0 +1,71 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { BindingMetadata, MetadataTag } from '@inversifyjs/core';
+
+jest.mock('./isBindingMetadataWithTag');
+jest.mock('./isAnyAncestorBindingMetadata');
+
+import { isAnyAncestorBindingMetadata } from './isAnyAncestorBindingMetadata';
+import { isAnyAncestorBindingMetadataWithTag } from './isAnyAncestorBindingMetadataWithTag';
+import { isBindingMetadataWithTag } from './isBindingMetadataWithTag';
+
+describe(isAnyAncestorBindingMetadataWithTag.name, () => {
+  let tagFixture: MetadataTag;
+  let tagValueFixture: unknown;
+
+  beforeAll(() => {
+    tagFixture = 'name-fixture';
+    tagValueFixture = Symbol();
+  });
+
+  describe('when called', () => {
+    let isBindingMetadataWithNameResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+    let isAnyAncestorBindingMetadataResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      isBindingMetadataWithNameResultMock = jest.fn();
+      isAnyAncestorBindingMetadataResultMock = jest.fn();
+
+      (
+        isBindingMetadataWithTag as jest.Mock<typeof isBindingMetadataWithTag>
+      ).mockReturnValueOnce(isBindingMetadataWithNameResultMock);
+
+      (
+        isAnyAncestorBindingMetadata as jest.Mock<
+          typeof isAnyAncestorBindingMetadata
+        >
+      ).mockReturnValueOnce(isAnyAncestorBindingMetadataResultMock);
+
+      result = isAnyAncestorBindingMetadataWithTag(tagFixture, tagValueFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isBindingMetadataWithTag()', () => {
+      expect(isBindingMetadataWithTag).toHaveBeenCalledTimes(1);
+      expect(isBindingMetadataWithTag).toHaveBeenCalledWith(
+        tagFixture,
+        tagValueFixture,
+      );
+    });
+
+    it('should call isAnyAncestorBindingMetadata()', () => {
+      expect(isAnyAncestorBindingMetadata).toHaveBeenCalledTimes(1);
+      expect(isAnyAncestorBindingMetadata).toHaveBeenCalledWith(
+        isBindingMetadataWithNameResultMock,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(isAnyAncestorBindingMetadataResultMock);
+    });
+  });
+});

--- a/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingMetadataWithTag.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingMetadataWithTag.ts
@@ -1,0 +1,11 @@
+import { BindingMetadata, MetadataTag } from '@inversifyjs/core';
+
+import { isAnyAncestorBindingMetadata } from './isAnyAncestorBindingMetadata';
+import { isBindingMetadataWithTag } from './isBindingMetadataWithTag';
+
+export function isAnyAncestorBindingMetadataWithTag(
+  tag: MetadataTag,
+  value: unknown,
+): (metadata: BindingMetadata) => boolean {
+  return isAnyAncestorBindingMetadata(isBindingMetadataWithTag(tag, value));
+}

--- a/packages/container/libraries/container/src/binding/calculations/isBindingMetadataWithServiceId.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isBindingMetadataWithServiceId.spec.ts
@@ -1,0 +1,64 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { ServiceIdentifier } from '@inversifyjs/common';
+import { BindingMetadata } from '@inversifyjs/core';
+
+import { isBindingMetadataWithServiceId } from './isBindingMetadataWithServiceId';
+
+describe(isBindingMetadataWithServiceId.name, () => {
+  describe('having a BindingMetadata with same serviceId', () => {
+    let serviceIdFixture: ServiceIdentifier;
+
+    let bindingMetadataFixture: BindingMetadata;
+
+    beforeAll(() => {
+      serviceIdFixture = 'service-id-fixture';
+
+      bindingMetadataFixture = {
+        serviceIdentifier: serviceIdFixture,
+      } as Partial<BindingMetadata> as BindingMetadata;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = isBindingMetadataWithServiceId(serviceIdFixture)(
+          bindingMetadataFixture,
+        );
+      });
+
+      it('should return true', () => {
+        expect(result).toBe(true);
+      });
+    });
+  });
+
+  describe('having a BindingMetadata with different serviceId', () => {
+    let serviceIdFixture: ServiceIdentifier;
+
+    let bindingMetadataFixture: BindingMetadata;
+
+    beforeAll(() => {
+      serviceIdFixture = 'service-id-fixture';
+
+      bindingMetadataFixture = {
+        serviceIdentifier: 'another-service-id-fixture',
+      } as Partial<BindingMetadata> as BindingMetadata;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = isBindingMetadataWithServiceId(serviceIdFixture)(
+          bindingMetadataFixture,
+        );
+      });
+
+      it('should return false', () => {
+        expect(result).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/container/libraries/container/src/binding/calculations/isBindingMetadataWithServiceId.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isBindingMetadataWithServiceId.ts
@@ -1,0 +1,9 @@
+import { ServiceIdentifier } from '@inversifyjs/common';
+import { BindingMetadata } from '@inversifyjs/core';
+
+export function isBindingMetadataWithServiceId(
+  serviceId: ServiceIdentifier,
+): (metadata: BindingMetadata) => boolean {
+  return (metadata: BindingMetadata): boolean =>
+    metadata.serviceIdentifier === serviceId;
+}

--- a/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadata.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadata.spec.ts
@@ -2,9 +2,9 @@ import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 import { BindingMetadata } from '@inversifyjs/core';
 
-import { isBindingMetadataWithRightParent } from './isBindingMetadataWithRightParent';
+import { isParentBindingMetadata } from './isParentBindingMetadata';
 
-describe(isBindingMetadataWithRightParent.name, () => {
+describe(isParentBindingMetadata.name, () => {
   let constraintMock: jest.Mock<(metadata: BindingMetadata) => boolean>;
   let metadataMock: jest.Mocked<BindingMetadata>;
 
@@ -21,7 +21,7 @@ describe(isBindingMetadataWithRightParent.name, () => {
     beforeAll(() => {
       metadataMock.getAncestor.mockReturnValueOnce(undefined);
 
-      result = isBindingMetadataWithRightParent(constraintMock)(metadataMock);
+      result = isParentBindingMetadata(constraintMock)(metadataMock);
     });
 
     afterAll(() => {
@@ -54,7 +54,7 @@ describe(isBindingMetadataWithRightParent.name, () => {
 
       constraintMock.mockReturnValueOnce(constraintResultFixture);
 
-      result = isBindingMetadataWithRightParent(constraintMock)(metadataMock);
+      result = isParentBindingMetadata(constraintMock)(metadataMock);
     });
 
     afterAll(() => {

--- a/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadata.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadata.ts
@@ -1,6 +1,6 @@
 import { BindingMetadata } from '@inversifyjs/core';
 
-export function isBindingMetadataWithRightParent(
+export function isParentBindingMetadata(
   constraint: (metadata: BindingMetadata) => boolean,
 ): (metadata: BindingMetadata) => boolean {
   return (metadata: BindingMetadata): boolean => {

--- a/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadataWithName.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadataWithName.spec.ts
@@ -3,10 +3,10 @@ import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import { BindingMetadata, MetadataName } from '@inversifyjs/core';
 
 jest.mock('./isBindingMetadataWithName');
-jest.mock('./isBindingMetadataWithRightParent');
+jest.mock('./isParentBindingMetadata');
 
 import { isBindingMetadataWithName } from './isBindingMetadataWithName';
-import { isBindingMetadataWithRightParent } from './isBindingMetadataWithRightParent';
+import { isParentBindingMetadata } from './isParentBindingMetadata';
 import { isParentBindingMetadataWithName } from './isParentBindingMetadataWithName';
 
 describe(isParentBindingMetadataWithName.name, () => {
@@ -20,7 +20,7 @@ describe(isParentBindingMetadataWithName.name, () => {
     let isBindingMetadataWithNameResultMock: jest.Mock<
       (metadata: BindingMetadata) => boolean
     >;
-    let isBindingMetadataWithRightParentResultMock: jest.Mock<
+    let isParentBindingMetadataResultMock: jest.Mock<
       (metadata: BindingMetadata) => boolean
     >;
 
@@ -28,17 +28,15 @@ describe(isParentBindingMetadataWithName.name, () => {
 
     beforeAll(() => {
       isBindingMetadataWithNameResultMock = jest.fn();
-      isBindingMetadataWithRightParentResultMock = jest.fn();
+      isParentBindingMetadataResultMock = jest.fn();
 
       (
         isBindingMetadataWithName as jest.Mock<typeof isBindingMetadataWithName>
       ).mockReturnValueOnce(isBindingMetadataWithNameResultMock);
 
       (
-        isBindingMetadataWithRightParent as jest.Mock<
-          typeof isBindingMetadataWithRightParent
-        >
-      ).mockReturnValueOnce(isBindingMetadataWithRightParentResultMock);
+        isParentBindingMetadata as jest.Mock<typeof isParentBindingMetadata>
+      ).mockReturnValueOnce(isParentBindingMetadataResultMock);
 
       result = isParentBindingMetadataWithName(nameFixture);
     });
@@ -52,15 +50,15 @@ describe(isParentBindingMetadataWithName.name, () => {
       expect(isBindingMetadataWithName).toHaveBeenCalledWith(nameFixture);
     });
 
-    it('should call isBindingMetadataWithRightParent()', () => {
-      expect(isBindingMetadataWithRightParent).toHaveBeenCalledTimes(1);
-      expect(isBindingMetadataWithRightParent).toHaveBeenCalledWith(
+    it('should call isParentBindingMetadata()', () => {
+      expect(isParentBindingMetadata).toHaveBeenCalledTimes(1);
+      expect(isParentBindingMetadata).toHaveBeenCalledWith(
         isBindingMetadataWithNameResultMock,
       );
     });
 
     it('should return expected result', () => {
-      expect(result).toBe(isBindingMetadataWithRightParentResultMock);
+      expect(result).toBe(isParentBindingMetadataResultMock);
     });
   });
 });

--- a/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadataWithName.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadataWithName.ts
@@ -1,10 +1,10 @@
 import { BindingMetadata, MetadataName } from '@inversifyjs/core';
 
 import { isBindingMetadataWithName } from './isBindingMetadataWithName';
-import { isBindingMetadataWithRightParent } from './isBindingMetadataWithRightParent';
+import { isParentBindingMetadata } from './isParentBindingMetadata';
 
 export function isParentBindingMetadataWithName(
   name: MetadataName,
 ): (metadata: BindingMetadata) => boolean {
-  return isBindingMetadataWithRightParent(isBindingMetadataWithName(name));
+  return isParentBindingMetadata(isBindingMetadataWithName(name));
 }

--- a/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadataWithServiceId.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadataWithServiceId.spec.ts
@@ -1,0 +1,70 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { BindingMetadata } from '@inversifyjs/core';
+
+jest.mock('./isBindingMetadataWithServiceId');
+jest.mock('./isParentBindingMetadata');
+
+import { ServiceIdentifier } from '@inversifyjs/common';
+
+import { isBindingMetadataWithServiceId } from './isBindingMetadataWithServiceId';
+import { isParentBindingMetadata } from './isParentBindingMetadata';
+import { isParentBindingMetadataWithServiceId } from './isParentBindingMetadataWithServiceId';
+
+describe(isParentBindingMetadataWithServiceId.name, () => {
+  let serviceIdFixture: ServiceIdentifier;
+
+  beforeAll(() => {
+    serviceIdFixture = 'name-fixture';
+  });
+
+  describe('when called', () => {
+    let isBindingMetadataWithNameResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+    let isParentBindingMetadataResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      isBindingMetadataWithNameResultMock = jest.fn();
+      isParentBindingMetadataResultMock = jest.fn();
+
+      (
+        isBindingMetadataWithServiceId as jest.Mock<
+          typeof isBindingMetadataWithServiceId
+        >
+      ).mockReturnValueOnce(isBindingMetadataWithNameResultMock);
+
+      (
+        isParentBindingMetadata as jest.Mock<typeof isParentBindingMetadata>
+      ).mockReturnValueOnce(isParentBindingMetadataResultMock);
+
+      result = isParentBindingMetadataWithServiceId(serviceIdFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isBindingMetadataWithServiceId()', () => {
+      expect(isBindingMetadataWithServiceId).toHaveBeenCalledTimes(1);
+      expect(isBindingMetadataWithServiceId).toHaveBeenCalledWith(
+        serviceIdFixture,
+      );
+    });
+
+    it('should call isParentBindingMetadata()', () => {
+      expect(isParentBindingMetadata).toHaveBeenCalledTimes(1);
+      expect(isParentBindingMetadata).toHaveBeenCalledWith(
+        isBindingMetadataWithNameResultMock,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(isParentBindingMetadataResultMock);
+    });
+  });
+});

--- a/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadataWithServiceId.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadataWithServiceId.ts
@@ -1,0 +1,11 @@
+import { ServiceIdentifier } from '@inversifyjs/common';
+import { BindingMetadata } from '@inversifyjs/core';
+
+import { isBindingMetadataWithServiceId } from './isBindingMetadataWithServiceId';
+import { isParentBindingMetadata } from './isParentBindingMetadata';
+
+export function isParentBindingMetadataWithServiceId(
+  serviceId: ServiceIdentifier,
+): (metadata: BindingMetadata) => boolean {
+  return isParentBindingMetadata(isBindingMetadataWithServiceId(serviceId));
+}

--- a/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadataWithTag.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadataWithTag.spec.ts
@@ -3,10 +3,10 @@ import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import { BindingMetadata, MetadataTag } from '@inversifyjs/core';
 
 jest.mock('./isBindingMetadataWithTag');
-jest.mock('./isBindingMetadataWithRightParent');
+jest.mock('./isParentBindingMetadata');
 
-import { isBindingMetadataWithRightParent } from './isBindingMetadataWithRightParent';
 import { isBindingMetadataWithTag } from './isBindingMetadataWithTag';
+import { isParentBindingMetadata } from './isParentBindingMetadata';
 import { isParentBindingMetadataWithTag } from './isParentBindingMetadataWithTag';
 
 describe(isParentBindingMetadataWithTag.name, () => {
@@ -22,7 +22,7 @@ describe(isParentBindingMetadataWithTag.name, () => {
     let isBindingMetadataWithNameResultMock: jest.Mock<
       (metadata: BindingMetadata) => boolean
     >;
-    let isBindingMetadataWithRightParentResultMock: jest.Mock<
+    let isParentBindingMetadataResultMock: jest.Mock<
       (metadata: BindingMetadata) => boolean
     >;
 
@@ -30,17 +30,15 @@ describe(isParentBindingMetadataWithTag.name, () => {
 
     beforeAll(() => {
       isBindingMetadataWithNameResultMock = jest.fn();
-      isBindingMetadataWithRightParentResultMock = jest.fn();
+      isParentBindingMetadataResultMock = jest.fn();
 
       (
         isBindingMetadataWithTag as jest.Mock<typeof isBindingMetadataWithTag>
       ).mockReturnValueOnce(isBindingMetadataWithNameResultMock);
 
       (
-        isBindingMetadataWithRightParent as jest.Mock<
-          typeof isBindingMetadataWithRightParent
-        >
-      ).mockReturnValueOnce(isBindingMetadataWithRightParentResultMock);
+        isParentBindingMetadata as jest.Mock<typeof isParentBindingMetadata>
+      ).mockReturnValueOnce(isParentBindingMetadataResultMock);
 
       result = isParentBindingMetadataWithTag(tagFixture, tagValueFixture);
     });
@@ -57,15 +55,15 @@ describe(isParentBindingMetadataWithTag.name, () => {
       );
     });
 
-    it('should call isBindingMetadataWithRightParent()', () => {
-      expect(isBindingMetadataWithRightParent).toHaveBeenCalledTimes(1);
-      expect(isBindingMetadataWithRightParent).toHaveBeenCalledWith(
+    it('should call isParentBindingMetadata()', () => {
+      expect(isParentBindingMetadata).toHaveBeenCalledTimes(1);
+      expect(isParentBindingMetadata).toHaveBeenCalledWith(
         isBindingMetadataWithNameResultMock,
       );
     });
 
     it('should return expected result', () => {
-      expect(result).toBe(isBindingMetadataWithRightParentResultMock);
+      expect(result).toBe(isParentBindingMetadataResultMock);
     });
   });
 });

--- a/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadataWithTag.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadataWithTag.ts
@@ -1,11 +1,11 @@
 import { BindingMetadata, MetadataTag } from '@inversifyjs/core';
 
-import { isBindingMetadataWithRightParent } from './isBindingMetadataWithRightParent';
 import { isBindingMetadataWithTag } from './isBindingMetadataWithTag';
+import { isParentBindingMetadata } from './isParentBindingMetadata';
 
 export function isParentBindingMetadataWithTag(
   tag: MetadataTag,
   value: unknown,
 ): (metadata: BindingMetadata) => boolean {
-  return isBindingMetadataWithRightParent(isBindingMetadataWithTag(tag, value));
+  return isParentBindingMetadata(isBindingMetadataWithTag(tag, value));
 }

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntax.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntax.ts
@@ -52,7 +52,22 @@ export interface BindWhenFluentSyntax<T> {
   when(
     constraint: (metadata: BindingMetadata) => boolean,
   ): BindOnFluentSyntax<T>;
+  whenAnyAncestor(
+    constraint: (metadata: BindingMetadata) => boolean,
+  ): BindOnFluentSyntax<T>;
+  whenAnyAncestorIs(
+    serviceIdentifier: ServiceIdentifier,
+  ): BindOnFluentSyntax<T>;
+  whenAnyAncestorNamed(name: MetadataName): BindOnFluentSyntax<T>;
+  whenAnyAncestorTagged(
+    tag: MetadataTag,
+    tagValue: unknown,
+  ): BindOnFluentSyntax<T>;
   whenNamed(name: MetadataName): BindOnFluentSyntax<T>;
+  whenParent(
+    constraint: (metadata: BindingMetadata) => boolean,
+  ): BindOnFluentSyntax<T>;
+  whenParentIs(serviceIdentifier: ServiceIdentifier): BindOnFluentSyntax<T>;
   whenParentNamed(name: MetadataName): BindOnFluentSyntax<T>;
   whenParentTagged(tag: MetadataTag, tagValue: unknown): BindOnFluentSyntax<T>;
   whenTagged(tag: MetadataTag, tagValue: unknown): BindOnFluentSyntax<T>;

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.spec.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.spec.ts
@@ -1,9 +1,15 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 jest.mock('../actions/getBindingId');
+jest.mock('../calculations/isAnyAncestorBindingMetadata');
+jest.mock('../calculations/isAnyAncestorBindingMetadataWithName');
+jest.mock('../calculations/isAnyAncestorBindingMetadataWithServiceId');
+jest.mock('../calculations/isAnyAncestorBindingMetadataWithTag');
 jest.mock('../calculations/isBindingMetadataWithName');
 jest.mock('../calculations/isBindingMetadataWithTag');
+jest.mock('../calculations/isParentBindingMetadata');
 jest.mock('../calculations/isParentBindingMetadataWithName');
+jest.mock('../calculations/isParentBindingMetadataWithServiceId');
 jest.mock('../calculations/isParentBindingMetadataWithTag');
 
 import { ServiceIdentifier } from '@inversifyjs/common';
@@ -30,9 +36,15 @@ import {
 
 import { Writable } from '../../common/models/Writable';
 import { getBindingId } from '../actions/getBindingId';
+import { isAnyAncestorBindingMetadata } from '../calculations/isAnyAncestorBindingMetadata';
+import { isAnyAncestorBindingMetadataWithName } from '../calculations/isAnyAncestorBindingMetadataWithName';
+import { isAnyAncestorBindingMetadataWithServiceId } from '../calculations/isAnyAncestorBindingMetadataWithServiceId';
+import { isAnyAncestorBindingMetadataWithTag } from '../calculations/isAnyAncestorBindingMetadataWithTag';
 import { isBindingMetadataWithName } from '../calculations/isBindingMetadataWithName';
 import { isBindingMetadataWithTag } from '../calculations/isBindingMetadataWithTag';
+import { isParentBindingMetadata } from '../calculations/isParentBindingMetadata';
 import { isParentBindingMetadataWithName } from '../calculations/isParentBindingMetadataWithName';
+import { isParentBindingMetadataWithServiceId } from '../calculations/isParentBindingMetadataWithServiceId';
 import { isParentBindingMetadataWithTag } from '../calculations/isParentBindingMetadataWithTag';
 import {
   BindInFluentSyntaxImplementation,
@@ -684,6 +696,125 @@ describe(BindWhenFluentSyntaxImplementation.name, () => {
     });
   });
 
+  describe('.whenAnyAncestor', () => {
+    let constraintFixture: (metadata: BindingMetadata) => boolean;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      constraintFixture = () => true;
+
+      result =
+        bindWhenFluentSyntaxImplementation.whenAnyAncestor(constraintFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isAnyAncestorBindingMetadata', () => {
+      expect(isAnyAncestorBindingMetadata).toHaveBeenCalledTimes(1);
+      expect(isAnyAncestorBindingMetadata).toHaveBeenCalledWith(
+        constraintFixture,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBeInstanceOf(BindOnFluentSyntaxImplementation);
+    });
+  });
+
+  describe('.whenAnyAncestorIs', () => {
+    let serviceIdFixture: ServiceIdentifier;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      serviceIdFixture = 'name-fixture';
+
+      result =
+        bindWhenFluentSyntaxImplementation.whenAnyAncestorIs(serviceIdFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isAnyAncestorBindingMetadataWithServiceId', () => {
+      expect(isAnyAncestorBindingMetadataWithServiceId).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(isAnyAncestorBindingMetadataWithServiceId).toHaveBeenCalledWith(
+        serviceIdFixture,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBeInstanceOf(BindOnFluentSyntaxImplementation);
+    });
+  });
+
+  describe('.whenAnyAncestorNamed', () => {
+    let nameFixture: MetadataName;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      nameFixture = 'name-fixture';
+
+      result =
+        bindWhenFluentSyntaxImplementation.whenAnyAncestorNamed(nameFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isAnyAncestorBindingMetadataWithName', () => {
+      expect(isAnyAncestorBindingMetadataWithName).toHaveBeenCalledTimes(1);
+      expect(isAnyAncestorBindingMetadataWithName).toHaveBeenCalledWith(
+        nameFixture,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBeInstanceOf(BindOnFluentSyntaxImplementation);
+    });
+  });
+
+  describe('.whenAnyAncestorTagged', () => {
+    let tagFixture: MetadataTag;
+    let tagValueFixture: unknown;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      tagFixture = 'tag-fixture';
+      tagValueFixture = Symbol();
+
+      result = bindWhenFluentSyntaxImplementation.whenAnyAncestorTagged(
+        tagFixture,
+        tagValueFixture,
+      );
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isAnyAncestorBindingMetadataWithTag', () => {
+      expect(isAnyAncestorBindingMetadataWithTag).toHaveBeenCalledTimes(1);
+      expect(isAnyAncestorBindingMetadataWithTag).toHaveBeenCalledWith(
+        tagFixture,
+        tagValueFixture,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBeInstanceOf(BindOnFluentSyntaxImplementation);
+    });
+  });
+
   describe('.whenNamed', () => {
     let nameFixture: MetadataName;
 
@@ -702,6 +833,59 @@ describe(BindWhenFluentSyntaxImplementation.name, () => {
     it('should call isBindingMetadataWithName', () => {
       expect(isBindingMetadataWithName).toHaveBeenCalledTimes(1);
       expect(isBindingMetadataWithName).toHaveBeenCalledWith(nameFixture);
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBeInstanceOf(BindOnFluentSyntaxImplementation);
+    });
+  });
+
+  describe('.whenParent', () => {
+    let constraintFixture: (metadata: BindingMetadata) => boolean;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      constraintFixture = () => true;
+
+      result = bindWhenFluentSyntaxImplementation.whenParent(constraintFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isParentBindingMetadata', () => {
+      expect(isParentBindingMetadata).toHaveBeenCalledTimes(1);
+      expect(isParentBindingMetadata).toHaveBeenCalledWith(constraintFixture);
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBeInstanceOf(BindOnFluentSyntaxImplementation);
+    });
+  });
+
+  describe('.whenParentIs', () => {
+    let serviceIdFixture: ServiceIdentifier;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      serviceIdFixture = 'name-fixture';
+
+      result =
+        bindWhenFluentSyntaxImplementation.whenParentIs(serviceIdFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isParentBindingMetadataWithServiceId', () => {
+      expect(isParentBindingMetadataWithServiceId).toHaveBeenCalledTimes(1);
+      expect(isParentBindingMetadataWithServiceId).toHaveBeenCalledWith(
+        serviceIdFixture,
+      );
     });
 
     it('should return expected result', () => {

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.ts
@@ -27,9 +27,15 @@ import {
 import { Writable } from '../../common/models/Writable';
 import { BindingConstraintUtils } from '../../container/binding/utils/BindingConstraintUtils';
 import { getBindingId } from '../actions/getBindingId';
+import { isAnyAncestorBindingMetadata } from '../calculations/isAnyAncestorBindingMetadata';
+import { isAnyAncestorBindingMetadataWithName } from '../calculations/isAnyAncestorBindingMetadataWithName';
+import { isAnyAncestorBindingMetadataWithServiceId } from '../calculations/isAnyAncestorBindingMetadataWithServiceId';
+import { isAnyAncestorBindingMetadataWithTag } from '../calculations/isAnyAncestorBindingMetadataWithTag';
 import { isBindingMetadataWithName } from '../calculations/isBindingMetadataWithName';
 import { isBindingMetadataWithTag } from '../calculations/isBindingMetadataWithTag';
+import { isParentBindingMetadata } from '../calculations/isParentBindingMetadata';
 import { isParentBindingMetadataWithName } from '../calculations/isParentBindingMetadataWithName';
+import { isParentBindingMetadataWithServiceId } from '../calculations/isParentBindingMetadataWithServiceId';
 import { isParentBindingMetadataWithTag } from '../calculations/isParentBindingMetadataWithTag';
 import {
   BindInFluentSyntax,
@@ -297,8 +303,45 @@ export class BindWhenFluentSyntaxImplementation<T>
     return new BindOnFluentSyntaxImplementation(this.#binding);
   }
 
+  public whenAnyAncestor(
+    constraint: (metadata: BindingMetadata) => boolean,
+  ): BindOnFluentSyntax<T> {
+    return this.when(isAnyAncestorBindingMetadata(constraint));
+  }
+
+  public whenAnyAncestorIs(
+    serviceIdentifier: ServiceIdentifier,
+  ): BindOnFluentSyntax<T> {
+    return this.when(
+      isAnyAncestorBindingMetadataWithServiceId(serviceIdentifier),
+    );
+  }
+
+  public whenAnyAncestorNamed(name: MetadataName): BindOnFluentSyntax<T> {
+    return this.when(isAnyAncestorBindingMetadataWithName(name));
+  }
+
+  public whenAnyAncestorTagged(
+    tag: MetadataTag,
+    tagValue: unknown,
+  ): BindOnFluentSyntax<T> {
+    return this.when(isAnyAncestorBindingMetadataWithTag(tag, tagValue));
+  }
+
   public whenNamed(name: MetadataName): BindOnFluentSyntax<T> {
     return this.when(isBindingMetadataWithName(name));
+  }
+
+  public whenParent(
+    constraint: (metadata: BindingMetadata) => boolean,
+  ): BindOnFluentSyntax<T> {
+    return this.when(isParentBindingMetadata(constraint));
+  }
+
+  public whenParentIs(
+    serviceIdentifier: ServiceIdentifier,
+  ): BindOnFluentSyntax<T> {
+    return this.when(isParentBindingMetadataWithServiceId(serviceIdentifier));
   }
 
   public whenParentNamed(name: MetadataName): BindOnFluentSyntax<T> {


### PR DESCRIPTION
### Added
- Added `isAnyAncestorBindingMetadataWithTag`.
- Added `isAnyAncestorBindingMetadataWithServiceId`.
- Added `isAnyAncestorBindingMetadata`.
- Added `isParentBindingMetadataWithServiceId`.
- Added `isBindingMetadataWithServiceId`.

### Changed
- Updated `BindWhenFluentSyntax` with additional constraints.