### PR TITLE
Update bind to syntax with to resolved value

### DIFF
--- a/.changeset/rich-bananas-smell.md
+++ b/.changeset/rich-bananas-smell.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/container": minor
+---
+
+Updated `BindToFluentSyntax` with `.toResolvedValue`

--- a/packages/container/libraries/container/src/binding/calculations/isResolvedValueMetadataInjectOptions.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isResolvedValueMetadataInjectOptions.spec.ts
@@ -1,0 +1,45 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { LazyServiceIdentifier } from '@inversifyjs/common';
+
+import { ResolvedValueInjectOptions } from '../models/ResolvedValueInjectOptions';
+import { isResolvedValueMetadataInjectOptions } from './isResolvedValueMetadataInjectOptions';
+
+describe(isResolvedValueMetadataInjectOptions.name, () => {
+  describe.each<[string, ResolvedValueInjectOptions<unknown>, boolean]>([
+    ['symbol serviceIdentifier', Symbol(), false],
+    ['function serviceIdentifier', class {}, false],
+    ['string serviceIdentifier', 'service-id', false],
+    [
+      'LazyServiceIdentifier',
+      new LazyServiceIdentifier(() => 'service-id'),
+      false,
+    ],
+    [
+      'ResolvedValueMetadataInjectOptions',
+      {
+        serviceIdentifier: 'service-id',
+      },
+      true,
+    ],
+  ])(
+    'having %s options',
+    (
+      _description: string,
+      options: ResolvedValueInjectOptions<unknown>,
+      expected: boolean,
+    ) => {
+      describe('when called', () => {
+        let result: boolean;
+
+        beforeAll(() => {
+          result = isResolvedValueMetadataInjectOptions(options);
+        });
+
+        it(`should return ${String(expected)}`, () => {
+          expect(result).toBe(expected);
+        });
+      });
+    },
+  );
+});

--- a/packages/container/libraries/container/src/binding/calculations/isResolvedValueMetadataInjectOptions.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isResolvedValueMetadataInjectOptions.ts
@@ -1,0 +1,12 @@
+import { LazyServiceIdentifier } from '@inversifyjs/common';
+
+import {
+  ResolvedValueInjectOptions,
+  ResolvedValueMetadataInjectOptions,
+} from '../models/ResolvedValueInjectOptions';
+
+export function isResolvedValueMetadataInjectOptions<T>(
+  options: ResolvedValueInjectOptions<T>,
+): options is ResolvedValueMetadataInjectOptions<T> {
+  return typeof options === 'object' && !LazyServiceIdentifier.is(options);
+}

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntax.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntax.ts
@@ -11,6 +11,8 @@ import {
   ResolutionContext,
 } from '@inversifyjs/core';
 
+import { ResolvedValueInjectOptions } from './ResolvedValueInjectOptions';
+
 export interface BindToFluentSyntax<T> {
   to(type: Newable<T>): BindInWhenOnFluentSyntax<T>;
   toSelf(): BindInWhenOnFluentSyntax<T>;
@@ -28,6 +30,11 @@ export interface BindToFluentSyntax<T> {
       ? (context: ResolutionContext) => T
       : never,
   ): BindWhenOnFluentSyntax<T>;
+  toResolvedValue(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    factory: (...args: any[]) => T,
+    injectOptions?: ResolvedValueInjectOptions<T>[],
+  ): BindInWhenOnFluentSyntax<T>;
   toService(service: ServiceIdentifier<T>): void;
 }
 

--- a/packages/container/libraries/container/src/binding/models/ResolvedValueInjectOptions.ts
+++ b/packages/container/libraries/container/src/binding/models/ResolvedValueInjectOptions.ts
@@ -1,0 +1,20 @@
+import { LazyServiceIdentifier, ServiceIdentifier } from '@inversifyjs/common';
+import { MetadataName, MetadataTag } from '@inversifyjs/core';
+
+export type ResolvedValueInjectOptions<T> =
+  | LazyServiceIdentifier<T>
+  | ResolvedValueMetadataInjectOptions<T>
+  | ServiceIdentifier<T>;
+
+export interface ResolvedValueMetadataInjectOptions<T> {
+  isMultiple?: true;
+  name?: MetadataName;
+  optional?: true;
+  serviceIdentifier: ServiceIdentifier<T> | LazyServiceIdentifier<T>;
+  tags?: ResolvedValueMetadataInjectTagOptions[];
+}
+
+export interface ResolvedValueMetadataInjectTagOptions {
+  key: MetadataTag;
+  value: unknown;
+}

--- a/packages/container/libraries/container/src/index.ts
+++ b/packages/container/libraries/container/src/index.ts
@@ -9,6 +9,11 @@ import {
   BindWhenOnFluentSyntax,
 } from './binding/models/BindingFluentSyntax';
 import {
+  ResolvedValueInjectOptions,
+  ResolvedValueMetadataInjectOptions,
+  ResolvedValueMetadataInjectTagOptions,
+} from './binding/models/ResolvedValueInjectOptions';
+import {
   ContainerModule,
   ContainerModuleLoadOptions,
 } from './container/models/ContainerModule';
