### PR TITLE
Update PlanResultCacheService to avoid collisions with chained service related plans

### DIFF
--- a/.changeset/bright-times-relax.md
+++ b/.changeset/bright-times-relax.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": patch
+---
+
+Updated `GetPlanOptions` with `chained` property

--- a/.changeset/shiny-boats-worry.md
+++ b/.changeset/shiny-boats-worry.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": patch
+---
+
+Updated `PlanResultCacheService` to avoid collisions with chained service related plans

--- a/packages/container/libraries/container/src/container/services/ServiceResolutionManager.spec.ts
+++ b/packages/container/libraries/container/src/container/services/ServiceResolutionManager.spec.ts
@@ -125,7 +125,7 @@ describe(ServiceResolutionManager, () => {
           const expectedGetPlanOptions: GetPlanOptions = {
             isMultiple: false,
             name: getOptionsFixture.name,
-            optional: getOptionsFixture.optional,
+            optional: getOptionsFixture.optional ?? false,
             serviceIdentifier: serviceIdentifierFixture,
             tag: getOptionsFixture.tag,
           };
@@ -169,7 +169,7 @@ describe(ServiceResolutionManager, () => {
           const expectedGetPlanOptions: GetPlanOptions = {
             isMultiple: false,
             name: getOptionsFixture.name,
-            optional: getOptionsFixture.optional,
+            optional: getOptionsFixture.optional ?? false,
             serviceIdentifier: serviceIdentifierFixture,
             tag: getOptionsFixture.tag,
           };
@@ -251,7 +251,7 @@ describe(ServiceResolutionManager, () => {
           const expectedGetPlanOptions: GetPlanOptions = {
             isMultiple: false,
             name: getOptionsFixture.name,
-            optional: getOptionsFixture.optional,
+            optional: getOptionsFixture.optional ?? false,
             serviceIdentifier: serviceIdentifierFixture,
             tag: getOptionsFixture.tag,
           };
@@ -345,7 +345,7 @@ describe(ServiceResolutionManager, () => {
           const expectedGetPlanOptions: GetPlanOptions = {
             isMultiple: false,
             name: getOptionsFixture.name,
-            optional: getOptionsFixture.optional,
+            optional: getOptionsFixture.optional ?? false,
             serviceIdentifier: serviceIdentifierFixture,
             tag: getOptionsFixture.tag,
           };
@@ -389,7 +389,7 @@ describe(ServiceResolutionManager, () => {
           const expectedGetPlanOptions: GetPlanOptions = {
             isMultiple: false,
             name: getOptionsFixture.name,
-            optional: getOptionsFixture.optional,
+            optional: getOptionsFixture.optional ?? false,
             serviceIdentifier: serviceIdentifierFixture,
             tag: getOptionsFixture.tag,
           };
@@ -481,7 +481,7 @@ describe(ServiceResolutionManager, () => {
           const expectedGetPlanOptions: GetPlanOptions = {
             isMultiple: false,
             name: getOptionsFixture.name,
-            optional: getOptionsFixture.optional,
+            optional: getOptionsFixture.optional ?? false,
             serviceIdentifier: serviceIdentifierFixture,
             tag: getOptionsFixture.tag,
           };
@@ -525,7 +525,7 @@ describe(ServiceResolutionManager, () => {
           const expectedGetPlanOptions: GetPlanOptions = {
             isMultiple: false,
             name: getOptionsFixture.name,
-            optional: getOptionsFixture.optional,
+            optional: getOptionsFixture.optional ?? false,
             serviceIdentifier: serviceIdentifierFixture,
             tag: getOptionsFixture.tag,
           };
@@ -542,7 +542,7 @@ describe(ServiceResolutionManager, () => {
           const expectedGetPlanOptions: GetPlanOptions = {
             isMultiple: false,
             name: getOptionsFixture.name,
-            optional: getOptionsFixture.optional,
+            optional: getOptionsFixture.optional ?? false,
             serviceIdentifier: serviceIdentifierFixture,
             tag: getOptionsFixture.tag,
           };
@@ -627,7 +627,7 @@ describe(ServiceResolutionManager, () => {
           const expectedGetPlanOptions: GetPlanOptions = {
             isMultiple: false,
             name: getOptionsFixture.name,
-            optional: getOptionsFixture.optional,
+            optional: getOptionsFixture.optional ?? false,
             serviceIdentifier: serviceIdentifierFixture,
             tag: getOptionsFixture.tag,
           };
@@ -735,7 +735,7 @@ describe(ServiceResolutionManager, () => {
           const expectedGetPlanOptions: GetPlanOptions = {
             isMultiple: false,
             name: getOptionsFixture.name,
-            optional: getOptionsFixture.optional,
+            optional: getOptionsFixture.optional ?? false,
             serviceIdentifier: serviceIdentifierFixture,
             tag: getOptionsFixture.tag,
           };
@@ -781,7 +781,7 @@ describe(ServiceResolutionManager, () => {
           const expectedGetPlanOptions: GetPlanOptions = {
             isMultiple: false,
             name: getOptionsFixture.name,
-            optional: getOptionsFixture.optional,
+            optional: getOptionsFixture.optional ?? false,
             serviceIdentifier: serviceIdentifierFixture,
             tag: getOptionsFixture.tag,
           };
@@ -876,7 +876,7 @@ describe(ServiceResolutionManager, () => {
           const expectedGetPlanOptions: GetPlanOptions = {
             isMultiple: false,
             name: getOptionsFixture.name,
-            optional: getOptionsFixture.optional,
+            optional: getOptionsFixture.optional ?? false,
             serviceIdentifier: serviceIdentifierFixture,
             tag: getOptionsFixture.tag,
           };
@@ -922,7 +922,7 @@ describe(ServiceResolutionManager, () => {
           const expectedGetPlanOptions: GetPlanOptions = {
             isMultiple: false,
             name: getOptionsFixture.name,
-            optional: getOptionsFixture.optional,
+            optional: getOptionsFixture.optional ?? false,
             serviceIdentifier: serviceIdentifierFixture,
             tag: getOptionsFixture.tag,
           };
@@ -1000,9 +1000,10 @@ describe(ServiceResolutionManager, () => {
 
         it('should call planResultCacheService.get()', () => {
           const expectedGetPlanOptions: GetPlanOptions = {
+            chained: true,
             isMultiple: true,
             name: optionsFixture.name,
-            optional: undefined,
+            optional: false,
             serviceIdentifier: serviceIdentifierFixture,
             tag: optionsFixture.tag,
           };
@@ -1042,9 +1043,10 @@ describe(ServiceResolutionManager, () => {
 
         it('should call planResultCacheService.set()', () => {
           const expectedGetPlanOptions: GetPlanOptions = {
+            chained: true,
             isMultiple: true,
             name: undefined,
-            optional: undefined,
+            optional: false,
             serviceIdentifier: serviceIdentifierFixture,
             tag: undefined,
           };
@@ -1124,9 +1126,10 @@ describe(ServiceResolutionManager, () => {
 
       it('should call planResultCacheService.get()', () => {
         const expectedGetPlanOptions: GetPlanOptions = {
+          chained: false,
           isMultiple: true,
           name: getOptionsFixture.name,
-          optional: getOptionsFixture.optional,
+          optional: getOptionsFixture.optional ?? false,
           serviceIdentifier: serviceIdentifierFixture,
           tag: getOptionsFixture.tag,
         };
@@ -1169,9 +1172,10 @@ describe(ServiceResolutionManager, () => {
 
       it('should call planResultCacheService.set()', () => {
         const expectedGetPlanOptions: GetPlanOptions = {
+          chained: false,
           isMultiple: true,
           name: getOptionsFixture.name,
-          optional: getOptionsFixture.optional,
+          optional: getOptionsFixture.optional ?? false,
           serviceIdentifier: serviceIdentifierFixture,
           tag: getOptionsFixture.tag,
         };
@@ -1254,9 +1258,10 @@ describe(ServiceResolutionManager, () => {
 
       it('should call planResultCacheService.get()', () => {
         const expectedGetPlanOptions: GetPlanOptions = {
+          chained: false,
           isMultiple: true,
           name: getOptionsFixture.name,
-          optional: getOptionsFixture.optional,
+          optional: getOptionsFixture.optional ?? false,
           serviceIdentifier: serviceIdentifierFixture,
           tag: getOptionsFixture.tag,
         };
@@ -1299,9 +1304,10 @@ describe(ServiceResolutionManager, () => {
 
       it('should call planResultCacheService.set()', () => {
         const expectedGetPlanOptions: GetPlanOptions = {
+          chained: false,
           isMultiple: true,
           name: getOptionsFixture.name,
-          optional: getOptionsFixture.optional,
+          optional: getOptionsFixture.optional ?? false,
           serviceIdentifier: serviceIdentifierFixture,
           tag: getOptionsFixture.tag,
         };
@@ -1390,9 +1396,10 @@ describe(ServiceResolutionManager, () => {
 
       it('should call planResultCacheService.get()', () => {
         const expectedGetPlanOptions: GetPlanOptions = {
+          chained: false,
           isMultiple: true,
           name: getOptionsFixture.name,
-          optional: getOptionsFixture.optional,
+          optional: getOptionsFixture.optional ?? false,
           serviceIdentifier: serviceIdentifierFixture,
           tag: getOptionsFixture.tag,
         };
@@ -1435,9 +1442,10 @@ describe(ServiceResolutionManager, () => {
 
       it('should call planResultCacheService.set()', () => {
         const expectedGetPlanOptions: GetPlanOptions = {
+          chained: false,
           isMultiple: true,
           name: getOptionsFixture.name,
-          optional: getOptionsFixture.optional,
+          optional: getOptionsFixture.optional ?? false,
           serviceIdentifier: serviceIdentifierFixture,
           tag: getOptionsFixture.tag,
         };
@@ -1520,7 +1528,7 @@ describe(ServiceResolutionManager, () => {
         const expectedGetPlanOptions: GetPlanOptions = {
           isMultiple: false,
           name: getOptionsFixture.name,
-          optional: getOptionsFixture.optional,
+          optional: getOptionsFixture.optional ?? false,
           serviceIdentifier: serviceIdentifierFixture,
           tag: getOptionsFixture.tag,
         };
@@ -1564,7 +1572,7 @@ describe(ServiceResolutionManager, () => {
         const expectedGetPlanOptions: GetPlanOptions = {
           isMultiple: false,
           name: getOptionsFixture.name,
-          optional: getOptionsFixture.optional,
+          optional: getOptionsFixture.optional ?? false,
           serviceIdentifier: serviceIdentifierFixture,
           tag: getOptionsFixture.tag,
         };

--- a/packages/container/libraries/container/src/container/services/ServiceResolutionManager.ts
+++ b/packages/container/libraries/container/src/container/services/ServiceResolutionManager.ts
@@ -10,7 +10,9 @@ import {
   GetAllOptions,
   getClassMetadata,
   GetOptions,
+  GetOptionsTagConstraint,
   GetPlanOptions,
+  MetadataName,
   OptionalGetOptions,
   plan,
   PlanParams,
@@ -187,15 +189,31 @@ export class ServiceResolutionManager {
   #buildGetPlanOptions(
     isMultiple: boolean,
     serviceIdentifier: ServiceIdentifier,
-    options: GetOptions | undefined,
+    options: GetOptions | GetAllOptions | undefined,
   ): GetPlanOptions {
-    return {
-      isMultiple,
-      name: options?.name,
-      optional: options?.optional,
-      serviceIdentifier,
-      tag: options?.tag,
-    };
+    const name: MetadataName | undefined = options?.name;
+    const optional: boolean = options?.optional ?? false;
+    const tag: GetOptionsTagConstraint | undefined = options?.tag;
+
+    if (isMultiple) {
+      return {
+        chained:
+          (options as Partial<GetAllOptions> | undefined)?.chained ?? false,
+        isMultiple,
+        name,
+        optional,
+        serviceIdentifier,
+        tag,
+      };
+    } else {
+      return {
+        isMultiple,
+        name,
+        optional,
+        serviceIdentifier,
+        tag,
+      };
+    }
   }
 
   #buildPlanParams(

--- a/packages/container/libraries/core/src/index.ts
+++ b/packages/container/libraries/core/src/index.ts
@@ -60,7 +60,12 @@ import { SingleInjectionResolvedValueElementMetadata } from './metadata/models/S
 import { UnmanagedClassElementMetadata } from './metadata/models/UnmanagedClassElementMetadata';
 import { plan } from './planning/calculations/plan';
 import { BaseBindingNode } from './planning/models/BaseBindingNode';
+import { BaseGetPlanOptions } from './planning/models/BaseGetPlanOptions';
 import { BasePlanParams } from './planning/models/BasePlanParams';
+import { GetMultipleServicePlanOptions } from './planning/models/GetMultipleServicePlanOptions';
+import { GetPlanOptions } from './planning/models/GetPlanOptions';
+import { GetPlanOptionsTagConstraint } from './planning/models/GetPlanOptionsTagConstraint';
+import { GetSingleServicePlanOptions } from './planning/models/GetSingleServicePlanOptions';
 import { InstanceBindingNode } from './planning/models/InstanceBindingNode';
 import { LeafBindingNode } from './planning/models/LeafBindingNode';
 import { MultipleBindingPlanParamsConstraint } from './planning/models/MultipleBindingPlanParamsConstraint';
@@ -75,10 +80,7 @@ import { PlanServiceRedirectionBindingNode } from './planning/models/PlanService
 import { PlanTree } from './planning/models/PlanTree';
 import { ResolvedValueBindingNode } from './planning/models/ResolvedValueBindingNode';
 import { SingleBindingPlanParamsConstraint } from './planning/models/SingleBindingPlanParamsConstraint';
-import {
-  GetPlanOptions,
-  PlanResultCacheService,
-} from './planning/services/PlanResultCacheService';
+import { PlanResultCacheService } from './planning/services/PlanResultCacheService';
 import { resolve } from './resolution/actions/resolve';
 import { resolveBindingsDeactivations } from './resolution/actions/resolveBindingsDeactivations';
 import { resolveModuleDeactivations } from './resolution/actions/resolveModuleDeactivations';
@@ -96,6 +98,7 @@ import { Resolved } from './resolution/models/Resolved';
 export type {
   BaseBinding,
   BaseBindingNode,
+  BaseGetPlanOptions,
   BaseManagedClassElementMetadata,
   BasePlanParams,
   Binding,
@@ -116,9 +119,12 @@ export type {
   Factory,
   FactoryBinding,
   GetAllOptions,
+  GetMultipleServicePlanOptions,
   GetOptions,
   GetOptionsTagConstraint,
   GetPlanOptions,
+  GetPlanOptionsTagConstraint,
+  GetSingleServicePlanOptions,
   InstanceBinding,
   InstanceBindingNode,
   LeafBindingNode,

--- a/packages/container/libraries/core/src/planning/models/BaseGetPlanOptions.ts
+++ b/packages/container/libraries/core/src/planning/models/BaseGetPlanOptions.ts
@@ -1,0 +1,11 @@
+import { ServiceIdentifier } from '@inversifyjs/common';
+
+import { MetadataName } from '../../metadata/models/MetadataName';
+import { GetPlanOptionsTagConstraint } from './GetPlanOptionsTagConstraint';
+
+export interface BaseGetPlanOptions {
+  serviceIdentifier: ServiceIdentifier;
+  name: MetadataName | undefined;
+  optional: boolean;
+  tag: GetPlanOptionsTagConstraint | undefined;
+}

--- a/packages/container/libraries/core/src/planning/models/GetMultipleServicePlanOptions.ts
+++ b/packages/container/libraries/core/src/planning/models/GetMultipleServicePlanOptions.ts
@@ -1,0 +1,6 @@
+import { BaseGetPlanOptions } from './BaseGetPlanOptions';
+
+export interface GetMultipleServicePlanOptions extends BaseGetPlanOptions {
+  chained: boolean;
+  isMultiple: true;
+}

--- a/packages/container/libraries/core/src/planning/models/GetPlanOptions.ts
+++ b/packages/container/libraries/core/src/planning/models/GetPlanOptions.ts
@@ -1,0 +1,6 @@
+import { GetMultipleServicePlanOptions } from './GetMultipleServicePlanOptions';
+import { GetSingleServicePlanOptions } from './GetSingleServicePlanOptions';
+
+export type GetPlanOptions =
+  | GetSingleServicePlanOptions
+  | GetMultipleServicePlanOptions;

--- a/packages/container/libraries/core/src/planning/models/GetPlanOptionsTagConstraint.ts
+++ b/packages/container/libraries/core/src/planning/models/GetPlanOptionsTagConstraint.ts
@@ -1,0 +1,6 @@
+import { MetadataTag } from '../../metadata/models/MetadataTag';
+
+export interface GetPlanOptionsTagConstraint {
+  key: MetadataTag;
+  value: unknown;
+}

--- a/packages/container/libraries/core/src/planning/models/GetSingleServicePlanOptions.ts
+++ b/packages/container/libraries/core/src/planning/models/GetSingleServicePlanOptions.ts
@@ -1,0 +1,5 @@
+import { BaseGetPlanOptions } from './BaseGetPlanOptions';
+
+export interface GetSingleServicePlanOptions extends BaseGetPlanOptions {
+  isMultiple: false;
+}

--- a/packages/container/libraries/core/src/planning/services/PlanResultCacheService.spec.ts
+++ b/packages/container/libraries/core/src/planning/services/PlanResultCacheService.spec.ts
@@ -1,216 +1,354 @@
 import { beforeAll, describe, expect, it, Mocked, vitest } from 'vitest';
 
+import { GetPlanOptions } from '../models/GetPlanOptions';
 import { PlanResult } from '../models/PlanResult';
-import {
+import { PlanResultCacheService } from './PlanResultCacheService';
+
+const planOptionsAndStringDescriptionPairList: [string, GetPlanOptions][] = [
+  [
+    'isMultiple false and optional false',
+    {
+      isMultiple: false,
+      name: undefined,
+      optional: false,
+      serviceIdentifier: 'service-id',
+      tag: undefined,
+    },
+  ],
+  [
+    'isMultiple false and optional true',
+    {
+      isMultiple: false,
+      name: undefined,
+      optional: true,
+      serviceIdentifier: 'service-id',
+      tag: undefined,
+    },
+  ],
+  [
+    'isMultiple true and optional false',
+    {
+      chained: false,
+      isMultiple: true,
+      name: undefined,
+      optional: false,
+      serviceIdentifier: 'service-id',
+      tag: undefined,
+    },
+  ],
+  [
+    'isMultiple true and optional true',
+    {
+      chained: false,
+      isMultiple: true,
+      name: undefined,
+      optional: true,
+      serviceIdentifier: 'service-id',
+      tag: undefined,
+    },
+  ],
+  [
+    'isMultiple false, optional false and name',
+    {
+      isMultiple: false,
+      name: 'name',
+      optional: false,
+      serviceIdentifier: 'service-id',
+      tag: undefined,
+    },
+  ],
+  [
+    'isMultiple false, optional true and name',
+    {
+      isMultiple: false,
+      name: 'name',
+      optional: true,
+      serviceIdentifier: 'service-id',
+      tag: undefined,
+    },
+  ],
+  [
+    'isMultiple true, optional false and name',
+    {
+      chained: false,
+      isMultiple: true,
+      name: 'name',
+      optional: false,
+      serviceIdentifier: 'service-id',
+      tag: undefined,
+    },
+  ],
+  [
+    'isMultiple true, optional true and name',
+    {
+      chained: false,
+      isMultiple: true,
+      name: 'name',
+      optional: true,
+      serviceIdentifier: 'service-id',
+      tag: undefined,
+    },
+  ],
+  [
+    'isMultiple false, optional false and tag',
+    {
+      isMultiple: false,
+      name: undefined,
+      optional: false,
+      serviceIdentifier: 'service-id',
+      tag: {
+        key: 'key',
+        value: 'value',
+      },
+    },
+  ],
+  [
+    'isMultiple false, optional true and tag',
+    {
+      isMultiple: false,
+      name: undefined,
+      optional: true,
+      serviceIdentifier: 'service-id',
+      tag: {
+        key: 'key',
+        value: 'value',
+      },
+    },
+  ],
+  [
+    'isMultiple true, optional false and tag',
+    {
+      chained: false,
+      isMultiple: true,
+      name: undefined,
+      optional: false,
+      serviceIdentifier: 'service-id',
+      tag: {
+        key: 'key',
+        value: 'value',
+      },
+    },
+  ],
+  [
+    'isMultiple true, optional true and tag',
+    {
+      chained: false,
+      isMultiple: true,
+      name: undefined,
+      optional: true,
+      serviceIdentifier: 'service-id',
+      tag: {
+        key: 'key',
+        value: 'value',
+      },
+    },
+  ],
+  [
+    'isMultiple false, optional false, name and tag',
+    {
+      isMultiple: false,
+      name: 'name',
+      optional: false,
+      serviceIdentifier: 'service-id',
+      tag: {
+        key: 'key',
+        value: 'value',
+      },
+    },
+  ],
+  [
+    'isMultiple false, optional true, name and tag',
+    {
+      isMultiple: false,
+      name: 'name',
+      optional: true,
+      serviceIdentifier: 'service-id',
+      tag: {
+        key: 'key',
+        value: 'value',
+      },
+    },
+  ],
+  [
+    'isMultiple true, optional false, name and tag',
+    {
+      chained: false,
+      isMultiple: true,
+      name: 'name',
+      optional: false,
+      serviceIdentifier: 'service-id',
+      tag: {
+        key: 'key',
+        value: 'value',
+      },
+    },
+  ],
+  [
+    'isMultiple true, optional true, name and tag',
+    {
+      chained: false,
+      isMultiple: true,
+      name: 'name',
+      optional: true,
+      serviceIdentifier: 'service-id',
+      tag: {
+        key: 'key',
+        value: 'value',
+      },
+    },
+  ],
+  [
+    'chained true, isMultiple true and optional false',
+    {
+      chained: true,
+      isMultiple: true,
+      name: undefined,
+      optional: false,
+      serviceIdentifier: 'service-id',
+      tag: undefined,
+    },
+  ],
+  [
+    'chained true, isMultiple true and optional true',
+    {
+      chained: true,
+      isMultiple: true,
+      name: undefined,
+      optional: true,
+      serviceIdentifier: 'service-id',
+      tag: undefined,
+    },
+  ],
+  [
+    'chained true, isMultiple true, optional false and name',
+    {
+      chained: true,
+      isMultiple: true,
+      name: 'name',
+      optional: false,
+      serviceIdentifier: 'service-id',
+      tag: undefined,
+    },
+  ],
+  [
+    'chained true, isMultiple true, optional true and name',
+    {
+      chained: true,
+      isMultiple: true,
+      name: 'name',
+      optional: true,
+      serviceIdentifier: 'service-id',
+      tag: undefined,
+    },
+  ],
+  [
+    'chained true, isMultiple true, optional false and tag',
+    {
+      chained: true,
+      isMultiple: true,
+      name: undefined,
+      optional: false,
+      serviceIdentifier: 'service-id',
+      tag: {
+        key: 'key',
+        value: 'value',
+      },
+    },
+  ],
+  [
+    'chained true, isMultiple true, optional true and tag',
+    {
+      chained: true,
+      isMultiple: true,
+      name: undefined,
+      optional: true,
+      serviceIdentifier: 'service-id',
+      tag: {
+        key: 'key',
+        value: 'value',
+      },
+    },
+  ],
+  [
+    'chained true, isMultiple true, optional false, name and tag',
+    {
+      chained: true,
+      isMultiple: true,
+      name: 'name',
+      optional: false,
+      serviceIdentifier: 'service-id',
+      tag: {
+        key: 'key',
+        value: 'value',
+      },
+    },
+  ],
+  [
+    'chained true, isMultiple true, optional true, name and tag',
+    {
+      chained: true,
+      isMultiple: true,
+      name: 'name',
+      optional: true,
+      serviceIdentifier: 'service-id',
+      tag: {
+        key: 'key',
+        value: 'value',
+      },
+    },
+  ],
+];
+
+const planOptionsList: GetPlanOptions[] =
+  planOptionsAndStringDescriptionPairList.map(
+    ([_, options]: [string, GetPlanOptions]) => options,
+  );
+
+const stringDescriptionAndPlanOptionsAndOtherPlanOptionsListTupleList: [
+  string,
   GetPlanOptions,
-  PlanResultCacheService,
-} from './PlanResultCacheService';
+  GetPlanOptions[],
+][] = planOptionsAndStringDescriptionPairList.map(
+  ([stringDescription, options]: [string, GetPlanOptions]) => [
+    stringDescription,
+    options,
+    planOptionsList.filter(
+      (planOptions: GetPlanOptions) => planOptions !== options,
+    ),
+  ],
+);
 
 describe(PlanResultCacheService, () => {
   describe('.set', () => {
-    describe.each<[string, GetPlanOptions]>([
-      [
-        'isMultiple false and optional false',
-        {
-          isMultiple: false,
-          name: undefined,
-          optional: false,
-          serviceIdentifier: 'service-id',
-          tag: undefined,
-        },
-      ],
-      [
-        'isMultiple false and optional true',
-        {
-          isMultiple: false,
-          name: undefined,
-          optional: true,
-          serviceIdentifier: 'service-id',
-          tag: undefined,
-        },
-      ],
-      [
-        'isMultiple true and optional false',
-        {
-          isMultiple: true,
-          name: undefined,
-          optional: false,
-          serviceIdentifier: 'service-id',
-          tag: undefined,
-        },
-      ],
-      [
-        'isMultiple true and optional true',
-        {
-          isMultiple: true,
-          name: undefined,
-          optional: true,
-          serviceIdentifier: 'service-id',
-          tag: undefined,
-        },
-      ],
-      [
-        'isMultiple false, optional false and name',
-        {
-          isMultiple: false,
-          name: 'name',
-          optional: false,
-          serviceIdentifier: 'service-id',
-          tag: undefined,
-        },
-      ],
-      [
-        'isMultiple false, optional true and name',
-        {
-          isMultiple: false,
-          name: 'name',
-          optional: true,
-          serviceIdentifier: 'service-id',
-          tag: undefined,
-        },
-      ],
-      [
-        'isMultiple true, optional false and name',
-        {
-          isMultiple: true,
-          name: 'name',
-          optional: false,
-          serviceIdentifier: 'service-id',
-          tag: undefined,
-        },
-      ],
-      [
-        'isMultiple true, optional true and name',
-        {
-          isMultiple: true,
-          name: 'name',
-          optional: true,
-          serviceIdentifier: 'service-id',
-          tag: undefined,
-        },
-      ],
-      [
-        'isMultiple false, optional false and tag',
-        {
-          isMultiple: false,
-          name: undefined,
-          optional: false,
-          serviceIdentifier: 'service-id',
-          tag: {
-            key: 'key',
-            value: 'value',
-          },
-        },
-      ],
-      [
-        'isMultiple false, optional true and tag',
-        {
-          isMultiple: false,
-          name: undefined,
-          optional: true,
-          serviceIdentifier: 'service-id',
-          tag: {
-            key: 'key',
-            value: 'value',
-          },
-        },
-      ],
-      [
-        'isMultiple true, optional false and tag',
-        {
-          isMultiple: true,
-          name: undefined,
-          optional: false,
-          serviceIdentifier: 'service-id',
-          tag: {
-            key: 'key',
-            value: 'value',
-          },
-        },
-      ],
-      [
-        'isMultiple true, optional true and tag',
-        {
-          isMultiple: true,
-          name: undefined,
-          optional: true,
-          serviceIdentifier: 'service-id',
-          tag: {
-            key: 'key',
-            value: 'value',
-          },
-        },
-      ],
-      [
-        'isMultiple false, optional false, name and tag',
-        {
-          isMultiple: false,
-          name: 'name',
-          optional: false,
-          serviceIdentifier: 'service-id',
-          tag: {
-            key: 'key',
-            value: 'value',
-          },
-        },
-      ],
-      [
-        'isMultiple false, optional true, name and tag',
-        {
-          isMultiple: false,
-          name: 'name',
-          optional: true,
-          serviceIdentifier: 'service-id',
-          tag: {
-            key: 'key',
-            value: 'value',
-          },
-        },
-      ],
-      [
-        'isMultiple true, optional false, name and tag',
-        {
-          isMultiple: true,
-          name: 'name',
-          optional: false,
-          serviceIdentifier: 'service-id',
-          tag: {
-            key: 'key',
-            value: 'value',
-          },
-        },
-      ],
-      [
-        'isMultiple true, optional true, name and tag',
-        {
-          isMultiple: true,
-          name: 'name',
-          optional: true,
-          serviceIdentifier: 'service-id',
-          tag: {
-            key: 'key',
-            value: 'value',
-          },
-        },
-      ],
-    ])('having options with  %s', (_: string, options: GetPlanOptions) => {
-      describe('when called', () => {
-        let planService: PlanResultCacheService;
+    describe.each<[string, GetPlanOptions, GetPlanOptions[]]>(
+      stringDescriptionAndPlanOptionsAndOtherPlanOptionsListTupleList,
+    )(
+      'having options with  %s',
+      (_: string, options: GetPlanOptions, otherPlans: GetPlanOptions[]) => {
+        describe('when called', () => {
+          let planService: PlanResultCacheService;
 
-        let planResult: PlanResult;
+          let planResultFixture: PlanResult;
 
-        beforeAll(() => {
-          planService = new PlanResultCacheService();
+          beforeAll(() => {
+            planService = new PlanResultCacheService();
 
-          planResult = {} as PlanResult;
-          planService.set(options, planResult);
+            planResultFixture = {} as PlanResult;
+            planService.set(options, planResultFixture);
+          });
+
+          it('should store the plan result', () => {
+            expect(planService.get(options)).toBe(planResultFixture);
+          });
+
+          it('should not store the plan result for other options', () => {
+            for (const otherPlan of otherPlans) {
+              expect(planService.get(otherPlan)).toBeUndefined();
+            }
+          });
         });
-
-        it('should store the plan result', () => {
-          expect(planService.get(options)).toBe(planResult);
-        });
-      });
-    });
+      },
+    );
   });
 
   describe('.clearCache', () => {


### PR DESCRIPTION
### Changed
- Updated `GetPlanOptions` with `chained` property.
- Updated `PlanResultCacheService` to avoid collisions with chained service related plans.