### PR TITLE
Add prehandler and postHandler middlewares

### DIFF
--- a/packages/http/libraries/core/src/http/decorators/ApplyMiddleware.ts
+++ b/packages/http/libraries/core/src/http/decorators/ApplyMiddleware.ts
@@ -6,18 +6,21 @@ import { Newable } from 'inversify';
 
 import { controllerMethodMiddlewareMetadataReflectKey } from '../../reflectMetadata/data/controllerMethodMiddlewareMetadataReflectKey';
 import { controllerMiddlewareMetadataReflectKey } from '../../reflectMetadata/data/controllerMiddlewareMetadataReflectKey';
+import { ApplyMiddlewareOptions } from '../models/ApplyMiddlewareOptions';
 import { ControllerFunction } from '../models/ControllerFunction';
 import { Middleware } from '../models/Middleware';
 
 export function applyMiddleware(
-  ...middlewareList: Newable<Middleware>[]
+  ...middlewareList: (Newable<Middleware> | ApplyMiddlewareOptions)[]
 ): ClassDecorator & MethodDecorator {
   return (
     target: object,
     _key?: string | symbol,
     descriptor?: PropertyDescriptor,
   ): void => {
-    let middlewareMetadataList: NewableFunction[] | undefined = undefined;
+    let middlewareMetadataList:
+      | (NewableFunction | ApplyMiddlewareOptions)[]
+      | undefined = undefined;
 
     if (descriptor === undefined) {
       middlewareMetadataList = getReflectMetadata(

--- a/packages/http/libraries/core/src/http/models/ApplyMiddlewareOptions.ts
+++ b/packages/http/libraries/core/src/http/models/ApplyMiddlewareOptions.ts
@@ -1,0 +1,8 @@
+import { Newable } from 'inversify';
+
+import { Middleware } from './Middleware';
+
+export interface ApplyMiddlewareOptions {
+  phase: 'preHandler' | 'postHandler';
+  middleware: Newable<Middleware> | Newable<Middleware>[];
+}

--- a/packages/http/libraries/core/src/http/models/RouteParams.ts
+++ b/packages/http/libraries/core/src/http/models/RouteParams.ts
@@ -1,8 +1,9 @@
 import { RequestHandler } from './RequestHandler';
-import { RouteParams } from './RouteParams';
+import { RequestMethodType } from './RequestMethodType';
 
-export interface RouterParams<TRequest, TResponse, TNextFunction> {
+export interface RouteParams<TRequest, TResponse, TNextFunction> {
   guardList: RequestHandler<TRequest, TResponse, TNextFunction>[] | undefined;
+  handler: RequestHandler<TRequest, TResponse, TNextFunction>;
   path: string;
   postHandlerMiddlewareList:
     | RequestHandler<TRequest, TResponse, TNextFunction>[]
@@ -10,5 +11,5 @@ export interface RouterParams<TRequest, TResponse, TNextFunction> {
   preHandlerMiddlewareList:
     | RequestHandler<TRequest, TResponse, TNextFunction>[]
     | undefined;
-  routeParamsList: RouteParams<TRequest, TResponse, TNextFunction>[];
+  requestMethodType: RequestMethodType;
 }

--- a/packages/http/libraries/core/src/http/typeguard/isApplyMiddlewareOptions.spec.ts
+++ b/packages/http/libraries/core/src/http/typeguard/isApplyMiddlewareOptions.spec.ts
@@ -1,0 +1,50 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { ApplyMiddlewareOptions } from '../models/ApplyMiddlewareOptions';
+import { Middleware } from '../models/Middleware';
+import { isApplyMiddlewareOptions } from './isApplyMiddlewareOptions';
+
+class TestMiddleware implements Middleware {
+  public execute(_request: Request, _response: Response): void {
+    throw new Error('Method not implemented.');
+  }
+}
+
+describe(isApplyMiddlewareOptions.name, () => {
+  describe('having a value that is ApplyMiddlewareOptions', () => {
+    describe('when called', () => {
+      let valueFixture: ApplyMiddlewareOptions;
+      let result: boolean;
+
+      beforeAll(() => {
+        valueFixture = {
+          middleware: TestMiddleware,
+          phase: 'preHandler',
+        };
+
+        result = isApplyMiddlewareOptions(valueFixture);
+      });
+
+      it('should return true', () => {
+        expect(result).toBe(true);
+      });
+    });
+  });
+
+  describe('having a value that is not ApplyMiddlewareOptions', () => {
+    describe('when called', () => {
+      let valueFixture: unknown;
+      let result: boolean;
+
+      beforeAll(() => {
+        valueFixture = {};
+
+        result = isApplyMiddlewareOptions(valueFixture);
+      });
+
+      it('should return false', () => {
+        expect(result).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/http/libraries/core/src/http/typeguard/isApplyMiddlewareOptions.ts
+++ b/packages/http/libraries/core/src/http/typeguard/isApplyMiddlewareOptions.ts
@@ -1,0 +1,13 @@
+import { ApplyMiddlewareOptions } from '../models/ApplyMiddlewareOptions';
+
+export function isApplyMiddlewareOptions(
+  value: unknown,
+): value is ApplyMiddlewareOptions {
+  const applyMiddlewareOptions: ApplyMiddlewareOptions =
+    value as ApplyMiddlewareOptions;
+
+  return (
+    typeof applyMiddlewareOptions.middleware === 'function' &&
+    typeof applyMiddlewareOptions.phase === 'string'
+  );
+}

--- a/packages/http/libraries/core/src/index.ts
+++ b/packages/http/libraries/core/src/index.ts
@@ -23,6 +23,7 @@ import { Guard } from './http/guard/Guard';
 import { HttpAdapterOptions } from './http/models/HttpAdapterOptions';
 import { Middleware } from './http/models/Middleware';
 import { RequestHandler } from './http/models/RequestHandler';
+import { RouteParams } from './http/models/RouteParams';
 import { RouterParams } from './http/models/RouterParams';
 import { BadGatewayHttpResponse } from './http/responses/error/BadGatewayHttpResponse';
 import { BadRequestHttpResponse } from './http/responses/error/BadRequestHttpResponse';
@@ -54,7 +55,13 @@ import { OkHttpResponse } from './http/responses/success/OkHttpResponse';
 import { PartialContentHttpResponse } from './http/responses/success/PartialContentHttpResponse';
 import { ResetContentHttpResponse } from './http/responses/success/ResetContentHttpResponse';
 
-export type { HttpAdapterOptions, RequestHandler, RouterParams, Middleware };
+export type {
+  HttpAdapterOptions,
+  RequestHandler,
+  RouteParams,
+  RouterParams,
+  Middleware,
+};
 
 export {
   BadRequestHttpResponse,

--- a/packages/http/libraries/core/src/routerExplorer/converter/ApplyMiddlewareOptionsToNewableFunctionConverter.ts
+++ b/packages/http/libraries/core/src/routerExplorer/converter/ApplyMiddlewareOptionsToNewableFunctionConverter.ts
@@ -1,0 +1,49 @@
+import { ApplyMiddlewareOptions } from '../../http/models/ApplyMiddlewareOptions';
+import { isApplyMiddlewareOptions } from '../../http/typeguard/isApplyMiddlewareOptions';
+import { Converter } from './Converter';
+
+export class ApplyMiddlewareOptionsToNewableFunctionConverter
+  implements
+    Converter<
+      (NewableFunction | ApplyMiddlewareOptions)[],
+      {
+        postHandlerMiddlewareList: NewableFunction[];
+        preHandlerMiddlewareList: NewableFunction[];
+      }
+    >
+{
+  public convert(input: (NewableFunction | ApplyMiddlewareOptions)[]): {
+    postHandlerMiddlewareList: NewableFunction[];
+    preHandlerMiddlewareList: NewableFunction[];
+  } {
+    const result: {
+      postHandlerMiddlewareList: NewableFunction[];
+      preHandlerMiddlewareList: NewableFunction[];
+    } = {
+      postHandlerMiddlewareList: [],
+      preHandlerMiddlewareList: [],
+    };
+
+    for (const item of input) {
+      if (isApplyMiddlewareOptions(item)) {
+        const middlewareList: NewableFunction[] = [];
+
+        if (Array.isArray(item.middleware)) {
+          middlewareList.push(...item.middleware);
+        } else {
+          middlewareList.push(item.middleware);
+        }
+
+        if (item.phase === 'postHandler') {
+          result.postHandlerMiddlewareList.push(...middlewareList);
+        } else {
+          result.preHandlerMiddlewareList.push(...middlewareList);
+        }
+      } else {
+        result.preHandlerMiddlewareList.push(item);
+      }
+    }
+
+    return result;
+  }
+}

--- a/packages/http/libraries/core/src/routerExplorer/converter/Converter.ts
+++ b/packages/http/libraries/core/src/routerExplorer/converter/Converter.ts
@@ -1,0 +1,3 @@
+export interface Converter<TInput, TOutput> {
+  convert(input: TInput): TOutput;
+}

--- a/packages/http/libraries/core/src/routerExplorer/model/RouterExplorerControllerMetadata.ts
+++ b/packages/http/libraries/core/src/routerExplorer/model/RouterExplorerControllerMetadata.ts
@@ -1,9 +1,10 @@
 import { RouterExplorerControllerMethodMetadata } from './RouterExplorerControllerMethodMetadata';
 
 export interface RouterExplorerControllerMetadata {
-  path: string;
-  target: NewableFunction;
   controllerMethodMetadataList: RouterExplorerControllerMethodMetadata[];
   guardList: NewableFunction[] | undefined;
-  middlewareList: NewableFunction[] | undefined;
+  path: string;
+  postHandlerMiddlewareList: NewableFunction[] | undefined;
+  preHandlerMiddlewareList: NewableFunction[] | undefined;
+  target: NewableFunction;
 }

--- a/packages/http/libraries/core/src/routerExplorer/model/RouterExplorerControllerMethodMetadata.ts
+++ b/packages/http/libraries/core/src/routerExplorer/model/RouterExplorerControllerMethodMetadata.ts
@@ -4,10 +4,11 @@ import { HttpStatusCode } from '../../http/responses/HttpStatusCode';
 
 export interface RouterExplorerControllerMethodMetadata {
   guardList: NewableFunction[] | undefined;
-  middlewareList: NewableFunction[] | undefined;
   methodKey: string | symbol;
-  path: string;
-  requestMethodType: RequestMethodType;
   parameterMetadataList: ControllerMethodParameterMetadata[];
+  path: string;
+  postHandlerMiddlewareList: NewableFunction[] | undefined;
+  preHandlerMiddlewareList: NewableFunction[] | undefined;
+  requestMethodType: RequestMethodType;
   statusCode: HttpStatusCode | undefined;
 }


### PR DESCRIPTION
### Added
- Add ApplyMiddlewareOptions
- Add isApplyMiddleware typeguard
- Add ApplyMiddlewareOptionsToNewableFunctionConverter
- RouteParam to package index

### Refactored
- Refactor applyMiddleware parameter type to use ApplyMiddlewareOptions
- Refactor RouterExplorer to use preHandler and postHandler middlewares
- Refactor InversifyHttpAdapter to use preHandler and postHandler middlewares