### PR TITLE
Update BindingWhenFluentSyntax with parent constraints

### DIFF
--- a/.changeset/cyan-forks-grow.md
+++ b/.changeset/cyan-forks-grow.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/container": minor
+---
+
+Updated `BindWhenFluentSyntax` with `whenNoParentIs`

--- a/.changeset/lovely-news-sort.md
+++ b/.changeset/lovely-news-sort.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/container": minor
+---
+
+Updated `BindWhenFluentSyntax` with `whenNoParent`

--- a/.changeset/many-horses-drum.md
+++ b/.changeset/many-horses-drum.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/container": minor
+---
+
+Updated `BindWhenFluentSyntax` with `whenNoParentNamed`

--- a/.changeset/real-meals-crash.md
+++ b/.changeset/real-meals-crash.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/container": minor
+---
+
+Updated `BindWhenFluentSyntax` with `whenNoParentTagged`

--- a/packages/container/libraries/container/src/binding/calculations/isNotParentBindingMetadata.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNotParentBindingMetadata.spec.ts
@@ -1,0 +1,78 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { BindingMetadata } from '@inversifyjs/core';
+
+import { isNotParentBindingMetadata } from './isNotParentBindingMetadata';
+
+describe(isNotParentBindingMetadata.name, () => {
+  let constraintMock: jest.Mock<(metadata: BindingMetadata) => boolean>;
+  let metadataMock: jest.Mocked<BindingMetadata>;
+
+  beforeAll(() => {
+    constraintMock = jest.fn();
+    metadataMock = {
+      getAncestor: jest.fn(),
+    } as Partial<jest.Mocked<BindingMetadata>> as jest.Mocked<BindingMetadata>;
+  });
+
+  describe('when called, and metadata.getAncestor() returns undefined', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      metadataMock.getAncestor.mockReturnValueOnce(undefined);
+
+      result = isNotParentBindingMetadata(constraintMock)(metadataMock);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call metadata.getAncestor()', () => {
+      expect(metadataMock.getAncestor).toHaveBeenCalledTimes(1);
+      expect(metadataMock.getAncestor).toHaveBeenCalledWith();
+    });
+
+    it('should not call constraint()', () => {
+      expect(constraintMock).not.toHaveBeenCalled();
+    });
+
+    it('should return true', () => {
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('when called, and metadata.getAncestor() returns BindingMetadata', () => {
+    let constraintResultFixture: boolean;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      constraintResultFixture = true;
+
+      metadataMock.getAncestor.mockReturnValueOnce(metadataMock);
+
+      constraintMock.mockReturnValueOnce(constraintResultFixture);
+
+      result = isNotParentBindingMetadata(constraintMock)(metadataMock);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call metadata.getAncestor()', () => {
+      expect(metadataMock.getAncestor).toHaveBeenCalledTimes(1);
+      expect(metadataMock.getAncestor).toHaveBeenCalledWith();
+    });
+
+    it('should call constraint()', () => {
+      expect(constraintMock).toHaveBeenCalledTimes(1);
+      expect(constraintMock).toHaveBeenCalledWith(metadataMock);
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(!constraintResultFixture);
+    });
+  });
+});

--- a/packages/container/libraries/container/src/binding/calculations/isNotParentBindingMetadata.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNotParentBindingMetadata.ts
@@ -1,0 +1,12 @@
+import { BindingMetadata } from '@inversifyjs/core';
+
+export function isNotParentBindingMetadata(
+  constraint: (metadata: BindingMetadata) => boolean,
+): (metadata: BindingMetadata) => boolean {
+  return (metadata: BindingMetadata): boolean => {
+    const ancestorMetadata: BindingMetadata | undefined =
+      metadata.getAncestor();
+
+    return ancestorMetadata === undefined || !constraint(ancestorMetadata);
+  };
+}

