### PR TITLE
Remove ServiceIdentifier Function in favor of AbstractNewable

### DIFF
--- a/.changeset/add-abstract-newable-type.md
+++ b/.changeset/add-abstract-newable-type.md
@@ -1,0 +1,7 @@
+---
+"@inversifyjs/common": patch
+---
+
+Replace Function with AbstractNewable in ServiceIdentifier type
+
+ServiceIdentifier now uses AbstractNewable instead of Function to better represent abstract classes. This provides better type safety and semantics.

--- a/.changeset/nice-carpets-bow.md
+++ b/.changeset/nice-carpets-bow.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/container": patch
+---
+
+Updated `BindToFluentSyntaxImplementation` with better generic constraints

--- a/packages/container/libraries/common/src/index.ts
+++ b/packages/container/libraries/common/src/index.ts
@@ -1,10 +1,19 @@
 import { isPromise } from './common/calculations/isPromise';
 import { BaseEither, Either, Left, Right } from './either/models/Either';
 import { stringifyServiceIdentifier } from './services/calculations/stringifyServiceIdentifier';
+import { AbstractNewable } from './services/models/AbstractNewable';
 import { LazyServiceIdentifier } from './services/models/LazyServiceIdentifier';
 import { Newable } from './services/models/Newable';
 import { ServiceIdentifier } from './services/models/ServiceIdentifier';
 
-export type { BaseEither, Either, Left, Newable, Right, ServiceIdentifier };
+export type {
+  AbstractNewable,
+  BaseEither,
+  Either,
+  Left,
+  Newable,
+  Right,
+  ServiceIdentifier,
+};
 
 export { isPromise, LazyServiceIdentifier, stringifyServiceIdentifier };

--- a/packages/container/libraries/common/src/services/models/AbstractNewable.ts
+++ b/packages/container/libraries/common/src/services/models/AbstractNewable.ts
@@ -1,0 +1,5 @@
+export type AbstractNewable<
+  TInstance = unknown,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TArgs extends unknown[] = any[],
+> = abstract new (...args: TArgs) => TInstance;

--- a/packages/container/libraries/common/src/services/models/ServiceIdentifier.ts
+++ b/packages/container/libraries/common/src/services/models/ServiceIdentifier.ts
@@ -1,8 +1,8 @@
+import { AbstractNewable } from './AbstractNewable';
 import { Newable } from './Newable';
 
 export type ServiceIdentifier<TInstance = unknown> =
   | string
   | symbol
   | Newable<TInstance>
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  | Function;
+  | AbstractNewable<TInstance>;

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntax.spec-d.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntax.spec-d.ts
@@ -66,16 +66,17 @@ describe('BindToFluentSyntax', () => {
         ).toEqualTypeOf<BindInWhenOnFluentSyntax<unknown>>();
       });
 
