### PR TITLE
Update renovate to update example packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,11 +5,26 @@
     "pnpm": "10"
   },
   "extends": [
-    "config:base",
+    ":dependencyDashboard",
     ":disableRateLimiting",
-    ":semanticCommitScopeDisabled"
+    ":semanticCommitScopeDisabled",
+    ":semanticPrefixFixDepsChoreOthers",
+    "group:monorepos",
+    "group:recommended",
+    "mergeConfidence:age-confidence-badges",
+    "replacements:all",
+    "workarounds:all"
   ],
   "ignoreDeps": [],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/__tests__/**",
+    "**/test/**",
+    "**/tests/**",
+    "**/__fixtures__/**"
+  ],
   "packageRules": [
     {
       "enabled": false,


### PR DESCRIPTION
### Changed
- Updated renovate bot to update example packages.

### Context
It seems [config:recommended](https://docs.renovatebot.com/presets-config/#configrecommended) includes [:ignoreModulesAndTests](https://docs.renovatebot.com/presets-default/#ignoremodulesandtests) which ignores `examples` paths.