--- a/packages/container/libraries/container/src/binding/calculations/isNotParentBindingMetadataWithName.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNotParentBindingMetadataWithName.spec.ts
@@ -1,0 +1,66 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { BindingMetadata, MetadataName } from '@inversifyjs/core';
+
+jest.mock('./isBindingMetadataWithName');
+jest.mock('./isNotParentBindingMetadata');
+
+import { isBindingMetadataWithName } from './isBindingMetadataWithName';
+import { isNotParentBindingMetadata } from './isNotParentBindingMetadata';
+import { isNotParentBindingMetadataWithName } from './isNotParentBindingMetadataWithName';
+
+describe(isNotParentBindingMetadataWithName.name, () => {
+  let nameFixture: MetadataName;
+
+  beforeAll(() => {
+    nameFixture = 'name-fixture';
+  });
+
+  describe('when called', () => {
+    let isBindingMetadataWithNameResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+    let isNotParentBindingMetadataResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      isBindingMetadataWithNameResultMock = jest.fn();
+      isNotParentBindingMetadataResultMock = jest.fn();
+
+      (
+        isBindingMetadataWithName as jest.Mock<typeof isBindingMetadataWithName>
+      ).mockReturnValueOnce(isBindingMetadataWithNameResultMock);
+
+      (
+        isNotParentBindingMetadata as jest.Mock<
+          typeof isNotParentBindingMetadata
+        >
+      ).mockReturnValueOnce(isNotParentBindingMetadataResultMock);
+
+      result = isNotParentBindingMetadataWithName(nameFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isBindingMetadataWithName()', () => {
+      expect(isBindingMetadataWithName).toHaveBeenCalledTimes(1);
+      expect(isBindingMetadataWithName).toHaveBeenCalledWith(nameFixture);
+    });
+
+    it('should call isNotParentBindingMetadata()', () => {
+      expect(isNotParentBindingMetadata).toHaveBeenCalledTimes(1);
+      expect(isNotParentBindingMetadata).toHaveBeenCalledWith(
+        isBindingMetadataWithNameResultMock,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(isNotParentBindingMetadataResultMock);
+    });
+  });
+});

--- a/packages/container/libraries/container/src/binding/calculations/isNotParentBindingMetadataWithName.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNotParentBindingMetadataWithName.ts
@@ -1,0 +1,10 @@
+import { BindingMetadata, MetadataName } from '@inversifyjs/core';
+
+import { isBindingMetadataWithName } from './isBindingMetadataWithName';
+import { isNotParentBindingMetadata } from './isNotParentBindingMetadata';
+
+export function isNotParentBindingMetadataWithName(
+  name: MetadataName,
+): (metadata: BindingMetadata) => boolean {
+  return isNotParentBindingMetadata(isBindingMetadataWithName(name));
+}

--- a/packages/container/libraries/container/src/binding/calculations/isNotParentBindingMetadataWithServiceId.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNotParentBindingMetadataWithServiceId.spec.ts
@@ -1,0 +1,72 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { BindingMetadata } from '@inversifyjs/core';
+
+jest.mock('./isBindingMetadataWithServiceId');
+jest.mock('./isNotParentBindingMetadata');
+
+import { ServiceIdentifier } from '@inversifyjs/common';
+
+import { isBindingMetadataWithServiceId } from './isBindingMetadataWithServiceId';
+import { isNotParentBindingMetadata } from './isNotParentBindingMetadata';
+import { isNotParentBindingMetadataWithServiceId } from './isNotParentBindingMetadataWithServiceId';
+
+describe(isNotParentBindingMetadataWithServiceId.name, () => {
+  let serviceIdFixture: ServiceIdentifier;
+
+  beforeAll(() => {
+    serviceIdFixture = 'name-fixture';
+  });
+
+  describe('when called', () => {
+    let isBindingMetadataWithNameResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+    let isNotParentBindingMetadataResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      isBindingMetadataWithNameResultMock = jest.fn();
+      isNotParentBindingMetadataResultMock = jest.fn();
+
+      (
+        isBindingMetadataWithServiceId as jest.Mock<
+          typeof isBindingMetadataWithServiceId
+        >
+      ).mockReturnValueOnce(isBindingMetadataWithNameResultMock);
+
+      (
+        isNotParentBindingMetadata as jest.Mock<
+          typeof isNotParentBindingMetadata
+        >
+      ).mockReturnValueOnce(isNotParentBindingMetadataResultMock);
+
+      result = isNotParentBindingMetadataWithServiceId(serviceIdFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isBindingMetadataWithServiceId()', () => {
+      expect(isBindingMetadataWithServiceId).toHaveBeenCalledTimes(1);
+      expect(isBindingMetadataWithServiceId).toHaveBeenCalledWith(
+        serviceIdFixture,
+      );
+    });
+
+    it('should call isNotParentBindingMetadata()', () => {
+      expect(isNotParentBindingMetadata).toHaveBeenCalledTimes(1);
+      expect(isNotParentBindingMetadata).toHaveBeenCalledWith(
+        isBindingMetadataWithNameResultMock,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(isNotParentBindingMetadataResultMock);
+    });
+  });
+});

