### PR TITLE
Fix dynamic value singleton scopes

### DIFF
--- a/packages/container/libraries/container/src/issues/containerGetShouldNotInstantiateAsyncSingletonBindingsTwice.spec.ts
+++ b/packages/container/libraries/container/src/issues/containerGetShouldNotInstantiateAsyncSingletonBindingsTwice.spec.ts
@@ -1,0 +1,63 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import 'reflect-metadata';
+
+import { inject, injectable } from '@inversifyjs/core';
+
+import { Container } from '../container/services/Container';
+
+class AsyncDependency {
+  public static async create(): Promise<AsyncDependency> {
+    return new AsyncDependency();
+  }
+}
+
+@injectable()
+class Dependency1 {
+  constructor(
+    @inject(AsyncDependency)
+    public readonly asyncDependency: AsyncDependency,
+  ) {}
+}
+
+@injectable()
+class Dependency2 {
+  constructor(
+    @inject(AsyncDependency) public readonly asyncDependency: AsyncDependency,
+  ) {}
+}
+
+@injectable()
+class Application {
+  constructor(
+    @inject(Dependency1)
+    public readonly dependency1: Dependency1,
+    @inject(Dependency2)
+    public readonly dependency2: Dependency2,
+  ) {}
+}
+
+describe('Container.get should not instantiate async singleton bindings twice', () => {
+  let result: unknown;
+
+  beforeAll(async () => {
+    const container: Container = new Container({ defaultScope: 'Singleton' });
+
+    container.bind(Application).toSelf();
+    container.bind(Dependency1).toSelf();
+    container.bind(Dependency2).toSelf();
+    container
+      .bind(AsyncDependency)
+      .toDynamicValue(async () => AsyncDependency.create());
+
+    result = await container.getAsync(Application);
+  });
+
+  it('should return expected value', () => {
+    expect(result).toBeInstanceOf(Application);
+
+    expect((result as Application).dependency1.asyncDependency).toBe(
+      (result as Application).dependency2.asyncDependency,
+    );
+  });
+});

--- a/packages/container/libraries/core/src/binding/models/ScopedBinding.ts
+++ b/packages/container/libraries/core/src/binding/models/ScopedBinding.ts
@@ -1,6 +1,6 @@
 import { Either } from '@inversifyjs/common';
 
-import { SyncResolved } from '../../resolution/models/Resolved';
+import { Resolved } from '../../resolution/models/Resolved';
 import { BaseBinding } from './BaseBinding';
 import { BindingActivation } from './BindingActivation';
 import { BindingDeactivation } from './BindingDeactivation';
@@ -12,7 +12,7 @@ export interface ScopedBinding<
   TScope extends BindingScope,
   TActivated,
 > extends BaseBinding<TType, TActivated> {
-  cache: Either<undefined, SyncResolved<TActivated>>;
+  cache: Either<undefined, Resolved<TActivated>>;
   readonly onActivation: BindingActivation<TActivated> | undefined;
   readonly onDeactivation: BindingDeactivation<TActivated> | undefined;
   readonly scope: TScope;

--- a/packages/container/libraries/core/src/resolution/actions/cacheResolvedValue.ts
+++ b/packages/container/libraries/core/src/resolution/actions/cacheResolvedValue.ts
@@ -15,6 +15,11 @@ export function cacheResolvedValue<
   resolvedValue: Resolved<TActivated>,
 ): Resolved<TActivated> {
   if (isPromise(resolvedValue)) {
+    binding.cache = {
+      isRight: true,
+      value: resolvedValue,
+    };
+
     return resolvedValue.then((syncResolvedValue: SyncResolved<TActivated>) =>
       cacheSyncResolvedValue(binding, syncResolvedValue),
     );


### PR DESCRIPTION
### Changed
- Updated `cacheResolvedValue` to set promise like resolved values until they are fullfilled.
- Updated `BindingScope.cache` type.