### PR TITLE
Update plan result with resolved value nodes

### DIFF
--- a/.changeset/hip-pandas-invent.md
+++ b/.changeset/hip-pandas-invent.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": minor
+---
+
+Added `ResolvedValueMetadata`

--- a/.changeset/red-cars-own.md
+++ b/.changeset/red-cars-own.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": minor
+---
+
+Updated `PlanServiceNodeParent` to include `ResolvedValueBindingNode`

--- a/.changeset/three-pets-shave.md
+++ b/.changeset/three-pets-shave.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": minor
+---
+
+Added `ResolvedValueBinding`

--- a/.changeset/violet-beans-own.md
+++ b/.changeset/violet-beans-own.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": minor
+---
+
+Added `ResolvedValueBindingNode`

--- a/packages/container/libraries/core/src/binding/models/Binding.ts
+++ b/packages/container/libraries/core/src/binding/models/Binding.ts
@@ -5,6 +5,7 @@ import { FactoryBinding } from './FactoryBinding';
 import { InstanceBinding } from './InstanceBinding';
 import { Provider } from './Provider';
 import { ProviderBinding } from './ProviderBinding';
+import { ResolvedValueBinding } from './ResolvedValueBinding';
 import { ServiceRedirectionBinding } from './ServiceRedirectionBinding';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -14,4 +15,5 @@ export type Binding<TActivated = any> =
   | (TActivated extends Factory<unknown> ? FactoryBinding<TActivated> : never)
   | InstanceBinding<TActivated>
   | (TActivated extends Provider<unknown> ? ProviderBinding<TActivated> : never)
+  | ResolvedValueBinding<TActivated>
   | ServiceRedirectionBinding<TActivated>;

--- a/packages/container/libraries/core/src/binding/models/BindingType.ts
+++ b/packages/container/libraries/core/src/binding/models/BindingType.ts
@@ -4,6 +4,7 @@ export type BindingType =
   | 'Factory'
   | 'Instance'
   | 'Provider'
