### PR TITLE
Update container internal services with getParent params

### DIFF
--- a/.changeset/wet-buttons-make.md
+++ b/.changeset/wet-buttons-make.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": patch
+---
+
+Updated `BindingService`, `ActivationsService` and `DeactivationsService` to receive a `getParent` param. This way restoring a parent container no longer leads to invalid parent references

--- a/packages/container/libraries/container/src/container/services/Container.spec.ts
+++ b/packages/container/libraries/container/src/container/services/Container.spec.ts
@@ -193,20 +193,23 @@ describe(Container, () => {
           expect(ActivationsService.build).toHaveBeenCalledTimes(2);
           expect(ActivationsService.build).toHaveBeenNthCalledWith(
             1,
-            undefined,
+            expect.any(Function),
           );
           expect(ActivationsService.build).toHaveBeenNthCalledWith(
             2,
-            activationServiceMock,
+            expect.any(Function),
           );
         });
 
         it('should call BindingService.build', () => {
           expect(BindingService.build).toHaveBeenCalledTimes(2);
-          expect(BindingService.build).toHaveBeenNthCalledWith(1, undefined);
+          expect(BindingService.build).toHaveBeenNthCalledWith(
+            1,
+            expect.any(Function),
+          );
           expect(BindingService.build).toHaveBeenNthCalledWith(
             2,
-            bindingServiceMock,
+            expect.any(Function),
           );
         });
 
@@ -214,11 +217,11 @@ describe(Container, () => {
           expect(DeactivationsService.build).toHaveBeenCalledTimes(2);
           expect(DeactivationsService.build).toHaveBeenNthCalledWith(
             1,
-            undefined,
+            expect.any(Function),
           );
           expect(DeactivationsService.build).toHaveBeenNthCalledWith(
             2,
-            deactivationServiceMock,
+            expect.any(Function),
           );
         });
 

