### PR TITLE
Add service identifier docs

### DIFF
--- a/packages/docs/services/inversify-site/docs/api/service-identifier.mdx
+++ b/packages/docs/services/inversify-site/docs/api/service-identifier.mdx
@@ -1,0 +1,69 @@
+---
+sidebar_position: 6
+title: ServiceIdentifier
+---
+import CodeBlock from '@theme/CodeBlock';
+
+# ServiceIdentifier
+
+## Overview
+
+`ServiceIdentifier` is a fundamental type that identifies services within the InversifyJS dependency injection container. It serves as a key for registering, locating, and retrieving services, acting as a bridge between service registration and resolution.
+
+## Definition
+
+`ServiceIdentifier` is a union type that can be one of:
+
+```typescript
+type ServiceIdentifier<TInstance = unknown> =
+  | string
+  | symbol
+  | Newable<TInstance>
+  | Function;
+```
+
+Where `Newable` is defined as:
+
+```typescript
+type Newable<
+  TInstance = unknown,
+  TArgs extends unknown[] = any[],
+> = new (...args: TArgs) => TInstance;
+```
+
+## Usage
+
+`ServiceIdentifier` is used throughout the InversifyJS API for:
+
+1. **Service Registration**: Binding services to the container
+2. **Service Resolution**: Retrieving services from the container
+3. **Service Configuration**: Setting activation/deactivation handlers
+
+### Examples
+
+```typescript
+// Using a class as a service identifier (most common)
+container.bind(UserService).toSelf();
+
+// Using a string as a service identifier
+container.bind("IUserService").to(UserService);
+
+// Using a symbol as a service identifier
+const userServiceId: ServiceIdentifier<UserService> = Symbol("UserService");
+container.bind(userServiceId).to(UserService);
+
+// Resolving with a class identifier
+const firstUserService = container.get(UserService);
+
+// Resolving with a string identifier
+const secondUserService = container.get("IUserService");
+
+// Resolving with a symbol identifier
+const thirdUserService = container.get(userServiceId);
+```
+
+:::info[Type Inference support]
+
+When using generics with `ServiceIdentifier<T>`, TypeScript can infer the resolved type. In the example above, `thirdUserService` is automatically typed as `UserService` because `userServiceId` was defined as `ServiceIdentifier<UserService>`.
+
+:::

--- a/packages/docs/services/inversify-site/versioned_docs/version-6.x/api/service-identifier.mdx
+++ b/packages/docs/services/inversify-site/versioned_docs/version-6.x/api/service-identifier.mdx
@@ -1,0 +1,71 @@
+---
+sidebar_position: 6
+title: ServiceIdentifier
+---
+import CodeBlock from '@theme/CodeBlock';
+
+# ServiceIdentifier
+
+## Overview
+
+`ServiceIdentifier` is a fundamental type that identifies services within the InversifyJS dependency injection container. It serves as a key for registering, locating, and retrieving services, acting as a bridge between service registration and resolution.
+
+## Definition
+
+`ServiceIdentifier` is a union type that can be one of:
+
+```typescript
+type ServiceIdentifier<TInstance = unknown> =
+  | string
+  | symbol
+  | Newable<TInstance>
+  | Function;
+```
+
+Where `Newable` is defined as:
+
+```typescript
+type Newable<
+  TInstance = unknown,
+  TArgs extends unknown[] = any[],
+> = new (...args: TArgs) => TInstance;
+```
+
+## Usage
+
+`ServiceIdentifier` is used throughout the InversifyJS API for:
+
+1. **Service Registration**: Binding services to the container
+2. **Service Resolution**: Retrieving services from the container
+3. **Service Configuration**: Setting activation/deactivation handlers
+
+### Registration Examples
+
+```typescript
+// Using a class as a service identifier (most common)
+container.bind(UserService).toSelf();
+
+// Using a string as a service identifier
+container.bind("IUserService").to(UserService);
+
+// Using a symbol as a service identifier
+const userServiceId: interfaces.ServiceIdentifier<UserService> =
+  Symbol("UserService");
+
+container.bind(userServiceId).to(UserService);
+
+// Resolving with a class identifier
+const firstUserService = container.get(UserService);
+
+// Resolving with a string identifier
+const secondUserService = container.get("IUserService");
+
+// Resolving with a symbol identifier
+const thirdUserService = container.get(userServiceId);
+```
+
+:::info[Type Inference support]
+
+When using generics with `ServiceIdentifier<T>`, TypeScript can infer the resolved type. In the example above, `thirdUserService` is automatically typed as `UserService` because `userServiceId` was defined as `ServiceIdentifier<UserService>`.
+
+:::

