### PR TITLE
Extract curry planning modules

### DIFF
--- a/packages/container/examples/plugin-example/package.json
+++ b/packages/container/examples/plugin-example/package.json
@@ -17,7 +17,7 @@
     "typescript": "5.9.2"
   },
   "peerDependencies": {
-    "inversify": "^7.6.1"
+    "inversify": "^7.7.0"
   },
   "homepage": "https://inversify.io",
   "keywords": [

--- a/packages/container/libraries/binding-decorators/package.json
+++ b/packages/container/libraries/binding-decorators/package.json
@@ -24,7 +24,7 @@
     "vitest": "3.2.4"
   },
   "peerDependencies": {
-    "inversify": "^7.6.1"
+    "inversify": "^7.7.0"
   },
   "homepage": "https://inversify.io",
   "keywords": [

--- a/packages/container/libraries/core/src/binding/fixtures/ResolvedValueBindingFixtures.ts
+++ b/packages/container/libraries/core/src/binding/fixtures/ResolvedValueBindingFixtures.ts
@@ -1,3 +1,4 @@
+import { ResolvedValueElementMetadataKind } from '../../metadata/models/ResolvedValueElementMetadataKind';
 import { bindingScopeValues } from '../models/BindingScope';
 import { bindingTypeValues } from '../models/BindingType';
 import { ResolvedValueBinding } from '../models/ResolvedValueBinding';
@@ -21,6 +22,23 @@ export class ResolvedValueBindingFixtures {
       scope: bindingScopeValues.Singleton,
       serviceIdentifier: Symbol(),
       type: bindingTypeValues.ResolvedValue,
+    };
+  }
+
+  public static get withSingleInjectionMetadata(): ResolvedValueBinding<unknown> {
+    return {
+      ...ResolvedValueBindingFixtures.any,
+      metadata: {
+        arguments: [
+          {
+            kind: ResolvedValueElementMetadataKind.singleInjection,
+            name: undefined,
+            optional: false,
+            tags: new Map(),
+            value: Symbol(),
+          },
+        ],
+      },
     };
   }
 }

--- a/packages/container/libraries/core/src/binding/fixtures/ResolvedValueBindingFixtures.ts
+++ b/packages/container/libraries/core/src/binding/fixtures/ResolvedValueBindingFixtures.ts
@@ -1,0 +1,26 @@
+import { bindingScopeValues } from '../models/BindingScope';
+import { bindingTypeValues } from '../models/BindingType';
+import { ResolvedValueBinding } from '../models/ResolvedValueBinding';
+
+export class ResolvedValueBindingFixtures {
+  public static get any(): ResolvedValueBinding<unknown> {
+    return {
+      cache: {
+        isRight: false,
+        value: undefined,
+      },
+      factory: () => Symbol(),
+      id: 1,
+      isSatisfiedBy: () => true,
+      metadata: {
+        arguments: [],
+      },
+      moduleId: undefined,
+      onActivation: undefined,
+      onDeactivation: undefined,
+      scope: bindingScopeValues.Singleton,
+      serviceIdentifier: Symbol(),
+      type: bindingTypeValues.ResolvedValue,
+    };
+  }
+}

--- a/packages/container/libraries/core/src/binding/fixtures/ServiceRedirectionBindingFixtures.ts
+++ b/packages/container/libraries/core/src/binding/fixtures/ServiceRedirectionBindingFixtures.ts
@@ -1,0 +1,15 @@
+import { bindingTypeValues } from '../models/BindingType';
+import { ServiceRedirectionBinding } from '../models/ServiceRedirectionBinding';
+
+export class ServiceRedirectionBindingFixtures {
+  public static get any(): ServiceRedirectionBinding<unknown> {
+    return {
+      id: 1,
+      isSatisfiedBy: () => true,
+      moduleId: undefined,
+      serviceIdentifier: Symbol(),
+      targetServiceIdentifier: Symbol(),
+      type: bindingTypeValues.ServiceRedirection,
+    };
+  }
+}

