### PR TITLE
Update BindOnFluentSyntaxImplementation

### DIFF
--- a/.changeset/dirty-pans-drum.md
+++ b/.changeset/dirty-pans-drum.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/container": patch
+---
+
+Updated `BindOnFluentSyntaxImplementation.onDeactivation` to throw an error on non singleton scoped bindings

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.ts
@@ -1,4 +1,8 @@
-import { Newable, ServiceIdentifier } from '@inversifyjs/common';
+import {
+  Newable,
+  ServiceIdentifier,
+  stringifyServiceIdentifier,
+} from '@inversifyjs/common';
 import {
   Binding,
   BindingActivation,
@@ -33,6 +37,8 @@ import { getBindingId } from '@inversifyjs/core';
 
 import { Writable } from '../../common/models/Writable';
 import { BindingConstraintUtils } from '../../container/binding/utils/BindingConstraintUtils';
+import { InversifyContainerError } from '../../error/models/InversifyContainerError';
+import { InversifyContainerErrorKind } from '../../error/models/InversifyContainerErrorKind';
 import { buildBindingIdentifier } from '../calculations/buildBindingIdentifier';
 import { isAnyAncestorBindingConstraints } from '../calculations/isAnyAncestorBindingConstraints';
 import { isAnyAncestorBindingConstraintsWithName } from '../calculations/isAnyAncestorBindingConstraintsWithName';
@@ -396,6 +402,13 @@ export class BindOnFluentSyntaxImplementation<T>
     deactivation: BindingDeactivation<T>,
   ): BindWhenFluentSyntax<T> {
     this.#binding.onDeactivation = deactivation;
+
+    if (this.#binding.scope !== bindingScopeValues.Singleton) {
+      throw new InversifyContainerError(
+        InversifyContainerErrorKind.invalidOperation,
+        `Binding for service "${stringifyServiceIdentifier(this.#binding.serviceIdentifier)}" has a deactivation function, but its scope is not singleton. Deactivation functions can only be used with singleton bindings.`,
+      );
+    }
 
     return new BindWhenFluentSyntaxImplementation(this.#binding);
   }

--- a/packages/docs/services/inversify-site/docs/api/binding-syntax.mdx
+++ b/packages/docs/services/inversify-site/docs/api/binding-syntax.mdx
@@ -222,6 +222,12 @@ onDeactivation(deactivation: BindingDeactivation<T>): BindWhenFluentSyntax<T>;
 
 Sets a binding deactivation handler on a singleton scope binding. The deactivation handler is called when the binding is unbound from a container.
 
+:::warning
+
+Only singleton scoped bindings can have deactivation handlers. If you try to add a deactivation handler to a non-singleton binding, an error will be thrown.
+
+:::
+
 ## BindWhenFluentSyntax
 
 ```ts

--- a/packages/docs/services/inversify-site/versioned_docs/version-6.x/api/binding-syntax.mdx
+++ b/packages/docs/services/inversify-site/versioned_docs/version-6.x/api/binding-syntax.mdx
@@ -212,6 +212,12 @@ onDeactivation(fn: (injectable: T) => void | Promise<void>): BindingWhenSyntax<T
 
 Sets a binding deactivation handler on a singleton scope binding. The deactivation handler is called when the binding is unbound from a container.
 
+:::warning
+
+Only singleton scoped bindings can have deactivation handlers. If you try to add a deactivation handler to a non-singleton binding, an error will be thrown.
+
+:::
+
 ## BindingWhenSyntax
 
 ```ts

--- a/packages/docs/services/inversify-site/versioned_docs/version-7.x/api/binding-syntax.mdx
+++ b/packages/docs/services/inversify-site/versioned_docs/version-7.x/api/binding-syntax.mdx
@@ -222,6 +222,12 @@ onDeactivation(deactivation: BindingDeactivation<T>): BindWhenFluentSyntax<T>;
 
 Sets a binding deactivation handler on a singleton scope binding. The deactivation handler is called when the binding is unbound from a container.
 
+:::warning
+
+Only singleton scoped bindings can have deactivation handlers. If you try to add a deactivation handler to a non-singleton binding, an error will be thrown.
+
+:::
+
 ## BindWhenFluentSyntax
 
 ```ts


### PR DESCRIPTION
### Changed
- Updated `BindOnFluentSyntaxImplementation.onDeactivation` to throw an error on non singleton scoped bindings.

### Context
- Bug reported in #828 