### PR TITLE
Update controller method parameter metadata

### DIFF
--- a/packages/http/libraries/core/src/http/adapter/InversifyHttpAdapter.ts
+++ b/packages/http/libraries/core/src/http/adapter/InversifyHttpAdapter.ts
@@ -146,7 +146,10 @@ export abstract class InversifyHttpAdapter<
   #buildHandler(
     controller: Controller,
     controllerMethodKey: string | symbol,
-    controllerMethodParameterMetadataList: ControllerMethodParameterMetadata[],
+    controllerMethodParameterMetadataList: (
+      | ControllerMethodParameterMetadata
+      | undefined
+    )[],
     headerMetadataList: [string, string][],
     statusCode: HttpStatusCode | undefined,
     useNativeHandler: boolean,
@@ -183,7 +186,10 @@ export abstract class InversifyHttpAdapter<
   }
 
   async #buildHandlerParams(
-    controllerMethodParameterMetadataList: ControllerMethodParameterMetadata[],
+    controllerMethodParameterMetadataList: (
+      | ControllerMethodParameterMetadata
+      | undefined
+    )[],
     request: TRequest,
     response: TResponse,
     next: TNextFunction,
@@ -191,8 +197,14 @@ export abstract class InversifyHttpAdapter<
     return Promise.all(
       controllerMethodParameterMetadataList.map(
         async (
-          controllerMethodParameterMetadata: ControllerMethodParameterMetadata,
+          controllerMethodParameterMetadata:
+            | ControllerMethodParameterMetadata
+            | undefined,
         ) => {
+          if (controllerMethodParameterMetadata === undefined) {
+            return undefined;
+          }
+
           switch (controllerMethodParameterMetadata.parameterType) {
             case RequestMethodParameterType.BODY:
               return this._getBody(

--- a/packages/http/libraries/core/src/http/decorators/RequestParam.spec.ts
+++ b/packages/http/libraries/core/src/http/decorators/RequestParam.spec.ts
@@ -11,6 +11,7 @@ import { InversifyHttpAdapterError } from '../../error/models/InversifyHttpAdapt
 import { InversifyHttpAdapterErrorKind } from '../../error/models/InversifyHttpAdapterErrorKind';
 import { controllerMethodParameterMetadataReflectKey } from '../../reflectMetadata/data/controllerMethodParameterMetadataReflectKey';
 import { controllerMethodUseNativeHandlerMetadataReflectKey } from '../../reflectMetadata/data/controllerMethodUseNativeHandlerMetadataReflectKey';
+import { ControllerMethodParameterMetadata } from '../../routerExplorer/model/ControllerMethodParameterMetadata';
 import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
 import { requestParam } from './RequestParam';
 
@@ -48,7 +49,6 @@ describe(requestParam.name, () => {
           controllerMethodParameterMetadataReflectKey,
           [
             {
-              index: indexFixture,
               parameterName: undefined,
               parameterType: parameterTypeFixture,
             },
@@ -113,7 +113,7 @@ describe(requestParam.name, () => {
         targetFixture = {
           [keyFixture]: vitest.fn(),
         };
-        indexFixture = 0;
+        indexFixture = 2;
         parameterTypeFixture = RequestMethodParameterType.QUERY;
 
         requestParam(parameterTypeFixture)(
@@ -136,17 +136,20 @@ describe(requestParam.name, () => {
       });
 
       it('should call setReflectMetadata', () => {
+        const expectedControllerMethodParameterMetadata: (
+          | ControllerMethodParameterMetadata
+          | undefined
+        )[] = [];
+        expectedControllerMethodParameterMetadata[indexFixture] = {
+          parameterName: undefined,
+          parameterType: parameterTypeFixture,
+        };
+
         expect(setReflectMetadata).toHaveBeenCalledTimes(1);
         expect(setReflectMetadata).toHaveBeenCalledWith(
           targetFixture[keyFixture],
           controllerMethodParameterMetadataReflectKey,
-          [
-            {
-              index: indexFixture,
-              parameterName: undefined,
-              parameterType: parameterTypeFixture,
-            },
-          ],
+          expectedControllerMethodParameterMetadata,
         );
       });
     });
@@ -162,12 +165,11 @@ describe(requestParam.name, () => {
         targetFixture = {
           [keyFixture]: vitest.fn(),
         };
-        indexFixture = 1;
+        indexFixture = 2;
         parameterTypeFixture = RequestMethodParameterType.QUERY;
 
         vitest.mocked(getReflectMetadata).mockReturnValueOnce([
           {
-            index: 0,
             parameterName: 'parameterNameFixture',
             parameterType: RequestMethodParameterType.BODY,
           },
@@ -192,21 +194,24 @@ describe(requestParam.name, () => {
       });
 
       it('should call setReflectMetadata', () => {
+        const expectedControllerMethodParameterMetadata: (
+          | ControllerMethodParameterMetadata
+          | undefined
+        )[] = [
+          {
+            parameterName: 'parameterNameFixture',
+            parameterType: RequestMethodParameterType.BODY,
+          },
+        ];
+        expectedControllerMethodParameterMetadata[indexFixture] = {
+          parameterName: undefined,
+          parameterType: parameterTypeFixture,
+        };
+
         expect(setReflectMetadata).toHaveBeenCalledWith(
           targetFixture[keyFixture],
           controllerMethodParameterMetadataReflectKey,
-          [
-            {
-              index: 0,
-              parameterName: 'parameterNameFixture',
-              parameterType: RequestMethodParameterType.BODY,
-            },
-            {
-              index: indexFixture,
-              parameterName: undefined,
-              parameterType: parameterTypeFixture,
-            },
-          ],
+          expectedControllerMethodParameterMetadata,
         );
       });
     });

--- a/packages/http/libraries/core/src/http/decorators/RequestParam.ts
+++ b/packages/http/libraries/core/src/http/decorators/RequestParam.ts
@@ -33,27 +33,24 @@ export function requestParam(
       );
     }
 
-    let parameterMetadataList: ControllerMethodParameterMetadata[] | undefined =
-      getReflectMetadata(
-        controllerFunction,
-        controllerMethodParameterMetadataReflectKey,
-      );
+    let parameterMetadataList:
+      | (ControllerMethodParameterMetadata | undefined)[]
+      | undefined = getReflectMetadata(
+      controllerFunction,
+      controllerMethodParameterMetadataReflectKey,
+    );
 
     const controllerMethodParameterMetadata: ControllerMethodParameterMetadata =
       {
-        index,
         parameterName,
         parameterType,
       };
 
     if (parameterMetadataList === undefined) {
-      parameterMetadataList = [controllerMethodParameterMetadata];
-    } else {
-      insertParameterMetadata(
-        parameterMetadataList,
-        controllerMethodParameterMetadata,
-      );
+      parameterMetadataList = [];
     }
+
+    parameterMetadataList[index] = controllerMethodParameterMetadata;
 
     setReflectMetadata(
       controllerFunction,
@@ -72,21 +69,4 @@ export function requestParam(
       );
     }
   };
-}
-
-function insertParameterMetadata(
-  parameterMetadataList: ControllerMethodParameterMetadata[],
-  newParameterMetadata: ControllerMethodParameterMetadata,
-): void {
-  let i: number = 0;
-
-  while (
-    i < parameterMetadataList.length &&
-    (parameterMetadataList[i] as ControllerMethodParameterMetadata).index <
-      newParameterMetadata.index
-  ) {
-    i++;
-  }
-
-  parameterMetadataList.splice(i, 0, newParameterMetadata);
 }

--- a/packages/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadata.spec.ts
+++ b/packages/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadata.spec.ts
@@ -27,7 +27,10 @@ describe(buildRouterExplorerControllerMethodMetadata.name, () => {
   describe('when called', () => {
     let controllerMethodMetadataFixture: ControllerMethodMetadata;
     let controllerFixture: Controller;
-    let controllerMethodParameterMetadataListFixture: ControllerMethodParameterMetadata[];
+    let controllerMethodParameterMetadataListFixture: (
+      | ControllerMethodParameterMetadata
+      | undefined
+    )[];
     let controllerMethodStatusCodeMetadataFixture: undefined;
     let controllerMethodGuardListFixture: NewableFunction[];
     let controllerMethodMiddlewareListFixture: NewableFunction[];

--- a/packages/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadata.ts
+++ b/packages/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadata.ts
@@ -21,8 +21,10 @@ export function buildRouterExplorerControllerMethodMetadata(
     controllerMethodMetadata.methodKey
   ] as ControllerFunction;
 
-  const controllerMethodParameterMetadataList: ControllerMethodParameterMetadata[] =
-    exploreControllerMethodParameterMetadataList(targetFunction);
+  const controllerMethodParameterMetadataList: (
+    | ControllerMethodParameterMetadata
+    | undefined
+  )[] = exploreControllerMethodParameterMetadataList(targetFunction);
 
   const controllerMethodStatusCode: HttpStatusCode | undefined =
     exploreControllerMethodStatusCodeMetadata(targetFunction);

--- a/packages/http/libraries/core/src/routerExplorer/calculations/exploreControllerMethodParameterMetadataList.ts
+++ b/packages/http/libraries/core/src/routerExplorer/calculations/exploreControllerMethodParameterMetadataList.ts
@@ -6,7 +6,7 @@ import { ControllerMethodParameterMetadata } from '../model/ControllerMethodPara
 
 export function exploreControllerMethodParameterMetadataList(
   controllerMethod: ControllerFunction,
-): ControllerMethodParameterMetadata[] {
+): (ControllerMethodParameterMetadata | undefined)[] {
   return (
     getReflectMetadata(
       controllerMethod,

--- a/packages/http/libraries/core/src/routerExplorer/model/ControllerMethodParameterMetadata.ts
+++ b/packages/http/libraries/core/src/routerExplorer/model/ControllerMethodParameterMetadata.ts
@@ -1,7 +1,6 @@
 import { RequestMethodParameterType } from '../../http/models/RequestMethodParameterType';
 
 export interface ControllerMethodParameterMetadata {
-  index: number;
   parameterType: RequestMethodParameterType;
   parameterName?: string | undefined;
 }

--- a/packages/http/libraries/core/src/routerExplorer/model/RouterExplorerControllerMethodMetadata.ts
+++ b/packages/http/libraries/core/src/routerExplorer/model/RouterExplorerControllerMethodMetadata.ts
@@ -6,7 +6,7 @@ export interface RouterExplorerControllerMethodMetadata {
   guardList: NewableFunction[];
   headerMetadataList: [string, string][];
   methodKey: string | symbol;
-  parameterMetadataList: ControllerMethodParameterMetadata[];
+  parameterMetadataList: (ControllerMethodParameterMetadata | undefined)[];
   path: string;
   postHandlerMiddlewareList: NewableFunction[];
   preHandlerMiddlewareList: NewableFunction[];


### PR DESCRIPTION
### Changed
- Updated `ControllerMethodParameterMetadata` without `index`.
- Updated `RouterExplorerControllerMethodMetadata.parameterMetadataList`.
- Fixed `InversifyHttpAdapter.#buildHandlerParams` to build params in the right order.

### Motivation.
- An array data structure is good enough for us, we don't need `ControllerMethodParameterMetadata.index`. It's ok to have empty elements in our array if that simplifies the data structure, the handler logic and reduces the overhead. In addition, `InversifyHttpAdapter.#buildHandlerParams` was ignoring `ControllerMethodParameterMetadata.index` so this PR fixes that as well.