### PR TITLE
Fix OneToManyMap clone

### DIFF
--- a/.changeset/few-mirrors-watch.md
+++ b/.changeset/few-mirrors-watch.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/container": patch
+---
+
+Updated `Container` bind flow to properly bind dynamic values in the right default scope

--- a/.changeset/long-dryers-provide.md
+++ b/.changeset/long-dryers-provide.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/container": patch
+---
+
+Updated `Container.snapshot` to properly generate clone binding services

--- a/.changeset/metal-icons-move.md
+++ b/.changeset/metal-icons-move.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": patch
+---
+
+Updated `OneToManyMapStar.clone` to properly clone map array values

--- a/.changeset/thick-wombats-march.md
+++ b/.changeset/thick-wombats-march.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": patch
+---
+
+Updated `BindToFluentSyntaxImplementation.toDynamicValue` with right default scope

--- a/packages/container/libraries/core/src/common/models/OneToManyMapStar.spec.ts
+++ b/packages/container/libraries/core/src/common/models/OneToManyMapStar.spec.ts
@@ -14,6 +14,9 @@ interface RelationTest {
 
 describe(OneToManyMapStar.name, () => {
   describe('.clone', () => {
+    let modelFixture: unknown;
+    let relationFixture: Required<RelationTest>;
+
     let oneToManyMapStar: OneToManyMapStar<unknown, RelationTest>;
 
     beforeAll(() => {
@@ -26,21 +29,82 @@ describe(OneToManyMapStar.name, () => {
         },
       });
 
-      oneToManyMapStar.add(Symbol(), {
+      modelFixture = Symbol();
+
+      relationFixture = {
         [RelationKey.bar]: 2,
         [RelationKey.foo]: 'foo-value-fixture',
-      });
+      };
+
+      oneToManyMapStar.add(modelFixture, relationFixture);
     });
 
     describe('when called', () => {
+      let modelsFromRelationResult: unknown;
+
       let result: unknown;
 
       beforeAll(() => {
-        result = oneToManyMapStar.clone();
+        const clone: OneToManyMapStar<unknown, RelationTest> =
+          oneToManyMapStar.clone();
+
+        modelsFromRelationResult = [
+          ...(clone.get(RelationKey.bar, relationFixture[RelationKey.bar]) ??
+            []),
+        ];
+
+        result = clone;
       });
 
-      it('should return a clone', () => {
-        expect(result).toStrictEqual(oneToManyMapStar);
+      it('should return a OneToManyMapStar', () => {
+        expect(result).toBeInstanceOf(OneToManyMapStar);
+      });
+
+      it('should provide expected model', () => {
+        expect(modelsFromRelationResult).toStrictEqual([modelFixture]);
+      });
+    });
+
+    describe('when called, and a value is added', () => {
+      let originalModelsFromRelationResult: unknown;
+      let cloneModelsFromRelationResult: unknown;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        const clone: OneToManyMapStar<unknown, RelationTest> =
+          oneToManyMapStar.clone();
+
+        clone.add(modelFixture, relationFixture);
+
+        cloneModelsFromRelationResult = [
+          ...(clone.get(RelationKey.bar, relationFixture[RelationKey.bar]) ??
+            []),
+        ];
+
+        originalModelsFromRelationResult = [
+          ...(oneToManyMapStar.get(
+            RelationKey.bar,
+            relationFixture[RelationKey.bar],
+          ) ?? []),
+        ];
+
+        result = clone;
+      });
+
+      it('should return a OneToManyMapStar', () => {
+        expect(result).toBeInstanceOf(OneToManyMapStar);
+      });
+
+      it('should provide expected models from clone', () => {
+        expect(cloneModelsFromRelationResult).toStrictEqual([
+          modelFixture,
+          modelFixture,
+        ]);
+      });
+
+      it('should provide expected models from original', () => {
+        expect(originalModelsFromRelationResult).toStrictEqual([modelFixture]);
       });
     });
   });

--- a/packages/container/libraries/core/src/common/models/OneToManyMapStar.ts
+++ b/packages/container/libraries/core/src/common/models/OneToManyMapStar.ts
@@ -143,11 +143,11 @@ export class OneToManyMapStar<TModel, TRelation extends object>
   }
 
   #pushEntriesIntoMap<TKey, TValue>(
-    source: Map<TKey, TValue>,
-    target: Map<TKey, TValue>,
+    source: Map<TKey, TValue[]>,
+    target: Map<TKey, TValue[]>,
   ): void {
     for (const [key, value] of source) {
-      target.set(key, value);
+      target.set(key, [...value]);
     }
   }
 


### PR DESCRIPTION
### Changed
- Updated `OneToManyMapStar.clone` to provide right array values.