@@ -27,6 +32,9 @@ export type {
   ContainerModuleLoadOptions,
   ContainerOptions,
   IsBoundOptions,
+  ResolvedValueInjectOptions,
+  ResolvedValueMetadataInjectOptions,
+  ResolvedValueMetadataInjectTagOptions,
 };
 
 export {

--- a/packages/container/libraries/core/src/metadata/models/ResolvedValueElementMetadata.ts
+++ b/packages/container/libraries/core/src/metadata/models/ResolvedValueElementMetadata.ts
@@ -6,10 +6,7 @@ import { MetadataTag } from './MetadataTag';
 import { ResolvedValueElementMetadataKind } from './ResolvedValueElementMetadataKind';
 
 export interface ResolvedValueElementMetadata
-  extends BaseResolvedValueElementMetadata<
-    | ResolvedValueElementMetadataKind.singleInjection
-    | ResolvedValueElementMetadataKind.multipleInjection
-  > {
+  extends BaseResolvedValueElementMetadata<ResolvedValueElementMetadataKind> {
   name: MetadataName | undefined;
   optional: boolean;
   tags: Map<MetadataTag, unknown>;

--- a/packages/container/tools/e2e-tests/features/container/get.feature
+++ b/packages/container/tools/e2e-tests/features/container/get.feature
@@ -30,6 +30,16 @@ Feature: Get
         And container gets a value for service "warrior"
         Then value is an archer with a bow
 
+      Scenario: A resolved value binding is bound to a container and value is properly resolved
+        Given a service "army" resolved value binding as "army" depending on "warrior"
+        And a service "weapon" bow type binding as "bow"
+        And a service "warrior" archer type binding as "archer"
+        When "army" binding is bound to container
+        And "bow" binding is bound to container
+        And "archer" binding is bound to container
+        And container gets a value for service "army"
+        Then value is an array with an archer with a bow
+
     Rule: container provides an activated value given a service identifier
 
       Scenario: A binding with activation is bound to a container and value is properly resolved

--- a/packages/container/tools/e2e-tests/src/binding/step-definitions/givenDefinitions.ts
+++ b/packages/container/tools/e2e-tests/src/binding/step-definitions/givenDefinitions.ts
@@ -7,6 +7,7 @@ import {
   BindWhenFluentSyntax,
   BindWhenOnFluentSyntax,
   Container,
+  ResolvedValueInjectOptions,
 } from '@inversifyjs/container';
 import {
   BindingActivation,
@@ -119,6 +120,25 @@ function givenBindingToDynamicValue(
   });
 }
 
+function givenBindingToResolvedValue(
+  this: InversifyWorld,
+  serviceId: string,
+  injections: ResolvedValueInjectOptions<unknown>[],
+  bindingAlias: string | undefined,
+): void {
+  const parsedBindingAlias: string = bindingAlias ?? defaultAlias;
+
+  setBinding.bind(this)(parsedBindingAlias, {
+    bind: (container: Container): void => {
+      container
+        .bind(serviceId)
+        .toResolvedValue((...args: unknown[]) => args, injections);
+    },
+    kind: BindingParameterKind.dynamicValue,
+    serviceIdentifier: serviceId,
+  });
+}
+
 function givenDualWieldSwordmanTypeBinding(
   this: InversifyWorld,
   serviceId: string,
@@ -189,6 +209,17 @@ Given<InversifyWorld>(
   'a service {string} binding to dynamic value in {bindingScope} scope',
   function (serviceId: string, scope: BindingScope): void {
     givenBindingToDynamicValue.bind(this)(serviceId, scope);
+  },
+);
+
+Given<InversifyWorld>(
+  'a service {string} resolved value binding as {string} depending on {stringList}',
+  function (
+    serviceId: string,
+    bindingAlias: string,
+    injections: string[],
+  ): void {
+    givenBindingToResolvedValue.bind(this)(serviceId, injections, bindingAlias);
   },
 );
 

--- a/packages/container/tools/e2e-tests/src/container/step-definitions/thenDefinitions.ts
+++ b/packages/container/tools/e2e-tests/src/container/step-definitions/thenDefinitions.ts
@@ -135,6 +135,18 @@ Then<InversifyWorld>('value is an archer with a bow', function (): void {
 });
 
 Then<InversifyWorld>(
+  'value is an array with an archer with a bow',
+  function (): void {
+    const value: unknown =
+      getContainerGetRequestOrFail.bind(this)(defaultAlias);
+
+    assert.ok(Array.isArray(value));
+    assert.ok(value[0] instanceof Archer);
+    assert.ok(value[0].bow instanceof Bow);
+  },
+);
+
+Then<InversifyWorld>(
   'value is a sword with improved damage',
   function (): void {
     const value: unknown =


### PR DESCRIPTION
### Added
- Added `isResolvedValueMetadataInjectOptions`.
- Added `ResolvedValueInjectOptions`.

### Changed
- Updated `BindToFluentSyntax` with `toResolvedValue`.

### Context
Related to inversify/InversifyJS#1640
