### PR TITLE
Extract e2e request parameter

### DIFF
--- a/packages/http/libraries/fastify/package.json
+++ b/packages/http/libraries/fastify/package.json
@@ -49,7 +49,7 @@
   },
   "name": "@inversifyjs/http-fastify",
   "peerDependencies": {
-    "fastify": "^5.2.1",
+    "fastify": "^5.3.0",
     "inversify": "^7.5.0"
   },
   "private": true,

--- a/packages/http/libraries/fastify/src/adapter/InversifyFastifyHttpAdapter.ts
+++ b/packages/http/libraries/fastify/src/adapter/InversifyFastifyHttpAdapter.ts
@@ -1,6 +1,6 @@
 import { Stream } from 'node:stream';
 
-import cookie from '@fastify/cookie';
+import cookie, { FastifyCookieOptions } from '@fastify/cookie';
 import {
   HttpAdapterOptions,
   HttpStatusCode,
@@ -196,7 +196,11 @@ export class InversifyFastifyHttpAdapter extends InversifyHttpAdapter<
   #buildDefaultFastifyApp(customApp?: FastifyInstance): FastifyInstance {
     const app: FastifyInstance = customApp ?? fastify();
 
-    app.register(cookie);
+    app.register(
+      cookie as unknown as FastifyPluginCallback<
+        NonNullable<FastifyCookieOptions>
+      >,
+    );
 
     return app;
   }

--- a/packages/http/tools/e2e-tests/src/common/models/InversifyHttpWorld.ts
+++ b/packages/http/tools/e2e-tests/src/common/models/InversifyHttpWorld.ts
@@ -1,6 +1,7 @@
 import { IWorld } from '@cucumber/cucumber';
 import { Container } from 'inversify';
 
