### PR TITLE
Update docs with get all v6 workaround

### DIFF
--- a/packages/docs/services/inversify-site/docs/guides/migrating-from-v6.mdx
+++ b/packages/docs/services/inversify-site/docs/guides/migrating-from-v6.mdx
@@ -80,6 +80,12 @@ Additionally, `Container.getAll` and `Container.getAllAsync` now enforce binding
 
 In v6, `container.getAll` returned all bindings matching the service identifier. In v7, it only returns bindings that match both the service identifier and binding constraints.
 
+:::info
+
+If you need to simulate the old behavior, you can use custom constraints to accomplish this. Refer to this [issue](https://github.com/inversify/InversifyJS/issues/1796#issuecomment-2842402397) for more information.
+
+:::
+
 ### `load` and `unload` Methods
 
 These methods are now asynchronous and return a Promise. Synchronous alternatives, `loadSync` and `unloadSync`, are also available.

--- a/packages/docs/services/inversify-site/versioned_docs/version-7.x/guides/migrating-from-v6.mdx
+++ b/packages/docs/services/inversify-site/versioned_docs/version-7.x/guides/migrating-from-v6.mdx
@@ -80,6 +80,12 @@ Additionally, `Container.getAll` and `Container.getAllAsync` now enforce binding
 
 In v6, `container.getAll` returned all bindings matching the service identifier. In v7, it only returns bindings that match both the service identifier and binding constraints.
 
+:::info
+
+If you need to simulate the old behavior, you can use custom constraints to accomplish this. Refer to this [issue](https://github.com/inversify/InversifyJS/issues/1796#issuecomment-2842402397) for more information.
+
+:::
+
 ### `load` and `unload` Methods
 
 These methods are now asynchronous and return a Promise. Synchronous alternatives, `loadSync` and `unloadSync`, are also available.


### PR DESCRIPTION
### Changed
Updated migration guide with `getAll` v6 workaround.