### PR TITLE
Update plugin API with onPlan

### DIFF
--- a/.changeset/cuddly-bats-smile.md
+++ b/.changeset/cuddly-bats-smile.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/plugin": minor
+---
+
+Updated `PluginApi` with `onPlan`

--- a/.changeset/cuddly-lizards-yell.md
+++ b/.changeset/cuddly-lizards-yell.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/plugin": minor
+---
+
+Updated `PluginApi.define` with no this constraint

--- a/.changeset/icy-toes-exist.md
+++ b/.changeset/icy-toes-exist.md
@@ -1,5 +1,0 @@
----
-"@inversifyjs/plugin": minor
----
-
-Updated `PluginApi` with `TContainer` generic

--- a/.changeset/late-clowns-love.md
+++ b/.changeset/late-clowns-love.md
@@ -1,5 +1,0 @@
----
-"@inversifyjs/plugin": minor
----
-
-Updated PluginApi.define method to be bound to a Plugin

--- a/packages/container/examples/plugin-example/src/index.ts
+++ b/packages/container/examples/plugin-example/src/index.ts
@@ -12,10 +12,10 @@ declare module 'inversify' {
 }
 
 export class PluginExample extends Plugin<Container> {
-  public load(api: PluginApi<Container>): void {
+  public load(api: PluginApi): void {
     api.define(
       pluginExample,
-      function (this: Plugin<Container>): void {}.bind(this),
+      function (this: PluginExample): void {}.bind(this),
     );
   }
 }

--- a/packages/container/libraries/container/src/container/services/Container.spec.ts
+++ b/packages/container/libraries/container/src/container/services/Container.spec.ts
@@ -32,6 +32,7 @@ vitest.mock('../calculations/buildDeactivationParams');
 vitest.mock('./BindingManager');
 vitest.mock('./ContainerModuleManager');
 vitest.mock('./PluginManager');
+vitest.mock('./ServiceReferenceManager');
 vitest.mock('./ServiceResolutionManager');
 vitest.mock('./SnapshotManager');
 
@@ -42,6 +43,7 @@ import { BindingManager } from './BindingManager';
 import { Container } from './Container';
 import { ContainerModuleManager } from './ContainerModuleManager';
 import { PluginManager } from './PluginManager';
+import { ServiceReferenceManager } from './ServiceReferenceManager';
 import { ServiceResolutionManager } from './ServiceResolutionManager';
 import { SnapshotManager } from './SnapshotManager';
 
@@ -54,6 +56,7 @@ describe(Container, () => {
   let deactivationServiceMock: Mocked<DeactivationsService>;
   let planResultCacheServiceMock: Mocked<PlanResultCacheService>;
   let pluginManagerMock: Mocked<PluginManager>;
+  let serviceReferenceManagerMock: Mocked<ServiceReferenceManager>;
   let serviceResolutionManagerMock: Mocked<ServiceResolutionManager>;
   let snapshotManagerMock: Mocked<SnapshotManager>;
 
@@ -105,6 +108,14 @@ describe(Container, () => {
     pluginManagerMock = {
       register: vitest.fn(),
     } as Partial<Mocked<PluginManager>> as Mocked<PluginManager>;
+    serviceReferenceManagerMock = {
+      activationService: activationServiceMock,
+      bindingService: bindingServiceMock,
+      deactivationService: deactivationServiceMock,
+      planResultCacheService: planResultCacheServiceMock,
+    } as Partial<
+      Mocked<ServiceReferenceManager>
+    > as Mocked<ServiceReferenceManager>;
     serviceResolutionManagerMock = {
       get: vitest.fn(),
       getAll: vitest.fn(),
@@ -126,17 +137,13 @@ describe(Container, () => {
       .mocked(ActivationsService.build)
       .mockReturnValue(activationServiceMock);
 
-    vitest
-      .mocked(BindingManager)
-      .mockImplementation((): BindingManager => bindingManagerMock);
+    vitest.mocked(BindingManager).mockReturnValue(bindingManagerMock);
 
     vitest.mocked(BindingService.build).mockReturnValue(bindingServiceMock);
 
     vitest
       .mocked(ContainerModuleManager)
-      .mockImplementation((): ContainerModuleManager => {
-        return containerModuleManagerMock;
-      });
+      .mockReturnValue(containerModuleManagerMock);
 
     vitest
       .mocked(DeactivationsService.build)
@@ -144,19 +151,17 @@ describe(Container, () => {
 
     vitest
       .mocked(PlanResultCacheService)
-      .mockImplementation(
-        (): PlanResultCacheService => planResultCacheServiceMock,
-      );
+      .mockReturnValue(planResultCacheServiceMock);
+
+    vitest.mocked(PluginManager).mockReturnValue(pluginManagerMock);
 
     vitest
-      .mocked(PluginManager)
-      .mockImplementation((): PluginManager => pluginManagerMock);
+      .mocked(ServiceReferenceManager)
+      .mockReturnValue(serviceReferenceManagerMock);
 
     vitest
       .mocked(ServiceResolutionManager)
-      .mockImplementation((): ServiceResolutionManager => {
-        return serviceResolutionManagerMock;
-      });
+      .mockReturnValue(serviceResolutionManagerMock);
 
     vitest.mocked(SnapshotManager).mockImplementation((): SnapshotManager => {
       return snapshotManagerMock;
@@ -212,6 +217,37 @@ describe(Container, () => {
           expect(DeactivationsService.build).toHaveBeenNthCalledWith(
             2,
             deactivationServiceMock,
+          );
+        });
+
+        it('should call PlanResultCacheService()', () => {
+          expect(PlanResultCacheService).toHaveBeenCalledTimes(2);
+          expect(PlanResultCacheService).toHaveBeenNthCalledWith(1);
+          expect(PlanResultCacheService).toHaveBeenNthCalledWith(2);
+        });
+
+        it('should call planResultCacheService.subscribe()', () => {
+          expect(planResultCacheServiceMock.subscribe).toHaveBeenCalledTimes(1);
+          expect(planResultCacheServiceMock.subscribe).toHaveBeenCalledWith(
+            planResultCacheServiceMock,
+          );
+        });
+
+        it('should call ServiceReferenceManager()', () => {
+          expect(ServiceReferenceManager).toHaveBeenCalledTimes(2);
+          expect(ServiceReferenceManager).toHaveBeenNthCalledWith(
+            1,
+            activationServiceMock,
+            bindingServiceMock,
+            deactivationServiceMock,
+            planResultCacheServiceMock,
+          );
+          expect(ServiceReferenceManager).toHaveBeenNthCalledWith(
+            2,
+            activationServiceMock,
+            bindingServiceMock,
+            deactivationServiceMock,
+            planResultCacheServiceMock,
           );
         });
       });

--- a/packages/container/libraries/container/src/container/services/Container.ts
+++ b/packages/container/libraries/container/src/container/services/Container.ts
@@ -58,15 +58,17 @@ export class Container {
       defaultScope,
       this.#serviceReferenceManager,
     );
-    this.#pluginManager = new PluginManager(
-      this,
-      this.#serviceReferenceManager,
-    );
     this.#serviceResolutionManager = new ServiceResolutionManager(
       this.#serviceReferenceManager,
       autobind,
       defaultScope,
     );
+    this.#pluginManager = new PluginManager(
+      this,
+      this.#serviceReferenceManager,
+      this.#serviceResolutionManager,
+    );
+
     this.#snapshotManager = new SnapshotManager(this.#serviceReferenceManager);
   }
 

--- a/packages/container/libraries/container/src/container/services/PluginManager.spec.ts
+++ b/packages/container/libraries/container/src/container/services/PluginManager.spec.ts
@@ -15,21 +15,28 @@ import {
   DeactivationsService,
   PlanResultCacheService,
 } from '@inversifyjs/core';
-import { PluginContext } from '@inversifyjs/plugin';
+import {
+  isPlugin,
+  Plugin,
+  PluginApi,
+  PluginContext,
+} from '@inversifyjs/plugin';
 
 import { InversifyContainerError } from '../../error/models/InversifyContainerError';
 import { InversifyContainerErrorKind } from '../../error/models/InversifyContainerErrorKind';
 import type { Container } from './Container';
 import { PluginManager } from './PluginManager';
 import { ServiceReferenceManager } from './ServiceReferenceManager';
+import { ServiceResolutionManager } from './ServiceResolutionManager';
 
 describe(PluginManager, () => {
   let containerFixture: Container;
-  let serviceReferenceManager: ServiceReferenceManager;
+  let serviceReferenceManagerFixture: ServiceReferenceManager;
+  let serviceResolutionManagerMock: Mocked<ServiceResolutionManager>;
 
   beforeAll(() => {
     containerFixture = Symbol() as unknown as Container;
-    serviceReferenceManager = {
+    serviceReferenceManagerFixture = {
       activationService:
         {} as Partial<ActivationsService> as ActivationsService,
       bindingService: {} as Partial<BindingService> as BindingService,
@@ -38,6 +45,11 @@ describe(PluginManager, () => {
       planResultCacheService:
         {} as Partial<PlanResultCacheService> as PlanResultCacheService,
     } as Partial<ServiceReferenceManager> as ServiceReferenceManager;
+    serviceResolutionManagerMock = {
+      onPlan: vitest.fn(),
+    } as Partial<
+      Mocked<ServiceResolutionManager>
+    > as Mocked<ServiceResolutionManager>;
   });
 
   describe('.register', () => {
@@ -55,7 +67,8 @@ describe(PluginManager, () => {
           try {
             new PluginManager(
               containerFixture,
-              serviceReferenceManager,
+              serviceReferenceManagerFixture,
+              serviceResolutionManagerMock,
             ).register(pluginType);
           } catch (error: unknown) {
             result = error;
@@ -88,6 +101,67 @@ describe(PluginManager, () => {
           expect(result).toStrictEqual(
             expect.objectContaining(expectedErrorProperties),
           );
+        });
+      });
+    });
+
+    describe('having a plugin newable type', () => {
+      let pluginMock: Mocked<Plugin<Container>>;
+
+      let pluginType: Newable;
+
+      beforeAll(() => {
+        pluginMock = {
+          [isPlugin]: true,
+          load: vitest.fn(),
+        } as Partial<Mocked<Plugin<Container>>> as Mocked<Plugin<Container>>;
+
+        pluginType = vitest.fn().mockReturnValueOnce(pluginMock);
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          try {
+            new PluginManager(
+              containerFixture,
+              serviceReferenceManagerFixture,
+              serviceResolutionManagerMock,
+            ).register(pluginType);
+          } catch (error: unknown) {
+            result = error;
+          }
+        });
+
+        afterAll(() => {
+          vitest.clearAllMocks();
+        });
+
+        it('should call pluginType', () => {
+          const expected: Mocked<PluginContext> = {
+            activationService: expect.any(Object),
+            bindingService: expect.any(Object),
+            deactivationService: expect.any(Object),
+            planResultCacheService: expect.any(Object),
+          } as Partial<Mocked<PluginContext>> as Mocked<PluginContext>;
+
+          expect(pluginType).toHaveBeenCalledTimes(1);
+          expect(pluginType).toHaveBeenCalledWith(expected);
+        });
+
+        it('should call load method of the plugin instance', () => {
+          const expected: PluginApi = {
+            define: expect.any(Function),
+            onPlan: expect.any(Function),
+          };
+
+          expect(pluginMock.load).toHaveBeenCalledTimes(1);
+          expect(pluginMock.load).toHaveBeenCalledWith(expected);
+        });
+
+        it('should return undefined', () => {
+          expect(result).toBeUndefined();
         });
       });
     });

--- a/packages/container/libraries/container/src/container/services/PluginManager.ts
+++ b/packages/container/libraries/container/src/container/services/PluginManager.ts
@@ -16,17 +16,21 @@ import { InversifyContainerError } from '../../error/models/InversifyContainerEr
 import { InversifyContainerErrorKind } from '../../error/models/InversifyContainerErrorKind';
 import type { Container } from './Container';
 import { ServiceReferenceManager } from './ServiceReferenceManager';
+import { ServiceResolutionManager } from './ServiceResolutionManager';
 
 export class PluginManager {
-  readonly #pluginApi: PluginApi<Container>;
+  readonly #pluginApi: PluginApi;
   readonly #pluginContext: PluginContext;
+  readonly #serviceResolutionManager: ServiceResolutionManager;
   readonly #serviceReferenceManager: ServiceReferenceManager;
 
   constructor(
     container: Container,
     serviceReferenceManager: ServiceReferenceManager,
+    serviceResolutionManager: ServiceResolutionManager,
   ) {
     this.#serviceReferenceManager = serviceReferenceManager;
+    this.#serviceResolutionManager = serviceResolutionManager;
     this.#pluginApi = this.#buildPluginApi(container);
     this.#pluginContext = this.#buildPluginContext();
   }
@@ -46,12 +50,12 @@ export class PluginManager {
     (pluginInstance as Plugin<Container>).load(this.#pluginApi);
   }
 
-  #buildPluginApi(container: Container): PluginApi<Container> {
+  #buildPluginApi(container: Container): PluginApi {
     return {
       define: (
         name: string | symbol,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        method: (this: Plugin<Container>, ...args: any[]) => unknown,
+        method: (...args: any[]) => unknown,
       ): void => {
         if (Object.prototype.hasOwnProperty.call(container, name)) {
           throw new InversifyContainerError(
@@ -63,6 +67,9 @@ export class PluginManager {
         (container as unknown as Record<string | symbol, unknown>)[name] =
           method;
       },
+      onPlan: this.#serviceResolutionManager.onPlan.bind(
+        this.#serviceResolutionManager,
+      ),
     };
   }
 

--- a/packages/container/libraries/container/src/container/services/ServiceResolutionManager.ts
+++ b/packages/container/libraries/container/src/container/services/ServiceResolutionManager.ts
@@ -32,6 +32,10 @@ export class ServiceResolutionManager {
     serviceIdentifier: ServiceIdentifier<TInstance>,
   ) => Iterable<Binding<TInstance>> | undefined;
   #resolutionContext: ResolutionContext;
+  readonly #onPlanHandlers: ((
+    options: GetPlanOptions,
+    result: PlanResult,
+  ) => void)[];
   readonly #serviceReferenceManager: ServiceReferenceManager;
   #setBindingParamsPlan: <TInstance>(binding: Binding<TInstance>) => void;
 
@@ -56,6 +60,8 @@ export class ServiceResolutionManager {
       this.#serviceReferenceManager.bindingService.get.bind(
         this.#serviceReferenceManager.bindingService,
       );
+
+    this.#onPlanHandlers = [];
 
     this.#setBindingParamsPlan = this.#setBinding.bind(this);
 
@@ -152,6 +158,12 @@ export class ServiceResolutionManager {
     return this.#getFromPlanResult(planResult);
   }
 
+  public onPlan(
+    handler: (options: GetPlanOptions, result: PlanResult) => void,
+  ): void {
+    this.#onPlanHandlers.push(handler);
+  }
+
   #resetComputedProperties(): void {
     this.#getBindingsPlanParams =
       this.#serviceReferenceManager.bindingService.get.bind(
@@ -229,6 +241,10 @@ export class ServiceResolutionManager {
       getPlanOptions,
       planResult,
     );
+
+    for (const handler of this.#onPlanHandlers) {
+      handler(getPlanOptions, planResult);
+    }
 
     return planResult;
   }

--- a/packages/container/libraries/plugin/src/plugin/models/Plugin.ts
+++ b/packages/container/libraries/plugin/src/plugin/models/Plugin.ts
@@ -16,5 +16,5 @@ export abstract class Plugin<TContainer> {
     this._context = context;
   }
 
-  public abstract load(api: PluginApi<TContainer>): void;
+  public abstract load(api: PluginApi): void;
 }

--- a/packages/container/libraries/plugin/src/plugin/models/PluginApi.ts
+++ b/packages/container/libraries/plugin/src/plugin/models/PluginApi.ts
@@ -1,9 +1,10 @@
-import { Plugin } from './Plugin';
+import { GetPlanOptions, PlanResult } from '@inversifyjs/core';
 
-export interface PluginApi<TContainer> {
+export interface PluginApi {
   define(
     name: string | symbol,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    method: (this: Plugin<TContainer>, ...args: any[]) => unknown,
+    method: (...args: any[]) => unknown,
   ): void;
+  onPlan(handler: (options: GetPlanOptions, result: PlanResult) => void): void;
 }


### PR DESCRIPTION
### Changed
- Updated `PluginApi` with `onPlan`.
- Updated `PluginApi.define` with no `this` constraint.