### PR TITLE
feat: add Container#dispose method to clean up memory from child containers

### DIFF
--- a/.changeset/honest-eggs-cough.md
+++ b/.changeset/honest-eggs-cough.md
@@ -1,0 +1,11 @@
+---
+"@inversifyjs/container": minor
+"@inversifyjs/core": minor
+---
+
+Added `Container#dispose` method to clean up memory from child containers
+
+Child containers subscribe their plan cache to the parent container for cache invalidation.
+This would leak memory as the child plan cache would never be unsubscribed, growing the memory usage of the parent container with each new child container instantiation.
+
+The `Container#dispose` method should be called on child containers once they are no longer in use to free this memory.

--- a/packages/container/libraries/container/src/container/services/Container.ts
+++ b/packages/container/libraries/container/src/container/services/Container.ts
@@ -29,6 +29,7 @@ import { SnapshotManager } from './SnapshotManager';
 const DEFAULT_DEFAULT_SCOPE: BindingScope = bindingScopeValues.Transient;
 
 export class Container {
+  readonly #parent: Container | undefined;
   readonly #bindingManager: BindingManager;
   readonly #containerModuleManager: ContainerModuleManager;
   readonly #pluginManager: PluginManager;
@@ -37,6 +38,7 @@ export class Container {
   readonly #snapshotManager: SnapshotManager;
 
   constructor(options?: ContainerOptions) {
+    this.#parent = options?.parent;
     this.#serviceReferenceManager = this.#buildServiceReferenceManager(options);
 
     const autobind: boolean = options?.autobind ?? false;
@@ -70,6 +72,14 @@ export class Container {
     );
 
     this.#snapshotManager = new SnapshotManager(this.#serviceReferenceManager);
+  }
+
+  public dispose(): void {
+    if (this.#parent) {
+      this.#parent.#serviceReferenceManager.planResultCacheService.unsubscribe(
+        this.#serviceReferenceManager.planResultCacheService,
+      );
+    }
   }
 
   public bind<T>(

--- a/packages/container/libraries/core/src/planning/services/PlanResultCacheService.spec.ts
+++ b/packages/container/libraries/core/src/planning/services/PlanResultCacheService.spec.ts
@@ -264,5 +264,25 @@ describe(PlanResultCacheService.name, () => {
         expect(subscriberMock.clearCache).toHaveBeenCalledWith();
       });
     });
+
+    describe('when called with unsubscribed subscribers', () => {
+      let planService: PlanResultCacheService;
+      let subscriberMock: Mocked<PlanResultCacheService>;
+
+      beforeAll(() => {
+        planService = new PlanResultCacheService();
+        subscriberMock = {
+          clearCache: vitest.fn(),
+        } as unknown as Mocked<PlanResultCacheService>;
+
+        planService.subscribe(subscriberMock);
+        planService.unsubscribe(subscriberMock);
+        planService.clearCache();
+      });
+
+      it('should not call subscriber.clearCache()', () => {
+        expect(subscriberMock.clearCache).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/packages/container/libraries/core/src/planning/services/PlanResultCacheService.ts
+++ b/packages/container/libraries/core/src/planning/services/PlanResultCacheService.ts
@@ -54,7 +54,7 @@ export class PlanResultCacheService {
     Map<MetadataName, Map<MetadataTag, Map<unknown, PlanResult>>>
   >[];
 
-  readonly #subscribers: PlanResultCacheService[];
+  readonly #subscribers: Set<PlanResultCacheService>;
 
   constructor() {
     this.#serviceIdToValuePlanMap = this.#buildInitializedMapArray();
@@ -62,7 +62,7 @@ export class PlanResultCacheService {
     this.#namedTaggedServiceIdToValuePlanMap = this.#buildInitializedMapArray();
     this.#taggedServiceIdToValuePlanMap = this.#buildInitializedMapArray();
 
-    this.#subscribers = [];
+    this.#subscribers = new Set();
   }
 
   public clearCache(): void {
@@ -156,7 +156,11 @@ export class PlanResultCacheService {
   }
 
   public subscribe(subscriber: PlanResultCacheService): void {
-    this.#subscribers.push(subscriber);
+    this.#subscribers.add(subscriber);
+  }
+
+  public unsubscribe(subscriber: PlanResultCacheService): void {
+    this.#subscribers.delete(subscriber);
   }
 
   #buildInitializedMapArray<TKey, TValue>(): Map<TKey, TValue>[] {


### PR DESCRIPTION
The `dispose` method removes `PlanResultCacheService` subscriptions on the parent container to avoid leaking memory when constructing temporary child containers. It should be called once the child container is no longer in use.

I've converted the `#subscribers` array in `PlanResultCacheService` into a set so that removing child containers' cache services is O(1) rather than O(N) where N is the length of the array.

Fixes inversify/InversifyJS#1810