### PR TITLE
Update binding when fluent syntax with ancestor constraints

### DIFF
--- a/.changeset/itchy-grapes-vanish.md
+++ b/.changeset/itchy-grapes-vanish.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/container": minor
+---
+
+Updated `BindWhenFluentSyntax` with `whenNoAncestorTagged`

--- a/.changeset/polite-elephants-hunt.md
+++ b/.changeset/polite-elephants-hunt.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/container": minor
+---
+
+Updated `BindWhenFluentSyntax` with `whenNoAncestorIs`

--- a/.changeset/serious-kiwis-compete.md
+++ b/.changeset/serious-kiwis-compete.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/container": minor
+---
+
+Updated `BindWhenFluentSyntax` with `whenNoAncestorNamed`

--- a/.changeset/wicked-singers-chew.md
+++ b/.changeset/wicked-singers-chew.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/container": minor
+---
+
+Updated `BindWhenFluentSyntax` with `whenNoAncestor`

--- a/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingMetadata.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingMetadata.spec.ts
@@ -1,0 +1,93 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { BindingMetadata } from '@inversifyjs/core';
+
+import { isAnyAncestorBindingMetadata } from './isAnyAncestorBindingMetadata';
+import { isNoAncestorBindingMetadata } from './isNoAncestorBindingMetadata';
+
+jest.mock('./isAnyAncestorBindingMetadata');
+
+describe(isNoAncestorBindingMetadata.name, () => {
+  let constraintMock: jest.Mock<(metadata: BindingMetadata) => boolean>;
+  let isAnyAncestorBindingMetadataConstraintMock: jest.Mock<
+    (metadata: BindingMetadata) => boolean
+  >;
+
+  beforeAll(() => {
+    constraintMock = jest.fn();
+    isAnyAncestorBindingMetadataConstraintMock = jest.fn();
+    (
+      isAnyAncestorBindingMetadata as jest.Mock<
+        typeof isAnyAncestorBindingMetadata
+      >
+    ).mockReturnValue(isAnyAncestorBindingMetadataConstraintMock);
+  });
+
+  describe('when called, and isAnyAncestorBindingMetadata() returns true', () => {
+    let metadataFixture: BindingMetadata;
+    let result: boolean;
+
+    beforeAll(() => {
+      metadataFixture = Symbol() as unknown as BindingMetadata;
+      isAnyAncestorBindingMetadataConstraintMock.mockReturnValueOnce(true);
+
+      result = isNoAncestorBindingMetadata(constraintMock)(metadataFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isAnyAncestorBindingMetadata()', () => {
+      expect(isAnyAncestorBindingMetadata).toHaveBeenCalledTimes(1);
+      expect(isAnyAncestorBindingMetadata).toHaveBeenCalledWith(constraintMock);
+    });
+
+    it('should call isAnyAncestorBindingMetadataConstraint()', () => {
+      expect(isAnyAncestorBindingMetadataConstraintMock).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(isAnyAncestorBindingMetadataConstraintMock).toHaveBeenCalledWith(
+        metadataFixture,
+      );
+    });
+
+    it('should return false', () => {
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('when called, and isAnyAncestorBindingMetadata() returns false', () => {
+    let metadataFixture: BindingMetadata;
+    let result: boolean;
+
+    beforeAll(() => {
+      metadataFixture = {} as BindingMetadata;
+      isAnyAncestorBindingMetadataConstraintMock.mockReturnValueOnce(false);
+
+      result = isNoAncestorBindingMetadata(constraintMock)(metadataFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isAnyAncestorBindingMetadata()', () => {
+      expect(isAnyAncestorBindingMetadata).toHaveBeenCalledTimes(1);
+      expect(isAnyAncestorBindingMetadata).toHaveBeenCalledWith(constraintMock);
+    });
+
+    it('should call isAnyAncestorBindingMetadataConstraint()', () => {
+      expect(isAnyAncestorBindingMetadataConstraintMock).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(isAnyAncestorBindingMetadataConstraintMock).toHaveBeenCalledWith(
+        metadataFixture,
+      );
+    });
+
+    it('should return true', () => {
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingMetadata.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingMetadata.spec.ts
@@ -2,10 +2,10 @@ import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 import { BindingMetadata } from '@inversifyjs/core';
 
+jest.mock('./isAnyAncestorBindingMetadata');
+
 import { isAnyAncestorBindingMetadata } from './isAnyAncestorBindingMetadata';
 import { isNoAncestorBindingMetadata } from './isNoAncestorBindingMetadata';
-
-jest.mock('./isAnyAncestorBindingMetadata');
 
 describe(isNoAncestorBindingMetadata.name, () => {
   let constraintMock: jest.Mock<(metadata: BindingMetadata) => boolean>;

--- a/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingMetadata.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingMetadata.ts
@@ -1,0 +1,15 @@
+import { BindingMetadata } from '@inversifyjs/core';
+
+import { isAnyAncestorBindingMetadata } from './isAnyAncestorBindingMetadata';
+
+export function isNoAncestorBindingMetadata(
+  constraint: (metadata: BindingMetadata) => boolean,
+): (metadata: BindingMetadata) => boolean {
+  const isAnyAncestorBindingMetadataConstraint: (
+    metadata: BindingMetadata,
+  ) => boolean = isAnyAncestorBindingMetadata(constraint);
+
+  return (metadata: BindingMetadata): boolean => {
+    return !isAnyAncestorBindingMetadataConstraint(metadata);
+  };
+}

--- a/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingMetadataWithName.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingMetadataWithName.spec.ts
@@ -1,0 +1,66 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { BindingMetadata, MetadataName } from '@inversifyjs/core';
+
+jest.mock('./isBindingMetadataWithName');
+jest.mock('./isNoAncestorBindingMetadata');
+
+import { isBindingMetadataWithName } from './isBindingMetadataWithName';
+import { isNoAncestorBindingMetadata } from './isNoAncestorBindingMetadata';
+import { isNoAncestorBindingMetadataWithName } from './isNoAncestorBindingMetadataWithName';
+
+describe(isNoAncestorBindingMetadataWithName.name, () => {
+  let nameFixture: MetadataName;
+
+  beforeAll(() => {
+    nameFixture = 'name-fixture';
+  });
+
+  describe('when called', () => {
+    let isBindingMetadataWithNameResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+    let isNoAncestorBindingMetadataResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      isBindingMetadataWithNameResultMock = jest.fn();
+      isNoAncestorBindingMetadataResultMock = jest.fn();
+
+      (
+        isBindingMetadataWithName as jest.Mock<typeof isBindingMetadataWithName>
+      ).mockReturnValueOnce(isBindingMetadataWithNameResultMock);
+
+      (
+        isNoAncestorBindingMetadata as jest.Mock<
+          typeof isNoAncestorBindingMetadata
+        >
+      ).mockReturnValueOnce(isNoAncestorBindingMetadataResultMock);
+
+      result = isNoAncestorBindingMetadataWithName(nameFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isBindingMetadataWithName()', () => {
+      expect(isBindingMetadataWithName).toHaveBeenCalledTimes(1);
+      expect(isBindingMetadataWithName).toHaveBeenCalledWith(nameFixture);
+    });
+
+    it('should call isNoAncestorBindingMetadata()', () => {
+      expect(isNoAncestorBindingMetadata).toHaveBeenCalledTimes(1);
+      expect(isNoAncestorBindingMetadata).toHaveBeenCalledWith(
+        isBindingMetadataWithNameResultMock,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(isNoAncestorBindingMetadataResultMock);
+    });
+  });
+});

--- a/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingMetadataWithName.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingMetadataWithName.ts
@@ -1,0 +1,10 @@
+import { BindingMetadata, MetadataName } from '@inversifyjs/core';
+
+import { isBindingMetadataWithName } from './isBindingMetadataWithName';
+import { isNoAncestorBindingMetadata } from './isNoAncestorBindingMetadata';
+
+export function isNoAncestorBindingMetadataWithName(
+  name: MetadataName,
+): (metadata: BindingMetadata) => boolean {
+  return isNoAncestorBindingMetadata(isBindingMetadataWithName(name));
+}

--- a/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingMetadataWithServiceId.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingMetadataWithServiceId.spec.ts
@@ -1,0 +1,72 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { BindingMetadata } from '@inversifyjs/core';
+
+jest.mock('./isBindingMetadataWithServiceId');
+jest.mock('./isNoAncestorBindingMetadata');
+
+import { ServiceIdentifier } from '@inversifyjs/common';
+
+import { isBindingMetadataWithServiceId } from './isBindingMetadataWithServiceId';
+import { isNoAncestorBindingMetadata } from './isNoAncestorBindingMetadata';
+import { isNoAncestorBindingMetadataWithServiceId } from './isNoAncestorBindingMetadataWithServiceId';
+
+describe(isNoAncestorBindingMetadataWithServiceId.name, () => {
+  let serviceIdFixture: ServiceIdentifier;
+
+  beforeAll(() => {
+    serviceIdFixture = 'name-fixture';
+  });
+
+  describe('when called', () => {
+    let isBindingMetadataWithNameResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+    let isNoAncestorBindingMetadataResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      isBindingMetadataWithNameResultMock = jest.fn();
+      isNoAncestorBindingMetadataResultMock = jest.fn();
+
+      (
+        isBindingMetadataWithServiceId as jest.Mock<
+          typeof isBindingMetadataWithServiceId
+        >
+      ).mockReturnValueOnce(isBindingMetadataWithNameResultMock);
+
+      (
+        isNoAncestorBindingMetadata as jest.Mock<
+          typeof isNoAncestorBindingMetadata
+        >
+      ).mockReturnValueOnce(isNoAncestorBindingMetadataResultMock);
+
+      result = isNoAncestorBindingMetadataWithServiceId(serviceIdFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isBindingMetadataWithServiceId()', () => {
+      expect(isBindingMetadataWithServiceId).toHaveBeenCalledTimes(1);
+      expect(isBindingMetadataWithServiceId).toHaveBeenCalledWith(
+        serviceIdFixture,
+      );
+    });
+
+    it('should call isNoAncestorBindingMetadata()', () => {
+      expect(isNoAncestorBindingMetadata).toHaveBeenCalledTimes(1);
+      expect(isNoAncestorBindingMetadata).toHaveBeenCalledWith(
+        isBindingMetadataWithNameResultMock,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(isNoAncestorBindingMetadataResultMock);
+    });
+  });
+});

--- a/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingMetadataWithServiceId.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingMetadataWithServiceId.ts
@@ -1,0 +1,11 @@
+import { ServiceIdentifier } from '@inversifyjs/common';
+import { BindingMetadata } from '@inversifyjs/core';
+
+import { isBindingMetadataWithServiceId } from './isBindingMetadataWithServiceId';
+import { isNoAncestorBindingMetadata } from './isNoAncestorBindingMetadata';
+
+export function isNoAncestorBindingMetadataWithServiceId(
+  serviceId: ServiceIdentifier,
+): (metadata: BindingMetadata) => boolean {
+  return isNoAncestorBindingMetadata(isBindingMetadataWithServiceId(serviceId));
+}

--- a/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingMetadataWithTag.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingMetadataWithTag.spec.ts
@@ -1,0 +1,71 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { BindingMetadata, MetadataTag } from '@inversifyjs/core';
+
+jest.mock('./isBindingMetadataWithTag');
+jest.mock('./isNoAncestorBindingMetadata');
+
+import { isBindingMetadataWithTag } from './isBindingMetadataWithTag';
+import { isNoAncestorBindingMetadata } from './isNoAncestorBindingMetadata';
+import { isNoAncestorBindingMetadataWithTag } from './isNoAncestorBindingMetadataWithTag';
+
+describe(isNoAncestorBindingMetadataWithTag.name, () => {
+  let tagFixture: MetadataTag;
+  let tagValueFixture: unknown;
+
+  beforeAll(() => {
+    tagFixture = 'tag-fixture';
+    tagValueFixture = Symbol();
+  });
+
+  describe('when called', () => {
+    let isBindingMetadataWithNameResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+    let isNoAncestorBindingMetadataResultMock: jest.Mock<
+      (metadata: BindingMetadata) => boolean
+    >;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      isBindingMetadataWithNameResultMock = jest.fn();
+      isNoAncestorBindingMetadataResultMock = jest.fn();
+
+      (
+        isBindingMetadataWithTag as jest.Mock<typeof isBindingMetadataWithTag>
+      ).mockReturnValueOnce(isBindingMetadataWithNameResultMock);
+
+      (
+        isNoAncestorBindingMetadata as jest.Mock<
+          typeof isNoAncestorBindingMetadata
+        >
+      ).mockReturnValueOnce(isNoAncestorBindingMetadataResultMock);
+
+      result = isNoAncestorBindingMetadataWithTag(tagFixture, tagValueFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isBindingMetadataWithTag()', () => {
+      expect(isBindingMetadataWithTag).toHaveBeenCalledTimes(1);
+      expect(isBindingMetadataWithTag).toHaveBeenCalledWith(
+        tagFixture,
+        tagValueFixture,
+      );
+    });
+
+    it('should call isNoAncestorBindingMetadata()', () => {
+      expect(isNoAncestorBindingMetadata).toHaveBeenCalledTimes(1);
+      expect(isNoAncestorBindingMetadata).toHaveBeenCalledWith(
+        isBindingMetadataWithNameResultMock,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(isNoAncestorBindingMetadataResultMock);
+    });
+  });
+});

--- a/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingMetadataWithTag.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingMetadataWithTag.ts
@@ -1,0 +1,11 @@
+import { BindingMetadata, MetadataTag } from '@inversifyjs/core';
+
+import { isBindingMetadataWithTag } from './isBindingMetadataWithTag';
+import { isNoAncestorBindingMetadata } from './isNoAncestorBindingMetadata';
+
+export function isNoAncestorBindingMetadataWithTag(
+  tag: MetadataTag,
+  value: unknown,
+): (metadata: BindingMetadata) => boolean {
+  return isNoAncestorBindingMetadata(isBindingMetadataWithTag(tag, value));
+}

--- a/packages/container/libraries/container/src/binding/calculations/isNotParentBindingMetadataWithTag.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNotParentBindingMetadataWithTag.spec.ts
@@ -14,7 +14,7 @@ describe(isNotParentBindingMetadataWithTag.name, () => {
   let tagValueFixture: unknown;
 
   beforeAll(() => {
-    tagFixture = 'name-fixture';
+    tagFixture = 'tag-fixture';
     tagValueFixture = Symbol();
   });
 

--- a/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadataWithTag.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isParentBindingMetadataWithTag.spec.ts
@@ -14,7 +14,7 @@ describe(isParentBindingMetadataWithTag.name, () => {
   let tagValueFixture: unknown;
 
   beforeAll(() => {
-    tagFixture = 'name-fixture';
+    tagFixture = 'tag-fixture';
     tagValueFixture = Symbol();
   });
 

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntax.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntax.ts
@@ -67,6 +67,15 @@ export interface BindWhenFluentSyntax<T> {
   ): BindOnFluentSyntax<T>;
   whenDefault(): BindOnFluentSyntax<T>;
   whenNamed(name: MetadataName): BindOnFluentSyntax<T>;
+  whenNoAncestor(
+    constraint: (metadata: BindingMetadata) => boolean,
+  ): BindOnFluentSyntax<T>;
+  whenNoAncestorIs(serviceIdentifier: ServiceIdentifier): BindOnFluentSyntax<T>;
+  whenNoAncestorNamed(name: MetadataName): BindOnFluentSyntax<T>;
+  whenNoAncestorTagged(
+    tag: MetadataTag,
+    tagValue: unknown,
+  ): BindOnFluentSyntax<T>;
   whenNoParent(
     constraint: (metadata: BindingMetadata) => boolean,
   ): BindOnFluentSyntax<T>;

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.spec.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.spec.ts
@@ -9,6 +9,10 @@ jest.mock('../calculations/isAnyAncestorBindingMetadataWithServiceId');
 jest.mock('../calculations/isAnyAncestorBindingMetadataWithTag');
 jest.mock('../calculations/isBindingMetadataWithName');
 jest.mock('../calculations/isBindingMetadataWithTag');
+jest.mock('../calculations/isNoAncestorBindingMetadata');
+jest.mock('../calculations/isNoAncestorBindingMetadataWithTag');
+jest.mock('../calculations/isNoAncestorBindingMetadataWithServiceId');
+jest.mock('../calculations/isNoAncestorBindingMetadataWithName');
 jest.mock('../calculations/isNotParentBindingMetadata');
 jest.mock('../calculations/isNotParentBindingMetadataWithName');
 jest.mock('../calculations/isNotParentBindingMetadataWithServiceId');
@@ -52,6 +56,10 @@ import { isAnyAncestorBindingMetadataWithTag } from '../calculations/isAnyAncest
 import { isBindingMetadataWithName } from '../calculations/isBindingMetadataWithName';
 import { isBindingMetadataWithNoNameNorTags } from '../calculations/isBindingMetadataWithNoNameNorTags';
 import { isBindingMetadataWithTag } from '../calculations/isBindingMetadataWithTag';
+import { isNoAncestorBindingMetadata } from '../calculations/isNoAncestorBindingMetadata';
+import { isNoAncestorBindingMetadataWithName } from '../calculations/isNoAncestorBindingMetadataWithName';
+import { isNoAncestorBindingMetadataWithServiceId } from '../calculations/isNoAncestorBindingMetadataWithServiceId';
+import { isNoAncestorBindingMetadataWithTag } from '../calculations/isNoAncestorBindingMetadataWithTag';
 import { isNotParentBindingMetadata } from '../calculations/isNotParentBindingMetadata';
 import { isNotParentBindingMetadataWithName } from '../calculations/isNotParentBindingMetadataWithName';
 import { isNotParentBindingMetadataWithServiceId } from '../calculations/isNotParentBindingMetadataWithServiceId';
@@ -1169,6 +1177,123 @@ describe(BindWhenFluentSyntaxImplementation.name, () => {
       expect(isNotParentBindingMetadata).toHaveBeenCalledTimes(1);
       expect(isNotParentBindingMetadata).toHaveBeenCalledWith(
         constraintFixture,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBeInstanceOf(BindOnFluentSyntaxImplementation);
+    });
+  });
+
+  describe('.whenNoAncestor', () => {
+    let constraintFixture: (metadata: BindingMetadata) => boolean;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      constraintFixture = () => true;
+
+      result =
+        bindWhenFluentSyntaxImplementation.whenNoAncestor(constraintFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isNoAncestorBindingMetadata', () => {
+      expect(isNoAncestorBindingMetadata).toHaveBeenCalledTimes(1);
+      expect(isNoAncestorBindingMetadata).toHaveBeenCalledWith(
+        constraintFixture,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBeInstanceOf(BindOnFluentSyntaxImplementation);
+    });
+  });
+
+  describe('.whenNoAncestorIs', () => {
+    let serviceIdFixture: ServiceIdentifier;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      serviceIdFixture = 'service-id-fixture';
+
+      result =
+        bindWhenFluentSyntaxImplementation.whenNoAncestorIs(serviceIdFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isNoAncestorBindingMetadataWithServiceId', () => {
+      expect(isNoAncestorBindingMetadataWithServiceId).toHaveBeenCalledTimes(1);
+      expect(isNoAncestorBindingMetadataWithServiceId).toHaveBeenCalledWith(
+        serviceIdFixture,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBeInstanceOf(BindOnFluentSyntaxImplementation);
+    });
+  });
+
+  describe('.whenNoAncestorNamed', () => {
+    let nameFixture: MetadataName;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      nameFixture = 'name-fixture';
+
+      result =
+        bindWhenFluentSyntaxImplementation.whenNoAncestorNamed(nameFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isNoAncestorBindingMetadataWithName', () => {
+      expect(isNoAncestorBindingMetadataWithName).toHaveBeenCalledTimes(1);
+      expect(isNoAncestorBindingMetadataWithName).toHaveBeenCalledWith(
+        nameFixture,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBeInstanceOf(BindOnFluentSyntaxImplementation);
+    });
+  });
+
+  describe('.whenNoAncestorTagged', () => {
+    let tagFixture: MetadataTag;
+    let tagValueFixture: unknown;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      tagFixture = 'tag-fixture';
+      tagValueFixture = Symbol();
+
+      result = bindWhenFluentSyntaxImplementation.whenNoAncestorTagged(
+        tagFixture,
+        tagValueFixture,
+      );
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call isNoAncestorBindingMetadataWithTag', () => {
+      expect(isNoAncestorBindingMetadataWithTag).toHaveBeenCalledTimes(1);
+      expect(isNoAncestorBindingMetadataWithTag).toHaveBeenCalledWith(
+        tagFixture,
+        tagValueFixture,
       );
     });
 

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.ts
@@ -36,6 +36,10 @@ import { isAnyAncestorBindingMetadataWithTag } from '../calculations/isAnyAncest
 import { isBindingMetadataWithName } from '../calculations/isBindingMetadataWithName';
 import { isBindingMetadataWithNoNameNorTags } from '../calculations/isBindingMetadataWithNoNameNorTags';
 import { isBindingMetadataWithTag } from '../calculations/isBindingMetadataWithTag';
+import { isNoAncestorBindingMetadata } from '../calculations/isNoAncestorBindingMetadata';
+import { isNoAncestorBindingMetadataWithName } from '../calculations/isNoAncestorBindingMetadataWithName';
+import { isNoAncestorBindingMetadataWithServiceId } from '../calculations/isNoAncestorBindingMetadataWithServiceId';
+import { isNoAncestorBindingMetadataWithTag } from '../calculations/isNoAncestorBindingMetadataWithTag';
 import { isNotParentBindingMetadata } from '../calculations/isNotParentBindingMetadata';
 import { isNotParentBindingMetadataWithName } from '../calculations/isNotParentBindingMetadataWithName';
 import { isNotParentBindingMetadataWithServiceId } from '../calculations/isNotParentBindingMetadataWithServiceId';
@@ -382,6 +386,31 @@ export class BindWhenFluentSyntaxImplementation<T>
     tagValue: unknown,
   ): BindOnFluentSyntax<T> {
     return this.when(isBindingMetadataWithTag(tag, tagValue));
+  }
+
+  public whenNoAncestor(
+    constraint: (metadata: BindingMetadata) => boolean,
+  ): BindOnFluentSyntax<T> {
+    return this.when(isNoAncestorBindingMetadata(constraint));
+  }
+
+  public whenNoAncestorIs(
+    serviceIdentifier: ServiceIdentifier,
+  ): BindOnFluentSyntax<T> {
+    return this.when(
+      isNoAncestorBindingMetadataWithServiceId(serviceIdentifier),
+    );
+  }
+
+  public whenNoAncestorNamed(name: MetadataName): BindOnFluentSyntax<T> {
+    return this.when(isNoAncestorBindingMetadataWithName(name));
+  }
+
+  public whenNoAncestorTagged(
+    tag: MetadataTag,
+    tagValue: unknown,
+  ): BindOnFluentSyntax<T> {
+    return this.when(isNoAncestorBindingMetadataWithTag(tag, tagValue));
   }
 }
 


### PR DESCRIPTION
### Added
- Added `isNoAncestorBindingMetadataWithTag`.
- Added `isNoAncestorBindingMetadataWithServiceId`.
- Added `isNoAncestorBindingMetadataWithName`.
- Added `isNoAncestorBindingMetadata`.

### Changed
- Updated `BindWhenOnFluentSyntax` with ancestor constraints.
