### PR TITLE
Fix BindingService.clone

### DIFF
--- a/.changeset/modern-wings-battle.md
+++ b/.changeset/modern-wings-battle.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": patch
+---
+
+Updated `BindingService.clone` to properly clone bindings.

--- a/packages/container/libraries/container/src/issues/inversify-InversifyJs-issue-1806-containerSnapshotShouldNotBeUpdated.spec.ts
+++ b/packages/container/libraries/container/src/issues/inversify-InversifyJs-issue-1806-containerSnapshotShouldNotBeUpdated.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import 'reflect-metadata';
+
+import { Container } from '../container/services/Container';
+
+describe('inversify/InversifyJS#1806', () => {
+  it('container.get() should not update snapshot bindings', () => {
+    class Foo {}
+
+    const container: Container = new Container();
+
+    container.bind(Foo).toSelf().inSingletonScope();
+
+    container.snapshot();
+
+    const resolvedService: Foo = container.get(Foo);
+
+    container.restore();
+
+    const resolvedServiceAfterRestore: Foo = container.get(Foo);
+
+    expect(resolvedService).not.toBe(resolvedServiceAfterRestore);
+  });
+});

--- a/packages/container/libraries/core/src/binding/calculations/cloneBinding.spec.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneBinding.spec.ts
@@ -1,0 +1,370 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+import { bindingTypeValues } from '../models/BindingType';
+import { ConstantValueBinding } from '../models/ConstantValueBinding';
+import { DynamicValueBinding } from '../models/DynamicValueBinding';
+import { Factory } from '../models/Factory';
+import { FactoryBinding } from '../models/FactoryBinding';
+import { InstanceBinding } from '../models/InstanceBinding';
+import { Provider } from '../models/Provider';
+import { ProviderBinding } from '../models/ProviderBinding';
+import { ResolvedValueBinding } from '../models/ResolvedValueBinding';
+import { ServiceRedirectionBinding } from '../models/ServiceRedirectionBinding';
+import { cloneBinding } from './cloneBinding';
+import { cloneConstantValueBinding } from './cloneConstantValueBinding';
+import { cloneDynamicValueBinding } from './cloneDynamicValueBinding';
+import { cloneFactoryBinding } from './cloneFactoryBinding';
+import { cloneInstanceBinding } from './cloneInstanceBinding';
+import { cloneProviderBinding } from './cloneProviderBinding';
+import { cloneResolvedValueBinding } from './cloneResolvedValueBinding';
+import { cloneServiceRedirectionBinding } from './cloneServiceRedirectionBinding';
+
+// Mock all clone functions
+vitest.mock('./cloneConstantValueBinding');
+vitest.mock('./cloneDynamicValueBinding');
+vitest.mock('./cloneFactoryBinding');
+vitest.mock('./cloneInstanceBinding');
+vitest.mock('./cloneProviderBinding');
+vitest.mock('./cloneResolvedValueBinding');
+vitest.mock('./cloneServiceRedirectionBinding');
+
+describe(cloneBinding.name, () => {
+  // Common setup
+  beforeAll(() => {
+    // Reset mocks before each test
+    vitest.mocked(cloneConstantValueBinding).mockReset();
+    vitest.mocked(cloneDynamicValueBinding).mockReset();
+    vitest.mocked(cloneFactoryBinding).mockReset();
+    vitest.mocked(cloneInstanceBinding).mockReset();
+    vitest.mocked(cloneProviderBinding).mockReset();
+    vitest.mocked(cloneResolvedValueBinding).mockReset();
+    vitest.mocked(cloneServiceRedirectionBinding).mockReset();
+  });
+
+  afterAll(() => {
+    vitest.clearAllMocks();
+  });
+
+  describe('having a ConstantValueBinding', () => {
+    let bindingFixture: ConstantValueBinding<unknown>;
+
+    beforeAll(() => {
+      bindingFixture = {
+        cache: {
+          isRight: false,
+          value: undefined,
+        },
+        id: 0,
+        isSatisfiedBy: () => true,
+        moduleId: 1,
+        onActivation: vitest.fn(),
+        onDeactivation: vitest.fn(),
+        scope: 'Singleton',
+        serviceIdentifier: Symbol(),
+        type: bindingTypeValues.ConstantValue,
+        value: Symbol(),
+      };
+    });
+
+    describe('when called', () => {
+      let clonedBindingFixture: ConstantValueBinding<unknown>;
+      let result: unknown;
+
+      beforeAll(() => {
+        clonedBindingFixture = { ...bindingFixture };
+
+        vitest
+          .mocked(cloneConstantValueBinding)
+          .mockReturnValueOnce(clonedBindingFixture);
+
+        result = cloneBinding(bindingFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call cloneConstantValueBinding', () => {
+        expect(cloneConstantValueBinding).toHaveBeenCalledTimes(1);
+        expect(cloneConstantValueBinding).toHaveBeenCalledWith(bindingFixture);
+      });
+
+      it('should return the cloned binding', () => {
+        expect(result).toBe(clonedBindingFixture);
+      });
+    });
+  });
+
+  describe('having a DynamicValueBinding', () => {
+    let bindingFixture: DynamicValueBinding<unknown>;
+
+    beforeAll(() => {
+      bindingFixture = {
+        cache: {
+          isRight: false,
+          value: undefined,
+        },
+        id: 0,
+        isSatisfiedBy: () => true,
+        moduleId: 1,
+        onActivation: vitest.fn(),
+        onDeactivation: vitest.fn(),
+        scope: 'Singleton',
+        serviceIdentifier: Symbol(),
+        type: bindingTypeValues.DynamicValue,
+        value: vitest.fn(),
+      };
+    });
+
+    describe('when called', () => {
+      let clonedBindingFixture: DynamicValueBinding<unknown>;
+      let result: unknown;
+
+      beforeAll(() => {
+        clonedBindingFixture = { ...bindingFixture };
+
+        vitest
+          .mocked(cloneDynamicValueBinding)
+          .mockReturnValueOnce(clonedBindingFixture);
+
+        result = cloneBinding(bindingFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call cloneDynamicValueBinding', () => {
+        expect(cloneDynamicValueBinding).toHaveBeenCalledTimes(1);
+        expect(cloneDynamicValueBinding).toHaveBeenCalledWith(bindingFixture);
+      });
+
+      it('should return the cloned binding', () => {
+        expect(result).toBe(clonedBindingFixture);
+      });
+    });
+  });
+
+  describe('having a FactoryBinding', () => {
+    let bindingFixture: FactoryBinding<Factory<unknown>>;
+    let clonedBindingFixture: FactoryBinding<Factory<unknown>>;
+    let result: unknown;
+
+    beforeAll(() => {
+      bindingFixture = {
+        cache: {
+          isRight: false,
+          value: undefined,
+        },
+        factory: vitest.fn(),
+        id: 0,
+        isSatisfiedBy: () => true,
+        moduleId: 1,
+        onActivation: vitest.fn(),
+        onDeactivation: vitest.fn(),
+        scope: 'Singleton',
+        serviceIdentifier: Symbol(),
+        type: bindingTypeValues.Factory,
+      };
+
+      clonedBindingFixture = { ...bindingFixture };
+
+      vitest
+        .mocked(cloneFactoryBinding)
+        .mockReturnValueOnce(clonedBindingFixture);
+
+      result = cloneBinding(bindingFixture);
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call cloneFactoryBinding', () => {
+      expect(cloneFactoryBinding).toHaveBeenCalledTimes(1);
+      expect(cloneFactoryBinding).toHaveBeenCalledWith(bindingFixture);
+    });
+
+    it('should return the cloned binding', () => {
+      expect(result).toBe(clonedBindingFixture);
+    });
+  });
+
+  describe('having an InstanceBinding', () => {
+    let bindingFixture: InstanceBinding<unknown>;
+    let clonedBindingFixture: InstanceBinding<unknown>;
+    let result: unknown;
+
+    beforeAll(() => {
+      bindingFixture = {
+        cache: {
+          isRight: false,
+          value: undefined,
+        },
+        id: 0,
+        implementationType: class {},
+        isSatisfiedBy: () => true,
+        moduleId: 1,
+        onActivation: vitest.fn(),
+        onDeactivation: vitest.fn(),
+        scope: 'Singleton',
+        serviceIdentifier: Symbol(),
+        type: bindingTypeValues.Instance,
+      };
+
+      clonedBindingFixture = { ...bindingFixture };
+
+      vitest
+        .mocked(cloneInstanceBinding)
+        .mockReturnValueOnce(clonedBindingFixture);
+
+      result = cloneBinding(bindingFixture);
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call cloneInstanceBinding', () => {
+      expect(cloneInstanceBinding).toHaveBeenCalledTimes(1);
+      expect(cloneInstanceBinding).toHaveBeenCalledWith(bindingFixture);
+    });
+
+    it('should return the cloned binding', () => {
+      expect(result).toBe(clonedBindingFixture);
+    });
+  });
+
+  describe('having a ProviderBinding', () => {
+    let bindingFixture: ProviderBinding<Provider<unknown>>;
+    let clonedBindingFixture: ProviderBinding<Provider<unknown>>;
+    let result: unknown;
+
+    beforeAll(() => {
+      bindingFixture = {
+        cache: {
+          isRight: false,
+          value: undefined,
+        },
+        id: 0,
+        isSatisfiedBy: () => true,
+        moduleId: 1,
+        onActivation: vitest.fn(),
+        onDeactivation: vitest.fn(),
+        provider: vitest.fn(),
+        scope: 'Singleton',
+        serviceIdentifier: Symbol(),
+        type: bindingTypeValues.Provider,
+      };
+
+      clonedBindingFixture = { ...bindingFixture };
+
+      vitest
+        .mocked(cloneProviderBinding)
+        .mockReturnValueOnce(clonedBindingFixture);
+
+      result = cloneBinding(bindingFixture);
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call cloneProviderBinding', () => {
+      expect(cloneProviderBinding).toHaveBeenCalledTimes(1);
+      expect(cloneProviderBinding).toHaveBeenCalledWith(bindingFixture);
+    });
+
+    it('should return the cloned binding', () => {
+      expect(result).toBe(clonedBindingFixture);
+    });
+  });
+
+  describe('having a ResolvedValueBinding', () => {
+    let bindingFixture: ResolvedValueBinding<unknown>;
+    let clonedBindingFixture: ResolvedValueBinding<unknown>;
+    let result: unknown;
+
+    beforeAll(() => {
+      bindingFixture = {
+        cache: {
+          isRight: false,
+          value: undefined,
+        },
+        factory: vitest.fn(),
+        id: 0,
+        isSatisfiedBy: () => true,
+        metadata: {
+          arguments: [],
+        },
+        moduleId: 1,
+        onActivation: vitest.fn(),
+        onDeactivation: vitest.fn(),
+        scope: 'Singleton',
+        serviceIdentifier: Symbol(),
+        type: bindingTypeValues.ResolvedValue,
+      };
+
+      clonedBindingFixture = { ...bindingFixture };
+
+      vitest
+        .mocked(cloneResolvedValueBinding)
+        .mockReturnValueOnce(clonedBindingFixture);
+
+      result = cloneBinding(bindingFixture);
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call cloneResolvedValueBinding', () => {
+      expect(cloneResolvedValueBinding).toHaveBeenCalledTimes(1);
+      expect(cloneResolvedValueBinding).toHaveBeenCalledWith(bindingFixture);
+    });
+
+    it('should return the cloned binding', () => {
+      expect(result).toBe(clonedBindingFixture);
+    });
+  });
+
+  describe('having a ServiceRedirectionBinding', () => {
+    let bindingFixture: ServiceRedirectionBinding<unknown>;
+    let clonedBindingFixture: ServiceRedirectionBinding<unknown>;
+    let result: unknown;
+
+    beforeAll(() => {
+      bindingFixture = {
+        id: 0,
+        isSatisfiedBy: () => true,
+        moduleId: 1,
+        serviceIdentifier: Symbol(),
+        targetServiceIdentifier: Symbol(),
+        type: bindingTypeValues.ServiceRedirection,
+      };
+
+      clonedBindingFixture = { ...bindingFixture };
+
+      vitest
+        .mocked(cloneServiceRedirectionBinding)
+        .mockReturnValueOnce(clonedBindingFixture);
+
+      result = cloneBinding(bindingFixture);
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call cloneServiceRedirectionBinding', () => {
+      expect(cloneServiceRedirectionBinding).toHaveBeenCalledTimes(1);
+      expect(cloneServiceRedirectionBinding).toHaveBeenCalledWith(
+        bindingFixture,
+      );
+    });
+
+    it('should return the cloned binding', () => {
+      expect(result).toBe(clonedBindingFixture);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/binding/calculations/cloneBinding.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneBinding.ts
@@ -1,0 +1,45 @@
+import { Binding } from '../models/Binding';
+import { bindingTypeValues } from '../models/BindingType';
+import { Factory } from '../models/Factory';
+import { FactoryBinding } from '../models/FactoryBinding';
+import { Provider } from '../models/Provider';
+import { ProviderBinding } from '../models/ProviderBinding';
+import { cloneConstantValueBinding } from './cloneConstantValueBinding';
+import { cloneDynamicValueBinding } from './cloneDynamicValueBinding';
+import { cloneFactoryBinding } from './cloneFactoryBinding';
+import { cloneInstanceBinding } from './cloneInstanceBinding';
+import { cloneProviderBinding } from './cloneProviderBinding';
+import { cloneResolvedValueBinding } from './cloneResolvedValueBinding';
+import { cloneServiceRedirectionBinding } from './cloneServiceRedirectionBinding';
+
+/**
+ * Creates a deep clone of a binding.
+ *
+ * @param binding - The binding to clone
+ * @returns A clone of the binding
+ */
+export function cloneBinding<TActivated>(
+  binding: Binding<TActivated>,
+): Binding<TActivated> {
+  // Switch based on binding type to delegate to specific clone functions
+  switch (binding.type) {
+    case bindingTypeValues.ConstantValue:
+      return cloneConstantValueBinding(binding);
+    case bindingTypeValues.DynamicValue:
+      return cloneDynamicValueBinding(binding);
+    case bindingTypeValues.Factory:
+      return cloneFactoryBinding(
+        binding as FactoryBinding<TActivated & Factory<unknown>>,
+      ) as Binding<TActivated>;
+    case bindingTypeValues.Instance:
+      return cloneInstanceBinding(binding);
+    case bindingTypeValues.Provider:
+      return cloneProviderBinding(
+        binding as ProviderBinding<TActivated & Provider<unknown>>,
+      ) as Binding<TActivated>;
+    case bindingTypeValues.ResolvedValue:
+      return cloneResolvedValueBinding(binding);
+    case bindingTypeValues.ServiceRedirection:
+      return cloneServiceRedirectionBinding(binding);
+  }
+}

--- a/packages/container/libraries/core/src/binding/calculations/cloneBindingCache.spec.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneBindingCache.spec.ts
@@ -1,0 +1,58 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { Left, Right } from '@inversifyjs/common';
+
+import { cloneBindingCache } from './cloneBindingCache';
+
+describe(cloneBindingCache, () => {
+  describe('having a left cache', () => {
+    let cacheFixture: Left<undefined>;
+
+    beforeAll(() => {
+      cacheFixture = {
+        isRight: false,
+        value: undefined,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = cloneBindingCache(cacheFixture);
+      });
+
+      it('should return the same cache', () => {
+        expect(result).toBe(cacheFixture);
+      });
+    });
+  });
+
+  describe('having a right cache', () => {
+    let cacheFixture: Right<unknown>;
+
+    beforeAll(() => {
+      cacheFixture = {
+        isRight: true,
+        value: Symbol(),
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = cloneBindingCache(cacheFixture);
+      });
+
+      it('should return a cloned cache', () => {
+        const expectedCache: Right<unknown> = {
+          isRight: true,
+          value: cacheFixture.value,
+        };
+
+        expect(result).toStrictEqual(expectedCache);
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/binding/calculations/cloneBindingCache.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneBindingCache.ts
@@ -1,0 +1,17 @@
+import { Either } from '@inversifyjs/common';
+
+import { Resolved } from '../../resolution/models/Resolved';
+
+export function cloneBindingCache<TActivated>(
+  cache: Either<undefined, Resolved<TActivated>>,
+): Either<undefined, Resolved<TActivated>> {
+  if (cache.isRight) {
+    return {
+      isRight: true,
+      value: cache.value,
+    };
+  }
+
+  // A left cache is not cloned, just returned
+  return cache;
+}

--- a/packages/container/libraries/core/src/binding/calculations/cloneConstantValueBinding.spec.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneConstantValueBinding.spec.ts
@@ -1,0 +1,78 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+import { Left } from '@inversifyjs/common';
+
+vitest.mock('./cloneBindingCache');
+
+import { bindingScopeValues } from '../models/BindingScope';
+import { bindingTypeValues } from '../models/BindingType';
+import { ConstantValueBinding } from '../models/ConstantValueBinding';
+import { cloneBindingCache } from './cloneBindingCache';
+import { cloneConstantValueBinding } from './cloneConstantValueBinding';
+
+describe(cloneConstantValueBinding, () => {
+  let constantValueBindingFixture: ConstantValueBinding<unknown>;
+
+  beforeAll(() => {
+    constantValueBindingFixture = {
+      cache: {
+        isRight: false,
+        value: undefined,
+      },
+      id: 0,
+      isSatisfiedBy: () => true,
+      moduleId: 1,
+      onActivation: () => {},
+      onDeactivation: () => {},
+      scope: bindingScopeValues.Singleton,
+      serviceIdentifier: Symbol(),
+      type: bindingTypeValues.ConstantValue,
+      value: Symbol(),
+    };
+  });
+
+  describe('when called', () => {
+    let cacheFixture: Left<undefined>;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      cacheFixture = {
+        isRight: false,
+        value: undefined,
+      };
+
+      vitest.mocked(cloneBindingCache).mockReturnValueOnce(cacheFixture);
+
+      result = cloneConstantValueBinding(constantValueBindingFixture);
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call cloneBindingCache', () => {
+      expect(cloneBindingCache).toHaveBeenCalledTimes(1);
+      expect(cloneBindingCache).toHaveBeenCalledWith(
+        constantValueBindingFixture.cache,
+      );
+    });
+
+    it('should return a ConstantValueBinding', () => {
+      const expected: ConstantValueBinding<unknown> = {
+        cache: cacheFixture,
+        id: constantValueBindingFixture.id,
+        isSatisfiedBy: constantValueBindingFixture.isSatisfiedBy,
+        moduleId: constantValueBindingFixture.moduleId,
+        onActivation: constantValueBindingFixture.onActivation,
+        onDeactivation: constantValueBindingFixture.onDeactivation,
+        scope: constantValueBindingFixture.scope,
+        serviceIdentifier: constantValueBindingFixture.serviceIdentifier,
+        type: constantValueBindingFixture.type,
+        value: constantValueBindingFixture.value,
+      };
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/binding/calculations/cloneConstantValueBinding.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneConstantValueBinding.ts
@@ -1,0 +1,23 @@
+import { ConstantValueBinding } from '../models/ConstantValueBinding';
+import { cloneBindingCache } from './cloneBindingCache';
+
+/**
+ * Clones a ConstantValueBinding
+ */
+export function cloneConstantValueBinding<TActivated>(
+  binding: ConstantValueBinding<TActivated>,
+): ConstantValueBinding<TActivated> {
+  return {
+    cache: cloneBindingCache(binding.cache),
+    id: binding.id,
+    isSatisfiedBy: binding.isSatisfiedBy,
+    moduleId: binding.moduleId,
+    onActivation: binding.onActivation,
+    onDeactivation: binding.onDeactivation,
+    scope: binding.scope,
+    serviceIdentifier: binding.serviceIdentifier,
+    type: binding.type,
+    // The value is not cloned as it's a resolved value
+    value: binding.value,
+  };
+}

--- a/packages/container/libraries/core/src/binding/calculations/cloneDynamicValueBinding.spec.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneDynamicValueBinding.spec.ts
@@ -1,0 +1,78 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+import { Left } from '@inversifyjs/common';
+
+vitest.mock('./cloneBindingCache');
+
+import { bindingScopeValues } from '../models/BindingScope';
+import { bindingTypeValues } from '../models/BindingType';
+import { DynamicValueBinding } from '../models/DynamicValueBinding';
+import { cloneBindingCache } from './cloneBindingCache';
+import { cloneDynamicValueBinding } from './cloneDynamicValueBinding';
+
+describe(cloneDynamicValueBinding, () => {
+  let dynamicValueBindingFixture: DynamicValueBinding<unknown>;
+
+  beforeAll(() => {
+    dynamicValueBindingFixture = {
+      cache: {
+        isRight: false,
+        value: undefined,
+      },
+      id: 0,
+      isSatisfiedBy: () => true,
+      moduleId: 1,
+      onActivation: () => {},
+      onDeactivation: () => {},
+      scope: bindingScopeValues.Singleton,
+      serviceIdentifier: Symbol(),
+      type: bindingTypeValues.DynamicValue,
+      value: vitest.fn(),
+    };
+  });
+
+  describe('when called', () => {
+    let cacheFixture: Left<undefined>;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      cacheFixture = {
+        isRight: false,
+        value: undefined,
+      };
+
+      vitest.mocked(cloneBindingCache).mockReturnValueOnce(cacheFixture);
+
+      result = cloneDynamicValueBinding(dynamicValueBindingFixture);
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call cloneBindingCache', () => {
+      expect(cloneBindingCache).toHaveBeenCalledTimes(1);
+      expect(cloneBindingCache).toHaveBeenCalledWith(
+        dynamicValueBindingFixture.cache,
+      );
+    });
+
+    it('should return a DynamicValueBinding', () => {
+      const expected: DynamicValueBinding<unknown> = {
+        cache: cacheFixture,
+        id: dynamicValueBindingFixture.id,
+        isSatisfiedBy: dynamicValueBindingFixture.isSatisfiedBy,
+        moduleId: dynamicValueBindingFixture.moduleId,
+        onActivation: dynamicValueBindingFixture.onActivation,
+        onDeactivation: dynamicValueBindingFixture.onDeactivation,
+        scope: dynamicValueBindingFixture.scope,
+        serviceIdentifier: dynamicValueBindingFixture.serviceIdentifier,
+        type: dynamicValueBindingFixture.type,
+        value: dynamicValueBindingFixture.value,
+      };
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/binding/calculations/cloneDynamicValueBinding.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneDynamicValueBinding.ts
@@ -1,0 +1,23 @@
+import { DynamicValueBinding } from '../models/DynamicValueBinding';
+import { cloneBindingCache } from './cloneBindingCache';
+
+/**
+ * Clones a DynamicValueBinding
+ */
+export function cloneDynamicValueBinding<TActivated>(
+  binding: DynamicValueBinding<TActivated>,
+): DynamicValueBinding<TActivated> {
+  return {
+    cache: cloneBindingCache(binding.cache),
+    id: binding.id,
+    isSatisfiedBy: binding.isSatisfiedBy,
+    moduleId: binding.moduleId,
+    onActivation: binding.onActivation,
+    onDeactivation: binding.onDeactivation,
+    scope: binding.scope,
+    serviceIdentifier: binding.serviceIdentifier,
+    type: binding.type,
+    // The value is not cloned
+    value: binding.value,
+  };
+}

--- a/packages/container/libraries/core/src/binding/calculations/cloneFactoryBinding.spec.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneFactoryBinding.spec.ts
@@ -1,0 +1,79 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+import { Left } from '@inversifyjs/common';
+
+vitest.mock('./cloneBindingCache');
+
+import { bindingScopeValues } from '../models/BindingScope';
+import { bindingTypeValues } from '../models/BindingType';
+import { Factory } from '../models/Factory';
+import { FactoryBinding } from '../models/FactoryBinding';
+import { cloneBindingCache } from './cloneBindingCache';
+import { cloneFactoryBinding } from './cloneFactoryBinding';
+
+describe(cloneFactoryBinding, () => {
+  let factoryBindingFixture: FactoryBinding<Factory<unknown>>;
+
+  beforeAll(() => {
+    factoryBindingFixture = {
+      cache: {
+        isRight: false,
+        value: undefined,
+      },
+      factory: vitest.fn(),
+      id: 0,
+      isSatisfiedBy: () => true,
+      moduleId: 1,
+      onActivation: vitest.fn(),
+      onDeactivation: vitest.fn(),
+      scope: bindingScopeValues.Singleton,
+      serviceIdentifier: Symbol(),
+      type: bindingTypeValues.Factory,
+    };
+  });
+
+  describe('when called', () => {
+    let cacheFixture: Left<undefined>;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      cacheFixture = {
+        isRight: false,
+        value: undefined,
+      };
+
+      vitest.mocked(cloneBindingCache).mockReturnValueOnce(cacheFixture);
+
+      result = cloneFactoryBinding(factoryBindingFixture);
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call cloneBindingCache', () => {
+      expect(cloneBindingCache).toHaveBeenCalledTimes(1);
+      expect(cloneBindingCache).toHaveBeenCalledWith(
+        factoryBindingFixture.cache,
+      );
+    });
+
+    it('should return a FactoryBinding', () => {
+      const expected: FactoryBinding<Factory<unknown>> = {
+        cache: cacheFixture,
+        factory: factoryBindingFixture.factory,
+        id: factoryBindingFixture.id,
+        isSatisfiedBy: factoryBindingFixture.isSatisfiedBy,
+        moduleId: factoryBindingFixture.moduleId,
+        onActivation: factoryBindingFixture.onActivation,
+        onDeactivation: factoryBindingFixture.onDeactivation,
+        scope: factoryBindingFixture.scope,
+        serviceIdentifier: factoryBindingFixture.serviceIdentifier,
+        type: factoryBindingFixture.type,
+      };
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/binding/calculations/cloneFactoryBinding.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneFactoryBinding.ts
@@ -1,0 +1,23 @@
+import { Factory } from '../models/Factory';
+import { FactoryBinding } from '../models/FactoryBinding';
+import { cloneBindingCache } from './cloneBindingCache';
+
+/**
+ * Clones a FactoryBinding
+ */
+export function cloneFactoryBinding<TFactory extends Factory<unknown>>(
+  binding: FactoryBinding<TFactory>,
+): FactoryBinding<TFactory> {
+  return {
+    cache: cloneBindingCache(binding.cache),
+    factory: binding.factory,
+    id: binding.id,
+    isSatisfiedBy: binding.isSatisfiedBy,
+    moduleId: binding.moduleId,
+    onActivation: binding.onActivation,
+    onDeactivation: binding.onDeactivation,
+    scope: binding.scope,
+    serviceIdentifier: binding.serviceIdentifier,
+    type: binding.type,
+  };
+}

--- a/packages/container/libraries/core/src/binding/calculations/cloneInstanceBinding.spec.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneInstanceBinding.spec.ts
@@ -1,0 +1,78 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+import { Left } from '@inversifyjs/common';
+
+vitest.mock('./cloneBindingCache');
+
+import { bindingScopeValues } from '../models/BindingScope';
+import { bindingTypeValues } from '../models/BindingType';
+import { InstanceBinding } from '../models/InstanceBinding';
+import { cloneBindingCache } from './cloneBindingCache';
+import { cloneInstanceBinding } from './cloneInstanceBinding';
+
+describe(cloneInstanceBinding, () => {
+  let instanceBindingFixture: InstanceBinding<unknown>;
+
+  beforeAll(() => {
+    instanceBindingFixture = {
+      cache: {
+        isRight: false,
+        value: undefined,
+      },
+      id: 0,
+      implementationType: class {},
+      isSatisfiedBy: () => true,
+      moduleId: 1,
+      onActivation: vitest.fn(),
+      onDeactivation: vitest.fn(),
+      scope: bindingScopeValues.Singleton,
+      serviceIdentifier: Symbol(),
+      type: bindingTypeValues.Instance,
+    };
+  });
+
+  describe('when called', () => {
+    let cacheFixture: Left<undefined>;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      cacheFixture = {
+        isRight: false,
+        value: undefined,
+      };
+
+      vitest.mocked(cloneBindingCache).mockReturnValueOnce(cacheFixture);
+
+      result = cloneInstanceBinding(instanceBindingFixture);
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call cloneBindingCache', () => {
+      expect(cloneBindingCache).toHaveBeenCalledTimes(1);
+      expect(cloneBindingCache).toHaveBeenCalledWith(
+        instanceBindingFixture.cache,
+      );
+    });
+
+    it('should return a InstanceBinding', () => {
+      const expected: InstanceBinding<unknown> = {
+        cache: cacheFixture,
+        id: instanceBindingFixture.id,
+        implementationType: instanceBindingFixture.implementationType,
+        isSatisfiedBy: instanceBindingFixture.isSatisfiedBy,
+        moduleId: instanceBindingFixture.moduleId,
+        onActivation: instanceBindingFixture.onActivation,
+        onDeactivation: instanceBindingFixture.onDeactivation,
+        scope: instanceBindingFixture.scope,
+        serviceIdentifier: instanceBindingFixture.serviceIdentifier,
+        type: instanceBindingFixture.type,
+      };
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/binding/calculations/cloneInstanceBinding.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneInstanceBinding.ts
@@ -1,0 +1,22 @@
+import { InstanceBinding } from '../models/InstanceBinding';
+import { cloneBindingCache } from './cloneBindingCache';
+
+/**
+ * Clones an InstanceBinding
+ */
+export function cloneInstanceBinding<TActivated>(
+  binding: InstanceBinding<TActivated>,
+): InstanceBinding<TActivated> {
+  return {
+    cache: cloneBindingCache(binding.cache),
+    id: binding.id,
+    implementationType: binding.implementationType,
+    isSatisfiedBy: binding.isSatisfiedBy,
+    moduleId: binding.moduleId,
+    onActivation: binding.onActivation,
+    onDeactivation: binding.onDeactivation,
+    scope: binding.scope,
+    serviceIdentifier: binding.serviceIdentifier,
+    type: binding.type,
+  };
+}

--- a/packages/container/libraries/core/src/binding/calculations/cloneProviderBinding.spec.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneProviderBinding.spec.ts
@@ -1,0 +1,79 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+import { Left } from '@inversifyjs/common';
+
+vitest.mock('./cloneBindingCache');
+
+import { bindingScopeValues } from '../models/BindingScope';
+import { bindingTypeValues } from '../models/BindingType';
+import { Provider } from '../models/Provider';
+import { ProviderBinding } from '../models/ProviderBinding';
+import { cloneBindingCache } from './cloneBindingCache';
+import { cloneProviderBinding } from './cloneProviderBinding';
+
+describe(cloneProviderBinding, () => {
+  let providerBindingFixture: ProviderBinding<Provider<unknown>>;
+
+  beforeAll(() => {
+    providerBindingFixture = {
+      cache: {
+        isRight: false,
+        value: undefined,
+      },
+      id: 0,
+      isSatisfiedBy: () => true,
+      moduleId: 1,
+      onActivation: vitest.fn(),
+      onDeactivation: vitest.fn(),
+      provider: vitest.fn(),
+      scope: bindingScopeValues.Singleton,
+      serviceIdentifier: Symbol(),
+      type: bindingTypeValues.Provider,
+    };
+  });
+
+  describe('when called', () => {
+    let cacheFixture: Left<undefined>;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      cacheFixture = {
+        isRight: false,
+        value: undefined,
+      };
+
+      vitest.mocked(cloneBindingCache).mockReturnValueOnce(cacheFixture);
+
+      result = cloneProviderBinding(providerBindingFixture);
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call cloneBindingCache', () => {
+      expect(cloneBindingCache).toHaveBeenCalledTimes(1);
+      expect(cloneBindingCache).toHaveBeenCalledWith(
+        providerBindingFixture.cache,
+      );
+    });
+
+    it('should return a ProviderBinding', () => {
+      const expected: ProviderBinding<Provider<unknown>> = {
+        cache: cacheFixture,
+        id: providerBindingFixture.id,
+        isSatisfiedBy: providerBindingFixture.isSatisfiedBy,
+        moduleId: providerBindingFixture.moduleId,
+        onActivation: providerBindingFixture.onActivation,
+        onDeactivation: providerBindingFixture.onDeactivation,
+        provider: providerBindingFixture.provider,
+        scope: providerBindingFixture.scope,
+        serviceIdentifier: providerBindingFixture.serviceIdentifier,
+        type: providerBindingFixture.type,
+      };
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/binding/calculations/cloneProviderBinding.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneProviderBinding.ts
@@ -1,0 +1,23 @@
+import { Provider } from '../models/Provider';
+import { ProviderBinding } from '../models/ProviderBinding';
+import { cloneBindingCache } from './cloneBindingCache';
+
+/**
+ * Clones a ProviderBinding
+ */
+export function cloneProviderBinding<TProvider extends Provider<unknown>>(
+  binding: ProviderBinding<TProvider>,
+): ProviderBinding<TProvider> {
+  return {
+    cache: cloneBindingCache(binding.cache),
+    id: binding.id,
+    isSatisfiedBy: binding.isSatisfiedBy,
+    moduleId: binding.moduleId,
+    onActivation: binding.onActivation,
+    onDeactivation: binding.onDeactivation,
+    provider: binding.provider,
+    scope: binding.scope,
+    serviceIdentifier: binding.serviceIdentifier,
+    type: binding.type,
+  };
+}

--- a/packages/container/libraries/core/src/binding/calculations/cloneResolvedValueBinding.spec.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneResolvedValueBinding.spec.ts
@@ -1,0 +1,82 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+import { Left } from '@inversifyjs/common';
+
+vitest.mock('./cloneBindingCache');
+
+import { bindingScopeValues } from '../models/BindingScope';
+import { bindingTypeValues } from '../models/BindingType';
+import { ResolvedValueBinding } from '../models/ResolvedValueBinding';
+import { cloneBindingCache } from './cloneBindingCache';
+import { cloneResolvedValueBinding } from './cloneResolvedValueBinding';
+
+describe(cloneResolvedValueBinding, () => {
+  let resolvedValueBindingFixture: ResolvedValueBinding<unknown>;
+
+  beforeAll(() => {
+    resolvedValueBindingFixture = {
+      cache: {
+        isRight: false,
+        value: undefined,
+      },
+      factory: vitest.fn(),
+      id: 0,
+      isSatisfiedBy: () => true,
+      metadata: {
+        arguments: [],
+      },
+      moduleId: 1,
+      onActivation: vitest.fn(),
+      onDeactivation: vitest.fn(),
+      scope: bindingScopeValues.Singleton,
+      serviceIdentifier: Symbol(),
+      type: bindingTypeValues.ResolvedValue,
+    };
+  });
+
+  describe('when called', () => {
+    let cacheFixture: Left<undefined>;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      cacheFixture = {
+        isRight: false,
+        value: undefined,
+      };
+
+      vitest.mocked(cloneBindingCache).mockReturnValueOnce(cacheFixture);
+
+      result = cloneResolvedValueBinding(resolvedValueBindingFixture);
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call cloneBindingCache', () => {
+      expect(cloneBindingCache).toHaveBeenCalledTimes(1);
+      expect(cloneBindingCache).toHaveBeenCalledWith(
+        resolvedValueBindingFixture.cache,
+      );
+    });
+
+    it('should return a ResolvedValueBinding', () => {
+      const expected: ResolvedValueBinding<unknown> = {
+        cache: cacheFixture,
+        factory: resolvedValueBindingFixture.factory,
+        id: resolvedValueBindingFixture.id,
+        isSatisfiedBy: resolvedValueBindingFixture.isSatisfiedBy,
+        metadata: resolvedValueBindingFixture.metadata,
+        moduleId: resolvedValueBindingFixture.moduleId,
+        onActivation: resolvedValueBindingFixture.onActivation,
+        onDeactivation: resolvedValueBindingFixture.onDeactivation,
+        scope: resolvedValueBindingFixture.scope,
+        serviceIdentifier: resolvedValueBindingFixture.serviceIdentifier,
+        type: resolvedValueBindingFixture.type,
+      };
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/binding/calculations/cloneResolvedValueBinding.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneResolvedValueBinding.ts
@@ -1,0 +1,23 @@
+import { ResolvedValueBinding } from '../models/ResolvedValueBinding';
+import { cloneBindingCache } from './cloneBindingCache';
+
+/**
+ * Clones a ResolvedValueBinding
+ */
+export function cloneResolvedValueBinding<TActivated>(
+  binding: ResolvedValueBinding<TActivated>,
+): ResolvedValueBinding<TActivated> {
+  return {
+    cache: cloneBindingCache(binding.cache),
+    factory: binding.factory,
+    id: binding.id,
+    isSatisfiedBy: binding.isSatisfiedBy,
+    metadata: binding.metadata,
+    moduleId: binding.moduleId,
+    onActivation: binding.onActivation,
+    onDeactivation: binding.onDeactivation,
+    scope: binding.scope,
+    serviceIdentifier: binding.serviceIdentifier,
+    type: binding.type,
+  };
+}

--- a/packages/container/libraries/core/src/binding/calculations/cloneServiceRedirectionBinding.spec.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneServiceRedirectionBinding.spec.ts
@@ -1,0 +1,46 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+import { bindingTypeValues } from '../models/BindingType';
+import { ServiceRedirectionBinding } from '../models/ServiceRedirectionBinding';
+import { cloneServiceRedirectionBinding } from './cloneServiceRedirectionBinding';
+
+describe(cloneServiceRedirectionBinding, () => {
+  let serviceRedirectionBindingFixture: ServiceRedirectionBinding<unknown>;
+
+  beforeAll(() => {
+    serviceRedirectionBindingFixture = {
+      id: 0,
+      isSatisfiedBy: () => true,
+      moduleId: 1,
+      serviceIdentifier: Symbol(),
+      targetServiceIdentifier: Symbol(),
+      type: bindingTypeValues.ServiceRedirection,
+    };
+  });
+
+  describe('when called', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      result = cloneServiceRedirectionBinding(serviceRedirectionBindingFixture);
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should return a ServiceRedirectionBinding', () => {
+      const expected: ServiceRedirectionBinding<unknown> = {
+        id: serviceRedirectionBindingFixture.id,
+        isSatisfiedBy: serviceRedirectionBindingFixture.isSatisfiedBy,
+        moduleId: serviceRedirectionBindingFixture.moduleId,
+        serviceIdentifier: serviceRedirectionBindingFixture.serviceIdentifier,
+        targetServiceIdentifier:
+          serviceRedirectionBindingFixture.targetServiceIdentifier,
+        type: serviceRedirectionBindingFixture.type,
+      };
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/container/libraries/core/src/binding/calculations/cloneServiceRedirectionBinding.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneServiceRedirectionBinding.ts
@@ -1,0 +1,17 @@
+import { ServiceRedirectionBinding } from '../models/ServiceRedirectionBinding';
+
+/**
+ * Clones a ServiceRedirectionBinding
+ */
+export function cloneServiceRedirectionBinding<TActivated>(
+  binding: ServiceRedirectionBinding<TActivated>,
+): ServiceRedirectionBinding<TActivated> {
+  return {
+    id: binding.id,
+    isSatisfiedBy: binding.isSatisfiedBy,
+    moduleId: binding.moduleId,
+    serviceIdentifier: binding.serviceIdentifier,
+    targetServiceIdentifier: binding.targetServiceIdentifier,
+    type: binding.type,
+  };
+}

--- a/packages/container/libraries/core/src/binding/models/BaseBinding.ts
+++ b/packages/container/libraries/core/src/binding/models/BaseBinding.ts
@@ -9,5 +9,5 @@ export interface BaseBinding<TType extends BindingType, TActivated> {
   readonly serviceIdentifier: ServiceIdentifier<TActivated>;
   readonly type: TType;
 
-  isSatisfiedBy(constraints: BindingConstraints): boolean;
+  readonly isSatisfiedBy: (constraints: BindingConstraints) => boolean;
 }

--- a/packages/container/libraries/core/src/binding/services/BindingService.ts
+++ b/packages/container/libraries/core/src/binding/services/BindingService.ts
@@ -1,7 +1,11 @@
 import { ServiceIdentifier } from '@inversifyjs/common';
 
 import { Cloneable } from '../../common/models/Cloneable';
-import { OneToManyMapStar } from '../../common/models/OneToManyMapStar';
+import {
+  OneToManyMapStar,
+  OneToManyMapStartSpec,
+} from '../../common/models/OneToManyMapStar';
+import { cloneBinding } from '../calculations/cloneBinding';
 import { Binding } from '../models/Binding';
 
 enum BindingRelationKind {
@@ -16,17 +20,32 @@ export interface BindingRelation {
   [BindingRelationKind.serviceId]: ServiceIdentifier;
 }
 
+export class OneToManyBindingMapStar extends OneToManyMapStar<
+  Binding<unknown>,
+  BindingRelation
+> {
+  protected override _buildNewInstance(
+    spec: OneToManyMapStartSpec<BindingRelation>,
+  ): this {
+    return new OneToManyBindingMapStar(spec) as this;
+  }
+
+  protected override _cloneModel(model: Binding<unknown>): Binding<unknown> {
+    return cloneBinding(model);
+  }
+}
+
 export class BindingService implements Cloneable<BindingService> {
-  readonly #bindingMaps: OneToManyMapStar<Binding<unknown>, BindingRelation>;
+  readonly #bindingMaps: OneToManyBindingMapStar;
   readonly #parent: BindingService | undefined;
 
   private constructor(
     parent: BindingService | undefined,
-    bindingMaps?: OneToManyMapStar<Binding<unknown>, BindingRelation>,
+    bindingMaps?: OneToManyBindingMapStar,
   ) {
     this.#bindingMaps =
       bindingMaps ??
-      new OneToManyMapStar<Binding<unknown>, BindingRelation>({
+      new OneToManyBindingMapStar({
         id: {
           isOptional: false,
         },


### PR DESCRIPTION
### Added
- Added `cloneBinding`.
- Added `cloneServiceRedirectionBinding`.
- Added `cloneResolvedValueBinding`.
- Added `cloneProviderBinding`.
- Added `cloneInstanceBinding`.
- Added `cloneFactoryBinding`.
- Added `cloneDynamicValueBinding`.

### Changed
- Updated `BaseBinding.isSatisfiedBy` to be a property.
- Updated `ServiceBinding.clone` to properly clone bindings.

### Context
Related to inversify/InversifyJS#1806.