### PR TITLE
Update peer dependencies

### DIFF
--- a/.changeset/blue-jokes-camp.md
+++ b/.changeset/blue-jokes-camp.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/binding-decorators": patch
+---
+
+Updated inversify peer dependency

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
+# Refer to https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# for more information
+
 * @notaphplover
-packages/http/ @Adrianmjim
+packages/http/ @Adrianmjim @notaphplover

--- a/packages/container/libraries/binding-decorators/package.json
+++ b/packages/container/libraries/binding-decorators/package.json
@@ -25,7 +25,7 @@
     "typescript": "5.8.2"
   },
   "peerDependencies": {
-    "inversify": "^7.0.0-alpha.5"
+    "inversify": "^7.0.1"
   },
   "homepage": "https://inversify.io",
   "keywords": [

--- a/packages/http/libraries/core/package.json
+++ b/packages/http/libraries/core/package.json
@@ -49,7 +49,7 @@
   },
   "name": "@inversifyjs/http-core",
   "peerDependencies": {
-    "inversify": "7.0.0-alpha.5"
+    "inversify": "^7.0.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
### Changed
- Updated `peerDependencies` to no longer rely on alpha inversify versions.
- Updated codeowners.