-      it('when called, with as many "wrong" service identifier inject options as function parameters, should not throw a syntax error', () => {
+      it('when called, with as many "wrong" service identifier inject options as function parameters, should throw a syntax error', () => {
         const firstServiceIdentifier: ServiceIdentifier<number> =
           Symbol() as ServiceIdentifier<number>;
 
-        // Unlucky us, Newable<T> extends Function and therefore, it extends ServiceIdentifier<T2>
         const secondServiceIdentifier: Newable<object> = Object;
 
         expectTypeOf(
           bindToFluentSyntaxMock.toResolvedValue(factoryFixture, [
+            // @ts-expect-error :: Expected string service identifier
             firstServiceIdentifier,
+            // @ts-expect-error :: Expected number service identifier
             secondServiceIdentifier,
           ]),
         ).toEqualTypeOf<BindInWhenOnFluentSyntax<unknown>>();

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.ts
@@ -234,11 +234,10 @@ export class BindToFluentSyntaxImplementation<T>
     return new BindInWhenOnFluentSyntaxImplementation(binding);
   }
 
-  public toFactory(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    builder: T extends Factory<unknown, any>
-      ? (context: ResolutionContext) => T
-      : never,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public toFactory<T extends Factory<unknown, any>>(
+    this: BindToFluentSyntaxImplementation<T>,
+    builder: (context: ResolutionContext) => T,
   ): BindWhenOnFluentSyntax<T> {
     const binding: FactoryBinding<Factory<unknown>> = {
       cache: {
@@ -263,11 +262,10 @@ export class BindToFluentSyntaxImplementation<T>
     );
   }
 
-  public toProvider(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    provider: T extends Provider<unknown, any>
-      ? (context: ResolutionContext) => T
-      : never,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public toProvider<T extends Provider<unknown, any>>(
+    this: BindToFluentSyntaxImplementation<T>,
+    provider: (context: ResolutionContext) => T,
   ): BindWhenOnFluentSyntax<T> {
     const binding: ProviderBinding<Provider<unknown>> = {
       cache: {

--- a/packages/docs/services/inversify-site/blog/2025-06-23-introducing-abstract-newable-type/index.mdx
+++ b/packages/docs/services/inversify-site/blog/2025-06-23-introducing-abstract-newable-type/index.mdx
@@ -1,0 +1,78 @@
+---
+slug: introducing-abstract-newable-type
+title: Introducing AbstractNewable Type
+authors: [notaphplover]
+tags: [types]
+---
+
+We've improved the type safety and semantics of InversifyJS with the introduction of the `AbstractNewable` type.
+
+{/* truncate */}
+
+## What's new?
+
+In the latest update to `inversify`, we've replaced the generic `Function` type in `ServiceIdentifier` with a more specific and type-safe `AbstractNewable` type.
+
+### The Problem with Function
+
+Previously, `ServiceIdentifier<T>` included `Function` to support abstract classes as service identifiers. While this worked functionally, it had several drawbacks:
+
+1. **Lack of type safety**: `Function` is too broad and can represent any function, not just abstract constructors
+2. **Poor semantics**: It doesn't clearly communicate the intent to represent abstract classes
+3. **Developer experience**: No intellisense or type checking benefits when working with abstract class identifiers
+
+### The Solution: AbstractNewable
+
+The new `AbstractNewable` type is specifically designed to represent abstract class constructors:
+
+```typescript
+export type AbstractNewable<
+  TInstance = unknown,
+  TArgs extends unknown[] = any[],
+> = abstract new (...args: TArgs) => TInstance;
+```
+
+This type provides:
+
+- **Better type safety**: Only accepts abstract constructors
+- **Clear semantics**: Explicitly represents the intent to work with abstract classes
+- **Enhanced developer experience**: Better intellisense and type checking
+
+## Updated ServiceIdentifier Type
+
+The `ServiceIdentifier` type now looks like this:
+
+```typescript
+export type ServiceIdentifier<TInstance = unknown> =
+  | string
+  | symbol
+  | Newable<TInstance>
+  | AbstractNewable<TInstance>; // ✨ New!
+```
+
+This change means you can now use abstract classes as service identifiers with better type safety:
+
+```typescript
+abstract class AbstractService {
+  abstract doSomething(): void;
+}
+
+class ConcreteService extends AbstractService {
+  doSomething(): void {
+    console.log('Doing something...');
+  }
+}
+
+// Both of these now have better type safety
+const serviceId1: ServiceIdentifier<AbstractService> = AbstractService;
+const serviceId2: ServiceIdentifier<ConcreteService> = ConcreteService;
+```
+
+## Benefits for the Community
+
+This improvement brings several benefits:
+
+1. **Enhanced type safety**: Catch more errors at compile time
+2. **Better documentation**: Code is more self-documenting with explicit types
+3. **Improved developer experience**: Better intellisense and autocomplete
+4. **Cleaner foundation**: Better foundation for future abstract class-related features

--- a/packages/docs/services/inversify-site/blog/tags.yml
+++ b/packages/docs/services/inversify-site/blog/tags.yml
@@ -2,3 +2,8 @@ releases:
   label: Releases
   permalink: /releases
   description: InversifyJS releases related posts
+
+types:
+  label: Types
+  permalink: /types
+  description: InversifyJS types related posts

--- a/packages/docs/services/inversify-site/docs/api/service-identifier.mdx
+++ b/packages/docs/services/inversify-site/docs/api/service-identifier.mdx
@@ -19,7 +19,7 @@ type ServiceIdentifier<TInstance = unknown> =
   | string
   | symbol
   | Newable<TInstance>
-  | Function;
+  | AbstractNewable<TInstance>;
 ```
 
 Where `Newable` is defined as:

--- a/packages/docs/services/inversify-site/versioned_docs/version-7.x/api/service-identifier.mdx
+++ b/packages/docs/services/inversify-site/versioned_docs/version-7.x/api/service-identifier.mdx
@@ -19,7 +19,7 @@ type ServiceIdentifier<TInstance = unknown> =
   | string
   | symbol
   | Newable<TInstance>
-  | Function;
+  | AbstractNewable<TInstance>;
 ```
 
 Where `Newable` is defined as:
@@ -39,7 +39,7 @@ type Newable<
 2. **Service Resolution**: Retrieving services from the container
 3. **Service Configuration**: Setting activation/deactivation handlers
 
-### Registration Examples
+### Examples
 
 ```typescript
 // Using a class as a service identifier (most common)

--- a/packages/http/libraries/hono/package.json
+++ b/packages/http/libraries/hono/package.json
@@ -48,7 +48,7 @@
   },
   "name": "@inversifyjs/http-hono",
   "peerDependencies": {
-    "hono": "^4.7.11",
+    "hono": "^4.8.2",
     "inversify": "^7.5.2"
   },
   "private": true,


### PR DESCRIPTION
### Added
- Added `AbstractNewable`.
- Added blog entry.

### Changed
- Updated `ServiceIdentifier` without `Function` in favor of `AbstractNewable`.
- Updated `BindToFluentSyntaxImplementation.toFactory` and `BindToFluentSyntaxImplementation.toProvider` with better signatures.
- Updated `ServiceIdentifier` `API` docs.

### Context
This PR is related to inversify/InversifyJS#1829