### PR TITLE
Update reflect metadata utils with property param

### DIFF
--- a/.changeset/happy-dodos-cross.md
+++ b/.changeset/happy-dodos-cross.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/reflect-metadata-utils": minor
+---
+
+Updated API functions with optional propertyKey param

--- a/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/getOwnReflectMetadata.spec.ts
+++ b/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/getOwnReflectMetadata.spec.ts
@@ -1,45 +1,120 @@
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import 'reflect-metadata';
 
 import { getOwnReflectMetadata } from './getOwnReflectMetadata';
 
 describe(getOwnReflectMetadata.name, () => {
-  describe('when called, and no metadata is registered', () => {
-    let result: unknown;
+  describe('having no property key', () => {
+    let metadataKeyFixture: unknown;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    let targetFixture: Function;
 
     beforeAll(() => {
-      result = getOwnReflectMetadata(class {}, 'sample-key');
+      metadataKeyFixture = 'sample-key';
+      targetFixture = class {};
     });
 
-    it('should return undefined', () => {
-      expect(result).toBeUndefined();
+    describe('when called, and no metadata is registered', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = getOwnReflectMetadata(targetFixture, metadataKeyFixture);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when called, and metadata is registered', () => {
+      let result: unknown;
+
+      let metadataFixture: unknown;
+
+      beforeAll(() => {
+        metadataFixture = 'sample-metadata';
+
+        Reflect.defineMetadata(
+          metadataKeyFixture,
+          metadataFixture,
+          targetFixture,
+        );
+
+        result = getOwnReflectMetadata(targetFixture, metadataKeyFixture);
+      });
+
+      afterAll(() => {
+        Reflect.deleteMetadata(metadataKeyFixture, targetFixture);
+      });
+
+      it('should return metadata', () => {
+        expect(result).toBe(metadataFixture);
+      });
     });
   });
 
-  describe('when called, and metadata is registered', () => {
-    let result: unknown;
-
-    let metadataFixture: unknown;
+  describe('having property key', () => {
+    let metadataKeyFixture: unknown;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    let targetFixture: Function;
+    let propertyKeyFixture: string | symbol;
 
     beforeAll(() => {
-      metadataFixture = 'sample-metadata';
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-      const targetFixture: Function = class {};
-      const metadataKeyFixture: unknown = 'sample-key';
-
-      Reflect.defineMetadata(
-        metadataKeyFixture,
-        metadataFixture,
-        targetFixture,
-      );
-
-      result = getOwnReflectMetadata(targetFixture, metadataKeyFixture);
+      metadataKeyFixture = 'sample-key';
+      targetFixture = class {};
+      propertyKeyFixture = Symbol();
     });
 
-    it('should return metadata', () => {
-      expect(result).toBe(metadataFixture);
+    describe('when called, and no metadata is registered', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = getOwnReflectMetadata(
+          targetFixture,
+          metadataKeyFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when called, and metadata is registered', () => {
+      let result: unknown;
+
+      let metadataFixture: unknown;
+
+      beforeAll(() => {
+        metadataFixture = 'sample-metadata';
+
+        Reflect.defineMetadata(
+          metadataKeyFixture,
+          metadataFixture,
+          targetFixture,
+          propertyKeyFixture,
+        );
+
+        result = getOwnReflectMetadata(
+          targetFixture,
+          metadataKeyFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      afterAll(() => {
+        Reflect.deleteMetadata(
+          metadataKeyFixture,
+          targetFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      it('should return metadata', () => {
+        expect(result).toBe(metadataFixture);
+      });
     });
   });
 });

--- a/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/getOwnReflectMetadata.ts
+++ b/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/getOwnReflectMetadata.ts
@@ -2,6 +2,9 @@
 export function getOwnReflectMetadata<TMetadata>(
   target: object,
   metadataKey: unknown,
+  propertyKey?: string | symbol,
 ): TMetadata | undefined {
-  return Reflect.getOwnMetadata(metadataKey, target) as TMetadata | undefined;
+  return Reflect.getOwnMetadata(metadataKey, target, propertyKey) as
+    | TMetadata
+    | undefined;
 }

--- a/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/getReflectMetadata.spec.ts
+++ b/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/getReflectMetadata.spec.ts
@@ -1,45 +1,120 @@
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import 'reflect-metadata';
 
 import { getReflectMetadata } from './getReflectMetadata';
 
 describe(getReflectMetadata.name, () => {
-  describe('when called, and no metadata is registered', () => {
-    let result: unknown;
+  describe('having no property key', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    let targetFixture: Function;
+    let metadataKeyFixture: unknown;
 
     beforeAll(() => {
-      result = getReflectMetadata(class {}, 'sample-key');
+      targetFixture = class {};
+      metadataKeyFixture = 'sample-key';
     });
 
-    it('should return undefined', () => {
-      expect(result).toBeUndefined();
+    describe('when called, and no metadata is registered', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = getReflectMetadata(targetFixture, metadataKeyFixture);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when called, and metadata is registered', () => {
+      let result: unknown;
+
+      let metadataFixture: unknown;
+
+      beforeAll(() => {
+        metadataFixture = 'sample-metadata';
+
+        Reflect.defineMetadata(
+          metadataKeyFixture,
+          metadataFixture,
+          targetFixture,
+        );
+
+        result = getReflectMetadata(targetFixture, metadataKeyFixture);
+      });
+
+      afterAll(() => {
+        Reflect.deleteMetadata(metadataKeyFixture, targetFixture);
+      });
+
+      it('should return metadata', () => {
+        expect(result).toBe(metadataFixture);
+      });
     });
   });
 
-  describe('when called, and metadata is registered', () => {
-    let result: unknown;
-
-    let metadataFixture: unknown;
+  describe('having property key', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    let targetFixture: Function;
+    let metadataKeyFixture: unknown;
+    let propertyKeyFixture: string | symbol;
 
     beforeAll(() => {
-      metadataFixture = 'sample-metadata';
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-      const targetFixture: Function = class {};
-      const metadataKeyFixture: unknown = 'sample-key';
-
-      Reflect.defineMetadata(
-        metadataKeyFixture,
-        metadataFixture,
-        targetFixture,
-      );
-
-      result = getReflectMetadata(targetFixture, metadataKeyFixture);
+      targetFixture = class {};
+      metadataKeyFixture = 'sample-key';
+      propertyKeyFixture = Symbol();
     });
 
-    it('should return metadata', () => {
-      expect(result).toBe(metadataFixture);
+    describe('when called, and no metadata is registered', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = getReflectMetadata(
+          targetFixture,
+          metadataKeyFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when called, and metadata is registered', () => {
+      let result: unknown;
+
+      let metadataFixture: unknown;
+
+      beforeAll(() => {
+        metadataFixture = 'sample-metadata';
+
+        Reflect.defineMetadata(
+          metadataKeyFixture,
+          metadataFixture,
+          targetFixture,
+          propertyKeyFixture,
+        );
+
+        result = getReflectMetadata(
+          targetFixture,
+          metadataKeyFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      afterAll(() => {
+        Reflect.deleteMetadata(
+          metadataKeyFixture,
+          targetFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      it('should return metadata', () => {
+        expect(result).toBe(metadataFixture);
+      });
     });
   });
 });

--- a/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/getReflectMetadata.ts
+++ b/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/getReflectMetadata.ts
@@ -2,6 +2,9 @@
 export function getReflectMetadata<TMetadata>(
   target: object,
   metadataKey: unknown,
+  propertyKey?: string | symbol,
 ): TMetadata | undefined {
-  return Reflect.getMetadata(metadataKey, target) as TMetadata | undefined;
+  return Reflect.getMetadata(metadataKey, target, propertyKey) as
+    | TMetadata
+    | undefined;
 }

--- a/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/setReflectMetadata.spec.ts
+++ b/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/setReflectMetadata.spec.ts
@@ -1,45 +1,103 @@
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import 'reflect-metadata';
 
 import { setReflectMetadata } from './setReflectMetadata';
 
 describe(setReflectMetadata.name, () => {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  let targetFixture: Function;
-  let metadataKeyFixture: unknown;
-  let metadataFixture: unknown;
-
-  beforeAll(() => {
-    targetFixture = class {};
-    metadataKeyFixture = 'sample-key';
-    metadataFixture = 'metadata';
-  });
-
-  describe('when called', () => {
-    let reflectMetadata: unknown;
-    let result: unknown;
+  describe('having no property key', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    let targetFixture: Function;
+    let metadataKeyFixture: unknown;
+    let metadataFixture: unknown;
 
     beforeAll(() => {
+      targetFixture = class {};
+      metadataKeyFixture = 'sample-key';
       metadataFixture = 'metadata';
-      result = setReflectMetadata(
-        targetFixture,
-        metadataKeyFixture,
-        metadataFixture,
-      );
-
-      reflectMetadata = Reflect.getOwnMetadata(
-        metadataKeyFixture,
-        targetFixture,
-      );
     });
 
-    it('should set metadata', () => {
-      expect(reflectMetadata).toBe(metadataFixture);
+    describe('when called', () => {
+      let reflectMetadata: unknown;
+      let result: unknown;
+
+      beforeAll(() => {
+        metadataFixture = 'metadata';
+        result = setReflectMetadata(
+          targetFixture,
+          metadataKeyFixture,
+          metadataFixture,
+        );
+
+        reflectMetadata = Reflect.getOwnMetadata(
+          metadataKeyFixture,
+          targetFixture,
+        );
+      });
+
+      afterAll(() => {
+        Reflect.deleteMetadata(metadataKeyFixture, targetFixture);
+      });
+
+      it('should set metadata', () => {
+        expect(reflectMetadata).toBe(metadataFixture);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having property key', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    let targetFixture: Function;
+    let metadataKeyFixture: unknown;
+    let metadataFixture: unknown;
+    let propertyKeyFixture: string | symbol;
+
+    beforeAll(() => {
+      targetFixture = class {};
+      metadataKeyFixture = 'sample-key';
+      metadataFixture = 'metadata';
+      propertyKeyFixture = Symbol();
     });
 
-    it('should return undefined', () => {
-      expect(result).toBeUndefined();
+    describe('when called', () => {
+      let reflectMetadata: unknown;
+      let result: unknown;
+
+      beforeAll(() => {
+        metadataFixture = 'metadata';
+        result = setReflectMetadata(
+          targetFixture,
+          metadataKeyFixture,
+          metadataFixture,
+          propertyKeyFixture,
+        );
+
+        reflectMetadata = Reflect.getOwnMetadata(
+          metadataKeyFixture,
+          targetFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      afterAll(() => {
+        Reflect.deleteMetadata(
+          metadataKeyFixture,
+          targetFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      it('should set metadata', () => {
+        expect(reflectMetadata).toBe(metadataFixture);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
     });
   });
 });

--- a/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/setReflectMetadata.ts
+++ b/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/setReflectMetadata.ts
@@ -2,6 +2,7 @@ export function setReflectMetadata(
   target: object,
   metadataKey: unknown,
   metadata: unknown,
+  propertyKey?: string | symbol,
 ): void {
-  Reflect.defineMetadata(metadataKey, metadata, target);
+  Reflect.defineMetadata(metadataKey, metadata, target, propertyKey);
 }

--- a/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/updateOwnReflectMetadata.spec.ts
+++ b/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/updateOwnReflectMetadata.spec.ts
@@ -16,122 +16,264 @@ import { getOwnReflectMetadata } from './getOwnReflectMetadata';
 import { updateOwnReflectMetadata } from './updateOwnReflectMetadata';
 
 describe(updateOwnReflectMetadata.name, () => {
-  describe('when called, and getOwnReflectMetadata returns undefined', () => {
+  describe('having no property key', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
     let targetFixture: Function;
     let metadataKeyFixture: unknown;
     let buildDefaultValueMock: Mock<() => unknown>;
-    let defaultValueFixture: unknown;
     let callbackMock: Mock<(value: unknown) => unknown>;
-    let reflectMetadata: unknown;
 
     beforeAll(() => {
       targetFixture = class {};
-      defaultValueFixture = 'default-value';
       metadataKeyFixture = 'sample-key';
-      buildDefaultValueMock = vitest.fn(() => defaultValueFixture);
-      callbackMock = vitest
-        .fn<(value: unknown) => unknown>()
-        .mockImplementationOnce((value: unknown) => value);
-
-      vitest.mocked(getOwnReflectMetadata).mockReturnValueOnce(undefined);
-
-      updateOwnReflectMetadata(
-        targetFixture,
-        metadataKeyFixture,
-        buildDefaultValueMock,
-        callbackMock,
-      );
-
-      reflectMetadata = Reflect.getOwnMetadata(
-        metadataKeyFixture,
-        targetFixture,
-      );
+      buildDefaultValueMock = vitest.fn();
+      callbackMock = vitest.fn<(value: unknown) => unknown>();
     });
 
-    afterAll(() => {
-      vitest.clearAllMocks();
+    describe('when called, and getOwnReflectMetadata returns undefined', () => {
+      let defaultValueFixture: unknown;
+      let reflectMetadata: unknown;
+
+      beforeAll(() => {
+        defaultValueFixture = 'default-value';
+        buildDefaultValueMock.mockReturnValueOnce(defaultValueFixture);
+        callbackMock.mockImplementationOnce((value: unknown) => value);
+
+        vitest.mocked(getOwnReflectMetadata).mockReturnValueOnce(undefined);
+
+        updateOwnReflectMetadata(
+          targetFixture,
+          metadataKeyFixture,
+          buildDefaultValueMock,
+          callbackMock,
+        );
+
+        reflectMetadata = Reflect.getOwnMetadata(
+          metadataKeyFixture,
+          targetFixture,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+
+        Reflect.deleteMetadata(metadataKeyFixture, targetFixture);
+      });
+
+      it('should call getOwnReflectMetadata()', () => {
+        expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
+        expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+          targetFixture,
+          metadataKeyFixture,
+          undefined,
+        );
+      });
+
+      it('should call buildDefaultValue', () => {
+        expect(buildDefaultValueMock).toHaveBeenCalledTimes(1);
+        expect(buildDefaultValueMock).toHaveBeenCalledWith();
+      });
+
+      it('should call callback()', () => {
+        expect(callbackMock).toHaveBeenCalledTimes(1);
+        expect(callbackMock).toHaveBeenCalledWith(defaultValueFixture);
+      });
+
+      it('should define metadata', () => {
+        expect(reflectMetadata).toBe(defaultValueFixture);
+      });
     });
 
-    it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
-        targetFixture,
-        metadataKeyFixture,
-      );
-    });
+    describe('when called, and getOwnReflectMetadata returns metadata', () => {
+      let metadataFixture: unknown;
+      let reflectMetadata: unknown;
 
-    it('should call buildDefaultValue', () => {
-      expect(buildDefaultValueMock).toHaveBeenCalledTimes(1);
-      expect(buildDefaultValueMock).toHaveBeenCalledWith();
-    });
+      beforeAll(() => {
+        metadataFixture = 'metadata';
+        callbackMock.mockImplementationOnce((value: unknown) => value);
 
-    it('should call callback()', () => {
-      expect(callbackMock).toHaveBeenCalledTimes(1);
-      expect(callbackMock).toHaveBeenCalledWith(defaultValueFixture);
-    });
+        vitest
+          .mocked(getOwnReflectMetadata)
+          .mockReturnValueOnce(metadataFixture);
 
-    it('should define metadata', () => {
-      expect(reflectMetadata).toBe(defaultValueFixture);
+        updateOwnReflectMetadata(
+          targetFixture,
+          metadataKeyFixture,
+          buildDefaultValueMock,
+          callbackMock,
+        );
+
+        reflectMetadata = Reflect.getOwnMetadata(
+          metadataKeyFixture,
+          targetFixture,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+
+        Reflect.deleteMetadata(metadataKeyFixture, targetFixture);
+      });
+
+      it('should call getOwnReflectMetadata()', () => {
+        expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
+        expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+          targetFixture,
+          metadataKeyFixture,
+          undefined,
+        );
+      });
+
+      it('should not call buildDefaultValue()', () => {
+        expect(buildDefaultValueMock).not.toHaveBeenCalled();
+      });
+
+      it('should call callback()', () => {
+        expect(callbackMock).toHaveBeenCalledTimes(1);
+        expect(callbackMock).toHaveBeenCalledWith(metadataFixture);
+      });
+
+      it('should define metadata', () => {
+        expect(reflectMetadata).toBe(metadataFixture);
+      });
     });
   });
 
-  describe('when called, and getOwnReflectMetadata returns metadata', () => {
+  describe('having property key', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
     let targetFixture: Function;
-    let metadataFixture: unknown;
     let metadataKeyFixture: unknown;
     let buildDefaultValueMock: Mock<() => unknown>;
     let callbackMock: Mock<(value: unknown) => unknown>;
-    let reflectMetadata: unknown;
+    let propertyKeyFixture: string | symbol;
 
     beforeAll(() => {
       targetFixture = class {};
-      metadataFixture = 'metadata';
       metadataKeyFixture = 'sample-key';
       buildDefaultValueMock = vitest.fn();
-      callbackMock = vitest
-        .fn<(value: unknown) => unknown>()
-        .mockImplementationOnce((value: unknown) => value);
-
-      vitest.mocked(getOwnReflectMetadata).mockReturnValueOnce(metadataFixture);
-
-      updateOwnReflectMetadata(
-        targetFixture,
-        metadataKeyFixture,
-        buildDefaultValueMock,
-        callbackMock,
-      );
-
-      reflectMetadata = Reflect.getOwnMetadata(
-        metadataKeyFixture,
-        targetFixture,
-      );
+      callbackMock = vitest.fn<(value: unknown) => unknown>();
+      propertyKeyFixture = Symbol();
     });
 
-    afterAll(() => {
-      vitest.clearAllMocks();
+    describe('when called, and getOwnReflectMetadata() returns undefined', () => {
+      let defaultValueFixture: unknown;
+      let reflectMetadata: unknown;
+
+      beforeAll(() => {
+        defaultValueFixture = 'default-value';
+        buildDefaultValueMock.mockReturnValueOnce(defaultValueFixture);
+        callbackMock.mockImplementationOnce((value: unknown) => value);
+
+        vitest.mocked(getOwnReflectMetadata).mockReturnValueOnce(undefined);
+
+        updateOwnReflectMetadata(
+          targetFixture,
+          metadataKeyFixture,
+          buildDefaultValueMock,
+          callbackMock,
+          propertyKeyFixture,
+        );
+
+        reflectMetadata = Reflect.getOwnMetadata(
+          metadataKeyFixture,
+          targetFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+
+        Reflect.deleteMetadata(
+          metadataKeyFixture,
+          targetFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      it('should call getOwnReflectMetadata()', () => {
+        expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
+        expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+          targetFixture,
+          metadataKeyFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      it('should call buildDefaultValue', () => {
+        expect(buildDefaultValueMock).toHaveBeenCalledTimes(1);
+        expect(buildDefaultValueMock).toHaveBeenCalledWith();
+      });
+
+      it('should call callback()', () => {
+        expect(callbackMock).toHaveBeenCalledTimes(1);
+        expect(callbackMock).toHaveBeenCalledWith(defaultValueFixture);
+      });
+
+      it('should define metadata', () => {
+        expect(reflectMetadata).toBe(defaultValueFixture);
+      });
     });
 
-    it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
-        targetFixture,
-        metadataKeyFixture,
-      );
-    });
+    describe('when called, and getOwnReflectMetadata returns metadata', () => {
+      let metadataFixture: unknown;
+      let reflectMetadata: unknown;
 
-    it('should not call buildDefaultValue()', () => {
-      expect(buildDefaultValueMock).not.toHaveBeenCalled();
-    });
+      beforeAll(() => {
+        metadataFixture = 'metadata';
 
-    it('should call callback()', () => {
-      expect(callbackMock).toHaveBeenCalledTimes(1);
-      expect(callbackMock).toHaveBeenCalledWith(metadataFixture);
-    });
+        callbackMock.mockImplementationOnce((value: unknown) => value);
 
-    it('should define metadata', () => {
-      expect(reflectMetadata).toBe(metadataFixture);
+        vitest
+          .mocked(getOwnReflectMetadata)
+          .mockReturnValueOnce(metadataFixture);
+
+        updateOwnReflectMetadata(
+          targetFixture,
+          metadataKeyFixture,
+          buildDefaultValueMock,
+          callbackMock,
+          propertyKeyFixture,
+        );
+
+        reflectMetadata = Reflect.getOwnMetadata(
+          metadataKeyFixture,
+          targetFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+
+        Reflect.deleteMetadata(
+          metadataKeyFixture,
+          targetFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      it('should call getOwnReflectMetadata()', () => {
+        expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
+        expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+          targetFixture,
+          metadataKeyFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      it('should not call buildDefaultValue()', () => {
+        expect(buildDefaultValueMock).not.toHaveBeenCalled();
+      });
+
+      it('should call callback()', () => {
+        expect(callbackMock).toHaveBeenCalledTimes(1);
+        expect(callbackMock).toHaveBeenCalledWith(metadataFixture);
+      });
+
+      it('should define metadata', () => {
+        expect(reflectMetadata).toBe(metadataFixture);
+      });
     });
   });
 });

--- a/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/updateOwnReflectMetadata.ts
+++ b/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/updateOwnReflectMetadata.ts
@@ -5,11 +5,13 @@ export function updateOwnReflectMetadata<TMetadata>(
   metadataKey: unknown,
   buildDefaultValue: () => TMetadata,
   callback: (metadata: TMetadata) => TMetadata,
+  propertyKey?: string | symbol,
 ): void {
   const metadata: TMetadata =
-    getOwnReflectMetadata(target, metadataKey) ?? buildDefaultValue();
+    getOwnReflectMetadata(target, metadataKey, propertyKey) ??
+    buildDefaultValue();
 
   const updatedMetadata: TMetadata = callback(metadata);
 
-  Reflect.defineMetadata(metadataKey, updatedMetadata, target);
+  Reflect.defineMetadata(metadataKey, updatedMetadata, target, propertyKey);
 }

--- a/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/updateReflectMetadata.spec.ts
+++ b/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/updateReflectMetadata.spec.ts
@@ -16,122 +16,253 @@ import { getReflectMetadata } from './getReflectMetadata';
 import { updateReflectMetadata } from './updateReflectMetadata';
 
 describe(updateReflectMetadata.name, () => {
-  describe('when called, and getReflectMetadata returns undefined', () => {
+  describe('having no property key', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
     let targetFixture: Function;
     let metadataKeyFixture: unknown;
     let buildDefaultValueMock: Mock<() => unknown>;
-    let defaultValueFixture: unknown;
     let callbackMock: Mock<(value: unknown) => unknown>;
-    let reflectMetadata: unknown;
 
     beforeAll(() => {
       targetFixture = class {};
-      defaultValueFixture = 'default-value';
       metadataKeyFixture = 'sample-key';
-      buildDefaultValueMock = vitest.fn(() => defaultValueFixture);
-      callbackMock = vitest
-        .fn<(value: unknown) => unknown>()
-        .mockImplementationOnce((value: unknown) => value);
-
-      vitest.mocked(getReflectMetadata).mockReturnValueOnce(undefined);
-
-      updateReflectMetadata(
-        targetFixture,
-        metadataKeyFixture,
-        buildDefaultValueMock,
-        callbackMock,
-      );
-
-      reflectMetadata = Reflect.getOwnMetadata(
-        metadataKeyFixture,
-        targetFixture,
-      );
+      buildDefaultValueMock = vitest.fn();
+      callbackMock = vitest.fn();
     });
 
-    afterAll(() => {
-      vitest.clearAllMocks();
+    describe('when called, and getReflectMetadata returns undefined', () => {
+      let defaultValueFixture: unknown;
+      let reflectMetadata: unknown;
+
+      beforeAll(() => {
+        defaultValueFixture = 'default-value';
+        buildDefaultValueMock.mockReturnValueOnce(defaultValueFixture);
+        callbackMock.mockImplementationOnce((value: unknown) => value);
+
+        vitest.mocked(getReflectMetadata).mockReturnValueOnce(undefined);
+
+        updateReflectMetadata(
+          targetFixture,
+          metadataKeyFixture,
+          buildDefaultValueMock,
+          callbackMock,
+        );
+
+        reflectMetadata = Reflect.getOwnMetadata(
+          metadataKeyFixture,
+          targetFixture,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call getReflectMetadata()', () => {
+        expect(getReflectMetadata).toHaveBeenCalledTimes(1);
+        expect(getReflectMetadata).toHaveBeenCalledWith(
+          targetFixture,
+          metadataKeyFixture,
+          undefined,
+        );
+      });
+
+      it('should call buildDefaultValue', () => {
+        expect(buildDefaultValueMock).toHaveBeenCalledTimes(1);
+        expect(buildDefaultValueMock).toHaveBeenCalledWith();
+      });
+
+      it('should call callback()', () => {
+        expect(callbackMock).toHaveBeenCalledTimes(1);
+        expect(callbackMock).toHaveBeenCalledWith(defaultValueFixture);
+      });
+
+      it('should define metadata', () => {
+        expect(reflectMetadata).toBe(defaultValueFixture);
+      });
     });
 
-    it('should call getReflectMetadata()', () => {
-      expect(getReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getReflectMetadata).toHaveBeenCalledWith(
-        targetFixture,
-        metadataKeyFixture,
-      );
-    });
+    describe('when called, and getReflectMetadata returns metadata', () => {
+      let metadataFixture: unknown;
+      let reflectMetadata: unknown;
 
-    it('should call buildDefaultValue', () => {
-      expect(buildDefaultValueMock).toHaveBeenCalledTimes(1);
-      expect(buildDefaultValueMock).toHaveBeenCalledWith();
-    });
+      beforeAll(() => {
+        metadataFixture = 'metadata';
 
-    it('should call callback()', () => {
-      expect(callbackMock).toHaveBeenCalledTimes(1);
-      expect(callbackMock).toHaveBeenCalledWith(defaultValueFixture);
-    });
+        vitest.mocked(getReflectMetadata).mockReturnValueOnce(metadataFixture);
 
-    it('should define metadata', () => {
-      expect(reflectMetadata).toBe(defaultValueFixture);
+        callbackMock.mockImplementationOnce((value: unknown) => value);
+
+        updateReflectMetadata(
+          targetFixture,
+          metadataKeyFixture,
+          buildDefaultValueMock,
+          callbackMock,
+        );
+
+        reflectMetadata = Reflect.getOwnMetadata(
+          metadataKeyFixture,
+          targetFixture,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+
+        Reflect.deleteMetadata(metadataKeyFixture, targetFixture);
+      });
+
+      it('should call getReflectMetadata()', () => {
+        expect(getReflectMetadata).toHaveBeenCalledTimes(1);
+        expect(getReflectMetadata).toHaveBeenCalledWith(
+          targetFixture,
+          metadataKeyFixture,
+          undefined,
+        );
+      });
+
+      it('should not call buildDefaultValue()', () => {
+        expect(buildDefaultValueMock).not.toHaveBeenCalled();
+      });
+
+      it('should call callback()', () => {
+        expect(callbackMock).toHaveBeenCalledTimes(1);
+        expect(callbackMock).toHaveBeenCalledWith(metadataFixture);
+      });
+
+      it('should define metadata', () => {
+        expect(reflectMetadata).toBe(metadataFixture);
+      });
     });
   });
 
-  describe('when called, and getReflectMetadata returns metadata', () => {
+  describe('having property key', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
     let targetFixture: Function;
-    let metadataFixture: unknown;
     let metadataKeyFixture: unknown;
     let buildDefaultValueMock: Mock<() => unknown>;
     let callbackMock: Mock<(value: unknown) => unknown>;
-    let reflectMetadata: unknown;
+    let propertyKeyFixture: string | symbol;
 
     beforeAll(() => {
       targetFixture = class {};
-      metadataFixture = 'metadata';
       metadataKeyFixture = 'sample-key';
       buildDefaultValueMock = vitest.fn();
-      callbackMock = vitest
-        .fn<(value: unknown) => unknown>()
-        .mockImplementationOnce((value: unknown) => value);
-
-      vitest.mocked(getReflectMetadata).mockReturnValueOnce(metadataFixture);
-
-      updateReflectMetadata(
-        targetFixture,
-        metadataKeyFixture,
-        buildDefaultValueMock,
-        callbackMock,
-      );
-
-      reflectMetadata = Reflect.getOwnMetadata(
-        metadataKeyFixture,
-        targetFixture,
-      );
+      callbackMock = vitest.fn();
+      propertyKeyFixture = Symbol();
     });
 
-    afterAll(() => {
-      vitest.clearAllMocks();
+    describe('when called, and getReflectMetadata returns undefined', () => {
+      let defaultValueFixture: unknown;
+      let reflectMetadata: unknown;
+
+      beforeAll(() => {
+        defaultValueFixture = 'default-value';
+        buildDefaultValueMock.mockReturnValueOnce(defaultValueFixture);
+        callbackMock.mockImplementationOnce((value: unknown) => value);
+
+        vitest.mocked(getReflectMetadata).mockReturnValueOnce(undefined);
+
+        updateReflectMetadata(
+          targetFixture,
+          metadataKeyFixture,
+          buildDefaultValueMock,
+          callbackMock,
+          propertyKeyFixture,
+        );
+
+        reflectMetadata = Reflect.getOwnMetadata(
+          metadataKeyFixture,
+          targetFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call getReflectMetadata()', () => {
+        expect(getReflectMetadata).toHaveBeenCalledTimes(1);
+        expect(getReflectMetadata).toHaveBeenCalledWith(
+          targetFixture,
+          metadataKeyFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      it('should call buildDefaultValue', () => {
+        expect(buildDefaultValueMock).toHaveBeenCalledTimes(1);
+        expect(buildDefaultValueMock).toHaveBeenCalledWith();
+      });
+
+      it('should call callback()', () => {
+        expect(callbackMock).toHaveBeenCalledTimes(1);
+        expect(callbackMock).toHaveBeenCalledWith(defaultValueFixture);
+      });
+
+      it('should define metadata', () => {
+        expect(reflectMetadata).toBe(defaultValueFixture);
+      });
     });
 
-    it('should call getReflectMetadata()', () => {
-      expect(getReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getReflectMetadata).toHaveBeenCalledWith(
-        targetFixture,
-        metadataKeyFixture,
-      );
-    });
+    describe('when called, and getReflectMetadata returns metadata', () => {
+      let metadataFixture: unknown;
+      let reflectMetadata: unknown;
 
-    it('should not call buildDefaultValue()', () => {
-      expect(buildDefaultValueMock).not.toHaveBeenCalled();
-    });
+      beforeAll(() => {
+        metadataFixture = 'metadata';
 
-    it('should call callback()', () => {
-      expect(callbackMock).toHaveBeenCalledTimes(1);
-      expect(callbackMock).toHaveBeenCalledWith(metadataFixture);
-    });
+        vitest.mocked(getReflectMetadata).mockReturnValueOnce(metadataFixture);
 
-    it('should define metadata', () => {
-      expect(reflectMetadata).toBe(metadataFixture);
+        callbackMock.mockImplementationOnce((value: unknown) => value);
+
+        updateReflectMetadata(
+          targetFixture,
+          metadataKeyFixture,
+          buildDefaultValueMock,
+          callbackMock,
+          propertyKeyFixture,
+        );
+
+        reflectMetadata = Reflect.getOwnMetadata(
+          metadataKeyFixture,
+          targetFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+
+        Reflect.deleteMetadata(
+          metadataKeyFixture,
+          targetFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      it('should call getReflectMetadata()', () => {
+        expect(getReflectMetadata).toHaveBeenCalledTimes(1);
+        expect(getReflectMetadata).toHaveBeenCalledWith(
+          targetFixture,
+          metadataKeyFixture,
+          propertyKeyFixture,
+        );
+      });
+
+      it('should not call buildDefaultValue()', () => {
+        expect(buildDefaultValueMock).not.toHaveBeenCalled();
+      });
+
+      it('should call callback()', () => {
+        expect(callbackMock).toHaveBeenCalledTimes(1);
+        expect(callbackMock).toHaveBeenCalledWith(metadataFixture);
+      });
+
+      it('should define metadata', () => {
+        expect(reflectMetadata).toBe(metadataFixture);
+      });
     });
   });
 });

--- a/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/updateReflectMetadata.ts
+++ b/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/updateReflectMetadata.ts
@@ -5,11 +5,12 @@ export function updateReflectMetadata<TMetadata>(
   metadataKey: unknown,
   buildDefaultValue: () => TMetadata,
   callback: (metadata: TMetadata) => TMetadata,
+  propertyKey?: string | symbol,
 ): void {
   const metadata: TMetadata =
-    getReflectMetadata(target, metadataKey) ?? buildDefaultValue();
+    getReflectMetadata(target, metadataKey, propertyKey) ?? buildDefaultValue();
 
   const updatedMetadata: TMetadata = callback(metadata);
 
-  Reflect.defineMetadata(metadataKey, updatedMetadata, target);
+  Reflect.defineMetadata(metadataKey, updatedMetadata, target, propertyKey);
 }

--- a/packages/foundation/libraries/reflect-metadata-utils/src/types/Reflect.d.ts
+++ b/packages/foundation/libraries/reflect-metadata-utils/src/types/Reflect.d.ts
@@ -1,1 +1,24 @@
 import 'reflect-metadata';
+
+declare global {
+  namespace Reflect {
+    function getMetadata(
+      metadataKey: unknown,
+      target: object,
+      propertyKey?: string | symbol,
+    ): unknown;
+
+    function getOwnMetadata(
+      metadataKey: unknown,
+      target: object,
+      propertyKey?: string | symbol,
+    ): unknown;
+
+    function defineMetadata(
+      metadataKey: unknown,
+      metadataValue: unknown,
+      target: object,
+      propertyKey?: string | symbol,
+    ): void;
+  }
+}


### PR DESCRIPTION
### Changed
- Update `updateOwnReflectMetadata` with `propertyKey`.
- Update `updateReflectMetadata` with `propertyKey`.
- Update `Reflect` internal typings with optional property key.
- Update `setReflectMetadata` with `propertyKey`.
- Update `getReflectMetadata` with `propertyKey`.
- Update `getOwnReflectMetadata` with `propertyKey`.