--- a/packages/container/libraries/container/src/binding/calculations/isNotParentBindingMetadataWithServiceId.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNotParentBindingMetadataWithServiceId.ts
@@ -1,0 +1,11 @@
+import { ServiceIdentifier } from '@inversifyjs/common';
+import { BindingMetadata } from '@inversifyjs/core';
+
+import { isBindingMetadataWithServiceId } from './isBindingMetadataWithServiceId';
+import { isNotParentBindingMetadata } from './isNotParentBindingMetadata';
+
+export function isNotParentBindingMetadataWithServiceId(
+  serviceId: ServiceIdentifier,
+): (metadata: BindingMetadata) => boolean {
+  return isNotParentBindingMetadata(isBindingMetadataWithServiceId(serviceId));
+}

--- a/packages/container/libraries/container/src/binding/calculations/isNotParentBindingMetadataWithTag.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNotParentBindingMetadataWithTag.spec.ts
@@ -1,0 +1,71 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { BindingMetadata, MetadataTag } from '@inversifyjs/core';
+
+jest.mock('./isBindingMetadataWithTag');
+jest.mock('./isNotParentBindingMetadata');
+
+import { isBindingMetadataWithTag } from './isBindingMetadataWithTag';
+import { isNotParentBindingMetadata } from './isNotParentBindingMetadata';
+import { isNotParentBindingMetadataWithTag } from './isNotParentBindingMetadataWithTag';
+
+describe(isNotParentBindingMetadataWithTag.name, () => {
+  let tagFixture: MetadataTag;
+  let tagValueFixture: unknown;
+
+  beforeAll(() => {
+    tagFixture = 'name-fixture';
+    tagValueFixture = Symbol();
+  });
+
+  describe('when called', () => {
+    let isBindingMetadataWithNameResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+    let isNotParentBindingMetadataResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      isBindingMetadataWithNameResultMock = jest.fn();
+      isNotParentBindingMetadataResultMock = jest.fn();
+
+      (
+        isBindingMetadataWithTag as jest.Mock<typeof isBindingMetadataWithTag>
+      ).mockReturnValueOnce(isBindingMetadataWithNameResultMock);
+
+      (
+        isNotParentBindingMetadata as jest.Mock<
+          typeof isNotParentBindingMetadata
+        >
+      ).mockReturnValueOnce(isNotParentBindingMetadataResultMock);
+
+      result = isNotParentBindingMetadataWithTag(tagFixture, tagValueFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isBindingMetadataWithTag()', () => {
+      expect(isBindingMetadataWithTag).toHaveBeenCalledTimes(1);
+      expect(isBindingMetadataWithTag).toHaveBeenCalledWith(
+        tagFixture,
+        tagValueFixture,
+      );
+    });
+
+    it('should call isNotParentBindingMetadata()', () => {
+      expect(isNotParentBindingMetadata).toHaveBeenCalledTimes(1);
+      expect(isNotParentBindingMetadata).toHaveBeenCalledWith(
+        isBindingMetadataWithNameResultMock,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(isNotParentBindingMetadataResultMock);
+    });
+  });
+});

--- a/packages/container/libraries/container/src/binding/calculations/isNotParentBindingMetadataWithTag.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNotParentBindingMetadataWithTag.ts
@@ -1,0 +1,11 @@
+import { BindingMetadata, MetadataTag } from '@inversifyjs/core';
+
+import { isBindingMetadataWithTag } from './isBindingMetadataWithTag';
+import { isNotParentBindingMetadata } from './isNotParentBindingMetadata';
+
+export function isNotParentBindingMetadataWithTag(
+  tag: MetadataTag,
+  value: unknown,
+): (metadata: BindingMetadata) => boolean {
+  return isNotParentBindingMetadata(isBindingMetadataWithTag(tag, value));
+}

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntax.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntax.ts
@@ -67,6 +67,15 @@ export interface BindWhenFluentSyntax<T> {
   ): BindOnFluentSyntax<T>;
   whenDefault(): BindOnFluentSyntax<T>;
   whenNamed(name: MetadataName): BindOnFluentSyntax<T>;
