### PR TITLE
fix  Vscode eslint integration

### DIFF
--- a/packages/container/examples/plugin-example/eslint.config.mjs
+++ b/packages/container/examples/plugin-example/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/container/examples/plugin-usage-example/eslint.config.mjs
+++ b/packages/container/examples/plugin-usage-example/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/container/libraries/binding-decorators/eslint.config.mjs
+++ b/packages/container/libraries/binding-decorators/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/container/libraries/common/eslint.config.mjs
+++ b/packages/container/libraries/common/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/container/libraries/container/eslint.config.mjs
+++ b/packages/container/libraries/container/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/container/libraries/core/eslint.config.mjs
+++ b/packages/container/libraries/core/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/container/libraries/plugin-dispose/eslint.config.mjs
+++ b/packages/container/libraries/plugin-dispose/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/container/libraries/plugin/eslint.config.mjs
+++ b/packages/container/libraries/plugin/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/container/libraries/strongly-typed/eslint.config.mjs
+++ b/packages/container/libraries/strongly-typed/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/container/tools/container-benchmarks/eslint.config.mjs
+++ b/packages/container/tools/container-benchmarks/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/container/tools/e2e-tests/eslint.config.mjs
+++ b/packages/container/tools/e2e-tests/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/docs/tools/binding-decorators-code-examples/eslint.config.mjs
+++ b/packages/docs/tools/binding-decorators-code-examples/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/docs/tools/code-examples-devkit/eslint.config.mjs
+++ b/packages/docs/tools/code-examples-devkit/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/docs/tools/inversify-code-examples/eslint.config.mjs
+++ b/packages/docs/tools/inversify-code-examples/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/foundation/libraries/benchmark-utils/eslint.config.mjs
+++ b/packages/foundation/libraries/benchmark-utils/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/foundation/libraries/prototype-utils/eslint.config.mjs
+++ b/packages/foundation/libraries/prototype-utils/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/foundation/libraries/reflect-metadata-utils/eslint.config.mjs
+++ b/packages/foundation/libraries/reflect-metadata-utils/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/foundation/tools/eslint-config/index.js
+++ b/packages/foundation/tools/eslint-config/index.js
@@ -161,66 +161,68 @@ function buildBaseConfig() {
   };
 }
 
