### PR TITLE
Remove benchmark packages from root dependencies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,7 @@ jobs:
         run: |
               EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
               echo "result<<$EOF" >> $GITHUB_OUTPUT
-              echo "$(pnpm exec container-benchmarks-run-cjs)" >> $GITHUB_OUTPUT
+              echo "$(pnpm run benchmarks:container:cjs)" >> $GITHUB_OUTPUT
               echo "$EOF" >> $GITHUB_OUTPUT
 
       - name: Run benchmarks (ESM)
@@ -68,7 +68,7 @@ jobs:
         run: |
               EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
               echo "result<<$EOF" >> $GITHUB_OUTPUT
-              echo "$(pnpm exec container-benchmarks-run-esm)" >> $GITHUB_OUTPUT
+              echo "$(pnpm run benchmarks:container:esm)" >> $GITHUB_OUTPUT
               echo "$EOF" >> $GITHUB_OUTPUT
 
       - uses: actions/github-script@v7

--- a/package.json
+++ b/package.json
@@ -9,8 +9,6 @@
     "@commitlint/cli": "19.7.1",
     "@commitlint/config-conventional": "19.7.1",
     "@commitlint/prompt-cli": "19.7.1",
-    "@inversifyjs/container-benchmarks": "workspace:*",
-    "@inversifyjs/http-benchmarks": "workspace:*",
     "@inversifyjs/foundation-eslint-config": "workspace:*",
     "@inversifyjs/foundation-prettier-config": "workspace:*",
     "@inversifyjs/foundation-rollup-config": "workspace:*",
@@ -34,6 +32,10 @@
     "url": "git+https://github.com/inversify/monorepo.git"
   },
   "scripts": {
+    "benchmarks:container:cjs": "pnpm run --filter \"@inversifyjs/container-benchmarks\" benchmarks:run:cjs",
+    "benchmarks:container:esm": "pnpm run --filter \"@inversifyjs/container-benchmarks\" benchmarks:run:esm",
+    "benchmarks:http:cjs": "pnpm run --filter \"@inversifyjs/http-benchmarks\" benchmarks:run:cjs",
+    "benchmarks:http:esm": "pnpm run --filter \"@inversifyjs/http-benchmarks\" benchmarks:run:esm",
     "build": "turbo run build",
     "commit": "commit",
     "deploy:binding-decorators:pages": "pnpm run --filter \"@inversifyjs/inversify-binding-decorators-docs-site\" deploy",

--- a/packages/container/tools/container-benchmarks/package.json
+++ b/packages/container/tools/container-benchmarks/package.json
@@ -4,10 +4,6 @@
     "url": "https://github.com/inversify/monorepo/issues"
   },
   "description": "InversifyJs benchmarks package",
-  "bin": {
-    "container-benchmarks-run-cjs": "./bin/run-cjs.cjs",
-    "container-benchmarks-run-esm": "./bin/run-esm.mjs"
-  },
   "dependencies": {
     "@inversifyjs/benchmark-utils": "workspace:*",
     "@inversifyjs/container": "workspace:*",
@@ -52,6 +48,8 @@
     "url": "git+https://github.com/inversify/monorepo.git"
   },
   "scripts": {
+    "benchmarks:run:cjs": "./bin/run-cjs.cjs",
+    "benchmarks:run:esm": "./bin/run-esm.mjs",
     "build": "pnpm run build:cjs && pnpm run build:esm",
     "build:cjs": "tsc --build tsconfig.cjs.json && pnpm exec foundation-ts-package-cjs ./lib/cjs",
     "build:esm": "rollup -c ./rollup.config.mjs && pnpm exec foundation-ts-package-esm ./lib/esm",

--- a/packages/http/tools/http-benchmarks/package.json
+++ b/packages/http/tools/http-benchmarks/package.json
@@ -4,10 +4,6 @@
     "url": "https://github.com/inversify/monorepo/issues"
   },
   "description": "InversifyJs benchmarks package",
-  "bin": {
-    "http-benchmarks-run-cjs": "./bin/run-cjs.cjs",
-    "http-benchmarks-run-esm": "./bin/run-esm.mjs"
-  },
   "dependencies": {
     "@inversifyjs/benchmark-utils": "workspace:*",
     "@nestjs/common": "11.0.11",
@@ -53,6 +49,8 @@
     "url": "git+https://github.com/inversify/monorepo.git"
   },
   "scripts": {
+    "benchmarks:run:cjs": "./bin/run-cjs.cjs",
+    "benchmarks:run:esm": "./bin/run-esm.mjs",
     "build": "pnpm run build:cjs && pnpm run build:esm",
     "build:cjs": "tsc --build tsconfig.cjs.json && pnpm exec foundation-ts-package-cjs ./lib/cjs",
     "build:esm": "rollup -c ./rollup.config.mjs && pnpm exec foundation-ts-package-esm ./lib/esm",


### PR DESCRIPTION
### Changed
- Removed benchamar packages from root dependencies in favor of npm scripts.

### Context
Since root dependencies are considered dependencies of every package, `turbo` was unable to properly cache build and test tasks. For exmaple, an update in the `core` package was impacting in the container benchmarks, triggering the cache invalidation of every package. 