+  whenNoParent(
+    constraint: (metadata: BindingMetadata) => boolean,
+  ): BindOnFluentSyntax<T>;
+  whenNoParentIs(serviceIdentifier: ServiceIdentifier): BindOnFluentSyntax<T>;
+  whenNoParentNamed(name: MetadataName): BindOnFluentSyntax<T>;
+  whenNoParentTagged(
+    tag: MetadataTag,
+    tagValue: unknown,
+  ): BindOnFluentSyntax<T>;
   whenParent(
     constraint: (metadata: BindingMetadata) => boolean,
   ): BindOnFluentSyntax<T>;

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.spec.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.spec.ts
@@ -9,6 +9,10 @@ jest.mock('../calculations/isAnyAncestorBindingMetadataWithServiceId');
 jest.mock('../calculations/isAnyAncestorBindingMetadataWithTag');
 jest.mock('../calculations/isBindingMetadataWithName');
 jest.mock('../calculations/isBindingMetadataWithTag');
+jest.mock('../calculations/isNotParentBindingMetadata');
+jest.mock('../calculations/isNotParentBindingMetadataWithName');
+jest.mock('../calculations/isNotParentBindingMetadataWithServiceId');
+jest.mock('../calculations/isNotParentBindingMetadataWithTag');
 jest.mock('../calculations/isParentBindingMetadata');
 jest.mock('../calculations/isParentBindingMetadataWithName');
 jest.mock('../calculations/isParentBindingMetadataWithServiceId');
@@ -48,6 +52,10 @@ import { isAnyAncestorBindingMetadataWithTag } from '../calculations/isAnyAncest
 import { isBindingMetadataWithName } from '../calculations/isBindingMetadataWithName';
 import { isBindingMetadataWithNoNameNorTags } from '../calculations/isBindingMetadataWithNoNameNorTags';
 import { isBindingMetadataWithTag } from '../calculations/isBindingMetadataWithTag';
+import { isNotParentBindingMetadata } from '../calculations/isNotParentBindingMetadata';
+import { isNotParentBindingMetadataWithName } from '../calculations/isNotParentBindingMetadataWithName';
+import { isNotParentBindingMetadataWithServiceId } from '../calculations/isNotParentBindingMetadataWithServiceId';
+import { isNotParentBindingMetadataWithTag } from '../calculations/isNotParentBindingMetadataWithTag';
 import { isParentBindingMetadata } from '../calculations/isParentBindingMetadata';
 import { isParentBindingMetadataWithName } from '../calculations/isParentBindingMetadataWithName';
 import { isParentBindingMetadataWithServiceId } from '../calculations/isParentBindingMetadataWithServiceId';
