### PR TITLE
Add custom logger to HttpAdapterOptions

### DIFF
--- a/packages/http/libraries/core/src/http/adapter/InversifyHttpAdapter.ts
+++ b/packages/http/libraries/core/src/http/adapter/InversifyHttpAdapter.ts
@@ -26,7 +26,7 @@ export abstract class InversifyHttpAdapter<
 > {
   readonly #container: Container;
   readonly #httpAdapterOptions: InternalHttpAdapterOptions;
-  readonly #logger: Logger;
+  #logger: Logger;
   readonly #routerExplorer: RouterExplorer;
 
   constructor(container: Container, httpAdapterOptions?: HttpAdapterOptions) {
@@ -44,9 +44,19 @@ export abstract class InversifyHttpAdapter<
   #parseHttpAdapterOptions(
     httpAdapterOptions?: HttpAdapterOptions,
   ): InternalHttpAdapterOptions {
-    return {
-      logger: httpAdapterOptions?.logger ?? true,
+    const internalHttpAdapterOptions: InternalHttpAdapterOptions = {
+      logger: true,
     };
+
+    if (httpAdapterOptions?.logger !== undefined) {
+      if (typeof httpAdapterOptions.logger === 'boolean') {
+        internalHttpAdapterOptions.logger = httpAdapterOptions.logger;
+      } else {
+        this.#logger = httpAdapterOptions.logger;
+      }
+    }
+
+    return internalHttpAdapterOptions;
   }
 
   async #registerControllers(): Promise<void> {

--- a/packages/http/libraries/core/src/http/models/HttpAdapterOptions.ts
+++ b/packages/http/libraries/core/src/http/models/HttpAdapterOptions.ts
@@ -1,3 +1,5 @@
+import { Logger } from '@inversifyjs/logger';
+
 export interface HttpAdapterOptions {
-  logger?: boolean;
+  logger?: boolean | Logger;
 }


### PR DESCRIPTION
### Added
- Add custom logger to HttpAdapterOptions

### Motivation
In some scenarios, users will want to pass a custom logger to the adapter to handle the adapter's logs in a custom way