### PR TITLE
Update binding deactivation to handle async cached values

### DIFF
--- a/packages/container/libraries/core/src/binding/fixtures/ConstantValueBindingFixtures.ts
+++ b/packages/container/libraries/core/src/binding/fixtures/ConstantValueBindingFixtures.ts
@@ -48,23 +48,34 @@ export class ConstantValueBindingFixtures {
     };
   }
 
-  public static get withOnDeactivationAsync(): ConstantValueBinding<unknown> {
+  public static get withCacheWithIsRightTrueOnDeactivationAsync(): ConstantValueBinding<unknown> {
     return {
       ...ConstantValueBindingFixtures.any,
       onDeactivation: async (): Promise<void> => undefined,
     };
   }
 
-  public static get withOnDeactivationSync(): ConstantValueBinding<unknown> {
+  public static get withCacheWithIsRightTrueAndAsyncValueAndOnDeactivationSync(): ConstantValueBinding<unknown> {
     return {
       ...ConstantValueBindingFixtures.any,
+      cache: {
+        isRight: true,
+        value: Promise.resolve(Symbol()),
+      },
       onDeactivation: (): void => undefined,
     };
   }
 
-  public static get withOnDeactivationUndefined(): ConstantValueBinding<unknown> {
+  public static get withCacheWithIsRightTrueAndOnDeactivationSync(): ConstantValueBinding<unknown> {
     return {
-      ...ConstantValueBindingFixtures.any,
+      ...ConstantValueBindingFixtures.withCacheWithIsRightTrue,
+      onDeactivation: (): void => undefined,
+    };
+  }
+
+  public static get withCacheWithIsRightTrueAndOnDeactivationUndefined(): ConstantValueBinding<unknown> {
+    return {
+      ...ConstantValueBindingFixtures.withCacheWithIsRightTrue,
       onDeactivation: undefined,
     };
   }

--- a/packages/container/libraries/core/src/binding/fixtures/InstanceBindingFixtures.ts
+++ b/packages/container/libraries/core/src/binding/fixtures/InstanceBindingFixtures.ts
@@ -21,10 +21,30 @@ export class InstanceBindingFixtures {
     };
   }
 
-  public static get withCacheWithScopeSingleton(): InstanceBinding<unknown> {
+  public static get withScopeSingleton(): InstanceBinding<unknown> {
     return {
       ...InstanceBindingFixtures.any,
       scope: bindingScopeValues.Singleton,
+    };
+  }
+
+  public static get withCacheIsRightAndAsyncValueAndScopeSingleton(): InstanceBinding<unknown> {
+    return {
+      ...InstanceBindingFixtures.withScopeSingleton,
+      cache: {
+        isRight: true,
+        value: Promise.resolve({}),
+      },
+    };
+  }
+
+  public static get withCacheIsRightAndScopeSingleton(): InstanceBinding<unknown> {
+    return {
+      ...InstanceBindingFixtures.withScopeSingleton,
+      cache: {
+        isRight: true,
+        value: {},
+      },
     };
   }
 }

--- a/packages/container/libraries/core/src/metadata/fixtures/ClassMetadataFixtures.ts
+++ b/packages/container/libraries/core/src/metadata/fixtures/ClassMetadataFixtures.ts
@@ -15,6 +15,20 @@ export class ClassMetadataFixtures {
     return fixture;
   }
 
+  public static get withNoPreDestroyMethodName(): ClassMetadata {
+    const fixture: ClassMetadata = {
+      constructorArguments: [],
+      lifecycle: {
+        postConstructMethodName: undefined,
+        preDestroyMethodName: undefined,
+      },
+      properties: new Map(),
+      scope: undefined,
+    };
+
+    return fixture;
+  }
+
   public static get withPreDestroyMethodName(): ClassMetadata {
     const fixture: ClassMetadata = {
       constructorArguments: [],

--- a/packages/container/libraries/core/src/resolution/actions/resolveBindingDeactivations.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveBindingDeactivations.spec.ts
@@ -1,18 +1,36 @@
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
+jest.mock('./resolveBindingPreDestroy');
 jest.mock('./resolveBindingServiceDeactivations');
 
+import { Right } from '@inversifyjs/common';
+
 import { ConstantValueBindingFixtures } from '../../binding/fixtures/ConstantValueBindingFixtures';
-import { ConstantValueBinding } from '../../binding/models/ConstantValueBinding';
+import { Binding } from '../../binding/models/Binding';
+import { bindingScopeValues } from '../../binding/models/BindingScope';
+import { BindingType } from '../../binding/models/BindingType';
+import { ScopedBinding } from '../../binding/models/ScopedBinding';
 import { DeactivationParams } from '../models/DeactivationParams';
+import { Resolved } from '../models/Resolved';
 import { resolveBindingDeactivations } from './resolveBindingDeactivations';
+import { resolveBindingPreDestroy } from './resolveBindingPreDestroy';
 import { resolveBindingServiceDeactivations } from './resolveBindingServiceDeactivations';
+
+const CACHE_KEY_TYPE: keyof ScopedBinding<
+  BindingType,
+  typeof bindingScopeValues.Singleton,
+  unknown
+> = 'cache';
+
+type CachedSingletonScopedBinding<TResolved> = Binding &
+  ScopedBinding<BindingType, typeof bindingScopeValues.Singleton, TResolved> & {
+    [CACHE_KEY_TYPE]: Right<Resolved<TResolved>>;
+  };
 
 describe(resolveBindingDeactivations.name, () => {
   describe('having a binding with no deactivation', () => {
     let paramsMock: jest.Mocked<DeactivationParams>;
-    let bindingFixture: ConstantValueBinding<unknown>;
-    let resolvedValueFixture: unknown;
+    let bindingFixture: CachedSingletonScopedBinding<unknown>;
 
     beforeAll(() => {
       paramsMock = {
@@ -21,44 +39,88 @@ describe(resolveBindingDeactivations.name, () => {
       } as Partial<
         jest.Mocked<DeactivationParams>
       > as jest.Mocked<DeactivationParams>;
-      bindingFixture = ConstantValueBindingFixtures.withOnDeactivationUndefined;
-      resolvedValueFixture = Symbol();
+      bindingFixture =
+        ConstantValueBindingFixtures.withCacheWithIsRightTrueAndOnDeactivationUndefined as CachedSingletonScopedBinding<unknown>;
     });
 
-    describe('when called', () => {
+    describe('when called, and resolveBindingPreDestroy() returns undefined', () => {
       let result: unknown;
 
       beforeAll(() => {
-        result = resolveBindingDeactivations(
-          paramsMock,
-          bindingFixture,
-          resolvedValueFixture,
-        );
+        result = resolveBindingDeactivations(paramsMock, bindingFixture);
       });
 
       afterAll(() => {
         jest.clearAllMocks();
       });
 
+      it('should call resolveBindingPreDestroy()', () => {
+        expect(resolveBindingPreDestroy).toHaveBeenCalledTimes(1);
+        expect(resolveBindingPreDestroy).toHaveBeenCalledWith(
+          paramsMock,
+          bindingFixture,
+        );
+      });
+
       it('should call resolveBindingServiceDeactivations()', () => {
+        const bindingCache: Right<Resolved<unknown>> = bindingFixture.cache;
+
         expect(resolveBindingServiceDeactivations).toHaveBeenCalledTimes(1);
         expect(resolveBindingServiceDeactivations).toHaveBeenCalledWith(
           paramsMock,
           bindingFixture.serviceIdentifier,
-          resolvedValueFixture,
+          bindingCache.value,
         );
       });
 
       it('should return undefined', () => {
         expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when called, and resolveBindingPreDestroy() returns Promise', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        (
+          resolveBindingPreDestroy as jest.Mock<typeof resolveBindingPreDestroy>
+        ).mockReturnValueOnce(Promise.resolve(undefined));
+
+        result = resolveBindingDeactivations(paramsMock, bindingFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call resolveBindingPreDestroy()', () => {
+        expect(resolveBindingPreDestroy).toHaveBeenCalledTimes(1);
+        expect(resolveBindingPreDestroy).toHaveBeenCalledWith(
+          paramsMock,
+          bindingFixture,
+        );
+      });
+
+      it('should call resolveBindingServiceDeactivations()', () => {
+        const bindingCache: Right<Resolved<unknown>> = bindingFixture.cache;
+
+        expect(resolveBindingServiceDeactivations).toHaveBeenCalledTimes(1);
+        expect(resolveBindingServiceDeactivations).toHaveBeenCalledWith(
+          paramsMock,
+          bindingFixture.serviceIdentifier,
+          bindingCache.value,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toStrictEqual(Promise.resolve(undefined));
       });
     });
   });
 
   describe('having a binding with sync deactivation', () => {
     let paramsMock: jest.Mocked<DeactivationParams>;
-    let bindingFixture: ConstantValueBinding<unknown>;
-    let resolvedValueFixture: unknown;
+    let bindingFixture: CachedSingletonScopedBinding<unknown>;
 
     beforeAll(() => {
       paramsMock = {
@@ -67,31 +129,37 @@ describe(resolveBindingDeactivations.name, () => {
       } as Partial<
         jest.Mocked<DeactivationParams>
       > as jest.Mocked<DeactivationParams>;
-      bindingFixture = ConstantValueBindingFixtures.withOnDeactivationSync;
-      resolvedValueFixture = Symbol();
+      bindingFixture =
+        ConstantValueBindingFixtures.withCacheWithIsRightTrueAndOnDeactivationSync as CachedSingletonScopedBinding<unknown>;
     });
 
-    describe('when called', () => {
+    describe('when called, and resolveBindingPreDestroy() returns undefined', () => {
       let result: unknown;
 
       beforeAll(() => {
-        result = resolveBindingDeactivations(
-          paramsMock,
-          bindingFixture,
-          resolvedValueFixture,
-        );
+        result = resolveBindingDeactivations(paramsMock, bindingFixture);
       });
 
       afterAll(() => {
         jest.clearAllMocks();
       });
 
+      it('should call resolveBindingPreDestroy()', () => {
+        expect(resolveBindingPreDestroy).toHaveBeenCalledTimes(1);
+        expect(resolveBindingPreDestroy).toHaveBeenCalledWith(
+          paramsMock,
+          bindingFixture,
+        );
+      });
+
       it('should call resolveBindingServiceDeactivations()', () => {
+        const bindingCache: Right<Resolved<unknown>> = bindingFixture.cache;
+
         expect(resolveBindingServiceDeactivations).toHaveBeenCalledTimes(1);
         expect(resolveBindingServiceDeactivations).toHaveBeenCalledWith(
           paramsMock,
           bindingFixture.serviceIdentifier,
-          resolvedValueFixture,
+          bindingCache.value,
         );
       });
 
@@ -101,10 +169,9 @@ describe(resolveBindingDeactivations.name, () => {
     });
   });
 
-  describe('having a binding with async deactivation', () => {
+  describe('having a binding async cached value and sync deactivation', () => {
     let paramsMock: jest.Mocked<DeactivationParams>;
-    let bindingFixture: ConstantValueBinding<unknown>;
-    let resolvedValueFixture: unknown;
+    let bindingFixture: CachedSingletonScopedBinding<unknown>;
 
     beforeAll(() => {
       paramsMock = {
@@ -113,19 +180,66 @@ describe(resolveBindingDeactivations.name, () => {
       } as Partial<
         jest.Mocked<DeactivationParams>
       > as jest.Mocked<DeactivationParams>;
-      bindingFixture = ConstantValueBindingFixtures.withOnDeactivationAsync;
-      resolvedValueFixture = Symbol();
+      bindingFixture =
+        ConstantValueBindingFixtures.withCacheWithIsRightTrueAndAsyncValueAndOnDeactivationSync as CachedSingletonScopedBinding<unknown>;
+    });
+
+    describe('when called, and resolveBindingPreDestroy() returns undefined', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = resolveBindingDeactivations(paramsMock, bindingFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call resolveBindingPreDestroy()', () => {
+        expect(resolveBindingPreDestroy).toHaveBeenCalledTimes(1);
+        expect(resolveBindingPreDestroy).toHaveBeenCalledWith(
+          paramsMock,
+          bindingFixture,
+        );
+      });
+
+      it('should call resolveBindingServiceDeactivations()', async () => {
+        const bindingCache: Right<Resolved<unknown>> = bindingFixture.cache;
+
+        expect(resolveBindingServiceDeactivations).toHaveBeenCalledTimes(1);
+        expect(resolveBindingServiceDeactivations).toHaveBeenCalledWith(
+          paramsMock,
+          bindingFixture.serviceIdentifier,
+          await bindingCache.value,
+        );
+      });
+
+      it('should return Promise', () => {
+        expect(result).toStrictEqual(Promise.resolve(undefined));
+      });
+    });
+  });
+
+  describe('having a binding with async deactivation', () => {
+    let paramsMock: jest.Mocked<DeactivationParams>;
+    let bindingFixture: CachedSingletonScopedBinding<unknown>;
+
+    beforeAll(() => {
+      paramsMock = {
+        getBindings: jest.fn(),
+        getDeactivations: jest.fn(),
+      } as Partial<
+        jest.Mocked<DeactivationParams>
+      > as jest.Mocked<DeactivationParams>;
+      bindingFixture =
+        ConstantValueBindingFixtures.withCacheWithIsRightTrueOnDeactivationAsync as CachedSingletonScopedBinding<unknown>;
     });
 
     describe('when called', () => {
       let result: unknown;
 
       beforeAll(() => {
-        result = resolveBindingDeactivations(
-          paramsMock,
-          bindingFixture,
-          resolvedValueFixture,
-        );
+        result = resolveBindingDeactivations(paramsMock, bindingFixture);
       });
 
       afterAll(() => {
@@ -133,11 +247,13 @@ describe(resolveBindingDeactivations.name, () => {
       });
 
       it('should call resolveBindingServiceDeactivations()', () => {
+        const bindingCache: Right<Resolved<unknown>> = bindingFixture.cache;
+
         expect(resolveBindingServiceDeactivations).toHaveBeenCalledTimes(1);
         expect(resolveBindingServiceDeactivations).toHaveBeenCalledWith(
           paramsMock,
           bindingFixture.serviceIdentifier,
-          resolvedValueFixture,
+          bindingCache.value,
         );
       });
 

--- a/packages/container/libraries/core/src/resolution/actions/resolveBindingDeactivations.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveBindingDeactivations.ts
@@ -1,22 +1,80 @@
+import { isPromise, Right } from '@inversifyjs/common';
+
+import { Binding } from '../../binding/models/Binding';
+import { BindingDeactivation } from '../../binding/models/BindingDeactivation';
 import { bindingScopeValues } from '../../binding/models/BindingScope';
 import { BindingType } from '../../binding/models/BindingType';
 import { ScopedBinding } from '../../binding/models/ScopedBinding';
 import { DeactivationParams } from '../models/DeactivationParams';
+import { Resolved } from '../models/Resolved';
+import { resolveBindingPreDestroy } from './resolveBindingPreDestroy';
 import { resolveBindingServiceDeactivations } from './resolveBindingServiceDeactivations';
+
+const CACHE_KEY_TYPE: keyof ScopedBinding<
+  BindingType,
+  typeof bindingScopeValues.Singleton,
+  unknown
+> = 'cache';
+
+type CachedSingletonScopedBinding<TResolved> = Binding &
+  ScopedBinding<BindingType, typeof bindingScopeValues.Singleton, TResolved> & {
+    [CACHE_KEY_TYPE]: Right<Resolved<TResolved>>;
+  };
 
 export function resolveBindingDeactivations<TResolved>(
   params: DeactivationParams,
-  binding: ScopedBinding<
-    BindingType,
-    typeof bindingScopeValues.Singleton,
-    TResolved
-  >,
+  binding: CachedSingletonScopedBinding<TResolved>,
+): void | Promise<void> {
+  const preDestroyResult: void | Promise<void> = resolveBindingPreDestroy(
+    params,
+    binding,
+  );
+
+  if (preDestroyResult === undefined) {
+    return resolveBindingDeactivationsAfterPreDestroy(params, binding);
+  }
+
+  return preDestroyResult.then((): void | Promise<void> =>
+    resolveBindingDeactivationsAfterPreDestroy(params, binding),
+  );
+}
+
+function resolveBindingDeactivationsAfterPreDestroy<TResolved>(
+  params: DeactivationParams,
+  binding: CachedSingletonScopedBinding<TResolved>,
+): void | Promise<void> {
+  const bindingCache: Right<Resolved<TResolved>> = binding.cache;
+
+  if (isPromise(bindingCache.value)) {
+    return bindingCache.value.then(
+      (resolvedValue: TResolved): void | Promise<void> =>
+        resolveBindingDeactivationsAfterPreDestroyFromValue(
+          params,
+          binding,
+          resolvedValue,
+        ),
+    );
+  }
+
+  return resolveBindingDeactivationsAfterPreDestroyFromValue(
+    params,
+    binding,
+    bindingCache.value,
+  );
+}
+
+function resolveBindingDeactivationsAfterPreDestroyFromValue<TResolved>(
+  params: DeactivationParams,
+  binding: CachedSingletonScopedBinding<TResolved>,
   resolvedValue: TResolved,
 ): void | Promise<void> {
   let deactivationResult: void | Promise<void> = undefined;
 
   if (binding.onDeactivation !== undefined) {
-    deactivationResult = binding.onDeactivation(resolvedValue);
+    const bindingDeactivation: BindingDeactivation<TResolved> =
+      binding.onDeactivation;
+
+    deactivationResult = bindingDeactivation(resolvedValue);
   }
 
   if (deactivationResult === undefined) {

--- a/packages/container/libraries/core/src/resolution/actions/resolveBindingPreDestroy.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveBindingPreDestroy.spec.ts
@@ -1,0 +1,256 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { Right } from '@inversifyjs/common';
+
+import { ConstantValueBindingFixtures } from '../../binding/fixtures/ConstantValueBindingFixtures';
+import { InstanceBindingFixtures } from '../../binding/fixtures/InstanceBindingFixtures';
+import { Binding } from '../../binding/models/Binding';
+import { bindingScopeValues } from '../../binding/models/BindingScope';
+import { BindingType } from '../../binding/models/BindingType';
+import { InstanceBinding } from '../../binding/models/InstanceBinding';
+import { ScopedBinding } from '../../binding/models/ScopedBinding';
+import { ClassMetadataFixtures } from '../../metadata/fixtures/ClassMetadataFixtures';
+import { ClassMetadata } from '../../metadata/models/ClassMetadata';
+import { DeactivationParams } from '../models/DeactivationParams';
+import { Resolved } from '../models/Resolved';
+import { resolveBindingPreDestroy } from './resolveBindingPreDestroy';
+
+const CACHE_KEY_TYPE: keyof ScopedBinding<
+  BindingType,
+  typeof bindingScopeValues.Singleton,
+  unknown
+> = 'cache';
+
+type CachedSingletonScopedBinding<TResolved> = Binding &
+  ScopedBinding<BindingType, typeof bindingScopeValues.Singleton, TResolved> & {
+    [CACHE_KEY_TYPE]: Right<Resolved<TResolved>>;
+  };
+
+describe(resolveBindingPreDestroy.name, () => {
+  describe('having a binding with non instace type', () => {
+    let paramsMock: jest.Mocked<DeactivationParams>;
+    let bindingFixture: CachedSingletonScopedBinding<unknown>;
+
+    beforeAll(() => {
+      paramsMock = {
+        getClassMetadata: jest.fn(),
+      } as Partial<
+        jest.Mocked<DeactivationParams>
+      > as jest.Mocked<DeactivationParams>;
+      bindingFixture =
+        ConstantValueBindingFixtures.withCacheWithIsRightTrue as CachedSingletonScopedBinding<unknown>;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = resolveBindingPreDestroy(paramsMock, bindingFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a binding with instace type and sync cache with no preDestroy method', () => {
+    let paramsMock: jest.Mocked<DeactivationParams>;
+    let bindingFixture: CachedSingletonScopedBinding<unknown> &
+      InstanceBinding<unknown>;
+
+    beforeAll(() => {
+      paramsMock = {
+        getClassMetadata: jest.fn(),
+      } as Partial<
+        jest.Mocked<DeactivationParams>
+      > as jest.Mocked<DeactivationParams>;
+      bindingFixture =
+        InstanceBindingFixtures.withCacheIsRightAndScopeSingleton as CachedSingletonScopedBinding<unknown> &
+          InstanceBinding<unknown>;
+    });
+
+    describe('when called, and params.getClassMetadata() returns ClassMetadata with no preDestroyMethodName', () => {
+      let classMetadataFixture: ClassMetadata;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        classMetadataFixture = ClassMetadataFixtures.withNoPreDestroyMethodName;
+
+        paramsMock.getClassMetadata.mockReturnValueOnce(classMetadataFixture);
+
+        result = resolveBindingPreDestroy(paramsMock, bindingFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call params.getClassMetadata()', () => {
+        expect(paramsMock.getClassMetadata).toHaveBeenCalledTimes(1);
+        expect(paramsMock.getClassMetadata).toHaveBeenCalledWith(
+          bindingFixture.implementationType,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when called, and params.getClassMetadata() returns ClassMetadata with preDestroyMethodName', () => {
+      let classMetadataFixture: ClassMetadata;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        classMetadataFixture = ClassMetadataFixtures.withPreDestroyMethodName;
+
+        paramsMock.getClassMetadata.mockReturnValueOnce(classMetadataFixture);
+
+        result = resolveBindingPreDestroy(paramsMock, bindingFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call params.getClassMetadata()', () => {
+        expect(paramsMock.getClassMetadata).toHaveBeenCalledTimes(1);
+        expect(paramsMock.getClassMetadata).toHaveBeenCalledWith(
+          bindingFixture.implementationType,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a binding with instace type and async cache with no preDestroy method', () => {
+    let paramsMock: jest.Mocked<DeactivationParams>;
+    let bindingFixture: CachedSingletonScopedBinding<unknown> &
+      InstanceBinding<unknown>;
+
+    beforeAll(() => {
+      paramsMock = {
+        getClassMetadata: jest.fn(),
+      } as Partial<
+        jest.Mocked<DeactivationParams>
+      > as jest.Mocked<DeactivationParams>;
+      bindingFixture =
+        InstanceBindingFixtures.withCacheIsRightAndAsyncValueAndScopeSingleton as CachedSingletonScopedBinding<unknown> &
+          InstanceBinding<unknown>;
+    });
+
+    describe('when called, and params.getClassMetadata() returns ClassMetadata with no preDestroyMethodName', () => {
+      let classMetadataFixture: ClassMetadata;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        classMetadataFixture = ClassMetadataFixtures.withNoPreDestroyMethodName;
+
+        paramsMock.getClassMetadata.mockReturnValueOnce(classMetadataFixture);
+
+        result = resolveBindingPreDestroy(paramsMock, bindingFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call params.getClassMetadata()', () => {
+        expect(paramsMock.getClassMetadata).toHaveBeenCalledTimes(1);
+        expect(paramsMock.getClassMetadata).toHaveBeenCalledWith(
+          bindingFixture.implementationType,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toStrictEqual(Promise.resolve(undefined));
+      });
+    });
+  });
+
+  describe('having a binding with instace type and sync cache with preDestroy method', () => {
+    let paramsMock: jest.Mocked<DeactivationParams>;
+    let bindingFixture: CachedSingletonScopedBinding<unknown> &
+      InstanceBinding<unknown>;
+    let preDestroyMethodNameFixture: string;
+    let preDestroyMock: jest.Mock<(value: unknown) => void | Promise<void>>;
+
+    beforeAll(() => {
+      paramsMock = {
+        getClassMetadata: jest.fn(),
+      } as Partial<
+        jest.Mocked<DeactivationParams>
+      > as jest.Mocked<DeactivationParams>;
+
+      preDestroyMethodNameFixture = 'preDestroy';
+      preDestroyMock = jest.fn();
+
+      bindingFixture =
+        InstanceBindingFixtures.withCacheIsRightAndScopeSingleton as CachedSingletonScopedBinding<unknown> &
+          InstanceBinding<unknown>;
+
+      bindingFixture = {
+        ...bindingFixture,
+        cache: {
+          isRight: true,
+          value: {
+            [preDestroyMethodNameFixture]: preDestroyMock,
+          },
+        },
+      };
+    });
+
+    describe('when called, and params.getClassMetadata() returns ClassMetadata with preDestroyMethodName', () => {
+      let classMetadataFixture: ClassMetadata;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        classMetadataFixture = ClassMetadataFixtures.any;
+
+        classMetadataFixture = {
+          ...classMetadataFixture,
+          lifecycle: {
+            ...classMetadataFixture.lifecycle,
+            preDestroyMethodName: preDestroyMethodNameFixture,
+          },
+        };
+
+        paramsMock.getClassMetadata.mockReturnValueOnce(classMetadataFixture);
+
+        result = resolveBindingPreDestroy(paramsMock, bindingFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call params.getClassMetadata()', () => {
+        expect(paramsMock.getClassMetadata).toHaveBeenCalledTimes(1);
+        expect(paramsMock.getClassMetadata).toHaveBeenCalledWith(
+          bindingFixture.implementationType,
+        );
+      });
+
+      it('should call preDestroy() method', () => {
+        expect(preDestroyMock).toHaveBeenCalledTimes(1);
+        expect(preDestroyMock).toHaveBeenCalledWith();
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/resolution/actions/resolveBindingPreDestroy.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveBindingPreDestroy.ts
@@ -1,0 +1,62 @@
+import { isPromise, Right } from '@inversifyjs/common';
+
+import { Binding } from '../../binding/models/Binding';
+import { bindingScopeValues } from '../../binding/models/BindingScope';
+import {
+  BindingType,
+  bindingTypeValues,
+} from '../../binding/models/BindingType';
+import { ScopedBinding } from '../../binding/models/ScopedBinding';
+import { ClassMetadata } from '../../metadata/models/ClassMetadata';
+import { DeactivationParams } from '../models/DeactivationParams';
+import { Resolved } from '../models/Resolved';
+
+const CACHE_KEY_TYPE: keyof ScopedBinding<
+  BindingType,
+  typeof bindingScopeValues.Singleton,
+  unknown
+> = 'cache';
+
+type CachedSingletonScopedBinding<TResolved> = Binding &
+  ScopedBinding<BindingType, typeof bindingScopeValues.Singleton, TResolved> & {
+    [CACHE_KEY_TYPE]: Right<Resolved<TResolved>>;
+  };
+
+export function resolveBindingPreDestroy<TResolved>(
+  params: DeactivationParams,
+  binding: CachedSingletonScopedBinding<TResolved>,
+): void | Promise<void> {
+  if (binding.type === bindingTypeValues.Instance) {
+    const classMetadata: ClassMetadata = params.getClassMetadata(
+      binding.implementationType,
+    );
+
+    const instance: Resolved<Record<string | symbol, unknown>> = binding.cache
+      .value as Resolved<Record<string | symbol, unknown>>;
+
+    if (isPromise(instance)) {
+      return instance.then(
+        (instance: Record<string | symbol, unknown>): void | Promise<void> =>
+          resolveInstancePreDestroy(classMetadata, instance),
+      );
+    } else {
+      return resolveInstancePreDestroy(classMetadata, instance);
+    }
+  }
+}
+
+function resolveInstancePreDestroy(
+  classMetadata: ClassMetadata,
+  instance: Record<string | symbol, unknown>,
+): void | Promise<void> {
+  if (
+    classMetadata.lifecycle.preDestroyMethodName !== undefined &&
+    typeof instance[classMetadata.lifecycle.preDestroyMethodName] === 'function'
+  ) {
+    return (
+      instance[
+        classMetadata.lifecycle.preDestroyMethodName
+      ] as () => void | Promise<void>
+    )();
+  }
+}

--- a/packages/container/libraries/core/src/resolution/actions/resolveServiceDeactivations.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveServiceDeactivations.ts
@@ -1,19 +1,24 @@
-import { ServiceIdentifier } from '@inversifyjs/common';
+import { Right, ServiceIdentifier } from '@inversifyjs/common';
 
 import { isScopedBinding } from '../../binding/calculations/isScopedBinding';
 import { Binding } from '../../binding/models/Binding';
 import { bindingScopeValues } from '../../binding/models/BindingScope';
-import {
-  BindingType,
-  bindingTypeValues,
-} from '../../binding/models/BindingType';
+import { BindingType } from '../../binding/models/BindingType';
 import { ScopedBinding } from '../../binding/models/ScopedBinding';
-import { ClassMetadata } from '../../metadata/models/ClassMetadata';
 import { DeactivationParams } from '../models/DeactivationParams';
+import { Resolved } from '../models/Resolved';
 import { resolveBindingDeactivations } from './resolveBindingDeactivations';
 
-type SingletonScopedBinding = Binding &
-  ScopedBinding<BindingType, typeof bindingScopeValues.Singleton, unknown>;
+const CACHE_KEY_TYPE: keyof ScopedBinding<
+  BindingType,
+  typeof bindingScopeValues.Singleton,
+  unknown
+> = 'cache';
+
+type CachedSingletonScopedBinding<TResolved> = Binding &
+  ScopedBinding<BindingType, typeof bindingScopeValues.Singleton, TResolved> & {
+    [CACHE_KEY_TYPE]: Right<Resolved<TResolved>>;
+  };
 
 export function resolveServiceDeactivations(
   params: DeactivationParams,
@@ -26,35 +31,17 @@ export function resolveServiceDeactivations(
     return;
   }
 
-  const singletonScopedBindings: SingletonScopedBinding[] =
-    filterSinglentonScopedBindings(bindings);
+  const singletonScopedBindings: CachedSingletonScopedBinding<unknown>[] =
+    filterCachedSinglentonScopedBindings(bindings);
 
   const deactivationPromiseResults: Promise<void>[] = [];
 
   for (const binding of singletonScopedBindings) {
-    if (binding.cache.isRight) {
-      const preDestroyResult: void | Promise<void> = resolveBindingPreDestroy(
-        params,
-        binding,
-      );
+    const deactivationResult: void | Promise<void> =
+      resolveBindingDeactivations(params, binding);
 
-      let deactivationResult: void | Promise<void>;
-
-      if (preDestroyResult === undefined) {
-        deactivationResult = resolveBindingDeactivations(
-          params,
-          binding,
-          binding.cache.value,
-        );
-      } else {
-        deactivationResult = preDestroyResult.then((): void | Promise<void> =>
-          resolveBindingDeactivations(params, binding, binding.cache.value),
-        );
-      }
-
-      if (deactivationResult !== undefined) {
-        deactivationPromiseResults.push(deactivationResult);
-      }
+    if (deactivationResult !== undefined) {
+      deactivationPromiseResults.push(deactivationResult);
     }
   }
 
@@ -63,46 +50,20 @@ export function resolveServiceDeactivations(
   }
 }
 
-function filterSinglentonScopedBindings(
+function filterCachedSinglentonScopedBindings(
   bindings: Iterable<Binding>,
-): SingletonScopedBinding[] {
-  const filteredBindings: SingletonScopedBinding[] = [];
+): CachedSingletonScopedBinding<unknown>[] {
+  const filteredBindings: CachedSingletonScopedBinding<unknown>[] = [];
 
   for (const binding of bindings) {
     if (
       isScopedBinding(binding) &&
-      binding.scope === bindingScopeValues.Singleton
+      binding.scope === bindingScopeValues.Singleton &&
+      binding.cache.isRight
     ) {
-      filteredBindings.push(binding as SingletonScopedBinding);
+      filteredBindings.push(binding as CachedSingletonScopedBinding<unknown>);
     }
   }
 
   return filteredBindings;
-}
-
-function resolveBindingPreDestroy(
-  params: DeactivationParams,
-  binding: SingletonScopedBinding,
-): void | Promise<void> {
-  if (binding.type === bindingTypeValues.Instance) {
-    const classMetadata: ClassMetadata = params.getClassMetadata(
-      binding.implementationType,
-    );
-
-    if (classMetadata.lifecycle.preDestroyMethodName !== undefined) {
-      const instance: Record<string | symbol, unknown> = binding.cache
-        .value as Record<string | symbol, unknown>;
-
-      if (
-        typeof instance[classMetadata.lifecycle.preDestroyMethodName] ===
-        'function'
-      ) {
-        return (
-          instance[
-            classMetadata.lifecycle.preDestroyMethodName
-          ] as () => void | Promise<void>
-        )();
-      }
-    }
-  }
 }

--- a/packages/foundation/tools/rollup-config/lib/index.js
+++ b/packages/foundation/tools/rollup-config/lib/index.js
@@ -8,6 +8,8 @@ import { dts } from 'rollup-plugin-dts';
 
 import pathExists from './utils/pathExists.js';
 
+const NODE_REGEX = /^node:/;
+
 const PACKAGE_JSON_PATH = './package.json';
 
 if (!pathExists(PACKAGE_JSON_PATH)) {
@@ -36,7 +38,11 @@ function buildBundleConfig(inputFile, outputDir) {
   return [
     {
       input: inputFile,
-      external: [...packageDependencies, ...packagePeerDependencies],
+      external: [
+        NODE_REGEX,
+        ...packageDependencies,
+        ...packagePeerDependencies,
+      ],
       output: [
         {
           dir: outputDir,
@@ -87,7 +93,11 @@ export function buildMultiBundleConfig(inputFiles, outputDir) {
   return [
     {
       input: inputFiles,
-      external: [...packageDependencies, ...packagePeerDependencies],
+      external: [
+        NODE_REGEX,
+        ...packageDependencies,
+        ...packagePeerDependencies,
+      ],
       output: [
         {
           dir: outputDir,


### PR DESCRIPTION
### Changed
- Updated `resolveServiceDeactivations` to properly handle binding async cached values.
- Updated rollup config to set node dependencies as external.