@@ -1044,6 +1052,123 @@ describe(BindWhenFluentSyntaxImplementation.name, () => {
       expect(isBindingMetadataWithTag).toHaveBeenCalledWith(
         tagFixture,
         tagValueFixture,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBeInstanceOf(BindOnFluentSyntaxImplementation);
+    });
+  });
+
+  describe('.whenNoParentIs', () => {
+    let serviceIdFixture: ServiceIdentifier;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      serviceIdFixture = 'name-fixture';
+
+      result =
+        bindWhenFluentSyntaxImplementation.whenNoParentIs(serviceIdFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isNotParentBindingMetadataWithServiceId', () => {
+      expect(isNotParentBindingMetadataWithServiceId).toHaveBeenCalledTimes(1);
+      expect(isNotParentBindingMetadataWithServiceId).toHaveBeenCalledWith(
+        serviceIdFixture,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBeInstanceOf(BindOnFluentSyntaxImplementation);
+    });
+  });
+
+  describe('.whenNoParentNamed', () => {
+    let nameFixture: MetadataName;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      nameFixture = 'name-fixture';
+
+      result =
+        bindWhenFluentSyntaxImplementation.whenNoParentNamed(nameFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isNotParentBindingMetadataWithName', () => {
+      expect(isNotParentBindingMetadataWithName).toHaveBeenCalledTimes(1);
+      expect(isNotParentBindingMetadataWithName).toHaveBeenCalledWith(
+        nameFixture,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBeInstanceOf(BindOnFluentSyntaxImplementation);
+    });
+  });
+
+  describe('.whenNoParentTagged', () => {
+    let tagFixture: MetadataTag;
+    let tagValueFixture: unknown;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      tagFixture = 'tag-fixture';
+      tagValueFixture = Symbol();
+
+      result = bindWhenFluentSyntaxImplementation.whenNoParentTagged(
+        tagFixture,
+        tagValueFixture,
+      );
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isNotParentBindingMetadataWithTag', () => {
+      expect(isNotParentBindingMetadataWithTag).toHaveBeenCalledTimes(1);
+      expect(isNotParentBindingMetadataWithTag).toHaveBeenCalledWith(
+        tagFixture,
+        tagValueFixture,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBeInstanceOf(BindOnFluentSyntaxImplementation);
+    });
+  });
+
+  describe('.whenNoParent', () => {
+    let constraintFixture: (metadata: BindingMetadata) => boolean;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      constraintFixture = () => true;
+
+      result =
+        bindWhenFluentSyntaxImplementation.whenNoParent(constraintFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isNotParentBindingMetadata', () => {
+      expect(isNotParentBindingMetadata).toHaveBeenCalledTimes(1);
+      expect(isNotParentBindingMetadata).toHaveBeenCalledWith(
+        constraintFixture,
       );
     });
 

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.ts
@@ -36,6 +36,10 @@ import { isAnyAncestorBindingMetadataWithTag } from '../calculations/isAnyAncest
 import { isBindingMetadataWithName } from '../calculations/isBindingMetadataWithName';
 import { isBindingMetadataWithNoNameNorTags } from '../calculations/isBindingMetadataWithNoNameNorTags';
 import { isBindingMetadataWithTag } from '../calculations/isBindingMetadataWithTag';
+import { isNotParentBindingMetadata } from '../calculations/isNotParentBindingMetadata';
+import { isNotParentBindingMetadataWithName } from '../calculations/isNotParentBindingMetadataWithName';
+import { isNotParentBindingMetadataWithServiceId } from '../calculations/isNotParentBindingMetadataWithServiceId';
+import { isNotParentBindingMetadataWithTag } from '../calculations/isNotParentBindingMetadataWithTag';
 import { isParentBindingMetadata } from '../calculations/isParentBindingMetadata';
 import { isParentBindingMetadataWithName } from '../calculations/isParentBindingMetadataWithName';
 import { isParentBindingMetadataWithServiceId } from '../calculations/isParentBindingMetadataWithServiceId';
@@ -323,6 +327,31 @@ export class BindWhenFluentSyntaxImplementation<T>
 
   public whenNamed(name: MetadataName): BindOnFluentSyntax<T> {
     return this.when(isBindingMetadataWithName(name));
+  }
+
+  public whenNoParent(
+    constraint: (metadata: BindingMetadata) => boolean,
+  ): BindOnFluentSyntax<T> {
+    return this.when(isNotParentBindingMetadata(constraint));
+  }
+
+  public whenNoParentIs(
+    serviceIdentifier: ServiceIdentifier,
+  ): BindOnFluentSyntax<T> {
+    return this.when(
+      isNotParentBindingMetadataWithServiceId(serviceIdentifier),
+    );
+  }
+
+  public whenNoParentNamed(name: MetadataName): BindOnFluentSyntax<T> {
+    return this.when(isNotParentBindingMetadataWithName(name));
+  }
+
+  public whenNoParentTagged(
+    tag: MetadataTag,
+    tagValue: unknown,
+  ): BindOnFluentSyntax<T> {
+    return this.when(isNotParentBindingMetadataWithTag(tag, tagValue));
   }
 
   public whenParent(


### PR DESCRIPTION
### Changed
- Updated `BindWhenFluentSyntax` with `whenNoParent`.
- Updated `BindWhenFluentSyntax` with `whenNoParentIs`.
- Updated `BindWhenFluentSyntax` with `whenNoParentNamed`.
- Updated `BindWhenFluentSyntax` with `whenNoParentTagged`.