### PR TITLE
Update binding docs

### DIFF
--- a/packages/docs/services/inversify-site/docs/fundamentals/binding.mdx
+++ b/packages/docs/services/inversify-site/docs/fundamentals/binding.mdx
@@ -39,6 +39,12 @@ Whenever a promise-like value is resolved from a binding, the container will wai
 
 In the example, the `dbConnectionSymbol` database connection is resolved asynchronously. The container waits for promises to be resolved, passing an `AwesomeDbDriverConnection` instance to the resolve value factory instead of a `Promise<AwesomeDbDriverConnection>` one.
 
+:::warning
+
+Keep in mind async bindings require the use of `Container.getAsync` or `Container.getAllAsync` to resolve any related service.
+
+:::
+
 ## Binding properties
 
 A binding has the following properties:

--- a/packages/docs/services/inversify-site/versioned_docs/version-7.x/fundamentals/binding.mdx
+++ b/packages/docs/services/inversify-site/versioned_docs/version-7.x/fundamentals/binding.mdx
@@ -39,6 +39,12 @@ Whenever a promise-like value is resolved from a binding, the container will wai
 
 In the example, the `dbConnectionSymbol` database connection is resolved asynchronously. The container waits for promises to be resolved, passing an `AwesomeDbDriverConnection` instance to the resolve value factory instead of a `Promise<AwesomeDbDriverConnection>` one.
 
+:::warning
+
+Keep in mind async bindings require the use of `Container.getAsync` or `Container.getAllAsync` to resolve any related service.
+
+:::
+
 ## Binding properties
 
 A binding has the following properties:


### PR DESCRIPTION
### Changed
- Updated binding docs to reflect async bindings require the use of container async get methods.

### Context
We are trying to improve docs after feedback obtained at inversify/InversifyJS#1759.