### PR TITLE
Update container with cache service invalidations

### DIFF
--- a/packages/container/libraries/container/src/container/services/BindingManager.spec.ts
+++ b/packages/container/libraries/container/src/container/services/BindingManager.spec.ts
@@ -63,6 +63,7 @@ describe(BindingManager, () => {
       > as Mocked<DeactivationsService>,
       planResultCacheService: {
         clearCache: vitest.fn(),
+        invalidateService: vitest.fn(),
       } as Partial<
         Mocked<PlanResultCacheService>
       > as Mocked<PlanResultCacheService>,
@@ -546,13 +547,13 @@ describe(BindingManager, () => {
         ).toHaveBeenCalledWith(serviceIdentifierFixture);
       });
 
-      it('should call planResultCacheService.clearCache()', () => {
+      it('should call planResultCacheService.invalidateService()', () => {
         expect(
-          serviceReferenceManagerMock.planResultCacheService.clearCache,
+          serviceReferenceManagerMock.planResultCacheService.invalidateService,
         ).toHaveBeenCalledTimes(1);
         expect(
-          serviceReferenceManagerMock.planResultCacheService.clearCache,
-        ).toHaveBeenCalledWith();
+          serviceReferenceManagerMock.planResultCacheService.invalidateService,
+        ).toHaveBeenCalledWith(serviceIdentifierFixture);
       });
 
       it('should return BindToFluentSyntax', () => {
@@ -626,13 +627,13 @@ describe(BindingManager, () => {
         ).toHaveBeenCalledWith(serviceIdentifierFixture);
       });
 
-      it('should call planResultCacheService.clearCache()', () => {
+      it('should call planResultCacheService.invalidateService()', () => {
         expect(
-          serviceReferenceManagerMock.planResultCacheService.clearCache,
+          serviceReferenceManagerMock.planResultCacheService.invalidateService,
         ).toHaveBeenCalledTimes(1);
         expect(
-          serviceReferenceManagerMock.planResultCacheService.clearCache,
-        ).toHaveBeenCalledWith();
+          serviceReferenceManagerMock.planResultCacheService.invalidateService,
+        ).toHaveBeenCalledWith(serviceIdentifierFixture);
       });
 
       it('should return BindToFluentSyntax', () => {
@@ -711,13 +712,15 @@ describe(BindingManager, () => {
           ).toHaveBeenCalledWith(serviceIdentifierFixture);
         });
 
-        it('should call planResultCacheService.clearCache()', () => {
+        it('should call planResultCacheService.invalidateService()', () => {
           expect(
-            serviceReferenceManagerMock.planResultCacheService.clearCache,
+            serviceReferenceManagerMock.planResultCacheService
+              .invalidateService,
           ).toHaveBeenCalledTimes(1);
           expect(
-            serviceReferenceManagerMock.planResultCacheService.clearCache,
-          ).toHaveBeenCalledWith();
+            serviceReferenceManagerMock.planResultCacheService
+              .invalidateService,
+          ).toHaveBeenCalledWith(serviceIdentifierFixture);
         });
 
         it('should return undefined', () => {
@@ -781,13 +784,15 @@ describe(BindingManager, () => {
           ).toHaveBeenCalledWith(serviceIdentifierFixture);
         });
 
-        it('should call planResultCacheService.clearCache()', () => {
+        it('should call planResultCacheService.invalidateService()', () => {
           expect(
-            serviceReferenceManagerMock.planResultCacheService.clearCache,
+            serviceReferenceManagerMock.planResultCacheService
+              .invalidateService,
           ).toHaveBeenCalledTimes(1);
           expect(
-            serviceReferenceManagerMock.planResultCacheService.clearCache,
-          ).toHaveBeenCalledWith();
+            serviceReferenceManagerMock.planResultCacheService
+              .invalidateService,
+          ).toHaveBeenCalledWith(serviceIdentifierFixture);
         });
 
         it('should return undefined', () => {
@@ -868,13 +873,15 @@ describe(BindingManager, () => {
           ).toHaveBeenCalledWith(bindingIdentifierFixture.id);
         });
 
-        it('should call planResultCacheService.clearCache()', () => {
+        it('should call planResultCacheService.invalidateService()', () => {
           expect(
-            serviceReferenceManagerMock.planResultCacheService.clearCache,
+            serviceReferenceManagerMock.planResultCacheService
+              .invalidateService,
           ).toHaveBeenCalledTimes(1);
           expect(
-            serviceReferenceManagerMock.planResultCacheService.clearCache,
-          ).toHaveBeenCalledWith();
+            serviceReferenceManagerMock.planResultCacheService
+              .invalidateService,
+          ).toHaveBeenCalledWith(bindingMock.serviceIdentifier);
         });
 
         it('should return undefined', () => {
@@ -948,13 +955,15 @@ describe(BindingManager, () => {
           ).toHaveBeenCalledWith(bindingIdentifierFixture.id);
         });
 
-        it('should call planResultCacheService.clearCache()', () => {
+        it('should call planResultCacheService.invalidateService()', () => {
           expect(
-            serviceReferenceManagerMock.planResultCacheService.clearCache,
+            serviceReferenceManagerMock.planResultCacheService
+              .invalidateService,
           ).toHaveBeenCalledTimes(1);
           expect(
-            serviceReferenceManagerMock.planResultCacheService.clearCache,
-          ).toHaveBeenCalledWith();
+            serviceReferenceManagerMock.planResultCacheService
+              .invalidateService,
+          ).toHaveBeenCalledWith(bindingMock.serviceIdentifier);
         });
 
         it('should return undefined', () => {

--- a/packages/container/libraries/container/src/container/services/BindingManager.ts
+++ b/packages/container/libraries/container/src/container/services/BindingManager.ts
@@ -138,7 +138,9 @@ export class BindingManager {
 
   #setBinding(binding: Binding): void {
     this.#serviceReferenceManager.bindingService.set(binding);
-    this.#serviceReferenceManager.planResultCacheService.clearCache();
+    this.#serviceReferenceManager.planResultCacheService.invalidateService(
+      binding.serviceIdentifier,
+    );
   }
 
   #throwUnexpectedAsyncUnbindOperation(
@@ -191,17 +193,27 @@ export class BindingManager {
     );
 
     if (result === undefined) {
-      this.#clearAfterUnbindBindingIdentifier(identifier);
+      this.#clearAfterUnbindBindingIdentifier(bindings, identifier);
     } else {
       return result.then((): void => {
-        this.#clearAfterUnbindBindingIdentifier(identifier);
+        this.#clearAfterUnbindBindingIdentifier(bindings, identifier);
       });
     }
   }
 
-  #clearAfterUnbindBindingIdentifier(identifier: BindingIdentifier): void {
+  #clearAfterUnbindBindingIdentifier(
+    bindings: Iterable<Binding<unknown>> | undefined,
+    identifier: BindingIdentifier,
+  ): void {
     this.#serviceReferenceManager.bindingService.removeById(identifier.id);
-    this.#serviceReferenceManager.planResultCacheService.clearCache();
+
+    if (bindings !== undefined) {
+      for (const binding of bindings) {
+        this.#serviceReferenceManager.planResultCacheService.invalidateService(
+          binding.serviceIdentifier,
+        );
+      }
+    }
   }
 
   #unbindServiceIdentifier(
@@ -232,7 +244,9 @@ export class BindingManager {
       identifier,
     );
 
-    this.#serviceReferenceManager.planResultCacheService.clearCache();
+    this.#serviceReferenceManager.planResultCacheService.invalidateService(
+      identifier,
+    );
   }
 
   #isAnyValidBinding(

--- a/packages/container/libraries/container/src/container/services/ContainerModuleManager.ts
+++ b/packages/container/libraries/container/src/container/services/ContainerModuleManager.ts
@@ -164,7 +164,9 @@ export class ContainerModuleManager {
   #setBinding(binding: Binding): void {
     this.#serviceReferenceManager.bindingService.set(binding);
 
-    this.#serviceReferenceManager.planResultCacheService.clearCache();
+    this.#serviceReferenceManager.planResultCacheService.invalidateService(
+      binding.serviceIdentifier,
+    );
   }
 
   #unload(...modules: ContainerModule[]): (void | Promise<void>)[] {

--- a/packages/container/libraries/container/src/container/services/ServiceResolutionManager.ts
+++ b/packages/container/libraries/container/src/container/services/ServiceResolutionManager.ts
@@ -350,6 +350,8 @@ export class ServiceResolutionManager {
 
   #setBinding(binding: Binding): void {
     this.#serviceReferenceManager.bindingService.set(binding);
-    this.#serviceReferenceManager.planResultCacheService.clearCache();
+    this.#serviceReferenceManager.planResultCacheService.invalidateService(
+      binding.serviceIdentifier,
+    );
   }
 }

--- a/packages/container/libraries/core/src/planning/actions/plan.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/plan.spec.ts
@@ -1311,9 +1311,14 @@ describe(plan, () => {
         const instanceBindingNode: InstanceBindingNode = {
           binding: instanceBindingFixture,
           classMetadata: classMetadataFixture,
-          constructorParams: [constructorParamsPlanServiceNode],
+          constructorParams: [
+            expect.objectContaining(constructorParamsPlanServiceNode),
+          ],
           propertyParams: new Map([
-            [propertyKey, propertyParamsPlanServiceNode],
+            [
+              propertyKey,
+              expect.objectContaining(propertyParamsPlanServiceNode),
+            ],
           ]),
         };
 

--- a/packages/container/libraries/core/src/planning/actions/plan.ts
+++ b/packages/container/libraries/core/src/planning/actions/plan.ts
@@ -504,7 +504,7 @@ function handlePlanServiceNodeBuildFromClassElementMetadata(
     lazyPlanServiceNode,
   );
 
-  return serviceNode;
+  return lazyPlanServiceNode;
 }
 
 function handlePlanServiceNodeBuildFromResolvedValueElementMetadata(
@@ -545,7 +545,7 @@ function handlePlanServiceNodeBuildFromResolvedValueElementMetadata(
     lazyPlanServiceNode,
   );
 
-  return serviceNode;
+  return lazyPlanServiceNode;
 }
 
 function subplan(

--- a/packages/http/libraries/hono/package.json
+++ b/packages/http/libraries/hono/package.json
@@ -48,7 +48,7 @@
   },
   "name": "@inversifyjs/http-hono",
   "peerDependencies": {
-    "hono": "^4.8.9",
+    "hono": "^4.8.10",
     "inversify": "^7.6.1"
   },
   "private": true,


### PR DESCRIPTION
### Changed
- Updated `ServiceResolutionManager` to rely on `invalidateService`.
- Updated `ContainerModuleManager` to rely on `invalidateService`.
- Updated `BindingManager` to rely on `invalidateService`.
- Updated `plan` to properly provide lazy plan service node dependencies.