--- a/packages/docs/services/inversify-site/versioned_docs/version-7.x/api/service-identifier.mdx
+++ b/packages/docs/services/inversify-site/versioned_docs/version-7.x/api/service-identifier.mdx
@@ -1,0 +1,69 @@
+---
+sidebar_position: 6
+title: ServiceIdentifier
+---
+import CodeBlock from '@theme/CodeBlock';
+
+# ServiceIdentifier
+
+## Overview
+
+`ServiceIdentifier` is a fundamental type that identifies services within the InversifyJS dependency injection container. It serves as a key for registering, locating, and retrieving services, acting as a bridge between service registration and resolution.
+
+## Definition
+
+`ServiceIdentifier` is a union type that can be one of:
+
+```typescript
+type ServiceIdentifier<TInstance = unknown> =
+  | string
+  | symbol
+  | Newable<TInstance>
+  | Function;
+```
+
+Where `Newable` is defined as:
+
+```typescript
+type Newable<
+  TInstance = unknown,
+  TArgs extends unknown[] = any[],
+> = new (...args: TArgs) => TInstance;
+```
+
+## Usage
+
+`ServiceIdentifier` is used throughout the InversifyJS API for:
+
+1. **Service Registration**: Binding services to the container
+2. **Service Resolution**: Retrieving services from the container
+3. **Service Configuration**: Setting activation/deactivation handlers
+
+### Registration Examples
+
+```typescript
+// Using a class as a service identifier (most common)
+container.bind(UserService).toSelf();
+
+// Using a string as a service identifier
+container.bind("IUserService").to(UserService);
+
+// Using a symbol as a service identifier
+const userServiceId: ServiceIdentifier<UserService> = Symbol("UserService");
+container.bind(userServiceId).to(UserService);
+
+// Resolving with a class identifier
+const firstUserService = container.get(UserService);
+
+// Resolving with a string identifier
+const secondUserService = container.get("IUserService");
+
+// Resolving with a symbol identifier
+const thirdUserService = container.get(userServiceId);
+```
+
+:::info[Type Inference support]
+
+When using generics with `ServiceIdentifier<T>`, TypeScript can infer the resolved type. In the example above, `thirdUserService` is automatically typed as `UserService` because `userServiceId` was defined as `ServiceIdentifier<UserService>`.
+
+:::

--- a/packages/docs/tools/inversify-code-examples/src/examples/dependencyInversion.ts
+++ b/packages/docs/tools/inversify-code-examples/src/examples/dependencyInversion.ts
@@ -1,11 +1,15 @@
 // Is-inversify-import-example
-import { Container, inject, injectable } from 'inversify';
+import { Container, inject, injectable, interfaces } from 'inversify';
 
 interface Weapon {
   damage: number;
 }
 
-const weaponServiceId: symbol = Symbol.for('WeaponServiceId');
+const ninjaServiceId: interfaces.ServiceIdentifier<Ninja> =
+  Symbol.for('NinjaServiceId');
+
+const weaponServiceId: interfaces.ServiceIdentifier<Weapon> =
+  Symbol.for('WeaponServiceId');
 
 @injectable()
 class Katana {
@@ -22,10 +26,10 @@ class Ninja {
 
 const container: Container = new Container();
 
-container.bind(Ninja).toSelf();
+container.bind(ninjaServiceId).to(Ninja);
 container.bind(weaponServiceId).to(Katana);
 
-const ninja: Ninja = container.get(Ninja);
+const ninja: Ninja = container.get(ninjaServiceId);
 
 console.log(ninja.weapon.damage); // Prints 10
 // End-example

--- a/packages/docs/tools/inversify-code-examples/src/examples/v7/dependencyInversion.ts
+++ b/packages/docs/tools/inversify-code-examples/src/examples/v7/dependencyInversion.ts
@@ -1,11 +1,14 @@
 // Is-inversify-import-example
-import { Container, inject, injectable } from 'inversify7';
+import { Container, inject, injectable, ServiceIdentifier } from 'inversify7';
 
 interface Weapon {
   damage: number;
 }
 
-const weaponServiceId: symbol = Symbol.for('WeaponServiceId');
+const ninjaServiceId: ServiceIdentifier<Ninja> = Symbol.for('NinjaServiceId');
+
+const weaponServiceId: ServiceIdentifier<Weapon> =
+  Symbol.for('WeaponServiceId');
 
 @injectable()
 class Katana {
@@ -22,10 +25,10 @@ class Ninja {
 
 const container: Container = new Container();
 
-container.bind(Ninja).toSelf();
+container.bind(ninjaServiceId).to(Ninja);
 container.bind(weaponServiceId).to(Katana);
 
-const ninja: Ninja = container.get(Ninja);
+const ninja: Ninja = container.get(ninjaServiceId);
 
 console.log(ninja.weapon.damage); // Prints 10
 // End-example


### PR DESCRIPTION
### Added
- Added `ServiceIdentifier` API docs.

### Changed
- Updated dependency injection examples to rely in `ServiceIdentifier`.

### Context
Related to inversify/InversifyJS#1822. This PR aims to improve current docs illustrating `ServiceIdentifier` use cases.