+  | 'ResolvedValue'
   | 'ServiceRedirection';
 
 export const bindingTypeValues: { [TKey in BindingType]: TKey } = {
@@ -12,5 +13,6 @@ export const bindingTypeValues: { [TKey in BindingType]: TKey } = {
   Factory: 'Factory',
   Instance: 'Instance',
   Provider: 'Provider',
+  ResolvedValue: 'ResolvedValue',
   ServiceRedirection: 'ServiceRedirection',
 };

--- a/packages/container/libraries/core/src/binding/models/ResolvedValueBinding.ts
+++ b/packages/container/libraries/core/src/binding/models/ResolvedValueBinding.ts
@@ -1,0 +1,15 @@
+import { ResolvedValueMetadata } from '../../metadata/models/ResolvedValueMetadata';
+import { BindingScope } from './BindingScope';
+import { bindingTypeValues } from './BindingType';
+import { ScopedBinding } from './ScopedBinding';
+
+export interface ResolvedValueBinding<TActivated>
+  extends ScopedBinding<
+    typeof bindingTypeValues.ResolvedValue,
+    BindingScope,
+    TActivated
+  > {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly factory: (...args: any[]) => TActivated | Promise<TActivated>;
+  readonly metadata: ResolvedValueMetadata;
+}

--- a/packages/container/libraries/core/src/index.ts
+++ b/packages/container/libraries/core/src/index.ts
@@ -16,6 +16,7 @@ import { FactoryBinding } from './binding/models/FactoryBinding';
 import { InstanceBinding } from './binding/models/InstanceBinding';
 import { Provider } from './binding/models/Provider';
 import { ProviderBinding } from './binding/models/ProviderBinding';
+import { ResolvedValueBinding } from './binding/models/ResolvedValueBinding';
 import { ScopedBinding } from './binding/models/ScopedBinding';
 import { ServiceRedirectionBinding } from './binding/models/ServiceRedirectionBinding';
 import {
@@ -46,6 +47,9 @@ import { ClassMetadataLifecycle } from './metadata/models/ClassMetadataLifecycle
 import { ManagedClassElementMetadata } from './metadata/models/ManagedClassElementMetadata';
 import { MetadataName } from './metadata/models/MetadataName';
 import { MetadataTag } from './metadata/models/MetadataTag';
+import { ResolvedValueElementMetadata } from './metadata/models/ResolvedValueElementMetadata';
+import { ResolvedValueElementMetadataKind } from './metadata/models/ResolvedValueElementMetadataKind';
+import { ResolvedValueMetadata } from './metadata/models/ResolvedValueMetadata';
 import { UnmanagedClassElementMetadata } from './metadata/models/UnmanagedClassElementMetadata';
 import { plan } from './planning/calculations/plan';
 import { BaseBindingNode } from './planning/models/BaseBindingNode';
@@ -60,6 +64,7 @@ import { PlanServiceNode } from './planning/models/PlanServiceNode';
 import { PlanServiceNodeParent } from './planning/models/PlanServiceNodeParent';
 import { PlanServiceRedirectionBindingNode } from './planning/models/PlanServiceRedirectionBindingNode';
 import { PlanTree } from './planning/models/PlanTree';
+import { ResolvedValueBindingNode } from './planning/models/ResolvedValueBindingNode';
 import {
   GetPlanOptions,
   PlanResultCacheService,
@@ -96,9 +101,9 @@ export type {
   DynamicValueBuilder,
   Factory,
   FactoryBinding,
-  GetPlanOptions,
   GetOptions,
   GetOptionsTagConstraint,
+  GetPlanOptions,
   InstanceBinding,
   LeafBindingNode,
   ManagedClassElementMetadata,
@@ -119,6 +124,10 @@ export type {
   ResolutionContext,
   ResolutionParams,
   Resolved,
+  ResolvedValueBinding,
+  ResolvedValueBindingNode,
+  ResolvedValueElementMetadata,
+  ResolvedValueMetadata,
   ScopedBinding,
   ServiceRedirectionBinding,
   UnmanagedClassElementMetadata,
@@ -133,17 +142,18 @@ export {
   DeactivationsService,
   decorate,
   getClassMetadata,
-  multiInject,
   inject,
   injectable,
   injectFromBase,
+  multiInject,
   named,
   optional,
-  postConstruct,
   plan,
-  preDestroy,
   PlanResultCacheService,
+  postConstruct,
+  preDestroy,
   resolve,
+  ResolvedValueElementMetadataKind,
   resolveModuleDeactivations,
   resolveServiceDeactivations,
   tagged,

--- a/packages/container/libraries/core/src/metadata/models/BaseResolvedValueElementMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/models/BaseResolvedValueElementMetadata.ts
@@ -1,0 +1,3 @@
+export interface BaseResolvedValueElementMetadata<TKind> {
+  kind: TKind;
+}

--- a/packages/container/libraries/core/src/metadata/models/ResolvedValueElementMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/models/ResolvedValueElementMetadata.ts
@@ -1,0 +1,17 @@
+import { LazyServiceIdentifier, ServiceIdentifier } from '@inversifyjs/common';
+
+import { BaseResolvedValueElementMetadata } from './BaseResolvedValueElementMetadata';
+import { MetadataName } from './MetadataName';
+import { MetadataTag } from './MetadataTag';
+import { ResolvedValueElementMetadataKind } from './ResolvedValueElementMetadataKind';
+
+export interface ResolvedValueElementMetadata
+  extends BaseResolvedValueElementMetadata<
+    | ResolvedValueElementMetadataKind.singleInjection
+    | ResolvedValueElementMetadataKind.multipleInjection
+  > {
+  name: MetadataName | undefined;
+  optional: boolean;
+  tags: Map<MetadataTag, unknown>;
+  value: ServiceIdentifier | LazyServiceIdentifier;
+}

--- a/packages/container/libraries/core/src/metadata/models/ResolvedValueElementMetadataKind.ts
+++ b/packages/container/libraries/core/src/metadata/models/ResolvedValueElementMetadataKind.ts
@@ -1,0 +1,4 @@
+export enum ResolvedValueElementMetadataKind {
+  multipleInjection = 0,
+  singleInjection = 1,
+}

--- a/packages/container/libraries/core/src/metadata/models/ResolvedValueMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/models/ResolvedValueMetadata.ts
@@ -1,0 +1,5 @@
+import { ResolvedValueElementMetadata } from './ResolvedValueElementMetadata';
+
+export interface ResolvedValueMetadata {
+  arguments: ResolvedValueElementMetadata[];
+}

--- a/packages/container/libraries/core/src/planning/calculations/isInstanceBindingNode.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/isInstanceBindingNode.spec.ts
@@ -1,0 +1,54 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { bindingTypeValues } from '../../binding/models/BindingType';
+import { InstanceBindingNode } from '../models/InstanceBindingNode';
+import { PlanServiceNodeParent } from '../models/PlanServiceNodeParent';
+import { isInstanceBindingNode } from './isInstanceBindingNode';
+
+describe(isInstanceBindingNode.name, () => {
+  let node: PlanServiceNodeParent;
+
+  describe('having an InstanceBindingNode', () => {
+    beforeAll(() => {
+      node = {
+        binding: {
+          type: bindingTypeValues.Instance,
+        },
+      } as InstanceBindingNode;
+    });
+
+    describe('when called', () => {
+      let result: boolean;
+
+      beforeAll(() => {
+        result = isInstanceBindingNode(node);
+      });
+
+      it('should return true', () => {
+        expect(result).toBe(true);
+      });
+    });
+  });
+
+  describe('having a non InstanceBindingNode', () => {
+    beforeAll(() => {
+      node = {
+        binding: {
+          type: bindingTypeValues.ResolvedValue,
+        },
+      } as PlanServiceNodeParent;
+    });
+
+    describe('when called', () => {
+      let result: boolean;
+
+      beforeAll(() => {
+        result = isInstanceBindingNode(node);
+      });
+
+      it('should return false', () => {
+        expect(result).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/planning/calculations/isInstanceBindingNode.ts
+++ b/packages/container/libraries/core/src/planning/calculations/isInstanceBindingNode.ts
@@ -1,0 +1,9 @@
+import { bindingTypeValues } from '../../binding/models/BindingType';
+import { InstanceBindingNode } from '../models/InstanceBindingNode';
+import { PlanServiceNodeParent } from '../models/PlanServiceNodeParent';
+
+export function isInstanceBindingNode(
+  node: PlanServiceNodeParent,
+): node is InstanceBindingNode {
+  return node.binding.type === bindingTypeValues.Instance;
+}

--- a/packages/container/libraries/core/src/planning/models/PlanServiceNodeParent.ts
+++ b/packages/container/libraries/core/src/planning/models/PlanServiceNodeParent.ts
@@ -1,7 +1,9 @@
 import { InstanceBinding } from '../../binding/models/InstanceBinding';
+import { ResolvedValueBinding } from '../../binding/models/ResolvedValueBinding';
 import { InstanceBindingNode } from './InstanceBindingNode';
+import { ResolvedValueBindingNode } from './ResolvedValueBindingNode';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type PlanServiceNodeParent<TActivated = any> = InstanceBindingNode<
-  InstanceBinding<TActivated>
->;
+export type PlanServiceNodeParent<TActivated = any> =
+  | InstanceBindingNode<InstanceBinding<TActivated>>
+  | ResolvedValueBindingNode<ResolvedValueBinding<TActivated>>;

--- a/packages/container/libraries/core/src/planning/models/ResolvedValueBindingNode.ts
+++ b/packages/container/libraries/core/src/planning/models/ResolvedValueBindingNode.ts
@@ -1,0 +1,10 @@
+import { ResolvedValueBinding } from '../../binding/models/ResolvedValueBinding';
+import { BaseBindingNode } from './BaseBindingNode';
+import { PlanServiceNode } from './PlanServiceNode';
+
+export interface ResolvedValueBindingNode<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TBinding extends ResolvedValueBinding<any> = ResolvedValueBinding<any>,
+> extends BaseBindingNode<TBinding> {
+  readonly params: PlanServiceNode[];
+}

--- a/packages/container/libraries/core/src/resolution/actions/resolve.int.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolve.int.spec.ts
@@ -15,6 +15,7 @@ import { FactoryBinding } from '../../binding/models/FactoryBinding';
 import { InstanceBinding } from '../../binding/models/InstanceBinding';
 import { Provider } from '../../binding/models/Provider';
 import { ProviderBinding } from '../../binding/models/ProviderBinding';
+import { ResolvedValueBinding } from '../../binding/models/ResolvedValueBinding';
 import { ServiceRedirectionBinding } from '../../binding/models/ServiceRedirectionBinding';
 import { ActivationsService } from '../../binding/services/ActivationsService';
 import { BindingService } from '../../binding/services/BindingService';
@@ -25,6 +26,7 @@ import { getDefaultClassMetadata } from '../../metadata/calculations/getDefaultC
 import { inject } from '../../metadata/decorators/inject';
 import { optional } from '../../metadata/decorators/optional';
 import { ClassMetadata } from '../../metadata/models/ClassMetadata';
+import { ResolvedValueElementMetadataKind } from '../../metadata/models/ResolvedValueElementMetadataKind';
 import { plan } from '../../planning/calculations/plan';
 import { PlanParams } from '../../planning/models/PlanParams';
 import { PlanParamsConstraint } from '../../planning/models/PlanParamsConstraint';
@@ -45,6 +47,7 @@ enum ServiceIds {
   nonExistent = 'non-existent-service-id',
   priest = 'priest-instance-service-id',
   provider = 'provider-service-id',
+  resolvedValue = 'resolved-value-service-id',
   serviceRedirection = 'service-redirection-service-id',
   serviceRedirectionToNonExistent = 'service-redirection-to-non-existent-service-id',
 }
@@ -75,6 +78,7 @@ describe(resolve.name, () => {
   let instanceBinding: InstanceBinding<unknown>;
   let priestInstanceBinding: InstanceBinding<Priest>;
   let providerBinding: ProviderBinding<Provider<unknown>>;
+  let resolvedValueBinding: ResolvedValueBinding<unknown>;
   let serviceRedirectionBinding: ServiceRedirectionBinding<unknown>;
   let serviceRedirectionToNonExistentBinding: ServiceRedirectionBinding<unknown>;
 
@@ -203,6 +207,33 @@ describe(resolve.name, () => {
       type: bindingTypeValues.Provider,
     };
 
+    resolvedValueBinding = {
+      cache: {
+        isRight: false,
+        value: undefined,
+      },
+      factory: (param: unknown) => param,
+      id: 5,
+      isSatisfiedBy: () => true,
+      metadata: {
+        arguments: [
+          {
+            kind: ResolvedValueElementMetadataKind.singleInjection,
+            name: undefined,
+            optional: false,
+            tags: new Map(),
+            value: ServiceIds.constantValue,
+          },
+        ],
+      },
+      moduleId: undefined,
+      onActivation: undefined,
+      onDeactivation: undefined,
+      scope: bindingScopeValues.Singleton,
+      serviceIdentifier: ServiceIds.resolvedValue,
+      type: bindingTypeValues.ResolvedValue,
+    };
+
     serviceRedirectionBinding = {
       id: 6,
       isSatisfiedBy: () => true,
@@ -238,6 +269,7 @@ describe(resolve.name, () => {
     bindingService.set(instanceBinding);
     bindingService.set(priestInstanceBinding);
     bindingService.set(providerBinding);
+    bindingService.set(resolvedValueBinding);
     bindingService.set(serviceRedirectionBinding);
     bindingService.set(serviceRedirectionToNonExistentBinding);
 
@@ -468,6 +500,14 @@ describe(resolve.name, () => {
         serviceIdentifier: priestInstanceBinding.serviceIdentifier,
       }),
       () => new Priest(),
+    ],
+    [
+      'with resolved value bound service',
+      (): PlanParamsConstraint => ({
+        isMultiple: false,
+        serviceIdentifier: resolvedValueBinding.serviceIdentifier,
+      }),
+      () => constantValueBinding.value,
     ],
     [
       'with service redirection bound service',

--- a/packages/container/libraries/core/src/resolution/actions/resolveResolvedValueBindingNode.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveResolvedValueBindingNode.spec.ts
@@ -1,0 +1,123 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { ResolvedValueBinding } from '../../binding/models/ResolvedValueBinding';
+import { ResolvedValueBindingNode } from '../../planning/models/ResolvedValueBindingNode';
+import { ResolutionParams } from '../models/ResolutionParams';
+import { resolveResolvedValueBindingNode } from './resolveResolvedValueBindingNode';
+
+describe(resolveResolvedValueBindingNode.name, () => {
+  let resolveResolvedValueBindingParamsMock: jest.Mock<
+    (
+      params: ResolutionParams,
+      node: ResolvedValueBindingNode,
+    ) => unknown[] | Promise<unknown[]>
+  >;
+
+  let paramsFixture: ResolutionParams;
+  let nodeMock: jest.Mocked<ResolvedValueBindingNode>;
+
+  beforeAll(() => {
+    resolveResolvedValueBindingParamsMock = jest.fn();
+
+    paramsFixture = Symbol() as unknown as ResolutionParams;
+    nodeMock = {
+      binding: {
+        factory: jest.fn(),
+      } as Partial<jest.Mocked<ResolvedValueBinding<unknown>>> as jest.Mocked<
+        ResolvedValueBinding<unknown>
+      >,
+    } as Partial<
+      jest.Mocked<ResolvedValueBindingNode>
+    > as jest.Mocked<ResolvedValueBindingNode>;
+  });
+
+  describe('when called, and resolveResolvedValueBindingParams() returns an array', () => {
+    let constructorResolvedValues: unknown[];
+    let instanceResolvedValue: unknown;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      constructorResolvedValues = [Symbol()];
+      instanceResolvedValue = Symbol();
+
+      resolveResolvedValueBindingParamsMock.mockReturnValue(
+        constructorResolvedValues,
+      );
+
+      nodeMock.binding.factory.mockReturnValueOnce(instanceResolvedValue);
+
+      result = resolveResolvedValueBindingNode(
+        resolveResolvedValueBindingParamsMock,
+      )(paramsFixture, nodeMock);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call resolveResolvedValueBindingParams()', () => {
+      expect(resolveResolvedValueBindingParamsMock).toHaveBeenCalledTimes(1);
+      expect(resolveResolvedValueBindingParamsMock).toHaveBeenCalledWith(
+        paramsFixture,
+        nodeMock,
+      );
+    });
+
+    it('should call node.binding.factory()', () => {
+      expect(nodeMock.binding.factory).toHaveBeenCalledTimes(1);
+      expect(nodeMock.binding.factory).toHaveBeenCalledWith(
+        ...constructorResolvedValues,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(instanceResolvedValue);
+    });
+  });
+
+  describe('when called, and resolveResolvedValueBindingParams() returns an array promise', () => {
+    let constructorResolvedValues: unknown[];
+    let instanceResolvedValue: unknown;
+
+    let result: unknown;
+
+    beforeAll(async () => {
+      constructorResolvedValues = [Symbol()];
+      instanceResolvedValue = Symbol();
+
+      resolveResolvedValueBindingParamsMock.mockReturnValue(
+        Promise.resolve(constructorResolvedValues),
+      );
+
+      nodeMock.binding.factory.mockResolvedValueOnce(instanceResolvedValue);
+
+      result = await resolveResolvedValueBindingNode(
+        resolveResolvedValueBindingParamsMock,
+      )(paramsFixture, nodeMock);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call resolveResolvedValueBindingParams()', () => {
+      expect(resolveResolvedValueBindingParamsMock).toHaveBeenCalledTimes(1);
+      expect(resolveResolvedValueBindingParamsMock).toHaveBeenCalledWith(
+        paramsFixture,
+        nodeMock,
+      );
+    });
+
+    it('should call node.binding.factory()', () => {
+      expect(nodeMock.binding.factory).toHaveBeenCalledTimes(1);
+      expect(nodeMock.binding.factory).toHaveBeenCalledWith(
+        ...constructorResolvedValues,
+      );
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(instanceResolvedValue);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/resolution/actions/resolveResolvedValueBindingNode.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveResolvedValueBindingNode.ts
@@ -1,0 +1,37 @@
+import { isPromise } from '@inversifyjs/common';
+
+import { ResolvedValueBinding } from '../../binding/models/ResolvedValueBinding';
+import { ResolvedValueBindingNode } from '../../planning/models/ResolvedValueBindingNode';
+import { ResolutionParams } from '../models/ResolutionParams';
+import { Resolved } from '../models/Resolved';
+
+export function resolveResolvedValueBindingNode<
+  TActivated,
+  TBinding extends
+    ResolvedValueBinding<TActivated> = ResolvedValueBinding<TActivated>,
+>(
+  resolveResolvedValueBindingParams: (
+    params: ResolutionParams,
+    node: ResolvedValueBindingNode<TBinding>,
+  ) => unknown[] | Promise<unknown[]>,
+): (
+  params: ResolutionParams,
+  node: ResolvedValueBindingNode<TBinding>,
+) => Resolved<TActivated> {
+  return (
+    params: ResolutionParams,
+    node: ResolvedValueBindingNode<TBinding>,
+  ): Resolved<TActivated> => {
+    const paramValues: unknown[] | Promise<unknown[]> =
+      resolveResolvedValueBindingParams(params, node);
+
+    if (isPromise(paramValues)) {
+      return paramValues.then(
+        (resolvedParamValues: unknown[]): TActivated | Promise<TActivated> =>
+          node.binding.factory(...resolvedParamValues),
+      );
+    }
+
+    return node.binding.factory(...paramValues);
+  };
+}

--- a/packages/container/libraries/core/src/resolution/actions/resolveResolvedValueBindingParams.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveResolvedValueBindingParams.spec.ts
@@ -1,0 +1,102 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { ResolvedValueBinding } from '../../binding/models/ResolvedValueBinding';
+import { PlanServiceNode } from '../../planning/models/PlanServiceNode';
+import { ResolvedValueBindingNode } from '../../planning/models/ResolvedValueBindingNode';
+import { ResolutionParams } from '../models/ResolutionParams';
+import { resolveResolvedValueBindingParams } from './resolveResolvedValueBindingParams';
+
+describe(resolveResolvedValueBindingParams.name, () => {
+  describe('having ResolvedValueBindingNode with constructor param with PlanServiceNode value', () => {
+    let paramNodeFixture: PlanServiceNode;
+    let resolveServiceNodeMock: jest.Mock<
+      (params: ResolutionParams, serviceNode: PlanServiceNode) => unknown
+    >;
+
+    let paramsFixture: ResolutionParams;
+    let nodeFixture: ResolvedValueBindingNode<ResolvedValueBinding<unknown>>;
+
+    beforeAll(() => {
+      paramNodeFixture = {
+        bindings: undefined,
+        parent: undefined,
+        serviceIdentifier: 'service-id',
+      };
+      resolveServiceNodeMock = jest.fn();
+      paramsFixture = Symbol() as unknown as ResolutionParams;
+      nodeFixture = {
+        params: [paramNodeFixture],
+      } as Partial<
+        ResolvedValueBindingNode<ResolvedValueBinding<unknown>>
+      > as ResolvedValueBindingNode<ResolvedValueBinding<unknown>>;
+    });
+
+    describe('when called, and resolveServiceNode() return non Promise value', () => {
+      let resolvedValue: unknown;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        resolvedValue = Symbol();
+
+        resolveServiceNodeMock.mockReturnValueOnce(resolvedValue);
+
+        result = resolveResolvedValueBindingParams(resolveServiceNodeMock)(
+          paramsFixture,
+          nodeFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call resolveServiceNode()', () => {
+        expect(resolveServiceNodeMock).toHaveBeenCalledTimes(1);
+        expect(resolveServiceNodeMock).toHaveBeenCalledWith(
+          paramsFixture,
+          paramNodeFixture,
+        );
+      });
+
+      it('should return expected value', () => {
+        expect(result).toStrictEqual([resolvedValue]);
+      });
+    });
+
+    describe('when called, and resolveServiceNode() return Promise value', () => {
+      let resolvedValue: unknown;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        resolvedValue = Symbol();
+
+        resolveServiceNodeMock.mockReturnValueOnce(
+          Promise.resolve(resolvedValue),
+        );
+
+        result = resolveResolvedValueBindingParams(resolveServiceNodeMock)(
+          paramsFixture,
+          nodeFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call resolveServiceNode()', () => {
+        expect(resolveServiceNodeMock).toHaveBeenCalledTimes(1);
+        expect(resolveServiceNodeMock).toHaveBeenCalledWith(
+          paramsFixture,
+          paramNodeFixture,
+        );
+      });
+
+      it('should return expected value', () => {
+        expect(result).toStrictEqual(Promise.resolve([resolvedValue]));
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/resolution/actions/resolveResolvedValueBindingParams.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveResolvedValueBindingParams.ts
@@ -1,0 +1,35 @@
+import { isPromise } from '@inversifyjs/common';
+
+import { ResolvedValueBinding } from '../../binding/models/ResolvedValueBinding';
+import { PlanServiceNode } from '../../planning/models/PlanServiceNode';
+import { ResolvedValueBindingNode } from '../../planning/models/ResolvedValueBindingNode';
+import { ResolutionParams } from '../models/ResolutionParams';
+
+export function resolveResolvedValueBindingParams<
+  TActivated,
+  TBinding extends
+    ResolvedValueBinding<TActivated> = ResolvedValueBinding<TActivated>,
+>(
+  resolveServiceNode: (
+    params: ResolutionParams,
+    serviceNode: PlanServiceNode,
+  ) => unknown,
+): (
+  params: ResolutionParams,
+  node: ResolvedValueBindingNode<TBinding>,
+) => unknown[] | Promise<unknown[]> {
+  return (
+    params: ResolutionParams,
+    node: ResolvedValueBindingNode<TBinding>,
+  ): unknown[] | Promise<unknown[]> => {
+    const paramsResolvedValues: unknown[] = [];
+
+    for (const param of node.params) {
+      paramsResolvedValues.push(resolveServiceNode(params, param));
+    }
+
+    return paramsResolvedValues.some(isPromise)
+      ? Promise.all(paramsResolvedValues)
+      : paramsResolvedValues;
+  };
+}

--- a/packages/container/libraries/core/src/resolution/actions/resolveScopedResolvedValueBindingNode.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveScopedResolvedValueBindingNode.ts
@@ -1,0 +1,21 @@
+import { ResolvedValueBinding } from '../../binding/models/ResolvedValueBinding';
+import { ResolvedValueBindingNode } from '../../planning/models/ResolvedValueBindingNode';
+import { getResolvedValueNodeBinding } from '../calculations/getResolvedValueNodeBinding';
+import { ResolutionParams } from '../models/ResolutionParams';
+import { Resolved } from '../models/Resolved';
+import { resolveScoped } from './resolveScoped';
+
+export const resolveScopedResolvedValueBindingNode: <TActivated>(
+  resolve: (
+    params: ResolutionParams,
+    node: ResolvedValueBindingNode<ResolvedValueBinding<TActivated>>,
+  ) => Resolved<TActivated>,
+) => (
+  params: ResolutionParams,
+  node: ResolvedValueBindingNode<ResolvedValueBinding<TActivated>>,
+) => Resolved<TActivated> = <TActivated>(
+  resolve: (
+    params: ResolutionParams,
+    node: ResolvedValueBindingNode<ResolvedValueBinding<TActivated>>,
+  ) => Resolved<TActivated>,
+) => resolveScoped(getResolvedValueNodeBinding, resolve);

--- a/packages/container/libraries/core/src/resolution/calculations/getResolvedValueNodeBinding.spec.ts
+++ b/packages/container/libraries/core/src/resolution/calculations/getResolvedValueNodeBinding.spec.ts
@@ -1,0 +1,29 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { ResolvedValueBinding } from '../../binding/models/ResolvedValueBinding';
+import { ResolvedValueBindingNode } from '../../planning/models/ResolvedValueBindingNode';
+import { getResolvedValueNodeBinding } from './getResolvedValueNodeBinding';
+
+describe(getResolvedValueNodeBinding.name, () => {
+  let nodeFixture: ResolvedValueBindingNode<ResolvedValueBinding<unknown>>;
+
+  beforeAll(() => {
+    nodeFixture = {
+      binding: Symbol() as unknown as ResolvedValueBinding<unknown>,
+    } as Partial<
+      ResolvedValueBindingNode<ResolvedValueBinding<unknown>>
+    > as ResolvedValueBindingNode<ResolvedValueBinding<unknown>>;
+  });
+
+  describe('when called', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      result = getResolvedValueNodeBinding(nodeFixture);
+    });
+
+    it('should return expected value', () => {
+      expect(result).toBe(nodeFixture.binding);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/resolution/calculations/getResolvedValueNodeBinding.ts
+++ b/packages/container/libraries/core/src/resolution/calculations/getResolvedValueNodeBinding.ts
@@ -1,0 +1,8 @@
+import { ResolvedValueBinding } from '../../binding/models/ResolvedValueBinding';
+import { ResolvedValueBindingNode } from '../../planning/models/ResolvedValueBindingNode';
+
+export function getResolvedValueNodeBinding<TActivated>(
+  node: ResolvedValueBindingNode<ResolvedValueBinding<TActivated>>,
+): ResolvedValueBinding<TActivated> {
+  return node.binding;
+}


### PR DESCRIPTION
### Added
- Added `ResolvedValueMetadata`.
- Added `ResolvedValueBinding`.
- Added `ResolvedValueBindingNode`.

### Changed
- Updated `PlanServiceNodeParent` to include `ResolvedValueBindingNode`.

### Context
Related to inversify/InversifyJS#1640