### PR TITLE
Add injectable call to controller decorator

### DIFF
--- a/packages/http/libraries/core/src/http/decorators/Controller.spec.ts
+++ b/packages/http/libraries/core/src/http/decorators/Controller.spec.ts
@@ -1,78 +1,108 @@
 import { beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 jest.mock('@inversifyjs/reflect-metadata-utils');
+jest.mock('inversify');
 
 import {
   getReflectMetadata,
   setReflectMetadata,
 } from '@inversifyjs/reflect-metadata-utils';
+import { BindingScope, injectable } from 'inversify';
 
 import { controllerMetadataReflectKey } from '../../reflectMetadata/data/controllerMetadataReflectKey';
 import { controller } from './Controller';
 
 describe(controller.name, () => {
-  describe('when called with a string path', () => {
-    let pathFixture: string;
-    let decoratorFixture: ClassDecorator;
-    let targetFixture: NewableFunction;
+  describe('having a scope defined', () => {
+    describe('when called', () => {
+      let pathFixture: string;
+      let targetFixture: NewableFunction;
+      let scopeFixture: BindingScope;
+      let classDecoratorMock: jest.Mock<ClassDecorator>;
 
-    beforeAll(() => {
-      pathFixture = '/api';
-      targetFixture = class TestController {};
-      decoratorFixture = controller(pathFixture);
+      beforeAll(() => {
+        pathFixture = '/api';
+        targetFixture = class TestController {};
+        scopeFixture = {} as BindingScope;
+        classDecoratorMock = jest.fn();
 
-      decoratorFixture(targetFixture);
-    });
+        (injectable as jest.Mocked<typeof injectable>).mockReturnValue(
+          classDecoratorMock as ClassDecorator,
+        );
 
-    it('should get existing metadata', () => {
-      expect(getReflectMetadata).toHaveBeenCalledWith(
-        Reflect,
-        controllerMetadataReflectKey,
-      );
-    });
+        controller(pathFixture, scopeFixture)(targetFixture);
+      });
 
-    it('should set metadata with controller path', () => {
-      expect(setReflectMetadata).toHaveBeenCalledWith(
-        Reflect,
-        controllerMetadataReflectKey,
-        [
-          {
-            path: pathFixture,
-            target: targetFixture,
-          },
-        ],
-      );
+      it('should call injectable', () => {
+        expect(injectable).toHaveBeenCalledWith(scopeFixture);
+      });
+
+      it('should call ClassDecorator', () => {
+        expect(classDecoratorMock).toHaveBeenCalledWith(targetFixture);
+      });
     });
   });
 
-  describe('when called with options object', () => {
-    let optionsFixture: { controllerName: string; path: string };
-    let decoratorFixture: ClassDecorator;
-    let targetFixture: NewableFunction;
+  describe('having a undefined scope', () => {
+    describe('when called with a string path', () => {
+      let pathFixture: string;
+      let targetFixture: NewableFunction;
 
-    beforeAll(() => {
-      optionsFixture = {
-        controllerName: 'TestController',
-        path: '/api',
-      };
-      targetFixture = class TestController {};
-      decoratorFixture = controller(optionsFixture);
+      beforeAll(() => {
+        pathFixture = '/api';
+        targetFixture = class TestController {};
 
-      decoratorFixture(targetFixture);
+        controller(pathFixture)(targetFixture);
+      });
+
+      it('should get existing metadata', () => {
+        expect(getReflectMetadata).toHaveBeenCalledWith(
+          Reflect,
+          controllerMetadataReflectKey,
+        );
+      });
+
+      it('should set metadata with controller path', () => {
+        expect(setReflectMetadata).toHaveBeenCalledWith(
+          Reflect,
+          controllerMetadataReflectKey,
+          [
+            {
+              path: pathFixture,
+              target: targetFixture,
+            },
+          ],
+        );
+      });
     });
 
-    it('should set metadata with controller options', () => {
-      expect(setReflectMetadata).toHaveBeenCalledWith(
-        Reflect,
-        controllerMetadataReflectKey,
-        [
-          {
-            controllerName: optionsFixture.controllerName,
-            path: optionsFixture.path,
-            target: targetFixture,
-          },
-        ],
-      );
+    describe('when called with options object', () => {
+      let optionsFixture: { controllerName: string; path: string };
+      let targetFixture: NewableFunction;
+
+      beforeAll(() => {
+        optionsFixture = {
+          controllerName: 'TestController',
+          path: '/api',
+        };
+        targetFixture = class TestController {};
+
+        controller(optionsFixture)(targetFixture);
+      });
+
+      it('should set metadata with controller options', () => {
+        expect(setReflectMetadata).toHaveBeenCalledWith(
+          Reflect,
+          controllerMetadataReflectKey,
+          [
+            {
+              controllerName: optionsFixture.controllerName,
+              path: optionsFixture.path,
+              target: targetFixture,
+            },
+          ],
+        );
+      });
     });
   });
 });

--- a/packages/http/libraries/core/src/http/decorators/Controller.spec.ts
+++ b/packages/http/libraries/core/src/http/decorators/Controller.spec.ts
@@ -10,47 +10,25 @@ import {
 import { BindingScope, injectable } from 'inversify';
 
 import { controllerMetadataReflectKey } from '../../reflectMetadata/data/controllerMetadataReflectKey';
+import { ControllerOptions } from '../models/ControllerOptions';
 import { controller } from './Controller';
 
 describe(controller.name, () => {
-  describe('having a scope defined', () => {
+  describe('having a path', () => {
     describe('when called', () => {
       let pathFixture: string;
       let targetFixture: NewableFunction;
-      let scopeFixture: BindingScope;
       let classDecoratorMock: jest.Mock<ClassDecorator>;
 
       beforeAll(() => {
         pathFixture = '/api';
         targetFixture = class TestController {};
-        scopeFixture = {} as BindingScope;
+
         classDecoratorMock = jest.fn();
 
-        (injectable as jest.Mocked<typeof injectable>).mockReturnValue(
+        (injectable as jest.Mock<typeof injectable>).mockReturnValueOnce(
           classDecoratorMock as ClassDecorator,
         );
-
-        controller(pathFixture, scopeFixture)(targetFixture);
-      });
-
-      it('should call injectable', () => {
-        expect(injectable).toHaveBeenCalledWith(scopeFixture);
-      });
-
-      it('should call ClassDecorator', () => {
-        expect(classDecoratorMock).toHaveBeenCalledWith(targetFixture);
-      });
-    });
-  });
-
-  describe('having a undefined scope', () => {
-    describe('when called with a string path', () => {
-      let pathFixture: string;
-      let targetFixture: NewableFunction;
-
-      beforeAll(() => {
-        pathFixture = '/api';
-        targetFixture = class TestController {};
 
         controller(pathFixture)(targetFixture);
       });
@@ -60,6 +38,14 @@ describe(controller.name, () => {
           Reflect,
           controllerMetadataReflectKey,
         );
+      });
+
+      it('should call injectable', () => {
+        expect(injectable).toHaveBeenCalledWith(undefined);
+      });
+
+      it('should call ClassDecorator', () => {
+        expect(classDecoratorMock).toHaveBeenCalledWith(targetFixture);
       });
 
       it('should set metadata with controller path', () => {
@@ -75,10 +61,13 @@ describe(controller.name, () => {
         );
       });
     });
+  });
 
-    describe('when called with options object', () => {
+  describe('having a ControllerOptions', () => {
+    describe('when called and scope is undefined', () => {
       let optionsFixture: { controllerName: string; path: string };
       let targetFixture: NewableFunction;
+      let classDecoratorMock: jest.Mock<ClassDecorator>;
 
       beforeAll(() => {
         optionsFixture = {
@@ -87,7 +76,58 @@ describe(controller.name, () => {
         };
         targetFixture = class TestController {};
 
+        classDecoratorMock = jest.fn();
+
+        (injectable as jest.Mock<typeof injectable>).mockReturnValueOnce(
+          classDecoratorMock as ClassDecorator,
+        );
+
         controller(optionsFixture)(targetFixture);
+      });
+
+      it('should set metadata with controller options', () => {
+        expect(setReflectMetadata).toHaveBeenCalledWith(
+          Reflect,
+          controllerMetadataReflectKey,
+          [
+            {
+              controllerName: optionsFixture.controllerName,
+              path: optionsFixture.path,
+              target: targetFixture,
+            },
+          ],
+        );
+      });
+    });
+
+    describe('when called and scope is defined', () => {
+      let optionsFixture: ControllerOptions;
+      let targetFixture: NewableFunction;
+      let classDecoratorMock: jest.Mock<ClassDecorator>;
+
+      beforeAll(() => {
+        optionsFixture = {
+          controllerName: 'TestController',
+          path: '/api',
+          scope: 'Singleton',
+        };
+        targetFixture = class TestController {};
+
+        classDecoratorMock = jest.fn();
+
+        (injectable as jest.Mock<typeof injectable>).mockReturnValueOnce(
+          classDecoratorMock as ClassDecorator,
+        );
+
+        controller(optionsFixture)(targetFixture);
+      });
+
+      it('should call injectable', () => {
+        expect(injectable).toHaveBeenCalledWith(optionsFixture.scope);
+      });
+
+      it('should call ClassDecorator', () => {
+        expect(classDecoratorMock).toHaveBeenCalledWith(targetFixture);
       });
 
       it('should set metadata with controller options', () => {

--- a/packages/http/libraries/core/src/http/decorators/Controller.ts
+++ b/packages/http/libraries/core/src/http/decorators/Controller.ts
@@ -10,14 +10,14 @@ import { ControllerOptions } from '../models/ControllerOptions';
 
 export function controller(
   pathOrOptions?: string | ControllerOptions,
-  scope?: BindingScope,
 ): ClassDecorator {
   return (target: NewableFunction): void => {
-    injectable(scope)(target);
     const controllerMetadata: ControllerMetadata = {
       path: '/',
       target,
     };
+
+    let scope: BindingScope | undefined = undefined;
 
     if (pathOrOptions !== undefined) {
       if (typeof pathOrOptions === 'string') {
@@ -25,8 +25,11 @@ export function controller(
       } else {
         controllerMetadata.controllerName = pathOrOptions.controllerName;
         controllerMetadata.path = pathOrOptions.path ?? '/';
+        scope = pathOrOptions.scope;
       }
     }
+
+    injectable(scope)(target);
 
     let controllerMetadataList: ControllerMetadata[] | undefined =
       getReflectMetadata(Reflect, controllerMetadataReflectKey);

--- a/packages/http/libraries/core/src/http/decorators/Controller.ts
+++ b/packages/http/libraries/core/src/http/decorators/Controller.ts
@@ -2,6 +2,7 @@ import {
   getReflectMetadata,
   setReflectMetadata,
 } from '@inversifyjs/reflect-metadata-utils';
+import { BindingScope, injectable } from 'inversify';
 
 import { controllerMetadataReflectKey } from '../../reflectMetadata/data/controllerMetadataReflectKey';
 import { ControllerMetadata } from '../models/ControllerMetadata';
@@ -9,8 +10,10 @@ import { ControllerOptions } from '../models/ControllerOptions';
 
 export function controller(
   pathOrOptions?: string | ControllerOptions,
+  scope?: BindingScope,
 ): ClassDecorator {
   return (target: NewableFunction): void => {
+    injectable(scope)(target);
     const controllerMetadata: ControllerMetadata = {
       path: '/',
       target,

--- a/packages/http/libraries/core/src/http/models/ControllerOptions.ts
+++ b/packages/http/libraries/core/src/http/models/ControllerOptions.ts
@@ -1,4 +1,7 @@
+import { BindingScope } from 'inversify';
+
 export interface ControllerOptions {
-  path?: string;
   controllerName?: string;
+  path?: string;
+  scope?: BindingScope;
 }


### PR DESCRIPTION
### Added
- Add injectable call to controller decorator logic

### Motivation
With new version of inversify http integration, controllers are considered object of injection system. We need to add injectable call to controller logic.