### PR TITLE
Update injectable to filter out non userland emitted type metadata

### DIFF
--- a/.changeset/angry-windows-draw.md
+++ b/.changeset/angry-windows-draw.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": patch
+---
+
+Updated `injectable` to filter out non userland emitted metadata

--- a/.changeset/hip-dodos-refuse.md
+++ b/.changeset/hip-dodos-refuse.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": minor
+---
+
+Updated `injectFromBase` options to be optional.

--- a/packages/container/libraries/core/src/metadata/actions/updateClassMetadataWithTypescriptParameterTypes.ts
+++ b/packages/container/libraries/core/src/metadata/actions/updateClassMetadataWithTypescriptParameterTypes.ts
@@ -8,6 +8,7 @@ import { classMetadataReflectKey } from '../../reflectMetadata/data/classMetadat
 import { typescriptParameterTypesReflectKey } from '../../reflectMetadata/data/typescriptDesignParameterTypesReflectKey';
 import { buildClassElementMetadataFromTypescriptParameterType } from '../calculations/buildClassElementMetadataFromTypescriptParameterType';
 import { getDefaultClassMetadata } from '../calculations/getDefaultClassMetadata';
+import { isUserlandEmittedType } from '../calculations/isUserlandEmittedType';
 import { MaybeClassMetadata } from '../models/MaybeClassMetadata';
 
 export function updateClassMetadataWithTypescriptParameterTypes(
@@ -34,7 +35,10 @@ function updateMaybeClassMetadataWithTypescriptClassMetadata(
   return (classMetadata: MaybeClassMetadata): MaybeClassMetadata => {
     typescriptConstructorArguments.forEach(
       (constructorArgumentType: Newable, index: number): void => {
-        if (classMetadata.constructorArguments[index] === undefined) {
+        if (
+          classMetadata.constructorArguments[index] === undefined &&
+          isUserlandEmittedType(constructorArgumentType)
+        ) {
           classMetadata.constructorArguments[index] =
             buildClassElementMetadataFromTypescriptParameterType(
               constructorArgumentType,

--- a/packages/container/libraries/core/src/metadata/calculations/isUserlandEmittedType.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/isUserlandEmittedType.spec.ts
@@ -1,0 +1,30 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { Newable } from '@inversifyjs/common';
+
+import { isUserlandEmittedType } from './isUserlandEmittedType';
+
+describe(isUserlandEmittedType.name, () => {
+  describe.each<[string, Newable, boolean]>([
+    ['Array', Array, false],
+    ['BigInt', BigInt as unknown as Newable, false],
+    ['Boolean', Boolean, false],
+    ['Function', Function, false],
+    ['Number', Number, false],
+    ['Object', Object, false],
+    ['String', String, false],
+    ['custom class', class {}, true],
+  ])('having %s', (_: string, type: Newable, expectedResult: boolean) => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = isUserlandEmittedType(type);
+      });
+
+      it('should return the expected result', () => {
+        expect(result).toBe(expectedResult);
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/calculations/isUserlandEmittedType.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/isUserlandEmittedType.ts
@@ -1,0 +1,15 @@
+import { Newable } from '@inversifyjs/common';
+
+const NON_USERLAND_TYPES: unknown[] = [
+  Array,
+  BigInt,
+  Boolean,
+  Function,
+  Number,
+  Object,
+  String,
+];
+
+export function isUserlandEmittedType(type: Newable): boolean {
+  return !NON_USERLAND_TYPES.includes(type);
+}

--- a/packages/container/libraries/core/src/metadata/decorators/injectFromBase.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/injectFromBase.ts
@@ -6,7 +6,9 @@ import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKin
 import { InjectFromBaseOptions } from '../models/InjectFromBaseOptions';
 import { injectFrom } from './injectFrom';
 
-export function injectFromBase(options: InjectFromBaseOptions): ClassDecorator {
+export function injectFromBase(
+  options?: InjectFromBaseOptions,
+): ClassDecorator {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
   return (target: Function): void => {
     const baseType: Newable | undefined = getBaseType(target as Newable);


### PR DESCRIPTION
### Changed
- Updated `injectFromBase` options to be optional.
- Updated `injectable` decorator to filter out non userland emitted type metadata.