### PR TITLE
Fix provider and factory binding syntax

### DIFF
--- a/.changeset/hot-vans-begin.md
+++ b/.changeset/hot-vans-begin.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": minor
+---
+
+Updated `BindingToSyntax` with more flexible factory and provider constraints

--- a/.changeset/selfish-knives-tap.md
+++ b/.changeset/selfish-knives-tap.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": minor
+---
+
+Updated `Provider` with right args.

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntax.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntax.ts
@@ -17,12 +17,14 @@ export interface BindToFluentSyntax<T> {
   toConstantValue(value: T): BindWhenOnFluentSyntax<T>;
   toDynamicValue(builder: DynamicValueBuilder<T>): BindInWhenOnFluentSyntax<T>;
   toFactory(
-    factory: T extends Factory<unknown>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    factory: T extends Factory<unknown, any>
       ? (context: ResolutionContext) => T
       : never,
   ): BindWhenOnFluentSyntax<T>;
   toProvider(
-    provider: T extends Provider<unknown>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    provider: T extends Provider<unknown, any>
       ? (context: ResolutionContext) => T
       : never,
   ): BindWhenOnFluentSyntax<T>;

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.ts
@@ -178,7 +178,8 @@ export class BindToFluentSyntaxImplementation<T>
   }
 
   public toFactory(
-    builder: T extends Factory<unknown>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    builder: T extends Factory<unknown, any>
       ? (context: ResolutionContext) => T
       : never,
   ): BindWhenOnFluentSyntax<T> {
@@ -206,7 +207,8 @@ export class BindToFluentSyntaxImplementation<T>
   }
 
   public toProvider(
-    provider: T extends Provider<unknown>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    provider: T extends Provider<unknown, any>
       ? (context: ResolutionContext) => T
       : never,
   ): BindWhenOnFluentSyntax<T> {

--- a/packages/container/libraries/core/src/binding/models/Provider.ts
+++ b/packages/container/libraries/core/src/binding/models/Provider.ts
@@ -1,4 +1,4 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Provider<TActivated, in TArgs extends unknown[] = any[]> = (
-  ...args: TArgs[]
+  ...args: TArgs
 ) => Promise<TActivated>;


### PR DESCRIPTION
### Changed
- Updated `Provider` with right args.
- Updated `BindToFluentSyntax` with more flexible factory and provider constraints.