### PR TITLE
fix(core): fix child container memory leak (with caveat)

### DIFF
--- a/.changeset/eager-drinks-behave.md
+++ b/.changeset/eager-drinks-behave.md
@@ -1,0 +1,7 @@
+---
+"@inversifyjs/core": patch
+---
+
+Fixed child container memory leak in most cases
+
+Provided that there is a [job](https://tc39.es/ecma262/multipage/executable-code-and-execution-contexts.html#job) in the event loop after constructing a child container, its cache service will eventually be garbage collected along with the child container itself, rather than persisting until the parent container's garbage collection.


### PR DESCRIPTION
As suggested by https://github.com/inversify/monorepo/pull/715#discussion_r2102220927, this PR resolves memory leaks from child containers by storing child cache service subscriptions to the parent cache service using `WeakRef`.

This should fix memory leaks in real world applications which most likely involve [different jobs running in the JS event loop](https://tc39.es/ecma262/multipage/executable-code-and-execution-contexts.html#job) between child container instantiations. However, it is still possible for the process to run out of memory in the pathological case where there are no other jobs or not enough jobs between child container instantiations. This is because `WeakRef` imposes a constraint on its target, [preventing it from being garbage collected until a subsequent turn of the event loop](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef#notes_on_weakrefs).

Fixes https://github.com/inversify/InversifyJS/issues/1810

## Test script template

The below script contains comments of the form `// await job() // (N)` to indicate positions where we can force a job into the event loop and test how that affects memory usage.

This script should be run with `node --expose-gc` to allow it to force garbage collection at specific points.

```ts
const { Container } = require('inversify')
const { setTimeout } = require('node:timers/promises')

const logMemoryUsage = msg => {
  gc()
  console.log(msg, Math.round(process.memoryUsage().heapUsed / 1e6), 'MB')
}

const job = () => setTimeout(0)

;(async () => {
  // New scope so we can log memory usage after GC'ing the container.
  await (async () => {
    const container = new Container()
    const leak = async () => {
      const child = new Container({ parent: container })
      // await job() // (1)
    }

    logMemoryUsage('start:')
    for (let i = 0; i < 100_000; ++i) {
      await leak()
    }
    // await job() // (2)
    logMemoryUsage('after loop GC:')
  })()

  // await job() // (3)
  logMemoryUsage('after container GC:')
})()
```

## Results

For comparison, the last known good version (inversify@7.0.0-alpha.1) has no memory leaks:

| Start | After loop GC | After container GC |
| ----- | ------------- | ------------------ |
| 4 MB  | 4 MB          | 4 MB               |

The current latest version (inversify@7.5.1) has the same leak regardless of where we insert `await job()`:

| Start | After loop GC | After container GC |
| ----- | ------------- | ------------------ |
| 4 MB  | 342 MB        | 4 MB               |

The results for this PR are tabulated below:

| `await job()` position  | Start | After loop GC | After container GC |
| ----------------------- | ----- | ------------- | ------------------ |
| Within loop (1)         | 4 MB  | 8 MB          | 4 MB               |
| Before loop GC (2)      | 4 MB  | 9 MB          | 4 MB               |
| Before container GC (3) | 4 MB  | 348 MB        | 4 MB               |
| N/A                     | 4 MB  | 348 MB        | 344 MB             |

Despite the similarity between cases (1) and (2), all cases but (1) may lead to out-of-memory errors; running case (2) with `--max-old-space-size=200` causes it to crash because the child `PlanResultCacheService` instances cannot be garbage collected until `await job() // (2)` runs, meaning that the loop would require 348 MB of memory like the other cases. (This also explains the discrepancy in the "after loop GC" values between cases (1) and (2), as only case (1) resizes the `#subscribers` array.)

The case with no extra jobs (N/A) is especially interesting to compare against the current latest version. It performs _worse_ due to the constraints imposed by `WeakRef`. To reiterate, this is unlikely to cause problems in the real world, since useful applications tend to require additional jobs in the event loop (I assume).

With these caveats in mind, I'd like to hear the maintainers' thoughts on whether this is an acceptable solution to the memory leak problem.