### PR TITLE
Add get controller by name feature

### DIFF
--- a/packages/http/libraries/core/src/http/adapter/InversifyHttpAdapter.ts
+++ b/packages/http/libraries/core/src/http/adapter/InversifyHttpAdapter.ts
@@ -74,9 +74,12 @@ export abstract class InversifyHttpAdapter<
   ): RouterParams<TRequest, TResponse, TNextFunction>[] {
     return controllerMethodMetadataList.map(
       (controllerMethodMetadata: ControllerMethodMetadata) => {
-        const controller: Controller = this.#container.get(
-          controllerMetadata.target,
-        );
+        const controller: Controller =
+          controllerMetadata.controllerName === undefined
+            ? this.#container.get(controllerMetadata.target)
+            : this.#container.get(controllerMetadata.target, {
+                name: controllerMetadata.controllerName,
+              });
 
         const parameterMetadataList:
           | ControllerMethodParameterMetadata[]


### PR DESCRIPTION
### Added
- Add get controller by name feature to InversifyHttpAdapter

### Motivation
Currently, inversify container is able to inject multiple objects by name. With this feature, It's posible to match controllers injected by name with his class representation.