--- a/packages/container/libraries/core/src/metadata/fixtures/ClassMetadataFixtures.ts
+++ b/packages/container/libraries/core/src/metadata/fixtures/ClassMetadataFixtures.ts
@@ -1,3 +1,4 @@
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
 import { ClassMetadata } from '../models/ClassMetadata';
 
 export class ClassMetadataFixtures {
@@ -10,6 +11,36 @@ export class ClassMetadataFixtures {
       },
       properties: new Map(),
       scope: undefined,
+    };
+
+    return fixture;
+  }
+
+  public static get withUnmanagedConstructorArguments(): ClassMetadata {
+    const fixture: ClassMetadata = {
+      ...ClassMetadataFixtures.any,
+      constructorArguments: [
+        {
+          kind: ClassElementMetadataKind.unmanaged,
+        },
+      ],
+    };
+
+    return fixture;
+  }
+
+  public static get withSingleInjectionConstructorArguments(): ClassMetadata {
+    const fixture: ClassMetadata = {
+      ...ClassMetadataFixtures.any,
+      constructorArguments: [
+        {
+          kind: ClassElementMetadataKind.singleInjection,
+          name: undefined,
+          optional: false,
+          tags: new Map(),
+          value: Symbol(),
+        },
+      ],
     };
 
     return fixture;

--- a/packages/container/libraries/core/src/metadata/fixtures/ClassMetadataFixtures.ts
+++ b/packages/container/libraries/core/src/metadata/fixtures/ClassMetadataFixtures.ts
@@ -46,6 +46,26 @@ export class ClassMetadataFixtures {
     return fixture;
   }
 
+  public static get withSingleInjectionProperty(): ClassMetadata {
+    const fixture: ClassMetadata = {
+      ...ClassMetadataFixtures.any,
+      properties: new Map([
+        [
+          Symbol(),
+          {
+            kind: ClassElementMetadataKind.singleInjection,
+            name: undefined,
+            optional: false,
+            tags: new Map(),
+            value: Symbol(),
+          },
+        ],
+      ]),
+    };
+
+    return fixture;
+  }
+
   public static get withNoPreDestroyMethodName(): ClassMetadata {
     const fixture: ClassMetadata = {
       constructorArguments: [],

--- a/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNode.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNode.spec.ts
@@ -1,0 +1,269 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  Mock,
+  vitest,
+} from 'vitest';
+
+vitest.mock('../calculations/buildFilteredServiceBindings');
+vitest.mock('../calculations/buildPlanBindingConstraintsList');
+vitest.mock('../calculations/checkServiceNodeSingleInjectionBindings');
+
+import { Binding } from '../../binding/models/Binding';
+import {
+  BindingConstraintsImplementation,
+  InternalBindingConstraints,
+} from '../../binding/models/BindingConstraintsImplementation';
+import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { buildFilteredServiceBindings } from '../calculations/buildFilteredServiceBindings';
+import { buildPlanBindingConstraintsList } from '../calculations/buildPlanBindingConstraintsList';
+import { checkServiceNodeSingleInjectionBindings } from '../calculations/checkServiceNodeSingleInjectionBindings';
+import { BasePlanParams } from '../models/BasePlanParams';
+import { BindingNodeParent } from '../models/BindingNodeParent';
+import { PlanBindingNode } from '../models/PlanBindingNode';
+import { PlanParams } from '../models/PlanParams';
+import { PlanParamsOperations } from '../models/PlanParamsOperations';
+import { PlanServiceNode } from '../models/PlanServiceNode';
+import { curryBuildPlanServiceNode } from './curryBuildPlanServiceNode';
+
+describe(curryBuildPlanServiceNode, () => {
+  let buildServiceNodeBindingsMock: Mock<
+    (
+      params: BasePlanParams,
+      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      serviceBindings: Binding<unknown>[],
+      parentNode: BindingNodeParent,
+      chainedBindings: boolean,
+    ) => PlanBindingNode[]
+  >;
+
+  beforeAll(() => {
+    buildServiceNodeBindingsMock = vitest.fn();
+  });
+
+  describe('having PlanParams with rootConstraints.isMultiple true and chained false', () => {
+    let planParamsFixture: PlanParams;
+
+    beforeAll(() => {
+      planParamsFixture = {
+        autobindOptions: undefined,
+        operations: {} as Partial<PlanParamsOperations> as PlanParamsOperations,
+        rootConstraints: {
+          chained: false,
+          isMultiple: true,
+          serviceIdentifier: Symbol(),
+        },
+        servicesBranch: [],
+      };
+    });
+
+    describe('when called', () => {
+      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let bindingsFixture: Binding<unknown>[];
+      let planBindingNodesFixture: PlanBindingNode[];
+
+      let result: unknown;
+
+      beforeAll(() => {
+        bindingConstraintsListFixture =
+          new SingleInmutableLinkedList<InternalBindingConstraints>({
+            elem: Symbol() as unknown as InternalBindingConstraints,
+            previous: undefined,
+          });
+
+        bindingsFixture = [Symbol() as unknown as Binding<unknown>];
+        planBindingNodesFixture = [Symbol() as unknown as PlanBindingNode];
+
+        vitest
+          .mocked(buildPlanBindingConstraintsList)
+          .mockReturnValueOnce(bindingConstraintsListFixture);
+
+        vitest
+          .mocked(buildFilteredServiceBindings)
+          .mockReturnValueOnce(bindingsFixture);
+
+        buildServiceNodeBindingsMock.mockReturnValueOnce(
+          planBindingNodesFixture,
+        );
+
+        result = curryBuildPlanServiceNode(buildServiceNodeBindingsMock)(
+          planParamsFixture,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call buildPlanBindingConstraintsList()', () => {
+        expect(buildPlanBindingConstraintsList).toHaveBeenCalledTimes(1);
+        expect(buildPlanBindingConstraintsList).toHaveBeenCalledWith(
+          planParamsFixture,
+        );
+      });
+
+      it('should call buildFilteredServiceBindings()', () => {
+        expect(buildFilteredServiceBindings).toHaveBeenCalledTimes(1);
+        expect(buildFilteredServiceBindings).toHaveBeenCalledWith(
+          planParamsFixture,
+          new BindingConstraintsImplementation(
+            bindingConstraintsListFixture.last,
+          ),
+          { chained: false },
+        );
+      });
+
+      it('should call buildServiceNodeBindings()', () => {
+        const expectedServiceNode: BindingNodeParent = {
+          bindings: planBindingNodesFixture,
+          isContextFree: true,
+          serviceIdentifier:
+            planParamsFixture.rootConstraints.serviceIdentifier,
+        };
+
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledTimes(1);
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledWith(
+          planParamsFixture,
+          bindingConstraintsListFixture,
+          bindingsFixture,
+          expectedServiceNode,
+          false,
+        );
+      });
+
+      it('should return expected value', () => {
+        const expectedServiceNode: PlanServiceNode = {
+          bindings: planBindingNodesFixture,
+          isContextFree: true,
+          serviceIdentifier:
+            planParamsFixture.rootConstraints.serviceIdentifier,
+        };
+
+        expect(result).toStrictEqual(expectedServiceNode);
+      });
+    });
+  });
+
+  describe('having PlanParams with rootConstraints.isMultiple false', () => {
+    let planParamsFixture: PlanParams;
+
+    beforeAll(() => {
+      planParamsFixture = {
+        autobindOptions: undefined,
+        operations: {} as Partial<PlanParamsOperations> as PlanParamsOperations,
+        rootConstraints: {
+          isMultiple: false,
+          serviceIdentifier: Symbol(),
+        },
+        servicesBranch: [],
+      };
+    });
+
+    describe('when called', () => {
+      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let bindingsFixture: Binding<unknown>[];
+      let planBindingNodeFixture: PlanBindingNode;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        bindingConstraintsListFixture =
+          new SingleInmutableLinkedList<InternalBindingConstraints>({
+            elem: Symbol() as unknown as InternalBindingConstraints,
+            previous: undefined,
+          });
+
+        bindingsFixture = [Symbol() as unknown as Binding<unknown>];
+        planBindingNodeFixture = Symbol() as unknown as PlanBindingNode;
+
+        vitest
+          .mocked(buildPlanBindingConstraintsList)
+          .mockReturnValueOnce(bindingConstraintsListFixture);
+
+        vitest
+          .mocked(buildFilteredServiceBindings)
+          .mockReturnValueOnce(bindingsFixture);
+
+        buildServiceNodeBindingsMock.mockReturnValueOnce([
+          planBindingNodeFixture,
+        ]);
+
+        result = curryBuildPlanServiceNode(buildServiceNodeBindingsMock)(
+          planParamsFixture,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call buildPlanBindingConstraintsList()', () => {
+        expect(buildPlanBindingConstraintsList).toHaveBeenCalledTimes(1);
+        expect(buildPlanBindingConstraintsList).toHaveBeenCalledWith(
+          planParamsFixture,
+        );
+      });
+
+      it('should call buildFilteredServiceBindings()', () => {
+        expect(buildFilteredServiceBindings).toHaveBeenCalledTimes(1);
+        expect(buildFilteredServiceBindings).toHaveBeenCalledWith(
+          planParamsFixture,
+          new BindingConstraintsImplementation(
+            bindingConstraintsListFixture.last,
+          ),
+          { chained: false },
+        );
+      });
+
+      it('should call buildServiceNodeBindings()', () => {
+        const expectedServiceNode: BindingNodeParent = {
+          bindings: planBindingNodeFixture,
+          isContextFree: true,
+          serviceIdentifier:
+            planParamsFixture.rootConstraints.serviceIdentifier,
+        };
+
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledTimes(1);
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledWith(
+          planParamsFixture,
+          bindingConstraintsListFixture,
+          bindingsFixture,
+          expectedServiceNode,
+          false,
+        );
+      });
+
+      it('should call checkServiceNodeSingleInjectionBindings()', () => {
+        const expectedServiceNode: BindingNodeParent = {
+          bindings: planBindingNodeFixture,
+          isContextFree: true,
+          serviceIdentifier:
+            planParamsFixture.rootConstraints.serviceIdentifier,
+        };
+
+        expect(checkServiceNodeSingleInjectionBindings).toHaveBeenCalledTimes(
+          1,
+        );
+        expect(checkServiceNodeSingleInjectionBindings).toHaveBeenCalledWith(
+          expectedServiceNode,
+          false,
+          bindingConstraintsListFixture.last,
+        );
+      });
+
+      it('should return expected value', () => {
+        const expectedServiceNode: PlanServiceNode = {
+          bindings: planBindingNodeFixture,
+          isContextFree: true,
+          serviceIdentifier:
+            planParamsFixture.rootConstraints.serviceIdentifier,
+        };
+
+        expect(result).toStrictEqual(expectedServiceNode);
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNode.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNode.ts
@@ -1,0 +1,77 @@
+import { Binding } from '../../binding/models/Binding';
+import { BindingConstraints } from '../../binding/models/BindingConstraints';
+import {
+  BindingConstraintsImplementation,
+  InternalBindingConstraints,
+} from '../../binding/models/BindingConstraintsImplementation';
+import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { buildFilteredServiceBindings } from '../calculations/buildFilteredServiceBindings';
+import { buildPlanBindingConstraintsList } from '../calculations/buildPlanBindingConstraintsList';
+import { checkServiceNodeSingleInjectionBindings } from '../calculations/checkServiceNodeSingleInjectionBindings';
+import { BasePlanParams } from '../models/BasePlanParams';
+import { BindingNodeParent } from '../models/BindingNodeParent';
+import { PlanBindingNode } from '../models/PlanBindingNode';
+import { PlanParams } from '../models/PlanParams';
+import { PlanServiceNode } from '../models/PlanServiceNode';
+
+export function curryBuildPlanServiceNode(
+  buildServiceNodeBindings: (
+    params: BasePlanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    serviceBindings: Binding<unknown>[],
+    parentNode: BindingNodeParent,
+    chainedBindings: boolean,
+  ) => PlanBindingNode[],
+): (params: PlanParams) => PlanServiceNode {
+  return (params: PlanParams): PlanServiceNode => {
+    const bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints> =
+      buildPlanBindingConstraintsList(params);
+
+    const bindingConstraints: BindingConstraints =
+      new BindingConstraintsImplementation(bindingConstraintsList.last);
+
+    const chained: boolean = params.rootConstraints.isMultiple
+      ? params.rootConstraints.chained
+      : false;
+
+    const filteredServiceBindings: Binding<unknown>[] =
+      buildFilteredServiceBindings(params, bindingConstraints, {
+        chained,
+      });
+
+    const serviceNodeBindings: PlanBindingNode[] = [];
+
+    const serviceNode: PlanServiceNode = {
+      bindings: serviceNodeBindings,
+      isContextFree: true,
+      serviceIdentifier: params.rootConstraints.serviceIdentifier,
+    };
+
+    serviceNodeBindings.push(
+      ...buildServiceNodeBindings(
+        params,
+        bindingConstraintsList,
+        filteredServiceBindings,
+        serviceNode,
+        chained,
+      ),
+    );
+
+    serviceNode.isContextFree =
+      !bindingConstraintsList.last.elem.getAncestorsCalled;
+
+    if (!params.rootConstraints.isMultiple) {
+      checkServiceNodeSingleInjectionBindings(
+        serviceNode,
+        params.rootConstraints.isOptional ?? false,
+        bindingConstraintsList.last,
+      );
+
+      const [planBindingNode]: PlanBindingNode[] = serviceNodeBindings;
+
+      serviceNode.bindings = planBindingNode;
+    }
+
+    return serviceNode;
+  };
+}

--- a/packages/container/libraries/core/src/planning/actions/curryBuildServiceNodeBindings.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildServiceNodeBindings.spec.ts
@@ -1,0 +1,311 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  Mock,
+  Mocked,
+  vitest,
+} from 'vitest';
+
+vitest.mock('../calculations/buildFilteredServiceBindings');
+
+import { InstanceBindingFixtures } from '../../binding/fixtures/InstanceBindingFixtures';
+import { ResolvedValueBindingFixtures } from '../../binding/fixtures/ResolvedValueBindingFixtures';
+import { ServiceRedirectionBindingFixtures } from '../../binding/fixtures/ServiceRedirectionBindingFixtures';
+import { BindingConstraints } from '../../binding/models/BindingConstraints';
+import {
+  BindingConstraintsImplementation,
+  InternalBindingConstraints,
+} from '../../binding/models/BindingConstraintsImplementation';
+import { bindingScopeValues } from '../../binding/models/BindingScope';
+import { InstanceBinding } from '../../binding/models/InstanceBinding';
+import { ResolvedValueBinding } from '../../binding/models/ResolvedValueBinding';
+import { ServiceRedirectionBinding } from '../../binding/models/ServiceRedirectionBinding';
+import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { ClassMetadataFixtures } from '../../metadata/fixtures/ClassMetadataFixtures';
+import { ClassMetadata } from '../../metadata/models/ClassMetadata';
+import { buildFilteredServiceBindings } from '../calculations/buildFilteredServiceBindings';
+import { BasePlanParams } from '../models/BasePlanParams';
+import { PlanBindingNode } from '../models/PlanBindingNode';
+import { PlanParamsOperations } from '../models/PlanParamsOperations';
+import { PlanServiceNode } from '../models/PlanServiceNode';
+import { SubplanParams } from '../models/SubplanParams';
+import { curryBuildServiceNodeBindings } from './curryBuildServiceNodeBindings';
+
+describe(curryBuildServiceNodeBindings, () => {
+  let subplanMock: Mock<
+    (
+      params: SubplanParams,
+      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    ) => PlanBindingNode
+  >;
+
+  beforeAll(() => {
+    subplanMock = vitest.fn();
+  });
+
+  describe('having serviceBindings with InstanceBinding and PlanServiceNode parent node', () => {
+    let basePlanParamsMock: Mocked<BasePlanParams>;
+    let instanceBindingFixture: InstanceBinding<unknown>;
+    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let parentNodeFixture: PlanServiceNode;
+
+    beforeAll(() => {
+      basePlanParamsMock = {
+        autobindOptions: {
+          scope: bindingScopeValues.Transient,
+        },
+        operations: {
+          getClassMetadata: vitest.fn(),
+        } as Partial<PlanParamsOperations> as PlanParamsOperations,
+        servicesBranch: [],
+      };
+
+      instanceBindingFixture = InstanceBindingFixtures.any;
+
+      bindingConstraintsListFixture =
+        new SingleInmutableLinkedList<InternalBindingConstraints>({
+          elem: Symbol() as unknown as InternalBindingConstraints,
+          previous: undefined,
+        });
+
+      parentNodeFixture = {
+        bindings: [],
+        isContextFree: true,
+        serviceIdentifier: Symbol(),
+      };
+    });
+
+    describe('when called', () => {
+      let classMetadataFixture: ClassMetadata;
+      let planBindingNodeFixture: PlanBindingNode;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        classMetadataFixture = ClassMetadataFixtures.any;
+        planBindingNodeFixture = Symbol() as unknown as PlanBindingNode;
+
+        vitest
+          .mocked(basePlanParamsMock.operations.getClassMetadata)
+          .mockReturnValueOnce(classMetadataFixture);
+
+        subplanMock.mockReturnValueOnce(planBindingNodeFixture);
+
+        result = curryBuildServiceNodeBindings(subplanMock)(
+          basePlanParamsMock,
+          bindingConstraintsListFixture,
+          [instanceBindingFixture],
+          parentNodeFixture,
+          false,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call getClassMetadata()', () => {
+        expect(
+          basePlanParamsMock.operations.getClassMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          basePlanParamsMock.operations.getClassMetadata,
+        ).toHaveBeenCalledWith(instanceBindingFixture.implementationType);
+      });
+
+      it('should call subplan with correct params', () => {
+        const expectedSubplanParams: SubplanParams = {
+          autobindOptions: basePlanParamsMock.autobindOptions,
+          node: {
+            binding: instanceBindingFixture,
+            classMetadata: classMetadataFixture,
+            constructorParams: [],
+            propertyParams: new Map(),
+          },
+          operations: basePlanParamsMock.operations,
+          servicesBranch: basePlanParamsMock.servicesBranch,
+        };
+
+        expect(subplanMock).toHaveBeenCalledTimes(1);
+        expect(subplanMock).toHaveBeenCalledWith(
+          expectedSubplanParams,
+          bindingConstraintsListFixture,
+        );
+      });
+
+      it('should return PlanBindingNode[]', () => {
+        expect(result).toStrictEqual([planBindingNodeFixture]);
+      });
+    });
+  });
+
+  describe('having serviceBindings with ResolvedValueBinding and PlanServiceNode parent node', () => {
+    let basePlanParamsMock: Mocked<BasePlanParams>;
+    let resolvedValueBindingFixture: ResolvedValueBinding<unknown>;
+    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let parentNodeFixture: PlanServiceNode;
+
+    beforeAll(() => {
+      basePlanParamsMock = {
+        autobindOptions: {
+          scope: bindingScopeValues.Transient,
+        },
+        operations: {
+          getClassMetadata: vitest.fn(),
+        } as Partial<PlanParamsOperations> as PlanParamsOperations,
+        servicesBranch: [],
+      };
+
+      resolvedValueBindingFixture = ResolvedValueBindingFixtures.any;
+
+      bindingConstraintsListFixture =
+        new SingleInmutableLinkedList<InternalBindingConstraints>({
+          elem: Symbol() as unknown as InternalBindingConstraints,
+          previous: undefined,
+        });
+
+      parentNodeFixture = {
+        bindings: [],
+        isContextFree: true,
+        serviceIdentifier: Symbol(),
+      };
+    });
+
+    describe('when called', () => {
+      let planBindingNodeFixture: PlanBindingNode;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        planBindingNodeFixture = Symbol() as unknown as PlanBindingNode;
+
+        subplanMock.mockReturnValueOnce(planBindingNodeFixture);
+
+        result = curryBuildServiceNodeBindings(subplanMock)(
+          basePlanParamsMock,
+          bindingConstraintsListFixture,
+          [resolvedValueBindingFixture],
+          parentNodeFixture,
+          false,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call subplan with correct params', () => {
+        const expectedSubplanParams: SubplanParams = {
+          autobindOptions: basePlanParamsMock.autobindOptions,
+          node: {
+            binding: resolvedValueBindingFixture,
+            params: [],
+          },
+          operations: basePlanParamsMock.operations,
+          servicesBranch: basePlanParamsMock.servicesBranch,
+        };
+
+        expect(subplanMock).toHaveBeenCalledTimes(1);
+        expect(subplanMock).toHaveBeenCalledWith(
+          expectedSubplanParams,
+          bindingConstraintsListFixture,
+        );
+      });
+
+      it('should return PlanBindingNode[]', () => {
+        expect(result).toStrictEqual([planBindingNodeFixture]);
+      });
+    });
+  });
+
+  describe('having serviceBindings with ServiceRedirectionBinding and PlanServiceNode parent node', () => {
+    let basePlanParamsMock: Mocked<BasePlanParams>;
+    let serviceRedirectionBindingFixture: ServiceRedirectionBinding<unknown>;
+    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let parentNodeFixture: PlanServiceNode;
+
+    beforeAll(() => {
+      basePlanParamsMock = {
+        autobindOptions: {
+          scope: bindingScopeValues.Transient,
+        },
+        operations: {
+          getClassMetadata: vitest.fn(),
+        } as Partial<PlanParamsOperations> as PlanParamsOperations,
+        servicesBranch: [],
+      };
+
+      serviceRedirectionBindingFixture = ServiceRedirectionBindingFixtures.any;
+
+      bindingConstraintsListFixture =
+        new SingleInmutableLinkedList<InternalBindingConstraints>({
+          elem: Symbol() as unknown as InternalBindingConstraints,
+          previous: undefined,
+        });
+
+      parentNodeFixture = {
+        bindings: [],
+        isContextFree: true,
+        serviceIdentifier: Symbol(),
+      };
+    });
+
+    describe('when called', () => {
+      let planBindingNodeFixture: PlanBindingNode;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        planBindingNodeFixture = Symbol() as unknown as PlanBindingNode;
+
+        subplanMock.mockReturnValueOnce(planBindingNodeFixture);
+
+        vitest.mocked(buildFilteredServiceBindings).mockReturnValueOnce([]);
+
+        result = curryBuildServiceNodeBindings(subplanMock)(
+          basePlanParamsMock,
+          bindingConstraintsListFixture,
+          [serviceRedirectionBindingFixture],
+          parentNodeFixture,
+          false,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call buildFilteredServiceBindings()', () => {
+        const expectedBindingConstraints: BindingConstraints =
+          new BindingConstraintsImplementation(
+            bindingConstraintsListFixture.last,
+          );
+
+        expect(buildFilteredServiceBindings).toHaveBeenCalledTimes(1);
+        expect(buildFilteredServiceBindings).toHaveBeenCalledWith(
+          basePlanParamsMock,
+          expectedBindingConstraints,
+          {
+            chained: false,
+            customServiceIdentifier:
+              serviceRedirectionBindingFixture.targetServiceIdentifier,
+          },
+        );
+      });
+
+      it('should return PlanBindingNode[]', () => {
+        const expectedPlanBindingNodes: PlanBindingNode[] = [
+          {
+            binding: serviceRedirectionBindingFixture,
+            redirections: [],
+          },
+        ];
+
+        expect(result).toStrictEqual(expectedPlanBindingNodes);
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/planning/actions/curryBuildServiceNodeBindings.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildServiceNodeBindings.ts
@@ -1,0 +1,243 @@
+import { ServiceIdentifier } from '@inversifyjs/common';
+
+import { Binding } from '../../binding/models/Binding';
+import { BindingConstraints } from '../../binding/models/BindingConstraints';
+import {
+  BindingConstraintsImplementation,
+  InternalBindingConstraints,
+} from '../../binding/models/BindingConstraintsImplementation';
+import { bindingTypeValues } from '../../binding/models/BindingType';
+import { InstanceBinding } from '../../binding/models/InstanceBinding';
+import { ResolvedValueBinding } from '../../binding/models/ResolvedValueBinding';
+import { ServiceRedirectionBinding } from '../../binding/models/ServiceRedirectionBinding';
+import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { ClassMetadata } from '../../metadata/models/ClassMetadata';
+import { buildFilteredServiceBindings } from '../calculations/buildFilteredServiceBindings';
+import { isPlanServiceRedirectionBindingNode } from '../calculations/isPlanServiceRedirectionBindingNode';
+import { BasePlanParams } from '../models/BasePlanParams';
+import { BindingNodeParent } from '../models/BindingNodeParent';
+import { InstanceBindingNode } from '../models/InstanceBindingNode';
+import { PlanBindingNode } from '../models/PlanBindingNode';
+import { PlanServiceRedirectionBindingNode } from '../models/PlanServiceRedirectionBindingNode';
+import { ResolvedValueBindingNode } from '../models/ResolvedValueBindingNode';
+import { SubplanParams } from '../models/SubplanParams';
+
+export function curryBuildServiceNodeBindings(
+  subplan: (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  ) => PlanBindingNode,
+): (
+  params: BasePlanParams,
+  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  serviceBindings: Binding<unknown>[],
+  parentNode: BindingNodeParent,
+  chainedBindings: boolean,
+) => PlanBindingNode[] {
+  const buildInstancePlanBindingNode: (
+    params: BasePlanParams,
+    binding: InstanceBinding<unknown>,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  ) => PlanBindingNode = curryBuildInstancePlanBindingNode(subplan);
+  const buildResolvedValuePlanBindingNode: (
+    params: BasePlanParams,
+    binding: ResolvedValueBinding<unknown>,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  ) => PlanBindingNode = curryBuildResolvedValuePlanBindingNode(subplan);
+
+  const buildServiceNodeBindings: (
+    params: BasePlanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    serviceBindings: Binding<unknown>[],
+    parentNode: BindingNodeParent,
+    chainedBindings: boolean,
+  ) => PlanBindingNode[] = (
+    params: BasePlanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    serviceBindings: Binding<unknown>[],
+    parentNode: BindingNodeParent,
+    chainedBindings: boolean,
+  ): PlanBindingNode[] => {
+    const serviceIdentifier: ServiceIdentifier =
+      isPlanServiceRedirectionBindingNode(parentNode)
+        ? parentNode.binding.targetServiceIdentifier
+        : parentNode.serviceIdentifier;
+
+    params.servicesBranch.push(serviceIdentifier);
+
+    const planBindingNodes: PlanBindingNode[] = [];
+
+    for (const binding of serviceBindings) {
+      switch (binding.type) {
+        case bindingTypeValues.Instance: {
+          planBindingNodes.push(
+            buildInstancePlanBindingNode(
+              params,
+              binding,
+              bindingConstraintsList,
+            ),
+          );
+          break;
+        }
+        case bindingTypeValues.ResolvedValue: {
+          planBindingNodes.push(
+            buildResolvedValuePlanBindingNode(
+              params,
+              binding,
+              bindingConstraintsList,
+            ),
+          );
+          break;
+        }
+        case bindingTypeValues.ServiceRedirection: {
+          const planBindingNode: PlanBindingNode | undefined =
+            buildServiceRedirectionPlanBindingNode(
+              params,
+              bindingConstraintsList,
+              binding,
+              chainedBindings,
+            );
+
+          planBindingNodes.push(planBindingNode);
+
+          break;
+        }
+        default:
+          planBindingNodes.push({
+            binding: binding,
+          });
+      }
+    }
+
+    params.servicesBranch.pop();
+
+    return planBindingNodes;
+  };
+
+  const buildServiceRedirectionPlanBindingNode: (
+    params: BasePlanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    binding: ServiceRedirectionBinding<unknown>,
+    chainedBindings: boolean,
+  ) => PlanBindingNode = curryBuildServiceRedirectionPlanBindingNode(
+    buildServiceNodeBindings,
+  );
+
+  return buildServiceNodeBindings;
+}
+
+function curryBuildInstancePlanBindingNode(
+  subplan: (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  ) => PlanBindingNode,
+): (
+  params: BasePlanParams,
+  binding: InstanceBinding<unknown>,
+  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+) => PlanBindingNode {
+  return (
+    params: BasePlanParams,
+    binding: InstanceBinding<unknown>,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  ): PlanBindingNode => {
+    const classMetadata: ClassMetadata = params.operations.getClassMetadata(
+      binding.implementationType,
+    );
+
+    const childNode: InstanceBindingNode = {
+      binding: binding,
+      classMetadata,
+      constructorParams: [],
+      propertyParams: new Map(),
+    };
+
+    const subplanParams: SubplanParams = {
+      autobindOptions: params.autobindOptions,
+      node: childNode,
+      operations: params.operations,
+      servicesBranch: params.servicesBranch,
+    };
+
+    return subplan(subplanParams, bindingConstraintsList);
+  };
+}
+
+function curryBuildResolvedValuePlanBindingNode(
+  subplan: (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  ) => PlanBindingNode,
+): (
+  params: BasePlanParams,
+  binding: ResolvedValueBinding<unknown>,
+  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+) => PlanBindingNode {
+  return (
+    params: BasePlanParams,
+    binding: ResolvedValueBinding<unknown>,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  ): PlanBindingNode => {
+    const childNode: ResolvedValueBindingNode = {
+      binding: binding,
+      params: [],
+    };
+
+    const subplanParams: SubplanParams = {
+      autobindOptions: params.autobindOptions,
+      node: childNode,
+      operations: params.operations,
+      servicesBranch: params.servicesBranch,
+    };
+
+    return subplan(subplanParams, bindingConstraintsList);
+  };
+}
+
+function curryBuildServiceRedirectionPlanBindingNode(
+  buildServiceNodeBindings: (
+    params: BasePlanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    serviceBindings: Binding<unknown>[],
+    parentNode: BindingNodeParent,
+    chainedBindings: boolean,
+  ) => PlanBindingNode[],
+): (
+  params: BasePlanParams,
+  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  binding: ServiceRedirectionBinding<unknown>,
+  chainedBindings: boolean,
+) => PlanBindingNode {
+  return (
+    params: BasePlanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    binding: ServiceRedirectionBinding<unknown>,
+    chainedBindings: boolean,
+  ): PlanBindingNode => {
+    const childNode: PlanServiceRedirectionBindingNode = {
+      binding,
+      redirections: [],
+    };
+
+    const bindingConstraints: BindingConstraints =
+      new BindingConstraintsImplementation(bindingConstraintsList.last);
+
+    const filteredServiceBindings: Binding<unknown>[] =
+      buildFilteredServiceBindings(params, bindingConstraints, {
+        chained: chainedBindings,
+        customServiceIdentifier: binding.targetServiceIdentifier,
+      });
+
+    childNode.redirections.push(
+      ...buildServiceNodeBindings(
+        params,
+        bindingConstraintsList,
+        filteredServiceBindings,
+        childNode,
+        chainedBindings,
+      ),
+    );
+
+    return childNode;
+  };
+}

--- a/packages/container/libraries/core/src/planning/actions/currySubplan.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/currySubplan.spec.ts
@@ -1,0 +1,554 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  Mock,
+  vitest,
+} from 'vitest';
+
+vitest.mock(
+  '../calculations/tryBuildGetPlanOptionsFromManagedClassElementMetadata',
+);
+vitest.mock(
+  '../calculations/tryBuildGetPlanOptionsFromResolvedValueElementMetadata',
+);
+vitest.mock('./cacheNonRootPlanServiceNode');
+
+import { InstanceBindingFixtures } from '../../binding/fixtures/InstanceBindingFixtures';
+import { ResolvedValueBindingFixtures } from '../../binding/fixtures/ResolvedValueBindingFixtures';
+import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
+import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { ClassMetadataFixtures } from '../../metadata/fixtures/ClassMetadataFixtures';
+import { ManagedClassElementMetadata } from '../../metadata/models/ManagedClassElementMetadata';
+import { ResolvedValueElementMetadata } from '../../metadata/models/ResolvedValueElementMetadata';
+import { tryBuildGetPlanOptionsFromManagedClassElementMetadata } from '../calculations/tryBuildGetPlanOptionsFromManagedClassElementMetadata';
+import { tryBuildGetPlanOptionsFromResolvedValueElementMetadata } from '../calculations/tryBuildGetPlanOptionsFromResolvedValueElementMetadata';
+import { GetPlanOptions } from '../models/GetPlanOptions';
+import { InstanceBindingNode } from '../models/InstanceBindingNode';
+import { LazyPlanServiceNode } from '../models/LazyPlanServiceNode';
+import { PlanParamsOperations } from '../models/PlanParamsOperations';
+import { PlanResult } from '../models/PlanResult';
+import { PlanServiceNode } from '../models/PlanServiceNode';
+import { ResolvedValueBindingNode } from '../models/ResolvedValueBindingNode';
+import { SubplanParams } from '../models/SubplanParams';
+import { cacheNonRootPlanServiceNode } from './cacheNonRootPlanServiceNode';
+import { currySubplan } from './currySubplan';
+
+describe(currySubplan, () => {
+  let buildLazyPlanServiceNodeNodeFromClassElementMetadataMock: Mock<
+    (
+      params: SubplanParams,
+      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      elementMetadata: ManagedClassElementMetadata,
+    ) => PlanServiceNode
+  >;
+  let buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadataMock: Mock<
+    (
+      params: SubplanParams,
+      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      elementMetadata: ResolvedValueElementMetadata,
+    ) => PlanServiceNode
+  >;
+  let buildPlanServiceNodeFromClassElementMetadataMock: Mock<
+    (
+      params: SubplanParams,
+      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      elementMetadata: ManagedClassElementMetadata,
+    ) => PlanServiceNode | undefined
+  >;
+  let buildPlanServiceNodeFromResolvedValueElementMetadataMock: Mock<
+    (
+      params: SubplanParams,
+      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      elementMetadata: ResolvedValueElementMetadata,
+    ) => PlanServiceNode | undefined
+  >;
+
+  beforeAll(() => {
+    buildLazyPlanServiceNodeNodeFromClassElementMetadataMock = vitest.fn();
+    buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadataMock =
+      vitest.fn();
+    buildPlanServiceNodeFromClassElementMetadataMock = vitest.fn();
+    buildPlanServiceNodeFromResolvedValueElementMetadataMock = vitest.fn();
+  });
+
+  describe('having BasePlanParams with InstanceBindingNode with unmanaged constructor arguments', () => {
+    let instanceBindingNodeFixture: InstanceBindingNode;
+
+    let subplanParamsFixture: SubplanParams;
+
+    beforeAll(() => {
+      instanceBindingNodeFixture = {
+        binding: InstanceBindingFixtures.any,
+        classMetadata: ClassMetadataFixtures.withUnmanagedConstructorArguments,
+        constructorParams: [],
+        propertyParams: new Map(),
+      };
+
+      subplanParamsFixture = {
+        autobindOptions: undefined,
+        node: instanceBindingNodeFixture,
+        operations: {
+          getPlan: vitest.fn(),
+        } as Partial<PlanParamsOperations> as PlanParamsOperations,
+        servicesBranch: [],
+      };
+    });
+
+    describe('when called, and tryBuildGetPlanOptionsFromManagedClassElementMetadata() returns undefined', () => {
+      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        bindingConstraintsListFixture =
+          new SingleInmutableLinkedList<InternalBindingConstraints>({
+            elem: Symbol() as unknown as InternalBindingConstraints,
+            previous: undefined,
+          });
+
+        result = currySubplan(
+          buildLazyPlanServiceNodeNodeFromClassElementMetadataMock,
+          buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadataMock,
+          buildPlanServiceNodeFromClassElementMetadataMock,
+          buildPlanServiceNodeFromResolvedValueElementMetadataMock,
+        )(subplanParamsFixture, bindingConstraintsListFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should return PlanBindingNode', () => {
+        expect(result).toBe(instanceBindingNodeFixture);
+      });
+    });
+  });
+
+  describe('having BasePlanParams with InstanceBindingNode with single injection constructor arguments', () => {
+    let instanceBindingNodeFixture: InstanceBindingNode;
+
+    let subplanParamsMock: SubplanParams;
+
+    beforeAll(() => {
+      instanceBindingNodeFixture = {
+        binding: InstanceBindingFixtures.any,
+        classMetadata:
+          ClassMetadataFixtures.withSingleInjectionConstructorArguments,
+        constructorParams: [],
+        propertyParams: new Map(),
+      };
+
+      subplanParamsMock = {
+        autobindOptions: undefined,
+        node: instanceBindingNodeFixture,
+        operations: {
+          getPlan: vitest.fn(),
+        } as Partial<PlanParamsOperations> as PlanParamsOperations,
+        servicesBranch: [],
+      };
+    });
+
+    describe('when called, and tryBuildGetPlanOptionsFromManagedClassElementMetadata() returns undefined', () => {
+      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        bindingConstraintsListFixture =
+          new SingleInmutableLinkedList<InternalBindingConstraints>({
+            elem: Symbol() as unknown as InternalBindingConstraints,
+            previous: undefined,
+          });
+
+        vitest
+          .mocked(tryBuildGetPlanOptionsFromManagedClassElementMetadata)
+          .mockReturnValueOnce(undefined);
+
+        result = currySubplan(
+          buildLazyPlanServiceNodeNodeFromClassElementMetadataMock,
+          buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadataMock,
+          buildPlanServiceNodeFromClassElementMetadataMock,
+          buildPlanServiceNodeFromResolvedValueElementMetadataMock,
+        )(subplanParamsMock, bindingConstraintsListFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call tryBuildGetPlanOptionsFromManagedClassElementMetadata()', () => {
+        expect(
+          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
+        ).toHaveBeenCalledWith(
+          instanceBindingNodeFixture.classMetadata.constructorArguments[0],
+        );
+      });
+
+      it('should call buildPlanServiceNodeFromClassElementMetadata()', () => {
+        expect(
+          buildPlanServiceNodeFromClassElementMetadataMock,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          buildPlanServiceNodeFromClassElementMetadataMock,
+        ).toHaveBeenCalledWith(
+          subplanParamsMock,
+          bindingConstraintsListFixture,
+          instanceBindingNodeFixture.classMetadata.constructorArguments[0],
+        );
+      });
+
+      it('should call cacheNonRootPlanServiceNode()', () => {
+        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledTimes(1);
+        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledWith(
+          undefined,
+          subplanParamsMock.operations,
+          expect.any(LazyPlanServiceNode),
+        );
+      });
+
+      it('should return PlanBindingNode', () => {
+        expect(result).toBe(instanceBindingNodeFixture);
+      });
+    });
+
+    describe('when called, and tryBuildGetPlanOptionsFromManagedClassElementMetadata() returns GetPlanOptions and operations.getPlan() returns undefined', () => {
+      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let getPlanOptionsFixture: GetPlanOptions;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        bindingConstraintsListFixture =
+          new SingleInmutableLinkedList<InternalBindingConstraints>({
+            elem: Symbol() as unknown as InternalBindingConstraints,
+            previous: undefined,
+          });
+
+        getPlanOptionsFixture = Symbol() as unknown as GetPlanOptions;
+
+        vitest
+          .mocked(tryBuildGetPlanOptionsFromManagedClassElementMetadata)
+          .mockReturnValueOnce(getPlanOptionsFixture);
+
+        result = currySubplan(
+          buildLazyPlanServiceNodeNodeFromClassElementMetadataMock,
+          buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadataMock,
+          buildPlanServiceNodeFromClassElementMetadataMock,
+          buildPlanServiceNodeFromResolvedValueElementMetadataMock,
+        )(subplanParamsMock, bindingConstraintsListFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call tryBuildGetPlanOptionsFromManagedClassElementMetadata()', () => {
+        expect(
+          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
+        ).toHaveBeenCalledWith(
+          instanceBindingNodeFixture.classMetadata.constructorArguments[0],
+        );
+      });
+
+      it('should call operations.getPlan()', () => {
+        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledTimes(1);
+        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledWith(
+          getPlanOptionsFixture,
+        );
+      });
+
+      it('should call buildPlanServiceNodeFromClassElementMetadata()', () => {
+        expect(
+          buildPlanServiceNodeFromClassElementMetadataMock,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          buildPlanServiceNodeFromClassElementMetadataMock,
+        ).toHaveBeenCalledWith(
+          subplanParamsMock,
+          bindingConstraintsListFixture,
+          instanceBindingNodeFixture.classMetadata.constructorArguments[0],
+        );
+      });
+
+      it('should call cacheNonRootPlanServiceNode()', () => {
+        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledTimes(1);
+        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledWith(
+          getPlanOptionsFixture,
+          subplanParamsMock.operations,
+          expect.any(LazyPlanServiceNode),
+        );
+      });
+
+      it('should return PlanBindingNode', () => {
+        expect(result).toBe(instanceBindingNodeFixture);
+      });
+    });
+
+    describe('when called, and tryBuildGetPlanOptionsFromManagedClassElementMetadata() returns GetPlanOptions and operations.getPlan() returns context free plan', () => {
+      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let getPlanOptionsFixture: GetPlanOptions;
+      let planResultFixture: PlanResult;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        bindingConstraintsListFixture =
+          new SingleInmutableLinkedList<InternalBindingConstraints>({
+            elem: Symbol() as unknown as InternalBindingConstraints,
+            previous: undefined,
+          });
+
+        getPlanOptionsFixture = Symbol() as unknown as GetPlanOptions;
+
+        planResultFixture = {
+          tree: {
+            root: {
+              bindings: [],
+              isContextFree: true,
+              serviceIdentifier: Symbol(),
+            },
+          },
+        };
+
+        vitest
+          .mocked(tryBuildGetPlanOptionsFromManagedClassElementMetadata)
+          .mockReturnValueOnce(getPlanOptionsFixture);
+
+        vitest
+          .mocked(subplanParamsMock.operations.getPlan)
+          .mockReturnValueOnce(planResultFixture);
+
+        result = currySubplan(
+          buildLazyPlanServiceNodeNodeFromClassElementMetadataMock,
+          buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadataMock,
+          buildPlanServiceNodeFromClassElementMetadataMock,
+          buildPlanServiceNodeFromResolvedValueElementMetadataMock,
+        )(subplanParamsMock, bindingConstraintsListFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call tryBuildGetPlanOptionsFromManagedClassElementMetadata()', () => {
+        expect(
+          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
+        ).toHaveBeenCalledWith(
+          instanceBindingNodeFixture.classMetadata.constructorArguments[0],
+        );
+      });
+
+      it('should call operations.getPlan()', () => {
+        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledTimes(1);
+        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledWith(
+          getPlanOptionsFixture,
+        );
+      });
+
+      it('should not call buildPlanServiceNodeFromClassElementMetadata()', () => {
+        expect(
+          buildPlanServiceNodeFromClassElementMetadataMock,
+        ).not.toHaveBeenCalled();
+      });
+
+      it('should not call cacheNonRootPlanServiceNode()', () => {
+        expect(cacheNonRootPlanServiceNode).not.toHaveBeenCalled();
+      });
+
+      it('should return PlanBindingNode', () => {
+        expect(result).toBe(instanceBindingNodeFixture);
+      });
+    });
+
+    describe('when called, and tryBuildGetPlanOptionsFromManagedClassElementMetadata() returns GetPlanOptions and operations.getPlan() returns non context free plan', () => {
+      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let getPlanOptionsFixture: GetPlanOptions;
+      let planResultFixture: PlanResult;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        bindingConstraintsListFixture =
+          new SingleInmutableLinkedList<InternalBindingConstraints>({
+            elem: Symbol() as unknown as InternalBindingConstraints,
+            previous: undefined,
+          });
+
+        getPlanOptionsFixture = Symbol() as unknown as GetPlanOptions;
+
+        planResultFixture = {
+          tree: {
+            root: {
+              bindings: [],
+              isContextFree: false,
+              serviceIdentifier: Symbol(),
+            },
+          },
+        };
+
+        vitest
+          .mocked(tryBuildGetPlanOptionsFromManagedClassElementMetadata)
+          .mockReturnValueOnce(getPlanOptionsFixture);
+
+        vitest
+          .mocked(subplanParamsMock.operations.getPlan)
+          .mockReturnValueOnce(planResultFixture);
+
+        result = currySubplan(
+          buildLazyPlanServiceNodeNodeFromClassElementMetadataMock,
+          buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadataMock,
+          buildPlanServiceNodeFromClassElementMetadataMock,
+          buildPlanServiceNodeFromResolvedValueElementMetadataMock,
+        )(subplanParamsMock, bindingConstraintsListFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call tryBuildGetPlanOptionsFromManagedClassElementMetadata()', () => {
+        expect(
+          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
+        ).toHaveBeenCalledWith(
+          instanceBindingNodeFixture.classMetadata.constructorArguments[0],
+        );
+      });
+
+      it('should call operations.getPlan()', () => {
+        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledTimes(1);
+        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledWith(
+          getPlanOptionsFixture,
+        );
+      });
+
+      it('should call buildPlanServiceNodeFromClassElementMetadata()', () => {
+        expect(
+          buildPlanServiceNodeFromClassElementMetadataMock,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          buildPlanServiceNodeFromClassElementMetadataMock,
+        ).toHaveBeenCalledWith(
+          subplanParamsMock,
+          bindingConstraintsListFixture,
+          instanceBindingNodeFixture.classMetadata.constructorArguments[0],
+        );
+      });
+
+      it('should call cacheNonRootPlanServiceNode()', () => {
+        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledTimes(1);
+        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledWith(
+          getPlanOptionsFixture,
+          subplanParamsMock.operations,
+          expect.any(LazyPlanServiceNode),
+        );
+      });
+
+      it('should return PlanBindingNode', () => {
+        expect(result).toBe(instanceBindingNodeFixture);
+      });
+    });
+  });
+
+  describe('having BasePlanParams with ResolvedValueBindingNode with single injection metadata binding', () => {
+    let resolvedValueBindingNodeFixture: ResolvedValueBindingNode;
+
+    let subplanParamsMock: SubplanParams;
+
+    beforeAll(() => {
+      resolvedValueBindingNodeFixture = {
+        binding: ResolvedValueBindingFixtures.withSingleInjectionMetadata,
+        params: [],
+      };
+
+      subplanParamsMock = {
+        autobindOptions: undefined,
+        node: resolvedValueBindingNodeFixture,
+        operations: {
+          getPlan: vitest.fn(),
+        } as Partial<PlanParamsOperations> as PlanParamsOperations,
+        servicesBranch: [],
+      };
+    });
+
+    describe('when called, and tryBuildGetPlanOptionsFromResolvedValueElementMetadata() returns undefined', () => {
+      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        bindingConstraintsListFixture =
+          new SingleInmutableLinkedList<InternalBindingConstraints>({
+            elem: Symbol() as unknown as InternalBindingConstraints,
+            previous: undefined,
+          });
+
+        vitest
+          .mocked(tryBuildGetPlanOptionsFromResolvedValueElementMetadata)
+          .mockReturnValueOnce(undefined);
+
+        result = currySubplan(
+          buildLazyPlanServiceNodeNodeFromClassElementMetadataMock,
+          buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadataMock,
+          buildPlanServiceNodeFromClassElementMetadataMock,
+          buildPlanServiceNodeFromResolvedValueElementMetadataMock,
+        )(subplanParamsMock, bindingConstraintsListFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call tryBuildGetPlanOptionsFromResolvedValueElementMetadata()', () => {
+        expect(
+          tryBuildGetPlanOptionsFromResolvedValueElementMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          tryBuildGetPlanOptionsFromResolvedValueElementMetadata,
+        ).toHaveBeenCalledWith(
+          resolvedValueBindingNodeFixture.binding.metadata.arguments[0],
+        );
+      });
+
+      it('should call buildPlanServiceNodeFromResolvedValueElementMetadata()', () => {
+        expect(
+          buildPlanServiceNodeFromResolvedValueElementMetadataMock,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          buildPlanServiceNodeFromResolvedValueElementMetadataMock,
+        ).toHaveBeenCalledWith(
+          subplanParamsMock,
+          bindingConstraintsListFixture,
+          resolvedValueBindingNodeFixture.binding.metadata.arguments[0],
+        );
+      });
+
+      it('should call cacheNonRootPlanServiceNode()', () => {
+        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledTimes(1);
+        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledWith(
+          undefined,
+          subplanParamsMock.operations,
+          expect.any(LazyPlanServiceNode),
+        );
+      });
+
+      it('should return PlanBindingNode', () => {
+        expect(result).toBe(resolvedValueBindingNodeFixture);
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/planning/actions/currySubplan.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/currySubplan.spec.ts
@@ -464,6 +464,370 @@ describe(currySubplan, () => {
     });
   });
 
+  describe('having BasePlanParams with InstanceBindingNode with single injection property', () => {
+    let instanceBindingNodeFixture: InstanceBindingNode;
+
+    let subplanParamsMock: SubplanParams;
+
+    beforeAll(() => {
+      instanceBindingNodeFixture = {
+        binding: InstanceBindingFixtures.any,
+        classMetadata: ClassMetadataFixtures.withSingleInjectionProperty,
+        constructorParams: [],
+        propertyParams: new Map(),
+      };
+
+      subplanParamsMock = {
+        autobindOptions: undefined,
+        node: instanceBindingNodeFixture,
+        operations: {
+          getPlan: vitest.fn(),
+        } as Partial<PlanParamsOperations> as PlanParamsOperations,
+        servicesBranch: [],
+      };
+    });
+
+    describe('when called, and tryBuildGetPlanOptionsFromManagedClassElementMetadata() returns undefined', () => {
+      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        bindingConstraintsListFixture =
+          new SingleInmutableLinkedList<InternalBindingConstraints>({
+            elem: Symbol() as unknown as InternalBindingConstraints,
+            previous: undefined,
+          });
+
+        vitest
+          .mocked(tryBuildGetPlanOptionsFromManagedClassElementMetadata)
+          .mockReturnValueOnce(undefined);
+
+        result = currySubplan(
+          buildLazyPlanServiceNodeNodeFromClassElementMetadataMock,
+          buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadataMock,
+          buildPlanServiceNodeFromClassElementMetadataMock,
+          buildPlanServiceNodeFromResolvedValueElementMetadataMock,
+        )(subplanParamsMock, bindingConstraintsListFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call tryBuildGetPlanOptionsFromManagedClassElementMetadata()', () => {
+        const [property]: [string | symbol] = [
+          ...instanceBindingNodeFixture.classMetadata.properties.keys(),
+        ] as [string | symbol];
+
+        expect(
+          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
+        ).toHaveBeenCalledWith(
+          instanceBindingNodeFixture.classMetadata.properties.get(property),
+        );
+      });
+
+      it('should call buildPlanServiceNodeFromClassElementMetadata()', () => {
+        const [property]: [string | symbol] = [
+          ...instanceBindingNodeFixture.classMetadata.properties.keys(),
+        ] as [string | symbol];
+
+        expect(
+          buildPlanServiceNodeFromClassElementMetadataMock,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          buildPlanServiceNodeFromClassElementMetadataMock,
+        ).toHaveBeenCalledWith(
+          subplanParamsMock,
+          bindingConstraintsListFixture,
+          instanceBindingNodeFixture.classMetadata.properties.get(property),
+        );
+      });
+
+      it('should call cacheNonRootPlanServiceNode()', () => {
+        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledTimes(1);
+        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledWith(
+          undefined,
+          subplanParamsMock.operations,
+          expect.any(LazyPlanServiceNode),
+        );
+      });
+
+      it('should return PlanBindingNode', () => {
+        expect(result).toBe(instanceBindingNodeFixture);
+      });
+    });
+
+    describe('when called, and tryBuildGetPlanOptionsFromManagedClassElementMetadata() returns GetPlanOptions and operations.getPlan() returns undefined', () => {
+      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let getPlanOptionsFixture: GetPlanOptions;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        bindingConstraintsListFixture =
+          new SingleInmutableLinkedList<InternalBindingConstraints>({
+            elem: Symbol() as unknown as InternalBindingConstraints,
+            previous: undefined,
+          });
+
+        getPlanOptionsFixture = Symbol() as unknown as GetPlanOptions;
+
+        vitest
+          .mocked(tryBuildGetPlanOptionsFromManagedClassElementMetadata)
+          .mockReturnValueOnce(getPlanOptionsFixture);
+
+        result = currySubplan(
+          buildLazyPlanServiceNodeNodeFromClassElementMetadataMock,
+          buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadataMock,
+          buildPlanServiceNodeFromClassElementMetadataMock,
+          buildPlanServiceNodeFromResolvedValueElementMetadataMock,
+        )(subplanParamsMock, bindingConstraintsListFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call tryBuildGetPlanOptionsFromManagedClassElementMetadata()', () => {
+        const [property]: [string | symbol] = [
+          ...instanceBindingNodeFixture.classMetadata.properties.keys(),
+        ] as [string | symbol];
+
+        expect(
+          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
+        ).toHaveBeenCalledWith(
+          instanceBindingNodeFixture.classMetadata.properties.get(property),
+        );
+      });
+
+      it('should call operations.getPlan()', () => {
+        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledTimes(1);
+        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledWith(
+          getPlanOptionsFixture,
+        );
+      });
+
+      it('should call buildPlanServiceNodeFromClassElementMetadata()', () => {
+        const [property]: [string | symbol] = [
+          ...instanceBindingNodeFixture.classMetadata.properties.keys(),
+        ] as [string | symbol];
+
+        expect(
+          buildPlanServiceNodeFromClassElementMetadataMock,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          buildPlanServiceNodeFromClassElementMetadataMock,
+        ).toHaveBeenCalledWith(
+          subplanParamsMock,
+          bindingConstraintsListFixture,
+          instanceBindingNodeFixture.classMetadata.properties.get(property),
+        );
+      });
+
+      it('should call cacheNonRootPlanServiceNode()', () => {
+        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledTimes(1);
+        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledWith(
+          getPlanOptionsFixture,
+          subplanParamsMock.operations,
+          expect.any(LazyPlanServiceNode),
+        );
+      });
+
+      it('should return PlanBindingNode', () => {
+        expect(result).toBe(instanceBindingNodeFixture);
+      });
+    });
+
+    describe('when called, and tryBuildGetPlanOptionsFromManagedClassElementMetadata() returns GetPlanOptions and operations.getPlan() returns context free plan', () => {
+      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let getPlanOptionsFixture: GetPlanOptions;
+      let planResultFixture: PlanResult;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        bindingConstraintsListFixture =
+          new SingleInmutableLinkedList<InternalBindingConstraints>({
+            elem: Symbol() as unknown as InternalBindingConstraints,
+            previous: undefined,
+          });
+
+        getPlanOptionsFixture = Symbol() as unknown as GetPlanOptions;
+
+        planResultFixture = {
+          tree: {
+            root: {
+              bindings: [],
+              isContextFree: true,
+              serviceIdentifier: Symbol(),
+            },
+          },
+        };
+
+        vitest
+          .mocked(tryBuildGetPlanOptionsFromManagedClassElementMetadata)
+          .mockReturnValueOnce(getPlanOptionsFixture);
+
+        vitest
+          .mocked(subplanParamsMock.operations.getPlan)
+          .mockReturnValueOnce(planResultFixture);
+
+        result = currySubplan(
+          buildLazyPlanServiceNodeNodeFromClassElementMetadataMock,
+          buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadataMock,
+          buildPlanServiceNodeFromClassElementMetadataMock,
+          buildPlanServiceNodeFromResolvedValueElementMetadataMock,
+        )(subplanParamsMock, bindingConstraintsListFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call tryBuildGetPlanOptionsFromManagedClassElementMetadata()', () => {
+        const [property]: [string | symbol] = [
+          ...instanceBindingNodeFixture.classMetadata.properties.keys(),
+        ] as [string | symbol];
+
+        expect(
+          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
+        ).toHaveBeenCalledWith(
+          instanceBindingNodeFixture.classMetadata.properties.get(property),
+        );
+      });
+
+      it('should call operations.getPlan()', () => {
+        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledTimes(1);
+        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledWith(
+          getPlanOptionsFixture,
+        );
+      });
+
+      it('should not call buildPlanServiceNodeFromClassElementMetadata()', () => {
+        expect(
+          buildPlanServiceNodeFromClassElementMetadataMock,
+        ).not.toHaveBeenCalled();
+      });
+
+      it('should not call cacheNonRootPlanServiceNode()', () => {
+        expect(cacheNonRootPlanServiceNode).not.toHaveBeenCalled();
+      });
+
+      it('should return PlanBindingNode', () => {
+        expect(result).toBe(instanceBindingNodeFixture);
+      });
+    });
+
+    describe('when called, and tryBuildGetPlanOptionsFromManagedClassElementMetadata() returns GetPlanOptions and operations.getPlan() returns non context free plan', () => {
+      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let getPlanOptionsFixture: GetPlanOptions;
+      let planResultFixture: PlanResult;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        bindingConstraintsListFixture =
+          new SingleInmutableLinkedList<InternalBindingConstraints>({
+            elem: Symbol() as unknown as InternalBindingConstraints,
+            previous: undefined,
+          });
+
+        getPlanOptionsFixture = Symbol() as unknown as GetPlanOptions;
+
+        planResultFixture = {
+          tree: {
+            root: {
+              bindings: [],
+              isContextFree: false,
+              serviceIdentifier: Symbol(),
+            },
+          },
+        };
+
+        vitest
+          .mocked(tryBuildGetPlanOptionsFromManagedClassElementMetadata)
+          .mockReturnValueOnce(getPlanOptionsFixture);
+
+        vitest
+          .mocked(subplanParamsMock.operations.getPlan)
+          .mockReturnValueOnce(planResultFixture);
+
+        result = currySubplan(
+          buildLazyPlanServiceNodeNodeFromClassElementMetadataMock,
+          buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadataMock,
+          buildPlanServiceNodeFromClassElementMetadataMock,
+          buildPlanServiceNodeFromResolvedValueElementMetadataMock,
+        )(subplanParamsMock, bindingConstraintsListFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call tryBuildGetPlanOptionsFromManagedClassElementMetadata()', () => {
+        const [property]: [string | symbol] = [
+          ...instanceBindingNodeFixture.classMetadata.properties.keys(),
+        ] as [string | symbol];
+
+        expect(
+          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
+        ).toHaveBeenCalledWith(
+          instanceBindingNodeFixture.classMetadata.properties.get(property),
+        );
+      });
+
+      it('should call operations.getPlan()', () => {
+        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledTimes(1);
+        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledWith(
+          getPlanOptionsFixture,
+        );
+      });
+
+      it('should call buildPlanServiceNodeFromClassElementMetadata()', () => {
+        const [property]: [string | symbol] = [
+          ...instanceBindingNodeFixture.classMetadata.properties.keys(),
+        ] as [string | symbol];
+
+        expect(
+          buildPlanServiceNodeFromClassElementMetadataMock,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          buildPlanServiceNodeFromClassElementMetadataMock,
+        ).toHaveBeenCalledWith(
+          subplanParamsMock,
+          bindingConstraintsListFixture,
+          instanceBindingNodeFixture.classMetadata.properties.get(property),
+        );
+      });
+
+      it('should call cacheNonRootPlanServiceNode()', () => {
+        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledTimes(1);
+        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledWith(
+          getPlanOptionsFixture,
+          subplanParamsMock.operations,
+          expect.any(LazyPlanServiceNode),
+        );
+      });
+
+      it('should return PlanBindingNode', () => {
+        expect(result).toBe(instanceBindingNodeFixture);
+      });
+    });
+  });
+
   describe('having BasePlanParams with ResolvedValueBindingNode with single injection metadata binding', () => {
     let resolvedValueBindingNodeFixture: ResolvedValueBindingNode;
 

--- a/packages/container/libraries/core/src/planning/actions/currySubplan.ts
+++ b/packages/container/libraries/core/src/planning/actions/currySubplan.ts
@@ -1,0 +1,403 @@
+import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
+import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { ClassElementMetadata } from '../../metadata/models/ClassElementMetadata';
+import { ClassElementMetadataKind } from '../../metadata/models/ClassElementMetadataKind';
+import { ClassMetadata } from '../../metadata/models/ClassMetadata';
+import { ManagedClassElementMetadata } from '../../metadata/models/ManagedClassElementMetadata';
+import { ResolvedValueElementMetadata } from '../../metadata/models/ResolvedValueElementMetadata';
+import { ResolvedValueMetadata } from '../../metadata/models/ResolvedValueMetadata';
+import { getServiceFromMaybeLazyServiceIdentifier } from '../calculations/getServiceFromMaybeLazyServiceIdentifier';
+import { isInstanceBindingNode } from '../calculations/isInstanceBindingNode';
+import { tryBuildGetPlanOptionsFromManagedClassElementMetadata } from '../calculations/tryBuildGetPlanOptionsFromManagedClassElementMetadata';
+import { tryBuildGetPlanOptionsFromResolvedValueElementMetadata } from '../calculations/tryBuildGetPlanOptionsFromResolvedValueElementMetadata';
+import { GetPlanOptions } from '../models/GetPlanOptions';
+import { InstanceBindingNode } from '../models/InstanceBindingNode';
+import { LazyPlanServiceNode } from '../models/LazyPlanServiceNode';
+import { PlanBindingNode } from '../models/PlanBindingNode';
+import { PlanResult } from '../models/PlanResult';
+import { PlanServiceNode } from '../models/PlanServiceNode';
+import { ResolvedValueBindingNode } from '../models/ResolvedValueBindingNode';
+import { SubplanParams } from '../models/SubplanParams';
+import { cacheNonRootPlanServiceNode } from './cacheNonRootPlanServiceNode';
+
+class LazyManagedClassMetadataPlanServiceNode extends LazyPlanServiceNode {
+  readonly #params: SubplanParams;
+  readonly #buildLazyPlanServiceNodeNodeFromClassElementMetadata: (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ManagedClassElementMetadata,
+  ) => PlanServiceNode;
+  readonly #bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>;
+  readonly #elementMetadata: ManagedClassElementMetadata;
+
+  constructor(
+    params: SubplanParams,
+    buildLazyPlanServiceNodeNodeFromClassElementMetadata: (
+      params: SubplanParams,
+      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      elementMetadata: ManagedClassElementMetadata,
+    ) => PlanServiceNode,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ManagedClassElementMetadata,
+    serviceNode: PlanServiceNode | undefined,
+  ) {
+    super(
+      serviceNode,
+      getServiceFromMaybeLazyServiceIdentifier(elementMetadata.value),
+    );
+
+    this.#buildLazyPlanServiceNodeNodeFromClassElementMetadata =
+      buildLazyPlanServiceNodeNodeFromClassElementMetadata;
+    this.#params = params;
+    this.#bindingConstraintsList = bindingConstraintsList;
+    this.#elementMetadata = elementMetadata;
+  }
+
+  protected override _buildPlanServiceNode(): PlanServiceNode {
+    return this.#buildLazyPlanServiceNodeNodeFromClassElementMetadata(
+      this.#params,
+      this.#bindingConstraintsList,
+      this.#elementMetadata,
+    );
+  }
+}
+
+class LazyResolvedValueMetadataPlanServiceNode extends LazyPlanServiceNode {
+  readonly #params: SubplanParams;
+  readonly #buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadata: (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ResolvedValueElementMetadata,
+  ) => PlanServiceNode;
+  readonly #bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>;
+  readonly #resolvedValueElementMetadata: ResolvedValueElementMetadata;
+
+  constructor(
+    params: SubplanParams,
+    buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadata: (
+      params: SubplanParams,
+      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      elementMetadata: ResolvedValueElementMetadata,
+    ) => PlanServiceNode,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    resolvedValueElementMetadata: ResolvedValueElementMetadata,
+    serviceNode: PlanServiceNode | undefined,
+  ) {
+    super(
+      serviceNode,
+      getServiceFromMaybeLazyServiceIdentifier(
+        resolvedValueElementMetadata.value,
+      ),
+    );
+
+    this.#params = params;
+    this.#buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadata =
+      buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadata;
+    this.#bindingConstraintsList = bindingConstraintsList;
+    this.#resolvedValueElementMetadata = resolvedValueElementMetadata;
+  }
+
+  protected override _buildPlanServiceNode(): PlanServiceNode {
+    return this.#buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadata(
+      this.#params,
+      this.#bindingConstraintsList,
+      this.#resolvedValueElementMetadata,
+    );
+  }
+}
+
+export function currySubplan(
+  buildLazyPlanServiceNodeNodeFromClassElementMetadata: (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ManagedClassElementMetadata,
+  ) => PlanServiceNode,
+  buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadata: (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ResolvedValueElementMetadata,
+  ) => PlanServiceNode,
+  buildPlanServiceNodeFromClassElementMetadata: (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ManagedClassElementMetadata,
+  ) => PlanServiceNode | undefined,
+  buildPlanServiceNodeFromResolvedValueElementMetadata: (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ResolvedValueElementMetadata,
+  ) => PlanServiceNode | undefined,
+): (
+  params: SubplanParams,
+  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+) => PlanBindingNode {
+  const subplanInstanceBindingNode: (
+    params: SubplanParams,
+    node: InstanceBindingNode,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  ) => PlanBindingNode = currySubplanInstanceBindingNode(
+    buildLazyPlanServiceNodeNodeFromClassElementMetadata,
+    buildPlanServiceNodeFromClassElementMetadata,
+  );
+
+  const subplanResolvedValueBindingNode: (
+    params: SubplanParams,
+    node: ResolvedValueBindingNode,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  ) => PlanBindingNode = currySubplanResolvedValueBindingNode(
+    buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadata,
+    buildPlanServiceNodeFromResolvedValueElementMetadata,
+  );
+
+  return (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  ): PlanBindingNode => {
+    if (isInstanceBindingNode(params.node)) {
+      return subplanInstanceBindingNode(
+        params,
+        params.node,
+        bindingConstraintsList,
+      );
+    } else {
+      return subplanResolvedValueBindingNode(
+        params,
+        params.node,
+        bindingConstraintsList,
+      );
+    }
+  };
+}
+
+function currySubplanInstanceBindingNode(
+  buildLazyPlanServiceNodeNodeFromClassElementMetadata: (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ManagedClassElementMetadata,
+  ) => PlanServiceNode,
+  buildPlanServiceNodeFromClassElementMetadata: (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ManagedClassElementMetadata,
+  ) => PlanServiceNode | undefined,
+): (
+  params: SubplanParams,
+  node: InstanceBindingNode,
+  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+) => PlanBindingNode {
+  const handlePlanServiceNodeBuildFromClassElementMetadata: (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ClassElementMetadata,
+  ) => PlanServiceNode | undefined =
+    curryHandlePlanServiceNodeBuildFromClassElementMetadata(
+      buildLazyPlanServiceNodeNodeFromClassElementMetadata,
+      buildPlanServiceNodeFromClassElementMetadata,
+    );
+
+  return (
+    params: SubplanParams,
+    node: InstanceBindingNode,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  ): PlanBindingNode => {
+    const classMetadata: ClassMetadata = node.classMetadata;
+
+    for (const [
+      index,
+      elementMetadata,
+    ] of classMetadata.constructorArguments.entries()) {
+      node.constructorParams[index] =
+        handlePlanServiceNodeBuildFromClassElementMetadata(
+          params,
+          bindingConstraintsList,
+          elementMetadata,
+        );
+    }
+
+    for (const [propertyKey, elementMetadata] of classMetadata.properties) {
+      const planServiceNode: PlanServiceNode | undefined =
+        handlePlanServiceNodeBuildFromClassElementMetadata(
+          params,
+          bindingConstraintsList,
+          elementMetadata,
+        );
+
+      if (planServiceNode !== undefined) {
+        node.propertyParams.set(propertyKey, planServiceNode);
+      }
+    }
+
+    return params.node;
+  };
+}
+
+function currySubplanResolvedValueBindingNode(
+  buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadata: (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ResolvedValueElementMetadata,
+  ) => PlanServiceNode,
+  buildPlanServiceNodeFromResolvedValueElementMetadata: (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ResolvedValueElementMetadata,
+  ) => PlanServiceNode | undefined,
+): (
+  params: SubplanParams,
+  node: ResolvedValueBindingNode,
+  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+) => PlanBindingNode {
+  const handlePlanServiceNodeBuildFromResolvedValueElementMetadata: (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ResolvedValueElementMetadata,
+  ) => PlanServiceNode =
+    curryHandlePlanServiceNodeBuildFromResolvedValueElementMetadata(
+      buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadata,
+      buildPlanServiceNodeFromResolvedValueElementMetadata,
+    );
+
+  return (
+    params: SubplanParams,
+    node: ResolvedValueBindingNode,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  ): PlanBindingNode => {
+    const resolvedValueMetadata: ResolvedValueMetadata = node.binding.metadata;
+
+    for (const [
+      index,
+      elementMetadata,
+    ] of resolvedValueMetadata.arguments.entries()) {
+      node.params[index] =
+        handlePlanServiceNodeBuildFromResolvedValueElementMetadata(
+          params,
+          bindingConstraintsList,
+          elementMetadata,
+        );
+    }
+
+    return params.node;
+  };
+}
+
+function curryHandlePlanServiceNodeBuildFromClassElementMetadata(
+  buildLazyPlanServiceNodeNodeFromClassElementMetadata: (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ManagedClassElementMetadata,
+  ) => PlanServiceNode,
+  buildPlanServiceNodeFromClassElementMetadata: (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ManagedClassElementMetadata,
+  ) => PlanServiceNode | undefined,
+): (
+  params: SubplanParams,
+  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  elementMetadata: ClassElementMetadata,
+) => PlanServiceNode | undefined {
+  return (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ClassElementMetadata,
+  ): PlanServiceNode | undefined => {
+    if (elementMetadata.kind === ClassElementMetadataKind.unmanaged) {
+      return undefined;
+    }
+
+    const getPlanOptions: GetPlanOptions | undefined =
+      tryBuildGetPlanOptionsFromManagedClassElementMetadata(elementMetadata);
+
+    if (getPlanOptions !== undefined) {
+      const planResult: PlanResult | undefined =
+        params.operations.getPlan(getPlanOptions);
+
+      if (planResult !== undefined && planResult.tree.root.isContextFree) {
+        return planResult.tree.root;
+      }
+    }
+
+    const serviceNode: PlanServiceNode | undefined =
+      buildPlanServiceNodeFromClassElementMetadata(
+        params,
+        bindingConstraintsList,
+        elementMetadata,
+      );
+
+    const lazyPlanServiceNode: LazyPlanServiceNode =
+      new LazyManagedClassMetadataPlanServiceNode(
+        params,
+        buildLazyPlanServiceNodeNodeFromClassElementMetadata,
+        bindingConstraintsList,
+        elementMetadata,
+        serviceNode,
+      );
+
+    cacheNonRootPlanServiceNode(
+      getPlanOptions,
+      params.operations,
+      lazyPlanServiceNode,
+    );
+
+    return lazyPlanServiceNode;
+  };
+}
+
+function curryHandlePlanServiceNodeBuildFromResolvedValueElementMetadata(
+  buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadata: (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ResolvedValueElementMetadata,
+  ) => PlanServiceNode,
+  buildPlanServiceNodeFromResolvedValueElementMetadata: (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ResolvedValueElementMetadata,
+  ) => PlanServiceNode | undefined,
+): (
+  params: SubplanParams,
+  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  elementMetadata: ResolvedValueElementMetadata,
+) => PlanServiceNode {
+  return (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ResolvedValueElementMetadata,
+  ): PlanServiceNode => {
+    const getPlanOptions: GetPlanOptions | undefined =
+      tryBuildGetPlanOptionsFromResolvedValueElementMetadata(elementMetadata);
+
+    if (getPlanOptions !== undefined) {
+      const planResult: PlanResult | undefined =
+        params.operations.getPlan(getPlanOptions);
+
+      if (planResult !== undefined && planResult.tree.root.isContextFree) {
+        return planResult.tree.root;
+      }
+    }
+
+    const serviceNode: PlanServiceNode | undefined =
+      buildPlanServiceNodeFromResolvedValueElementMetadata(
+        params,
+        bindingConstraintsList,
+        elementMetadata,
+      );
+
+    const lazyPlanServiceNode: LazyPlanServiceNode =
+      new LazyResolvedValueMetadataPlanServiceNode(
+        params,
+        buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadata,
+        bindingConstraintsList,
+        elementMetadata,
+        serviceNode,
+      );
+
+    cacheNonRootPlanServiceNode(
+      getPlanOptions,
+      params.operations,
+      lazyPlanServiceNode,
+    );
+
+    return lazyPlanServiceNode;
+  };
+}

--- a/packages/container/libraries/core/src/planning/actions/plan.ts
+++ b/packages/container/libraries/core/src/planning/actions/plan.ts
@@ -6,48 +6,35 @@ import {
   BindingConstraintsImplementation,
   InternalBindingConstraints,
 } from '../../binding/models/BindingConstraintsImplementation';
-import { bindingTypeValues } from '../../binding/models/BindingType';
-import { InstanceBinding } from '../../binding/models/InstanceBinding';
-import { ResolvedValueBinding } from '../../binding/models/ResolvedValueBinding';
-import { ServiceRedirectionBinding } from '../../binding/models/ServiceRedirectionBinding';
 import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
 import { Writable } from '../../common/models/Writable';
-import { ClassElementMetadata } from '../../metadata/models/ClassElementMetadata';
 import { ClassElementMetadataKind } from '../../metadata/models/ClassElementMetadataKind';
-import { ClassMetadata } from '../../metadata/models/ClassMetadata';
 import { ManagedClassElementMetadata } from '../../metadata/models/ManagedClassElementMetadata';
 import { ResolvedValueElementMetadata } from '../../metadata/models/ResolvedValueElementMetadata';
 import { ResolvedValueElementMetadataKind } from '../../metadata/models/ResolvedValueElementMetadataKind';
-import { ResolvedValueMetadata } from '../../metadata/models/ResolvedValueMetadata';
 import { buildFilteredServiceBindings } from '../calculations/buildFilteredServiceBindings';
 import { buildGetPlanOptionsFromPlanParams } from '../calculations/buildGetPlanOptionsFromPlanParams';
-import { buildPlanBindingConstraintsList } from '../calculations/buildPlanBindingConstraintsList';
 import { checkServiceNodeSingleInjectionBindings } from '../calculations/checkServiceNodeSingleInjectionBindings';
 import { getServiceFromMaybeLazyServiceIdentifier } from '../calculations/getServiceFromMaybeLazyServiceIdentifier';
 import { handlePlanError } from '../calculations/handlePlanError';
-import { isInstanceBindingNode } from '../calculations/isInstanceBindingNode';
-import { isPlanServiceRedirectionBindingNode } from '../calculations/isPlanServiceRedirectionBindingNode';
-import { tryBuildGetPlanOptionsFromManagedClassElementMetadata } from '../calculations/tryBuildGetPlanOptionsFromManagedClassElementMetadata';
-import { tryBuildGetPlanOptionsFromResolvedValueElementMetadata } from '../calculations/tryBuildGetPlanOptionsFromResolvedValueElementMetadata';
 import { BasePlanParams } from '../models/BasePlanParams';
 import { BindingNodeParent } from '../models/BindingNodeParent';
 import { GetPlanOptions } from '../models/GetPlanOptions';
-import { InstanceBindingNode } from '../models/InstanceBindingNode';
 import { LazyPlanServiceNode } from '../models/LazyPlanServiceNode';
 import { PlanBindingNode } from '../models/PlanBindingNode';
 import { PlanParams } from '../models/PlanParams';
 import { PlanResult } from '../models/PlanResult';
 import { PlanServiceNode } from '../models/PlanServiceNode';
-import { PlanServiceRedirectionBindingNode } from '../models/PlanServiceRedirectionBindingNode';
-import { ResolvedValueBindingNode } from '../models/ResolvedValueBindingNode';
 import { SubplanParams } from '../models/SubplanParams';
-import { cacheNonRootPlanServiceNode } from './cacheNonRootPlanServiceNode';
+import { curryBuildPlanServiceNode } from './curryBuildPlanServiceNode';
+import { curryBuildServiceNodeBindings } from './curryBuildServiceNodeBindings';
+import { currySubplan } from './currySubplan';
 
 class LazyRootPlanServiceNode extends LazyPlanServiceNode {
   readonly #params: PlanParams;
 
   constructor(params: PlanParams, serviceNode: PlanServiceNode) {
-    super(serviceNode);
+    super(serviceNode, serviceNode.serviceIdentifier);
 
     this.#params = params;
   }
@@ -57,111 +44,26 @@ class LazyRootPlanServiceNode extends LazyPlanServiceNode {
   }
 }
 
-class LazyManagedClassMetadataPlanServiceNode extends LazyPlanServiceNode {
-  readonly #params: SubplanParams;
-  readonly #bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>;
-  readonly #elementMetadata: ManagedClassElementMetadata;
+const subplan: (
+  params: SubplanParams,
+  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+) => PlanBindingNode = currySubplan(
+  buildPlanServiceNodeFromClassElementMetadata,
+  buildPlanServiceNodeFromResolvedValueElementMetadata,
+  buildPlanServiceNodeFromClassElementMetadata,
+  buildPlanServiceNodeFromResolvedValueElementMetadata,
+);
 
-  constructor(
-    params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
-    elementMetadata: ManagedClassElementMetadata,
-    serviceNode: PlanServiceNode,
-  ) {
-    super(serviceNode);
+const buildServiceNodeBindings: (
+  params: BasePlanParams,
+  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  serviceBindings: Binding<unknown>[],
+  parentNode: BindingNodeParent,
+  chainedBindings: boolean,
+) => PlanBindingNode[] = curryBuildServiceNodeBindings(subplan);
 
-    this.#params = params;
-    this.#bindingConstraintsList = bindingConstraintsList;
-    this.#elementMetadata = elementMetadata;
-  }
-
-  protected override _buildPlanServiceNode(): PlanServiceNode {
-    return buildPlanServiceNodeFromClassElementMetadata(
-      this.#params,
-      this.#bindingConstraintsList,
-      this.#elementMetadata,
-    );
-  }
-}
-
-class LazyResolvedValueMetadataPlanServiceNode extends LazyPlanServiceNode {
-  readonly #params: SubplanParams;
-  readonly #bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>;
-  readonly #resolvedValueElementMetadata: ResolvedValueElementMetadata;
-
-  constructor(
-    params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
-    resolvedValueElementMetadata: ResolvedValueElementMetadata,
-    serviceNode: PlanServiceNode,
-  ) {
-    super(serviceNode);
-
-    this.#params = params;
-    this.#bindingConstraintsList = bindingConstraintsList;
-    this.#resolvedValueElementMetadata = resolvedValueElementMetadata;
-  }
-
-  protected override _buildPlanServiceNode(): PlanServiceNode {
-    return buildPlanServiceNodeFromResolvedValueElementMetadata(
-      this.#params,
-      this.#bindingConstraintsList,
-      this.#resolvedValueElementMetadata,
-    );
-  }
-}
-
-function buildPlanServiceNode(params: PlanParams): PlanServiceNode {
-  const bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints> =
-    buildPlanBindingConstraintsList(params);
-
-  const bindingConstraints: BindingConstraints =
-    new BindingConstraintsImplementation(bindingConstraintsList.last);
-
-  const chained: boolean = params.rootConstraints.isMultiple
-    ? params.rootConstraints.chained
-    : false;
-
-  const filteredServiceBindings: Binding<unknown>[] =
-    buildFilteredServiceBindings(params, bindingConstraints, {
-      chained,
-    });
-
-  const serviceNodeBindings: PlanBindingNode[] = [];
-
-  const serviceNode: PlanServiceNode = {
-    bindings: serviceNodeBindings,
-    isContextFree: true,
-    serviceIdentifier: params.rootConstraints.serviceIdentifier,
-  };
-
-  serviceNodeBindings.push(
-    ...buildServiceNodeBindings(
-      params,
-      bindingConstraintsList,
-      filteredServiceBindings,
-      serviceNode,
-      chained,
-    ),
-  );
-
-  serviceNode.isContextFree =
-    !bindingConstraintsList.last.elem.getAncestorsCalled;
-
-  if (!params.rootConstraints.isMultiple) {
-    checkServiceNodeSingleInjectionBindings(
-      serviceNode,
-      params.rootConstraints.isOptional ?? false,
-      bindingConstraintsList.last,
-    );
-
-    const [planBindingNode]: PlanBindingNode[] = serviceNodeBindings;
-
-    (serviceNode as Writable<PlanServiceNode>).bindings = planBindingNode;
-  }
-
-  return serviceNode;
-}
+const buildPlanServiceNode: (params: PlanParams) => PlanServiceNode =
+  curryBuildPlanServiceNode(buildServiceNodeBindings);
 
 export function plan(params: PlanParams): PlanResult {
   try {
@@ -190,32 +92,6 @@ export function plan(params: PlanParams): PlanResult {
   } catch (error: unknown) {
     handlePlanError(params, error);
   }
-}
-
-function buildInstancePlanBindingNode(
-  params: BasePlanParams,
-  binding: InstanceBinding<unknown>,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
-): PlanBindingNode {
-  const classMetadata: ClassMetadata = params.operations.getClassMetadata(
-    binding.implementationType,
-  );
-
-  const childNode: InstanceBindingNode = {
-    binding: binding,
-    classMetadata,
-    constructorParams: [],
-    propertyParams: new Map(),
-  };
-
-  const subplanParams: SubplanParams = {
-    autobindOptions: params.autobindOptions,
-    node: childNode,
-    operations: params.operations,
-    servicesBranch: params.servicesBranch,
-  };
-
-  return subplan(subplanParams, bindingConstraintsList);
 }
 
 function buildPlanServiceNodeFromClassElementMetadata(
@@ -348,278 +224,4 @@ function buildPlanServiceNodeFromResolvedValueElementMetadata(
   }
 
   return serviceNode;
-}
-
-function buildResolvedValuePlanBindingNode(
-  params: BasePlanParams,
-  binding: ResolvedValueBinding<unknown>,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
-): PlanBindingNode {
-  const childNode: ResolvedValueBindingNode = {
-    binding: binding,
-    params: [],
-  };
-
-  const subplanParams: SubplanParams = {
-    autobindOptions: params.autobindOptions,
-    node: childNode,
-    operations: params.operations,
-    servicesBranch: params.servicesBranch,
-  };
-
-  return subplan(subplanParams, bindingConstraintsList);
-}
-
-function buildServiceNodeBindings(
-  params: BasePlanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
-  serviceBindings: Binding<unknown>[],
-  parentNode: BindingNodeParent,
-  chainedBindings: boolean,
-): PlanBindingNode[] {
-  const serviceIdentifier: ServiceIdentifier =
-    isPlanServiceRedirectionBindingNode(parentNode)
-      ? parentNode.binding.targetServiceIdentifier
-      : parentNode.serviceIdentifier;
-
-  params.servicesBranch.push(serviceIdentifier);
-
-  const planBindingNodes: PlanBindingNode[] = [];
-
-  for (const binding of serviceBindings) {
-    switch (binding.type) {
-      case bindingTypeValues.Instance: {
-        planBindingNodes.push(
-          buildInstancePlanBindingNode(params, binding, bindingConstraintsList),
-        );
-        break;
-      }
-      case bindingTypeValues.ResolvedValue: {
-        planBindingNodes.push(
-          buildResolvedValuePlanBindingNode(
-            params,
-            binding,
-            bindingConstraintsList,
-          ),
-        );
-        break;
-      }
-      case bindingTypeValues.ServiceRedirection: {
-        const planBindingNode: PlanBindingNode | undefined =
-          buildServiceRedirectionPlanBindingNode(
-            params,
-            bindingConstraintsList,
-            binding,
-            chainedBindings,
-          );
-
-        planBindingNodes.push(planBindingNode);
-
-        break;
-      }
-      default:
-        planBindingNodes.push({
-          binding: binding,
-        });
-    }
-  }
-
-  params.servicesBranch.pop();
-
-  return planBindingNodes;
-}
-
-function buildServiceRedirectionPlanBindingNode(
-  params: BasePlanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
-  binding: ServiceRedirectionBinding<unknown>,
-  chainedBindings: boolean,
-): PlanBindingNode {
-  const childNode: PlanServiceRedirectionBindingNode = {
-    binding,
-    redirections: [],
-  };
-
-  const bindingConstraints: BindingConstraints =
-    new BindingConstraintsImplementation(bindingConstraintsList.last);
-
-  const filteredServiceBindings: Binding<unknown>[] =
-    buildFilteredServiceBindings(params, bindingConstraints, {
-      chained: chainedBindings,
-      customServiceIdentifier: binding.targetServiceIdentifier,
-    });
-
-  childNode.redirections.push(
-    ...buildServiceNodeBindings(
-      params,
-      bindingConstraintsList,
-      filteredServiceBindings,
-      childNode,
-      chainedBindings,
-    ),
-  );
-
-  return childNode;
-}
-
-function handlePlanServiceNodeBuildFromClassElementMetadata(
-  params: SubplanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
-  elementMetadata: ClassElementMetadata,
-): PlanServiceNode | undefined {
-  if (elementMetadata.kind === ClassElementMetadataKind.unmanaged) {
-    return undefined;
-  }
-
-  const getPlanOptions: GetPlanOptions | undefined =
-    tryBuildGetPlanOptionsFromManagedClassElementMetadata(elementMetadata);
-
-  if (getPlanOptions !== undefined) {
-    const planResult: PlanResult | undefined =
-      params.operations.getPlan(getPlanOptions);
-
-    if (planResult !== undefined && planResult.tree.root.isContextFree) {
-      return planResult.tree.root;
-    }
-  }
-
-  const serviceNode: PlanServiceNode =
-    buildPlanServiceNodeFromClassElementMetadata(
-      params,
-      bindingConstraintsList,
-      elementMetadata,
-    );
-
-  const lazyPlanServiceNode: LazyPlanServiceNode =
-    new LazyManagedClassMetadataPlanServiceNode(
-      params,
-      bindingConstraintsList,
-      elementMetadata,
-      serviceNode,
-    );
-
-  cacheNonRootPlanServiceNode(
-    getPlanOptions,
-    params.operations,
-    lazyPlanServiceNode,
-  );
-
-  return lazyPlanServiceNode;
-}
-
-function handlePlanServiceNodeBuildFromResolvedValueElementMetadata(
-  params: SubplanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
-  elementMetadata: ResolvedValueElementMetadata,
-): PlanServiceNode {
-  const getPlanOptions: GetPlanOptions | undefined =
-    tryBuildGetPlanOptionsFromResolvedValueElementMetadata(elementMetadata);
-
-  if (getPlanOptions !== undefined) {
-    const planResult: PlanResult | undefined =
-      params.operations.getPlan(getPlanOptions);
-
-    if (planResult !== undefined && planResult.tree.root.isContextFree) {
-      return planResult.tree.root;
-    }
-  }
-
-  const serviceNode: PlanServiceNode =
-    buildPlanServiceNodeFromResolvedValueElementMetadata(
-      params,
-      bindingConstraintsList,
-      elementMetadata,
-    );
-
-  const lazyPlanServiceNode: LazyPlanServiceNode =
-    new LazyResolvedValueMetadataPlanServiceNode(
-      params,
-      bindingConstraintsList,
-      elementMetadata,
-      serviceNode,
-    );
-
-  cacheNonRootPlanServiceNode(
-    getPlanOptions,
-    params.operations,
-    lazyPlanServiceNode,
-  );
-
-  return lazyPlanServiceNode;
-}
-
-function subplan(
-  params: SubplanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
-): PlanBindingNode {
-  if (isInstanceBindingNode(params.node)) {
-    return subplanInstanceBindingNode(
-      params,
-      params.node,
-      bindingConstraintsList,
-    );
-  } else {
-    return subplanResolvedValueBindingNode(
-      params,
-      params.node,
-      bindingConstraintsList,
-    );
-  }
-}
-
-function subplanInstanceBindingNode(
-  params: SubplanParams,
-  node: InstanceBindingNode,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
-): PlanBindingNode {
-  const classMetadata: ClassMetadata = node.classMetadata;
-
-  for (const [
-    index,
-    elementMetadata,
-  ] of classMetadata.constructorArguments.entries()) {
-    node.constructorParams[index] =
-      handlePlanServiceNodeBuildFromClassElementMetadata(
-        params,
-        bindingConstraintsList,
-        elementMetadata,
-      );
-  }
-
-  for (const [propertyKey, elementMetadata] of classMetadata.properties) {
-    const planServiceNode: PlanServiceNode | undefined =
-      handlePlanServiceNodeBuildFromClassElementMetadata(
-        params,
-        bindingConstraintsList,
-        elementMetadata,
-      );
-
-    if (planServiceNode !== undefined) {
-      node.propertyParams.set(propertyKey, planServiceNode);
-    }
-  }
-
-  return params.node;
-}
-
-function subplanResolvedValueBindingNode(
-  params: SubplanParams,
-  node: ResolvedValueBindingNode,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
-): PlanBindingNode {
-  const resolvedValueMetadata: ResolvedValueMetadata = node.binding.metadata;
-
-  for (const [
-    index,
-    elementMetadata,
-  ] of resolvedValueMetadata.arguments.entries()) {
-    node.params[index] =
-      handlePlanServiceNodeBuildFromResolvedValueElementMetadata(
-        params,
-        bindingConstraintsList,
-        elementMetadata,
-      );
-  }
-
-  return params.node;
 }

--- a/packages/container/libraries/core/src/planning/models/LazyPlanServiceNode.spec.ts
+++ b/packages/container/libraries/core/src/planning/models/LazyPlanServiceNode.spec.ts
@@ -8,6 +8,8 @@ import {
   vitest,
 } from 'vitest';
 
+import { ServiceIdentifier } from '@inversifyjs/common';
+
 import { LazyPlanServiceNode } from './LazyPlanServiceNode';
 import { PlanBindingNode } from './PlanBindingNode';
 import { PlanServiceNode } from './PlanServiceNode';
@@ -16,10 +18,11 @@ export class LazyPlanServiceNodeTest extends LazyPlanServiceNode {
   readonly #buildPlanServiceNodeMock: Mock<() => PlanServiceNode>;
 
   constructor(
-    serviceNode: PlanServiceNode,
+    serviceNode: PlanServiceNode | undefined,
+    serviceIdentifier: ServiceIdentifier,
     buildPlanServiceNode: Mock<() => PlanServiceNode>,
   ) {
-    super(serviceNode);
+    super(serviceNode, serviceIdentifier);
 
     this.#buildPlanServiceNodeMock = buildPlanServiceNode;
   }
@@ -48,6 +51,7 @@ describe(LazyPlanServiceNode, () => {
         beforeAll(() => {
           lazyPlanServiceNode = new LazyPlanServiceNodeTest(
             Symbol() as unknown as PlanServiceNode,
+            Symbol(),
             buildPlanServiceNodeMock,
           );
           lazyPlanServiceNode.invalidate();
@@ -96,6 +100,7 @@ describe(LazyPlanServiceNode, () => {
 
           lazyPlanServiceNode = new LazyPlanServiceNodeTest(
             planServiceNodeFixture,
+            Symbol(),
             buildPlanServiceNodeMock,
           );
 
@@ -129,6 +134,7 @@ describe(LazyPlanServiceNode, () => {
         beforeAll(() => {
           lazyPlanServiceNode = new LazyPlanServiceNodeTest(
             Symbol() as unknown as PlanServiceNode,
+            Symbol(),
             buildPlanServiceNodeMock,
           );
           lazyPlanServiceNode.invalidate();
@@ -177,6 +183,7 @@ describe(LazyPlanServiceNode, () => {
 
           lazyPlanServiceNode = new LazyPlanServiceNodeTest(
             planServiceNodeFixture,
+            Symbol(),
             buildPlanServiceNodeMock,
           );
 
@@ -201,6 +208,7 @@ describe(LazyPlanServiceNode, () => {
   describe('.serviceIdentifier', () => {
     describe('when called', () => {
       let planServiceNodeFixture: PlanServiceNode;
+      let serviceIdentifierFixture: ServiceIdentifier;
       let lazyPlanServiceNode: LazyPlanServiceNode;
 
       let result: unknown;
@@ -211,9 +219,11 @@ describe(LazyPlanServiceNode, () => {
           isContextFree: true,
           serviceIdentifier: Symbol(),
         };
+        serviceIdentifierFixture = Symbol();
 
         lazyPlanServiceNode = new LazyPlanServiceNodeTest(
           planServiceNodeFixture,
+          serviceIdentifierFixture,
           buildPlanServiceNodeMock,
         );
 
@@ -229,7 +239,7 @@ describe(LazyPlanServiceNode, () => {
       });
 
       it('should return expected value', () => {
-        expect(result).toBe(planServiceNodeFixture.serviceIdentifier);
+        expect(result).toBe(serviceIdentifierFixture);
       });
     });
   });

--- a/packages/container/libraries/core/src/planning/models/LazyPlanServiceNode.ts
+++ b/packages/container/libraries/core/src/planning/models/LazyPlanServiceNode.ts
@@ -12,10 +12,13 @@ export abstract class LazyPlanServiceNode implements PlanServiceNode {
   protected readonly _serviceIdentifier: ServiceIdentifier;
   protected _serviceNode: PlanServiceNode | undefined;
 
-  constructor(serviceNode: PlanServiceNode) {
+  constructor(
+    serviceNode: PlanServiceNode | undefined,
+    serviceIdentifier: ServiceIdentifier,
+  ) {
     this[isLazyPlanServiceNodeSymbol] = true;
-    this._serviceIdentifier = serviceNode.serviceIdentifier;
     this._serviceNode = serviceNode;
+    this._serviceIdentifier = serviceIdentifier;
   }
 
   public get bindings(): PlanBindingNode | PlanBindingNode[] | undefined {
@@ -51,6 +54,10 @@ export abstract class LazyPlanServiceNode implements PlanServiceNode {
 
   public invalidate(): void {
     this._serviceNode = undefined;
+  }
+
+  public isExpanded(): boolean {
+    return this._serviceNode !== undefined;
   }
 
   protected _getNode(): PlanServiceNode {

--- a/packages/container/libraries/core/src/planning/services/PlanResultCacheService.spec.ts
+++ b/packages/container/libraries/core/src/planning/services/PlanResultCacheService.spec.ts
@@ -26,7 +26,7 @@ class LazyPlanServiceNodeMock extends LazyPlanServiceNode {
     serviceNode: PlanServiceNode,
     buildPlanServiceNodeMock: Mock<() => PlanServiceNode>,
   ) {
-    super(serviceNode);
+    super(serviceNode, serviceNode.serviceIdentifier);
 
     this.buildPlanServiceNodeMock = buildPlanServiceNodeMock;
   }

--- a/packages/container/libraries/plugin-dispose/package.json
+++ b/packages/container/libraries/plugin-dispose/package.json
@@ -25,7 +25,7 @@
     "vitest": "3.2.4"
   },
   "peerDependencies": {
-    "inversify": "^7.6.1"
+    "inversify": "^7.7.0"
   },
   "homepage": "https://inversify.io",
   "keywords": [

--- a/packages/container/libraries/strongly-typed/package.json
+++ b/packages/container/libraries/strongly-typed/package.json
@@ -43,7 +43,7 @@
   },
   "name": "@inversifyjs/strongly-typed",
   "peerDependencies": {
-    "inversify": "^7.6.1"
+    "inversify": "^7.7.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/http/libraries/core/package.json
+++ b/packages/http/libraries/core/package.json
@@ -50,7 +50,7 @@
   "name": "@inversifyjs/http-core",
   "private": "true",
   "peerDependencies": {
-    "inversify": "^7.6.1"
+    "inversify": "^7.7.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/http/libraries/express-v4/package.json
+++ b/packages/http/libraries/express-v4/package.json
@@ -50,7 +50,7 @@
   "name": "@inversifyjs/http-express-v4",
   "peerDependencies": {
     "express": "^4.21.2",
-    "inversify": "^7.6.1"
+    "inversify": "^7.7.0"
   },
   "private": true,
   "repository": {

--- a/packages/http/libraries/express/package.json
+++ b/packages/http/libraries/express/package.json
@@ -50,7 +50,7 @@
   "name": "@inversifyjs/http-express",
   "peerDependencies": {
     "express": "^5.1.0",
-    "inversify": "^7.6.1"
+    "inversify": "^7.7.0"
   },
   "private": true,
   "repository": {

--- a/packages/http/libraries/fastify/package.json
+++ b/packages/http/libraries/fastify/package.json
@@ -50,7 +50,7 @@
   "name": "@inversifyjs/http-fastify",
   "peerDependencies": {
     "fastify": "^5.4.0",
-    "inversify": "^7.6.1"
+    "inversify": "^7.7.0"
   },
   "private": true,
   "repository": {

--- a/packages/http/libraries/hono/package.json
+++ b/packages/http/libraries/hono/package.json
@@ -48,8 +48,8 @@
   },
   "name": "@inversifyjs/http-hono",
   "peerDependencies": {
-    "hono": "^4.8.10",
-    "inversify": "^7.6.1"
+    "hono": "^4.8.12",
+    "inversify": "^7.7.0"
   },
   "private": true,
   "repository": {


### PR DESCRIPTION
### Added
- Added `currySubplan`.
- Added `curryBuildPlanServiceNode`.
- Added `curryBuildServiceNodeBindings`.

### Changed
Updated `plan` to rely on curry extracted functions.