--- a/packages/container/libraries/container/src/container/services/Container.ts
+++ b/packages/container/libraries/container/src/container/services/Container.ts
@@ -223,9 +223,9 @@ export class Container {
   ): ServiceReferenceManager {
     if (options?.parent === undefined) {
       return new ServiceReferenceManager(
-        ActivationsService.build(undefined),
-        BindingService.build(undefined),
-        DeactivationsService.build(undefined),
+        ActivationsService.build(() => undefined),
+        BindingService.build(() => undefined),
+        DeactivationsService.build(() => undefined),
         new PlanResultCacheService(),
       );
     }
@@ -233,19 +233,21 @@ export class Container {
     const planResultCacheService: PlanResultCacheService =
       new PlanResultCacheService();
 
-    options.parent.#serviceReferenceManager.planResultCacheService.subscribe(
+    const parent: Container = options.parent;
+
+    parent.#serviceReferenceManager.planResultCacheService.subscribe(
       planResultCacheService,
     );
 
     return new ServiceReferenceManager(
       ActivationsService.build(
-        options.parent.#serviceReferenceManager.activationService,
+        () => parent.#serviceReferenceManager.activationService,
       ),
       BindingService.build(
-        options.parent.#serviceReferenceManager.bindingService,
+        () => parent.#serviceReferenceManager.bindingService,
       ),
       DeactivationsService.build(
-        options.parent.#serviceReferenceManager.deactivationService,
+        () => parent.#serviceReferenceManager.deactivationService,
       ),
       planResultCacheService,
     );

--- a/packages/container/libraries/container/src/issues/inversify-InversifyJs-issue-1857-childContainerShouldPointToRightParentServicesAfterRestore.int.spec.ts
+++ b/packages/container/libraries/container/src/issues/inversify-InversifyJs-issue-1857-childContainerShouldPointToRightParentServicesAfterRestore.int.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import 'reflect-metadata';
+
+import { Container } from '../container/services/Container';
+
+describe('inversify/InversifyJS#1806', () => {
+  it('Child container should point to the right parent services after restore', () => {
+    const parent: Container = new Container();
+    const container: Container = new Container({ parent });
+
+    parent.bind<string>('weapon').toConstantValue('Katana');
+
+    parent.snapshot();
+    parent.restore();
+
+    parent.rebindSync<string>('weapon').toConstantValue('Shuriken');
+
+    expect(parent.get<string>('weapon')).to.equal('Shuriken');
+    expect(container.get<string>('weapon')).to.equal('Shuriken');
+  });
+});

--- a/packages/container/libraries/core/src/binding/services/ActivationsService.spec.ts
+++ b/packages/container/libraries/core/src/binding/services/ActivationsService.spec.ts
@@ -45,9 +45,11 @@ describe(ActivationsService, () => {
       OneToManyMapStar<BindingActivation, BindingActivationRelation>
     >;
 
-    parentActivationService = ActivationsService.build(undefined);
+    parentActivationService = ActivationsService.build(() => undefined);
 
-    activationsService = ActivationsService.build(parentActivationService);
+    activationsService = ActivationsService.build(
+      () => parentActivationService,
+    );
   });
 
   describe('.add', () => {

--- a/packages/container/libraries/core/src/binding/services/ActivationsService.ts
+++ b/packages/container/libraries/core/src/binding/services/ActivationsService.ts
@@ -20,11 +20,10 @@ export class ActivationsService implements Cloneable<ActivationsService> {
     BindingActivation,
     BindingActivationRelation
   >;
-
-  readonly #parent: ActivationsService | undefined;
+  readonly #getParent: () => ActivationsService | undefined;
 
   private constructor(
-    parent: ActivationsService | undefined,
+    getParent: () => ActivationsService | undefined,
     activationMaps?: OneToManyMapStar<
       BindingActivation,
       BindingActivationRelation
@@ -41,13 +40,13 @@ export class ActivationsService implements Cloneable<ActivationsService> {
         },
       });
 
-    this.#parent = parent;
+    this.#getParent = getParent;
   }
 
   public static build(
-    parent: ActivationsService | undefined,
+    getParent: () => ActivationsService | undefined,
   ): ActivationsService {
-    return new ActivationsService(parent);
+    return new ActivationsService(getParent);
   }
 
   public add(
@@ -59,7 +58,7 @@ export class ActivationsService implements Cloneable<ActivationsService> {
 
   public clone(): ActivationsService {
     const clone: ActivationsService = new ActivationsService(
-      this.#parent,
+      this.#getParent,
       this.#activationMaps.clone(),
     );
 
@@ -82,7 +81,7 @@ export class ActivationsService implements Cloneable<ActivationsService> {
     }
 
     const parentActivations: Iterable<BindingActivation> | undefined =
-      this.#parent?.get(serviceIdentifier);
+      this.#getParent()?.get(serviceIdentifier);
 
     if (parentActivations !== undefined) {
       activationIterables.push(parentActivations);

--- a/packages/container/libraries/core/src/binding/services/BindingService.spec.ts
+++ b/packages/container/libraries/core/src/binding/services/BindingService.spec.ts
@@ -38,9 +38,9 @@ describe(BindingService, () => {
       },
     }) as Mocked<OneToManyMapStar<Binding<unknown>, BindingRelation>>;
 
-    parentBindingService = BindingService.build(undefined);
+    parentBindingService = BindingService.build(() => undefined);
 
-    bindingService = BindingService.build(parentBindingService);
+    bindingService = BindingService.build(() => parentBindingService);
   });
 
   describe('.clone', () => {
@@ -160,7 +160,7 @@ describe(BindingService, () => {
       beforeAll(() => {
         bindingFixture = Symbol() as unknown as Binding<unknown>;
 
-        bindingServiceWithoutParent = BindingService.build(undefined);
+        bindingServiceWithoutParent = BindingService.build(() => undefined);
 
         bindingMapsMock.get.mockReturnValueOnce([bindingFixture]);
 

--- a/packages/container/libraries/core/src/binding/services/DeactivationsService.spec.ts
+++ b/packages/container/libraries/core/src/binding/services/DeactivationsService.spec.ts
@@ -44,10 +44,10 @@ describe(DeactivationsService, () => {
       OneToManyMapStar<BindingDeactivation, BindingDeactivationRelation>
     >;
 
-    parentDeactivationService = DeactivationsService.build(undefined);
+    parentDeactivationService = DeactivationsService.build(() => undefined);
 
     deactivationsService = DeactivationsService.build(
-      parentDeactivationService,
+      () => parentDeactivationService,
     );
   });
 

--- a/packages/container/libraries/core/src/binding/services/DeactivationsService.ts
+++ b/packages/container/libraries/core/src/binding/services/DeactivationsService.ts
@@ -21,10 +21,10 @@ export class DeactivationsService implements Cloneable<DeactivationsService> {
     BindingDeactivationRelation
   >;
 
-  readonly #parent: DeactivationsService | undefined;
+  readonly #getParent: () => DeactivationsService | undefined;
 
   private constructor(
-    parent: DeactivationsService | undefined,
+    getParent: () => DeactivationsService | undefined,
     deactivationMaps?: OneToManyMapStar<
       BindingDeactivation,
       BindingDeactivationRelation
@@ -41,13 +41,13 @@ export class DeactivationsService implements Cloneable<DeactivationsService> {
         },
       });
 
-    this.#parent = parent;
+    this.#getParent = getParent;
   }
 
   public static build(
-    parent: DeactivationsService | undefined,
+    getParent: () => DeactivationsService | undefined,
   ): DeactivationsService {
-    return new DeactivationsService(parent);
+    return new DeactivationsService(getParent);
   }
 
   public add(
@@ -59,7 +59,7 @@ export class DeactivationsService implements Cloneable<DeactivationsService> {
 
   public clone(): DeactivationsService {
     const clone: DeactivationsService = new DeactivationsService(
-      this.#parent,
+      this.#getParent,
       this.#deactivationMaps.clone(),
     );
 
@@ -82,7 +82,7 @@ export class DeactivationsService implements Cloneable<DeactivationsService> {
     }
 
     const parentDeactivations: Iterable<BindingDeactivation> | undefined =
-      this.#parent?.get(serviceIdentifier);
+      this.#getParent()?.get(serviceIdentifier);
 
     if (parentDeactivations !== undefined) {
       deactivationIterables.push(parentDeactivations);

--- a/packages/container/libraries/core/src/planning/actions/plan.int.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/plan.int.spec.ts
@@ -381,7 +381,7 @@ describe(plan, () => {
       type: bindingTypeValues.ServiceRedirection,
     };
 
-    bindingService = BindingService.build(undefined);
+    bindingService = BindingService.build(() => undefined);
 
     bindingService.set(constantValueBinding);
     bindingService.set(dynamicValueBinding);

--- a/packages/container/libraries/core/src/resolution/actions/resolve.int.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolve.int.spec.ts
@@ -254,8 +254,8 @@ describe(resolve, () => {
       type: bindingTypeValues.ServiceRedirection,
     };
 
-    activationService = ActivationsService.build(undefined);
-    bindingService = BindingService.build(undefined);
+    activationService = ActivationsService.build(() => undefined);
+    bindingService = BindingService.build(() => undefined);
 
     activationService.add(
       constantValueBindingWithActivation.onActivation as BindingActivation,


### PR DESCRIPTION
### Changed
- Updated container internal services with `getParent` params.
- Updated `Container` to build internal services accordingly.

### Context
This PR aims to fix inversify/InversifyJS#1857