### PR TITLE
Fix Container cache strategy

### DIFF
--- a/.changeset/warm-llamas-decide.md
+++ b/.changeset/warm-llamas-decide.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/container": patch
+---
+
+Updated `Container` to properly clear planning cache after new bindings are bound

--- a/packages/container/libraries/container/src/container/services/Container.int.spec.ts
+++ b/packages/container/libraries/container/src/container/services/Container.int.spec.ts
@@ -1,0 +1,201 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import 'reflect-metadata';
+
+import { injectable, multiInject } from '@inversifyjs/core';
+
+import {
+  ContainerModule,
+  ContainerModuleLoadOptions,
+} from '../models/ContainerModule';
+import { Container } from './Container';
+
+@injectable()
+class Gun {}
+
+@injectable()
+class Arsenal {
+  constructor(@multiInject(Gun) public guns: Gun[]) {}
+}
+
+describe(Container.name, () => {
+  describe('when container has one gun binding and one arsenal binding', () => {
+    describe('when container.get is called for Arsenal', () => {
+      let container: Container;
+
+      let arsenal: Arsenal;
+
+      beforeAll(() => {
+        container = new Container();
+
+        container.bind(Gun).to(Gun);
+        container.bind(Arsenal).to(Arsenal);
+
+        arsenal = container.get(Arsenal);
+      });
+
+      it('should provide an arsenal with two guns', () => {
+        expect(arsenal).toBeInstanceOf(Arsenal);
+        expect(arsenal.guns).toHaveLength(1);
+        arsenal.guns.forEach((gun: Gun) => expect(gun).toBeInstanceOf(Gun));
+      });
+    });
+
+    describe('when container.get is called twice and gun binding is unbound in the middle', () => {
+      let container: Container;
+      let arsenal: Arsenal;
+
+      beforeAll(async () => {
+        container = new Container();
+
+        container.bind(Gun).to(Gun);
+        container.bind(Arsenal).to(Arsenal);
+
+        // First call to get Arsenal
+        container.get(Arsenal);
+
+        // Unbind Gun
+        await container.unbind(Gun);
+
+        // Second call to get Arsenal
+        arsenal = container.get(Arsenal);
+      });
+
+      it('should provide an arsenal with no guns', () => {
+        expect(arsenal).toBeInstanceOf(Arsenal);
+        expect(arsenal.guns).toHaveLength(0);
+      });
+    });
+
+    describe('when container.get is called twice and all bindings are unbound in the middle', () => {
+      let container: Container;
+      let result: unknown;
+
+      beforeAll(async () => {
+        container = new Container();
+
+        container.bind(Gun).to(Gun);
+        container.bind(Arsenal).to(Arsenal);
+
+        // First call to get Arsenal
+        container.get(Arsenal);
+
+        // Unbind all bindings
+        await container.unbindAll();
+
+        // Second call to get Arsenal
+        try {
+          container.get(Arsenal);
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      it('should throw an Error', () => {
+        const expectedErrorProperties: Partial<Error> = {
+          message: `No bindings found for service: "Arsenal".
+
+Trying to resolve bindings for "Arsenal (Root service)".
+
+Binding metadata:
+- service identifier: Arsenal
+- name: -`,
+        };
+
+        expect(result).toBeInstanceOf(Error);
+        expect(result).toMatchObject(expectedErrorProperties);
+      });
+    });
+
+    describe('when container.get is called twice and gun binding is added in the middle', () => {
+      let container: Container;
+      let arsenal: Arsenal;
+
+      beforeAll(() => {
+        container = new Container();
+
+        container.bind(Gun).to(Gun);
+        container.bind(Arsenal).to(Arsenal);
+
+        // First call to get Arsenal
+        container.get(Arsenal);
+
+        // Add Gun binding
+        container.bind(Gun).to(Gun);
+
+        // Second call to get Arsenal
+        arsenal = container.get(Arsenal);
+      });
+
+      it('should provide an arsenal with one gun', () => {
+        expect(arsenal).toBeInstanceOf(Arsenal);
+        expect(arsenal.guns).toHaveLength(2);
+        arsenal.guns.forEach((gun: Gun) => expect(gun).toBeInstanceOf(Gun));
+      });
+    });
+
+    describe('when container.get is called twice and gun binding is unbound using a ContainerModule in the middle', () => {
+      let container: Container;
+      let arsenal: Arsenal;
+
+      beforeAll(async () => {
+        container = new Container();
+
+        container.bind(Gun).to(Gun);
+        container.bind(Arsenal).to(Arsenal);
+
+        // First call to get Arsenal
+        container.get(Arsenal);
+
+        // Create and load a ContainerModule to unbind Gun
+        const module: ContainerModule = new ContainerModule(
+          async ({ unbind }: ContainerModuleLoadOptions) => {
+            await unbind(Gun);
+          },
+        );
+
+        await container.load(module);
+
+        // Second call to get Arsenal
+        arsenal = container.get(Arsenal);
+      });
+
+      it('should provide an arsenal with no guns', () => {
+        expect(arsenal).toBeInstanceOf(Arsenal);
+        expect(arsenal.guns).toHaveLength(0);
+      });
+    });
+
+    describe('when container.get is called twice and gun binding is added using a ContainerModule in the middle', () => {
+      let container: Container;
+      let arsenal: Arsenal;
+
+      beforeAll(async () => {
+        container = new Container();
+
+        container.bind(Arsenal).to(Arsenal);
+
+        // First call to get Arsenal
+        container.get(Arsenal);
+
+        // Create and load a ContainerModule to bind Gun
+        const module: ContainerModule = new ContainerModule(
+          ({ bind }: ContainerModuleLoadOptions) => {
+            bind(Gun).to(Gun);
+          },
+        );
+
+        await container.load(module);
+
+        // Second call to get Arsenal
+        arsenal = container.get(Arsenal);
+      });
+
+      it('should provide an arsenal with one gun', () => {
+        expect(arsenal).toBeInstanceOf(Arsenal);
+        expect(arsenal.guns).toHaveLength(1);
+        arsenal.guns.forEach((gun: Gun) => expect(gun).toBeInstanceOf(Gun));
+      });
+    });
+  });
+});

--- a/packages/container/libraries/container/src/container/services/Container.ts
+++ b/packages/container/libraries/container/src/container/services/Container.ts
@@ -94,7 +94,7 @@ export class Container {
   ): BindToFluentSyntax<T> {
     return new BindToFluentSyntaxImplementation(
       (binding: Binding): void => {
-        this.#bindingService.set(binding);
+        this.#setBinding(binding);
       },
       undefined,
       this.#options.defaultScope,
@@ -343,7 +343,7 @@ export class Container {
       ): BindToFluentSyntax<T> => {
         return new BindToFluentSyntaxImplementation(
           (binding: Binding): void => {
-            this.#bindingService.set(binding);
+            this.#setBinding(binding);
           },
           moduleId,
           this.#options.defaultScope,
@@ -423,7 +423,7 @@ export class Container {
         serviceIdentifier,
       },
       servicesBranch: new Set(),
-      setBinding: this.#bindingService.set.bind(this.#bindingService),
+      setBinding: this.#setBinding.bind(this),
     };
 
     this.#handlePlanParamsRootConstraints(planParams, options);
@@ -529,5 +529,11 @@ export class Container {
     }
 
     return false;
+  }
+
+  #setBinding(binding: Binding): void {
+    this.#bindingService.set(binding);
+
+    this.#planResultCacheService.clearCache();
   }
 }


### PR DESCRIPTION
### Changed
- Updated `Container` to properly clear planning cache after new bindings are bound.