### PR TITLE
Update packages with no side effects

### DIFF
--- a/packages/container/libraries/common/package.json
+++ b/packages/container/libraries/common/package.json
@@ -72,6 +72,5 @@
     "test:uncommitted": "pnpm run test --changedSince=HEAD",
     "test:unit:js": "pnpm run test:js --selectProjects Unit"
   },
-  "sideEffects": false,
   "version": "1.4.0"
 }

--- a/packages/container/libraries/container/package.json
+++ b/packages/container/libraries/container/package.json
@@ -80,6 +80,5 @@
     "test:uncommitted": "pnpm run test --changedSince=HEAD",
     "test:unit:js": "pnpm run test:js --selectProjects Unit"
   },
-  "sideEffects": false,
   "version": "1.0.0"
 }

--- a/packages/container/libraries/core/.npmignore
+++ b/packages/container/libraries/core/.npmignore
@@ -6,6 +6,7 @@
 **/*.spec.js.map
 **/*.ts
 !lib/cjs/**/*.d.ts
+lib/cjs/**/fixtures/**
 lib/esm/**/*.d.ts.map
 !lib/esm/index.d.ts
 !lib/esm/index.d.ts.map

--- a/packages/container/libraries/core/CHANGELOG.md
+++ b/packages/container/libraries/core/CHANGELOG.md
@@ -5,9 +5,7 @@
 ### Patch Changes
 
 - 2cbb782: Updated ESM build to provide proper types regardless of the ts resolution module strategy in the userland.
-- Updated dependencies [2cbb782]
-- Updated dependencies [da1a1c4]
-- Updated dependencies [da1a1c4]
+- Updated dependencies
   - @inversifyjs/reflect-metadata-utils@0.2.4
   - @inversifyjs/common@1.4.0
 
@@ -16,7 +14,7 @@
 ### Patch Changes
 
 - 535ad85: Updated ESM build to be compatible with both bundler and NodeJS module resolution algorithms
-- Updated dependencies [535ad85]
+- Updated dependencies
   - @inversifyjs/reflect-metadata-utils@0.2.3
   - @inversifyjs/common@1.3.3
 
@@ -31,7 +29,7 @@
 ### Patch Changes
 
 - 2b629d6: Removed wrong os constraint.
-- Updated dependencies [2b629d6]
+- Updated dependencies
   - @inversifyjs/reflect-metadata-utils@0.2.2
   - @inversifyjs/common@1.3.2
 
@@ -40,7 +38,7 @@
 ### Patch Changes
 
 - 46b2569: Removed wrong dev engines constraint.
-- Updated dependencies [46b2569]
+- Updated dependencies
   - @inversifyjs/reflect-metadata-utils@0.2.1
   - @inversifyjs/common@1.3.1
 
@@ -67,14 +65,14 @@
 
 ### Patch Changes
 
-- Updated dependencies [611f75f]
+- Updated dependencies
   - @inversifyjs/common@1.3.0
 
 ## 1.1.1
 
 ### Patch Changes
 
-- Updated dependencies [cb8882f]
+- Updated dependencies
   - @inversifyjs/common@1.2.1
 
 ## 1.1.0
@@ -86,8 +84,6 @@
 
 ### Patch Changes
 
-- Updated dependencies [eff2876]
-- Updated dependencies [eff2876]
-- Updated dependencies [5dc74ff]
+- Updated dependencies
   - @inversifyjs/reflect-metadata-utils@0.2.0
   - @inversifyjs/common@1.2.0

--- a/packages/container/libraries/core/package.json
+++ b/packages/container/libraries/core/package.json
@@ -78,6 +78,5 @@
     "test:uncommitted": "pnpm run test --changedSince=HEAD",
     "test:unit:js": "pnpm run test:js --selectProjects Unit"
   },
-  "sideEffects": false,
   "version": "1.3.5"
 }

--- a/packages/container/libraries/strongly-typed/package.json
+++ b/packages/container/libraries/strongly-typed/package.json
@@ -70,6 +70,5 @@
     "test:uncommitted": "pnpm run test --changedSince=HEAD",
     "test:unit:js": "pnpm run test:js --selectProjects Unit"
   },
-  "sideEffects": false,
   "version": "1.2.2"
 }

--- a/packages/foundation/libraries/reflect-metadata-utils/package.json
+++ b/packages/foundation/libraries/reflect-metadata-utils/package.json
@@ -76,6 +76,5 @@
     "test:mutation": "stryker run",
     "test:uncommitted": "pnpm run test --changedSince=HEAD",
     "test:unit:js": "pnpm run test:js --selectProjects Unit"
-  },
-  "sideEffects": false
+  }
 }


### PR DESCRIPTION
### Changed
- Updated packages with no `sideEffects` field.
- Updated `.npmignore` to ignore fixture modules.
- Updated changelogs without duplicated lines.