### PR TITLE
Update migration guide

### DIFF
--- a/packages/docs/services/inversify-site/docs/guides/migrating-from-v6.mdx
+++ b/packages/docs/services/inversify-site/docs/guides/migrating-from-v6.mdx
@@ -86,3 +86,11 @@ In v6, the `Context` class was used to pass contextual information. Too many int
 In v6, binding constraints received a `Request` object. In v7, binding constraints receive a `BindingConstraints` object. This object is more focused on the user's needs and hides internal data structures to keep the API simple and maintainable.
 
 <CodeBlock language="ts">{bindingWhenSyntaxApiWhenSource}</CodeBlock>
+
+## Decorators API
+
+### Inheritance
+
+In previous versions of InversifyJS, injection inheritance was implicit. This behavior has been deprecated in v7 in favor of the `@injectFromBase` decorator. This decorator allows developers to explicitly decide whether or not to inherit injections from a base class, providing more control and avoiding edge cases related to constructor argument mismatches.
+
+For more details, refer to the [Inheritance documentation](../../fundamentals/inheritance).

--- a/packages/docs/services/inversify-site/versioned_docs/version-7.x/guides/migrating-from-v6.mdx
+++ b/packages/docs/services/inversify-site/versioned_docs/version-7.x/guides/migrating-from-v6.mdx
@@ -86,3 +86,11 @@ In v6, the `Context` class was used to pass contextual information. Too many int
 In v6, binding constraints received a `Request` object. In v7, binding constraints receive a `BindingConstraints` object. This object is more focused on the user's needs and hides internal data structures to keep the API simple and maintainable.
 
 <CodeBlock language="ts">{bindingWhenSyntaxApiWhenSource}</CodeBlock>
+
+## Decorators API
+
+### Inheritance
+
+In previous versions of InversifyJS, injection inheritance was implicit. This behavior has been deprecated in v7 in favor of the `@injectFromBase` decorator. This decorator allows developers to explicitly decide whether or not to inherit injections from a base class, providing more control and avoiding edge cases related to constructor argument mismatches.
+
+For more details, refer to the [Inheritance documentation](../../fundamentals/inheritance).


### PR DESCRIPTION
### Changed
- Updated `inversify` v7 migration guide with inheritance related breaking changes.

### Context
We're attempting to improve docs after feedback received in inversify/InversifyJs#1766.