+import { RequestParameter } from '../../http/models/RequestParameter';
 import { Server } from '../../server/models/Server';
 
 interface EntitiesMap {
@@ -15,6 +16,6 @@ interface ContainerRequests {
 export interface InversifyHttpWorld extends IWorld {
   readonly containerRequests: ContainerRequests;
   readonly entities: EntitiesMap;
-  readonly serverRequests: Map<string, Request>;
+  readonly serverRequests: Map<string, RequestParameter>;
   readonly serverResponses: Map<string, Response>;
 }

--- a/packages/http/tools/e2e-tests/src/http/models/RequestParameter.ts
+++ b/packages/http/tools/e2e-tests/src/http/models/RequestParameter.ts
@@ -1,0 +1,6 @@
+export interface RequestParameter {
+  readonly body: unknown;
+  readonly queryParameters: Record<string, string[]>;
+  readonly request: Request;
+  readonly urlParameters: Record<string, string>;
+}

--- a/packages/http/tools/e2e-tests/src/server/actions/setServerRequest.ts
+++ b/packages/http/tools/e2e-tests/src/server/actions/setServerRequest.ts
@@ -1,9 +1,10 @@
 import { InversifyHttpWorld } from '../../common/models/InversifyHttpWorld';
+import { RequestParameter } from '../../http/models/RequestParameter';
 
 export function setServerRequest(
   this: InversifyHttpWorld,
   alias: string,
-  request: Request,
+  request: RequestParameter,
 ): void {
   this.serverRequests.set(alias, request);
 }

--- a/packages/http/tools/e2e-tests/src/server/calculations/getServerRequestOrFail.ts
+++ b/packages/http/tools/e2e-tests/src/server/calculations/getServerRequestOrFail.ts
@@ -1,10 +1,11 @@
 import { InversifyHttpWorld } from '../../common/models/InversifyHttpWorld';
+import { RequestParameter } from '../../http/models/RequestParameter';
 
 export function getServerRequestOrFail(
   this: InversifyHttpWorld,
   alias: string,
-): Request {
-  const request: Request | undefined = this.serverRequests.get(alias);
+): RequestParameter {
+  const request: RequestParameter | undefined = this.serverRequests.get(alias);
 
   if (request === undefined) {
     throw new Error('Server request not found');

--- a/packages/http/tools/e2e-tests/src/warrior/body/step-definitions/givenDefinitions.ts
+++ b/packages/http/tools/e2e-tests/src/warrior/body/step-definitions/givenDefinitions.ts
@@ -60,8 +60,10 @@ function getMethodWarriorBodyNamedController(
 function givenWarriorRequestWithBodyForServer(
   this: InversifyHttpWorld,
   method: HttpMethod,
+  requestAlias?: string,
   serverAlias?: string,
 ): void {
+  const parsedRequestAlias: string = requestAlias ?? defaultAlias;
   const parsedServerAlias: string = serverAlias ?? defaultAlias;
   const server: Server = getServerOrFail.bind(this)(parsedServerAlias);
 
@@ -81,7 +83,13 @@ function givenWarriorRequestWithBodyForServer(
   };
 
   const request: Request = new Request(url, requestInit);
-  setServerRequest.bind(this)(parsedServerAlias, request);
+
+  setServerRequest.bind(this)(parsedRequestAlias, {
+    body: warriorRequest,
+    queryParameters: {},
+    request,
+    urlParameters: {},
+  });
 }
 
 function givenWarriorBodyControllerForContainer(

--- a/packages/http/tools/e2e-tests/src/warrior/body/step-definitions/thenDefinitions.ts
+++ b/packages/http/tools/e2e-tests/src/warrior/body/step-definitions/thenDefinitions.ts
@@ -3,23 +3,36 @@ import assert from 'node:assert';
 import { Then } from '@cucumber/cucumber';
 
 import { InversifyHttpWorld } from '../../../common/models/InversifyHttpWorld';
+import { RequestParameter } from '../../../http/models/RequestParameter';
+import { getServerRequestOrFail } from '../../../server/calculations/getServerRequestOrFail';
 import { getServerResponseOrFail } from '../../../server/calculations/getServerResponseOrFail';
 import { WarriorCreationResponse } from '../models/WarriorCreationResponse';
-import { WarriorCreationResponseType } from '../models/WarriorCreationResponseType';
+import { WarriorRequest } from '../models/WarriorRequest';
 
 async function thenResponseContainsTheCorrectBodyData(
   this: InversifyHttpWorld,
+  requestAlias?: string,
   responseAlias?: string,
 ): Promise<void> {
+  const parsedRequestAlias: string = requestAlias ?? 'default';
   const parsedResponseAlias: string = responseAlias ?? 'default';
+  const request: RequestParameter =
+    getServerRequestOrFail.bind(this)(parsedRequestAlias);
+
+  const requestBody: WarriorRequest | undefined = request.body as
+    | WarriorRequest
+    | undefined;
+
+  assert(requestBody !== undefined);
+
   const response: Response =
     getServerResponseOrFail.bind(this)(parsedResponseAlias);
 
   const warriorCreationResponse: WarriorCreationResponse =
     (await response.json()) as WarriorCreationResponse;
 
-  assert(warriorCreationResponse.name === 'Samurai');
-  assert(warriorCreationResponse.type === WarriorCreationResponseType.Melee);
+  assert(warriorCreationResponse.name === requestBody.name);
+  assert(warriorCreationResponse.type === requestBody.type);
 }
 
 Then<InversifyHttpWorld>(

--- a/packages/http/tools/e2e-tests/src/warrior/common/step-definitions/whenDefinitions.ts
+++ b/packages/http/tools/e2e-tests/src/warrior/common/step-definitions/whenDefinitions.ts
@@ -1,6 +1,7 @@
 import { When } from '@cucumber/cucumber';
 
 import { InversifyHttpWorld } from '../../../common/models/InversifyHttpWorld';
+import { RequestParameter } from '../../../http/models/RequestParameter';
 import { setServerResponse } from '../../../server/actions/setServerResponse';
 import { getServerRequestOrFail } from '../../../server/calculations/getServerRequestOrFail';
 
@@ -10,10 +11,10 @@ async function whenRequestIsSend(
 ): Promise<void> {
   const parsedRequestAlias: string = requestAlias ?? 'default';
 
-  const request: Request =
+  const requestParameter: RequestParameter =
     getServerRequestOrFail.bind(this)(parsedRequestAlias);
 
-  const response: Response = await fetch(request);
+  const response: Response = await fetch(requestParameter.request);
 
   setServerResponse.bind(this)(parsedRequestAlias, response);
 }

--- a/packages/http/tools/e2e-tests/src/warrior/headers/step-definitions/givenDefinitions.ts
+++ b/packages/http/tools/e2e-tests/src/warrior/headers/step-definitions/givenDefinitions.ts
@@ -79,7 +79,12 @@ function givenWarriorRequestWithHeadersForServer(
 
   const request: Request = new Request(url, requestInit);
 
-  setServerRequest.bind(this)(parsedServerAlias, request);
+  setServerRequest.bind(this)(parsedServerAlias, {
+    body: undefined,
+    queryParameters: {},
+    request,
+    urlParameters: {},
+  });
 }
 
 function givenWarriorHeadersControllerForContainer(

--- a/packages/http/tools/e2e-tests/src/warrior/params/step-definitions/givenDefinitions.ts
+++ b/packages/http/tools/e2e-tests/src/warrior/params/step-definitions/givenDefinitions.ts
@@ -63,14 +63,25 @@ function givenWarriorRequestWithParamsForServer(
   const parsedServerAlias: string = serverAlias ?? defaultAlias;
   const server: Server = getServerOrFail.bind(this)(parsedServerAlias);
 
-  const url: string = `http://${server.host}:${server.port.toString()}/warriors/123`;
+  const urlParameters: {
+    warrior: string;
+  } = {
+    warrior: '123',
+  };
+
+  const url: string = `http://${server.host}:${server.port.toString()}/warriors/${urlParameters.warrior}`;
 
   const requestInit: RequestInit = {
     method,
   };
 
   const request: Request = new Request(url, requestInit);
-  setServerRequest.bind(this)(parsedServerAlias, request);
+  setServerRequest.bind(this)(parsedServerAlias, {
+    body: undefined,
+    queryParameters: {},
+    request,
+    urlParameters,
+  });
 }
 
 function givenWarriorParamsControllerForContainer(

--- a/packages/http/tools/e2e-tests/src/warrior/params/step-definitions/thenDefinitions.ts
+++ b/packages/http/tools/e2e-tests/src/warrior/params/step-definitions/thenDefinitions.ts
@@ -3,21 +3,30 @@ import assert from 'node:assert';
 import { Then } from '@cucumber/cucumber';
 
 import { InversifyHttpWorld } from '../../../common/models/InversifyHttpWorld';
+import { RequestParameter } from '../../../http/models/RequestParameter';
+import { getServerRequestOrFail } from '../../../server/calculations/getServerRequestOrFail';
 import { getServerResponseOrFail } from '../../../server/calculations/getServerResponseOrFail';
 import { WarriorWithId } from '../models/WarriorWithId';
 
 async function thenResponseContainsTheCorrectUrlParameters(
   this: InversifyHttpWorld,
+  requestAlias?: string,
   responseAlias?: string,
 ): Promise<void> {
+  const parsedRequestAlias: string = requestAlias ?? 'default';
   const parsedResponseAlias: string = responseAlias ?? 'default';
 
+  const requestParameter: RequestParameter =
+    getServerRequestOrFail.bind(this)(parsedRequestAlias);
   const response: Response =
     getServerResponseOrFail.bind(this)(parsedResponseAlias);
 
   const warriorWithId: WarriorWithId = (await response.json()) as WarriorWithId;
 
-  assert(warriorWithId.id === '123');
+  assert(
+    warriorWithId.id ===
+      (requestParameter.urlParameters as { warrior: string }).warrior,
+  );
 }
 
 Then<InversifyHttpWorld>(

--- a/packages/http/tools/e2e-tests/src/warrior/query/step-definitions/givenDefinitions.ts
+++ b/packages/http/tools/e2e-tests/src/warrior/query/step-definitions/givenDefinitions.ts
@@ -66,14 +66,28 @@ function givenWarriorRequestWithQueryForServer(
 
   const server: Server = getServerOrFail.bind(this)(parsedServerAlias);
 
-  const url: string = `http://${server.host}:${server.port.toString()}/warriors?filter=test`;
+  const queryParameters: Record<string, string[]> = {
+    filter: ['test'],
+  };
+
+  const stringifiedQueryParameters: string = new URLSearchParams(
+    queryParameters,
+  ).toString();
+
+  const url: string = `http://${server.host}:${server.port.toString()}/warriors?${stringifiedQueryParameters}`;
 
   const requestInit: RequestInit = {
     method,
   };
 
   const request: Request = new Request(url, requestInit);
-  setServerRequest.bind(this)(parsedServerAlias, request);
+
+  setServerRequest.bind(this)(parsedServerAlias, {
+    body: undefined,
+    queryParameters,
+    request,
+    urlParameters: {},
+  });
 }
 
 function givenWarriorQueryControllerForContainer(

--- a/packages/http/tools/e2e-tests/src/warrior/query/step-definitions/thenDefinitions.ts
+++ b/packages/http/tools/e2e-tests/src/warrior/query/step-definitions/thenDefinitions.ts
@@ -3,22 +3,31 @@ import assert from 'node:assert';
 import { Then } from '@cucumber/cucumber';
 
 import { InversifyHttpWorld } from '../../../common/models/InversifyHttpWorld';
+import { RequestParameter } from '../../../http/models/RequestParameter';
+import { getServerRequestOrFail } from '../../../server/calculations/getServerRequestOrFail';
 import { getServerResponseOrFail } from '../../../server/calculations/getServerResponseOrFail';
 import { WarriorWithQuery } from '../models/WarriorWithQuery';
 
 async function thenResponseContainsTheCorrectUrlQueryParametersByName(
   this: InversifyHttpWorld,
+  requestAlias?: string,
   responseAlias?: string,
 ): Promise<void> {
+  const parsedRequestAlias: string = requestAlias ?? 'default';
   const parsedResponseAlias: string = responseAlias ?? 'default';
 
+  const requestParameter: RequestParameter =
+    getServerRequestOrFail.bind(this)(parsedRequestAlias);
   const response: Response =
     getServerResponseOrFail.bind(this)(parsedResponseAlias);
 
   const warriorWithQuery: WarriorWithQuery =
     (await response.json()) as WarriorWithQuery;
 
-  assert.ok(warriorWithQuery.filter === 'test');
+  assert.ok(
+    warriorWithQuery.filter ===
+      (requestParameter.queryParameters as { filter: [string] }).filter[0],
+  );
 }
 
 Then<InversifyHttpWorld>(

--- a/packages/http/tools/e2e-tests/src/warrior/serve/step-definitions/givenDefinitions.ts
+++ b/packages/http/tools/e2e-tests/src/warrior/serve/step-definitions/givenDefinitions.ts
@@ -47,7 +47,13 @@ function givenWarriorRequestForServer(
   };
 
   const request: Request = new Request(url, requestInit);
-  setServerRequest.bind(this)(parsedServerAlias, request);
+
+  setServerRequest.bind(this)(parsedServerAlias, {
+    body: undefined,
+    queryParameters: {},
+    request,
+    urlParameters: {},
+  });
 }
 
 function givenWarriorControllerForContainer(


### PR DESCRIPTION
### Added
- Added `RequestParameter`.

### Changed
- Updated world requests to be a map of `RequestParameter`.
- Updated given and then scenarios to properly handle request parameters.

### Motivation
Request info is often hard to get at assertion time. Url params must be extracted from the url, request bodies are flushed and no longer available... it's not easy at all. `RequestParameter` allow us to accomodate request relevant data in a friendly way so we can use it at assertion time.