-const baseRules = buildBaseConfig();
+export function buildDefaultConfig() {
+  const baseRules = buildBaseConfig();
 
-export default tseslint.config(
-  {
-    ...baseRules,
-    files: ['**/*.{cjs,mts,ts,tsx}'],
-    ignores: ['**/*.spec.{cjs,mts,ts,tsx}'],
-  },
-  {
-    ...baseRules,
-    extends: [...(baseRules.extends ?? [])],
-    files: ['**/*.spec.{cjs,mts,ts,tsx}'],
-    plugins: {
-      ...(baseRules.plugins ?? {}),
+  return tseslint.config(
+    {
+      ...baseRules,
+      files: ['**/*.{cjs,mts,ts,tsx}'],
+      ignores: ['**/*.spec.{cjs,mts,ts,tsx}'],
     },
-    rules: {
-      ...(baseRules.rules ?? {}),
-      '@typescript-eslint/no-confusing-void-expression': 'off',
-      '@typescript-eslint/unbound-method': 'off',
-      '@typescript-eslint/no-magic-numbers': 'off',
+    {
+      ...baseRules,
+      extends: [...(baseRules.extends ?? [])],
+      files: ['**/*.spec.{cjs,mts,ts,tsx}'],
+      plugins: {
+        ...(baseRules.plugins ?? {}),
+      },
+      rules: {
+        ...(baseRules.rules ?? {}),
+        '@typescript-eslint/no-confusing-void-expression': 'off',
+        '@typescript-eslint/unbound-method': 'off',
+        '@typescript-eslint/no-magic-numbers': 'off',
+      },
     },
-  },
-  {
-    files: ['**/*.spec.ts', '**/*.spec-d.ts'],
-    plugins: {
-      vitest,
+    {
+      files: ['**/*.spec.ts', '**/*.spec-d.ts'],
+      plugins: {
+        vitest,
+      },
+      rules: {
+        ...vitest.configs.recommended.rules,
+        ...vitest.configs.all.rules,
+        '@typescript-eslint/unbound-method': 'off',
+        '@typescript-eslint/no-confusing-void-expression': 'off',
+        '@typescript-eslint/no-magic-numbers': 'off',
+        '@typescript-eslint/no-unsafe-assignment': 'off',
+        'vitest/consistent-test-filename': 'off',
+        'vitest/consistent-vitest-vi': [
+          'error',
+          {
+            fn: 'vitest',
+          },
+        ],
+        'vitest/expect-expect': [
+          'error',
+          {
+            assertFunctionNames: ['assertType', 'expect', 'expectTypeOf'],
+          },
+        ],
+        'vitest/max-expects': 'off',
+        'vitest/max-nested-describe': 'off',
+        'vitest/no-hooks': 'off',
+        'vitest/no-importing-vitest-globals': 'off',
+        'vitest/prefer-expect-assertions': 'off',
+        'vitest/prefer-strict-equal': 'error',
+        'vitest/valid-title': 'off',
+        'vitest/prefer-lowercase-title': 'off',
+        'vitest/prefer-to-be-falsy': 'off',
+        'vitest/prefer-to-be-truthy': 'off',
+      },
     },
-    rules: {
-      ...vitest.configs.recommended.rules,
-      ...vitest.configs.all.rules,
-      '@typescript-eslint/unbound-method': 'off',
-      '@typescript-eslint/no-confusing-void-expression': 'off',
-      '@typescript-eslint/no-magic-numbers': 'off',
-      '@typescript-eslint/no-unsafe-assignment': 'off',
-      'vitest/consistent-test-filename': 'off',
-      'vitest/consistent-vitest-vi': [
-        'error',
-        {
-          fn: 'vitest',
-        },
-      ],
-      'vitest/expect-expect': [
-        'error',
-        {
-          assertFunctionNames: ['assertType', 'expect', 'expectTypeOf'],
-        },
-      ],
-      'vitest/max-expects': 'off',
-      'vitest/max-nested-describe': 'off',
-      'vitest/no-hooks': 'off',
-      'vitest/no-importing-vitest-globals': 'off',
-      'vitest/prefer-expect-assertions': 'off',
-      'vitest/prefer-strict-equal': 'error',
-      'vitest/valid-title': 'off',
-      'vitest/prefer-lowercase-title': 'off',
-      'vitest/prefer-to-be-falsy': 'off',
-      'vitest/prefer-to-be-truthy': 'off',
-    },
-  },
-  /** @type {import('typescript-eslint').ConfigWithExtends} */ (
-    eslintPrettierConfig
-  ),
-);
+    /** @type {import('typescript-eslint').ConfigWithExtends} */ (
+      eslintPrettierConfig
+    ),
+  );
+}

--- a/packages/http/libraries/core/eslint.config.mjs
+++ b/packages/http/libraries/core/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/http/libraries/express-v4/eslint.config.mjs
+++ b/packages/http/libraries/express-v4/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/http/libraries/express/eslint.config.mjs
+++ b/packages/http/libraries/express/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/http/libraries/fastify/eslint.config.mjs
+++ b/packages/http/libraries/fastify/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/http/libraries/hono/eslint.config.mjs
+++ b/packages/http/libraries/hono/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/http/tools/e2e-tests/eslint.config.mjs
+++ b/packages/http/tools/e2e-tests/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/http/tools/http-benchmarks/eslint.config.mjs
+++ b/packages/http/tools/http-benchmarks/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];

--- a/packages/logger/eslint.config.mjs
+++ b/packages/logger/eslint.config.mjs
@@ -1,3 +1,3 @@
-import myconfig from '@inversifyjs/foundation-eslint-config';
+import { buildDefaultConfig } from '@inversifyjs/foundation-eslint-config';
 
-export default [...myconfig];
+export default [...buildDefaultConfig()];


### PR DESCRIPTION
### Changed

Updated eslint config to rely on a buildDefaultConfig call. The previous config was causing issues with the node cache, caching eslint base config with unexpected current working directories