### PR TITLE
Add addRootServiceNodeBindingIfContextFree

### DIFF
--- a/packages/container/libraries/core/src/metadata/models/PlanServiceNodeUpdateResult.ts
+++ b/packages/container/libraries/core/src/metadata/models/PlanServiceNodeUpdateResult.ts
@@ -1,0 +1,4 @@
+export interface PlanServiceNodeBindingAddedResult {
+  isContextFreeBinding: boolean;
+  shouldInvalidateServiceNode: boolean;
+}

--- a/packages/container/libraries/core/src/planning/actions/addRootServiceNodeBindingIfContextFree.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/addRootServiceNodeBindingIfContextFree.spec.ts
@@ -1,0 +1,185 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  Mock,
+  Mocked,
+  vitest,
+} from 'vitest';
+
+vitest.mock('../calculations/buildPlanBindingConstraintsList');
+vitest.mock('./addServiceNodeBindingIfContextFree');
+
+import { ServiceIdentifier } from '@inversifyjs/common';
+
+import { Binding } from '../../binding/models/Binding';
+import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
+import { bindingScopeValues } from '../../binding/models/BindingScope';
+import { bindingTypeValues } from '../../binding/models/BindingType';
+import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { PlanServiceNodeBindingAddedResult } from '../../metadata/models/PlanServiceNodeUpdateResult';
+import { buildPlanBindingConstraintsList } from '../calculations/buildPlanBindingConstraintsList';
+import { LazyPlanServiceNode } from '../models/LazyPlanServiceNode';
+import { PlanParams } from '../models/PlanParams';
+import { PlanParamsOperations } from '../models/PlanParamsOperations';
+import { PlanServiceNode } from '../models/PlanServiceNode';
+import { addRootServiceNodeBindingIfContextFree } from './addRootServiceNodeBindingIfContextFree';
+import { addServiceNodeBindingIfContextFree } from './addServiceNodeBindingIfContextFree';
+
+class LazyPlanServiceNodeTest extends LazyPlanServiceNode {
+  readonly #buildPlanServiceNodeMock: Mock<() => PlanServiceNode>;
+
+  constructor(
+    serviceNode: PlanServiceNode | undefined,
+    serviceIdentifier: ServiceIdentifier,
+    buildPlanServiceNode: Mock<() => PlanServiceNode>,
+  ) {
+    super(serviceNode, serviceIdentifier);
+
+    this.#buildPlanServiceNodeMock = buildPlanServiceNode;
+  }
+
+  protected _buildPlanServiceNode(): PlanServiceNode {
+    return this.#buildPlanServiceNodeMock();
+  }
+}
+
+describe(addRootServiceNodeBindingIfContextFree, () => {
+  describe('having a non expanded lazy service node', () => {
+    let lazyPlanServiceNodeFixture: LazyPlanServiceNode;
+
+    beforeAll(() => {
+      lazyPlanServiceNodeFixture = new LazyPlanServiceNodeTest(
+        undefined,
+        Symbol(),
+        vitest.fn(),
+      );
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = addRootServiceNodeBindingIfContextFree(
+          Symbol() as unknown as PlanParams,
+          lazyPlanServiceNodeFixture,
+          Symbol() as unknown as Binding<unknown>,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should return expected value', () => {
+        const expected: PlanServiceNodeBindingAddedResult = {
+          isContextFreeBinding: true,
+          shouldInvalidateServiceNode: false,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having an expanded lazy service node with an array of bindings', () => {
+    let paramsFixture: PlanParams;
+    let lazyPlanServiceNodeFixture: LazyPlanServiceNode;
+    let bindingMock: Mocked<Binding<unknown>>;
+
+    beforeAll(() => {
+      paramsFixture = {
+        autobindOptions: undefined,
+        operations: Symbol() as unknown as PlanParamsOperations,
+        rootConstraints: {
+          chained: false,
+          isMultiple: true,
+          serviceIdentifier: Symbol(),
+        },
+        servicesBranch: [],
+      };
+
+      const serviceIdentifier: ServiceIdentifier = Symbol();
+
+      lazyPlanServiceNodeFixture = new LazyPlanServiceNodeTest(
+        {
+          bindings: [],
+          isContextFree: true,
+          serviceIdentifier: serviceIdentifier,
+        },
+        serviceIdentifier,
+        vitest.fn(),
+      );
+
+      bindingMock = {
+        cache: {
+          isRight: false,
+          value: undefined,
+        },
+        id: 1,
+        isSatisfiedBy: vitest.fn(),
+        moduleId: undefined,
+        onActivation: vitest.fn(),
+        onDeactivation: vitest.fn(),
+        scope: bindingScopeValues.Singleton,
+        serviceIdentifier,
+        type: bindingTypeValues.ConstantValue,
+        value: Symbol(),
+      };
+    });
+
+    describe('when called', () => {
+      let buildPlanBindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let planServiceNodeBindingAddedResultFixture: PlanServiceNodeBindingAddedResult;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        buildPlanBindingConstraintsListFixture = new SingleInmutableLinkedList({
+          elem: Symbol() as unknown as InternalBindingConstraints,
+          previous: undefined,
+        });
+
+        planServiceNodeBindingAddedResultFixture = {
+          isContextFreeBinding: true,
+          shouldInvalidateServiceNode: false,
+        };
+
+        vitest
+          .mocked(buildPlanBindingConstraintsList)
+          .mockReturnValueOnce(buildPlanBindingConstraintsListFixture);
+
+        vitest
+          .mocked(addServiceNodeBindingIfContextFree)
+          .mockReturnValueOnce(planServiceNodeBindingAddedResultFixture);
+
+        result = addRootServiceNodeBindingIfContextFree(
+          paramsFixture,
+          lazyPlanServiceNodeFixture,
+          bindingMock,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call addServiceNodeBindingIfContextFree()', () => {
+        expect(addServiceNodeBindingIfContextFree).toHaveBeenCalledTimes(1);
+        expect(addServiceNodeBindingIfContextFree).toHaveBeenCalledWith(
+          paramsFixture,
+          lazyPlanServiceNodeFixture,
+          bindingMock,
+          buildPlanBindingConstraintsListFixture,
+          false,
+        );
+      });
+
+      it('should return expected value', () => {
+        expect(result).toStrictEqual(planServiceNodeBindingAddedResultFixture);
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/planning/actions/addRootServiceNodeBindingIfContextFree.ts
+++ b/packages/container/libraries/core/src/planning/actions/addRootServiceNodeBindingIfContextFree.ts
@@ -1,0 +1,43 @@
+import { Binding } from '../../binding/models/Binding';
+import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
+import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { PlanServiceNodeBindingAddedResult } from '../../metadata/models/PlanServiceNodeUpdateResult';
+import { buildPlanBindingConstraintsList } from '../calculations/buildPlanBindingConstraintsList';
+import { LazyPlanServiceNode } from '../models/LazyPlanServiceNode';
+import { PlanParams } from '../models/PlanParams';
+import { PlanServiceNode } from '../models/PlanServiceNode';
+import { addServiceNodeBindingIfContextFree } from './addServiceNodeBindingIfContextFree';
+
+/**
+ * Attach a binding to the root service node if the binding is context-free.
+ * @param params The plan parameters.
+ * @param serviceNode The service node to attach the binding to.
+ * @param binding The binding to attach.
+ * @returns True if the binding requires ancestor metadata, false otherwise.
+ */
+export function addRootServiceNodeBindingIfContextFree(
+  params: PlanParams,
+  serviceNode: PlanServiceNode,
+  binding: Binding<unknown>,
+): PlanServiceNodeBindingAddedResult {
+  if (LazyPlanServiceNode.is(serviceNode) && !serviceNode.isExpanded()) {
+    return {
+      isContextFreeBinding: true,
+      shouldInvalidateServiceNode: false,
+    };
+  }
+
+  const bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints> =
+    buildPlanBindingConstraintsList(params);
+
+  const chained: boolean =
+    params.rootConstraints.isMultiple && params.rootConstraints.chained;
+
+  return addServiceNodeBindingIfContextFree(
+    params,
+    serviceNode,
+    binding,
+    bindingConstraintsList,
+    chained,
+  );
+}

--- a/packages/container/libraries/core/src/planning/actions/addServiceNodeBindingIfContextFree.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/addServiceNodeBindingIfContextFree.spec.ts
@@ -1,0 +1,705 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  Mock,
+  Mocked,
+  vitest,
+} from 'vitest';
+
+vitest.mock('./curryBuildServiceNodeBindings', () => {
+  const buildServiceNodeBindingsMock: Mock<
+    (
+      params: BasePlanParams,
+      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      serviceBindings: Binding<unknown>[],
+      parentNode: BindingNodeParent,
+      chainedBindings: boolean,
+    ) => PlanBindingNode[]
+  > = vitest.fn();
+
+  return {
+    curryBuildServiceNodeBindings: vitest
+      .fn()
+      .mockReturnValue(buildServiceNodeBindingsMock),
+  };
+});
+vitest.mock('./curryLazyBuildPlanServiceNodeFromClassElementMetadata');
+vitest.mock('./curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata');
+vitest.mock('./currySubplan');
+vitest.mock('./plan');
+
+import { ServiceIdentifier } from '@inversifyjs/common';
+
+import { Binding } from '../../binding/models/Binding';
+import {
+  BindingConstraintsImplementation,
+  InternalBindingConstraints,
+} from '../../binding/models/BindingConstraintsImplementation';
+import { bindingScopeValues } from '../../binding/models/BindingScope';
+import { bindingTypeValues } from '../../binding/models/BindingType';
+import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { InversifyCoreError } from '../../error/models/InversifyCoreError';
+import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
+import { PlanServiceNodeBindingAddedResult } from '../../metadata/models/PlanServiceNodeUpdateResult';
+import { BasePlanParams } from '../models/BasePlanParams';
+import { BindingNodeParent } from '../models/BindingNodeParent';
+import { LazyPlanServiceNode } from '../models/LazyPlanServiceNode';
+import { PlanBindingNode } from '../models/PlanBindingNode';
+import { PlanServiceNode } from '../models/PlanServiceNode';
+import { addServiceNodeBindingIfContextFree } from './addServiceNodeBindingIfContextFree';
+import { curryBuildServiceNodeBindings } from './curryBuildServiceNodeBindings';
+
+class LazyPlanServiceNodeTest extends LazyPlanServiceNode {
+  readonly #buildPlanServiceNodeMock: Mock<() => PlanServiceNode>;
+
+  constructor(
+    serviceNode: PlanServiceNode | undefined,
+    serviceIdentifier: ServiceIdentifier,
+    buildPlanServiceNode: Mock<() => PlanServiceNode>,
+  ) {
+    super(serviceNode, serviceIdentifier);
+
+    this.#buildPlanServiceNodeMock = buildPlanServiceNode;
+  }
+
+  protected _buildPlanServiceNode(): PlanServiceNode {
+    return this.#buildPlanServiceNodeMock();
+  }
+}
+
+describe(addServiceNodeBindingIfContextFree, () => {
+  let buildServiceNodeBindingsMock: Mock<
+    (
+      params: BasePlanParams,
+      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      serviceBindings: Binding<unknown>[],
+      parentNode: BindingNodeParent,
+      chainedBindings: boolean,
+    ) => PlanBindingNode[]
+  >;
+
+  beforeAll(() => {
+    buildServiceNodeBindingsMock = vitest.mocked(
+      curryBuildServiceNodeBindings(vitest.fn()),
+    );
+  });
+
+  describe('having a non expanded lazy service node', () => {
+    let lazyPlanServiceNodeFixture: LazyPlanServiceNode;
+
+    beforeAll(() => {
+      lazyPlanServiceNodeFixture = new LazyPlanServiceNodeTest(
+        undefined,
+        Symbol(),
+        vitest.fn(),
+      );
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = addServiceNodeBindingIfContextFree(
+          Symbol() as unknown as BasePlanParams,
+          lazyPlanServiceNodeFixture,
+          Symbol() as unknown as Binding<unknown>,
+          Symbol() as unknown as SingleInmutableLinkedList<InternalBindingConstraints>,
+          false,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should return expected value', () => {
+        const expected: PlanServiceNodeBindingAddedResult = {
+          isContextFreeBinding: true,
+          shouldInvalidateServiceNode: false,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having an expanded lazy service node with an array of bindings and bindingConstraintsList with elems with getAncestorsCalled false', () => {
+    let paramsFixture: BasePlanParams;
+    let lazyPlanServiceNodeFixture: LazyPlanServiceNode;
+    let bindingMock: Mocked<Binding<unknown>>;
+    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let chainedBindings: boolean;
+
+    beforeAll(() => {
+      paramsFixture = Symbol() as unknown as BasePlanParams;
+
+      const serviceIdentifier: ServiceIdentifier = Symbol();
+
+      lazyPlanServiceNodeFixture = new LazyPlanServiceNodeTest(
+        {
+          bindings: [],
+          isContextFree: true,
+          serviceIdentifier: serviceIdentifier,
+        },
+        serviceIdentifier,
+        vitest.fn(),
+      );
+
+      bindingMock = {
+        cache: {
+          isRight: false,
+          value: undefined,
+        },
+        id: 1,
+        isSatisfiedBy: vitest.fn(),
+        moduleId: undefined,
+        onActivation: vitest.fn(),
+        onDeactivation: vitest.fn(),
+        scope: bindingScopeValues.Singleton,
+        serviceIdentifier,
+        type: bindingTypeValues.ConstantValue,
+        value: Symbol(),
+      };
+
+      bindingConstraintsListFixture =
+        new SingleInmutableLinkedList<InternalBindingConstraints>({
+          elem: {
+            getAncestorsCalled: false,
+            name: undefined,
+            serviceIdentifier,
+            tags: new Map(),
+          },
+          previous: undefined,
+        });
+
+      chainedBindings = false;
+    });
+
+    describe('when called, and binding.isSatisfiedBy() returns false', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        bindingMock.isSatisfiedBy.mockReturnValueOnce(false);
+
+        result = addServiceNodeBindingIfContextFree(
+          paramsFixture,
+          lazyPlanServiceNodeFixture,
+          bindingMock,
+          bindingConstraintsListFixture,
+          chainedBindings,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call binding.isSatisfiedBy()', () => {
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+          new BindingConstraintsImplementation(
+            bindingConstraintsListFixture.last,
+          ),
+        );
+      });
+
+      it('should return expected value', () => {
+        const expected: PlanServiceNodeBindingAddedResult = {
+          isContextFreeBinding:
+            !bindingConstraintsListFixture.last.elem.getAncestorsCalled,
+          shouldInvalidateServiceNode: false,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+
+    describe('when called, and binding.isSatisfiedBy() returns true', () => {
+      let planBindingNodeFixture: PlanBindingNode;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        planBindingNodeFixture = Symbol() as unknown as PlanBindingNode;
+
+        bindingMock.isSatisfiedBy.mockReturnValueOnce(true);
+
+        buildServiceNodeBindingsMock.mockReturnValueOnce([
+          planBindingNodeFixture,
+        ]);
+
+        result = addServiceNodeBindingIfContextFree(
+          paramsFixture,
+          lazyPlanServiceNodeFixture,
+          bindingMock,
+          bindingConstraintsListFixture,
+          chainedBindings,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call binding.isSatisfiedBy()', () => {
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+          new BindingConstraintsImplementation(
+            bindingConstraintsListFixture.last,
+          ),
+        );
+      });
+
+      it('should call buildServiceNodeBindings()', () => {
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledTimes(1);
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledWith(
+          paramsFixture,
+          bindingConstraintsListFixture,
+          [bindingMock],
+          lazyPlanServiceNodeFixture,
+          chainedBindings,
+        );
+      });
+
+      it('should return expected value', () => {
+        const expected: PlanServiceNodeBindingAddedResult = {
+          isContextFreeBinding:
+            !bindingConstraintsListFixture.last.elem.getAncestorsCalled,
+          shouldInvalidateServiceNode: false,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having an expanded lazy service node with an array of bindings and bindingConstraintsList with elems with getAncestorsCalled true', () => {
+    let paramsFixture: BasePlanParams;
+    let lazyPlanServiceNodeFixture: LazyPlanServiceNode;
+    let bindingMock: Mocked<Binding<unknown>>;
+    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let chainedBindings: boolean;
+
+    beforeAll(() => {
+      paramsFixture = Symbol() as unknown as BasePlanParams;
+
+      const serviceIdentifier: ServiceIdentifier = Symbol();
+
+      lazyPlanServiceNodeFixture = new LazyPlanServiceNodeTest(
+        {
+          bindings: [],
+          isContextFree: true,
+          serviceIdentifier: serviceIdentifier,
+        },
+        serviceIdentifier,
+        vitest.fn(),
+      );
+
+      bindingMock = {
+        cache: {
+          isRight: false,
+          value: undefined,
+        },
+        id: 1,
+        isSatisfiedBy: vitest.fn(),
+        moduleId: undefined,
+        onActivation: vitest.fn(),
+        onDeactivation: vitest.fn(),
+        scope: bindingScopeValues.Singleton,
+        serviceIdentifier,
+        type: bindingTypeValues.ConstantValue,
+        value: Symbol(),
+      };
+
+      bindingConstraintsListFixture =
+        new SingleInmutableLinkedList<InternalBindingConstraints>({
+          elem: {
+            getAncestorsCalled: true,
+            name: undefined,
+            serviceIdentifier,
+            tags: new Map(),
+          },
+          previous: undefined,
+        });
+
+      chainedBindings = false;
+    });
+
+    describe('when called, and binding.isSatisfiedBy() returns true', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        bindingMock.isSatisfiedBy.mockReturnValueOnce(true);
+
+        result = addServiceNodeBindingIfContextFree(
+          paramsFixture,
+          lazyPlanServiceNodeFixture,
+          bindingMock,
+          bindingConstraintsListFixture,
+          chainedBindings,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call binding.isSatisfiedBy()', () => {
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+          new BindingConstraintsImplementation(
+            bindingConstraintsListFixture.last,
+          ),
+        );
+      });
+
+      it('should return expected value', () => {
+        const expected: PlanServiceNodeBindingAddedResult = {
+          isContextFreeBinding:
+            !bindingConstraintsListFixture.last.elem.getAncestorsCalled,
+          shouldInvalidateServiceNode: false,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having an expanded lazy service node with undefined bindings and bindingConstraintsList with elems with getAncestorsCalled false', () => {
+    let paramsFixture: BasePlanParams;
+    let lazyPlanServiceNodeFixture: LazyPlanServiceNode;
+    let bindingMock: Mocked<Binding<unknown>>;
+    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let chainedBindings: boolean;
+
+    beforeAll(() => {
+      paramsFixture = Symbol() as unknown as BasePlanParams;
+
+      const serviceIdentifier: ServiceIdentifier = Symbol();
+
+      lazyPlanServiceNodeFixture = new LazyPlanServiceNodeTest(
+        {
+          bindings: undefined,
+          isContextFree: true,
+          serviceIdentifier: serviceIdentifier,
+        },
+        serviceIdentifier,
+        vitest.fn(),
+      );
+
+      bindingMock = {
+        cache: {
+          isRight: false,
+          value: undefined,
+        },
+        id: 1,
+        isSatisfiedBy: vitest.fn(),
+        moduleId: undefined,
+        onActivation: vitest.fn(),
+        onDeactivation: vitest.fn(),
+        scope: bindingScopeValues.Singleton,
+        serviceIdentifier,
+        type: bindingTypeValues.ConstantValue,
+        value: Symbol(),
+      };
+
+      bindingConstraintsListFixture =
+        new SingleInmutableLinkedList<InternalBindingConstraints>({
+          elem: {
+            getAncestorsCalled: false,
+            name: undefined,
+            serviceIdentifier,
+            tags: new Map(),
+          },
+          previous: undefined,
+        });
+
+      chainedBindings = false;
+    });
+
+    describe('when called, and binding.isSatisfiedBy() returns true', () => {
+      let planBindingNodeFixture: PlanBindingNode;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        planBindingNodeFixture = Symbol() as unknown as PlanBindingNode;
+
+        bindingMock.isSatisfiedBy.mockReturnValueOnce(true);
+
+        buildServiceNodeBindingsMock.mockReturnValueOnce([
+          planBindingNodeFixture,
+        ]);
+
+        result = addServiceNodeBindingIfContextFree(
+          paramsFixture,
+          lazyPlanServiceNodeFixture,
+          bindingMock,
+          bindingConstraintsListFixture,
+          chainedBindings,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call binding.isSatisfiedBy()', () => {
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+          new BindingConstraintsImplementation(
+            bindingConstraintsListFixture.last,
+          ),
+        );
+      });
+
+      it('should call buildServiceNodeBindings()', () => {
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledTimes(1);
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledWith(
+          paramsFixture,
+          bindingConstraintsListFixture,
+          [bindingMock],
+          lazyPlanServiceNodeFixture,
+          chainedBindings,
+        );
+      });
+
+      it('should return expected value', () => {
+        const expected: PlanServiceNodeBindingAddedResult = {
+          isContextFreeBinding:
+            !bindingConstraintsListFixture.last.elem.getAncestorsCalled,
+          shouldInvalidateServiceNode: false,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having an expanded lazy service node with single binding and bindingConstraintsList with elems with getAncestorsCalled false', () => {
+    let paramsFixture: BasePlanParams;
+    let lazyPlanServiceNodeFixture: LazyPlanServiceNode;
+    let bindingMock: Mocked<Binding<unknown>>;
+    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let chainedBindings: boolean;
+
+    beforeAll(() => {
+      paramsFixture = Symbol() as unknown as BasePlanParams;
+
+      const serviceIdentifier: ServiceIdentifier = Symbol();
+
+      lazyPlanServiceNodeFixture = new LazyPlanServiceNodeTest(
+        {
+          bindings: Symbol() as unknown as PlanBindingNode,
+          isContextFree: true,
+          serviceIdentifier: serviceIdentifier,
+        },
+        serviceIdentifier,
+        vitest.fn(),
+      );
+
+      bindingMock = {
+        cache: {
+          isRight: false,
+          value: undefined,
+        },
+        id: 1,
+        isSatisfiedBy: vitest.fn(),
+        moduleId: undefined,
+        onActivation: vitest.fn(),
+        onDeactivation: vitest.fn(),
+        scope: bindingScopeValues.Singleton,
+        serviceIdentifier,
+        type: bindingTypeValues.ConstantValue,
+        value: Symbol(),
+      };
+
+      bindingConstraintsListFixture =
+        new SingleInmutableLinkedList<InternalBindingConstraints>({
+          elem: {
+            getAncestorsCalled: false,
+            name: undefined,
+            serviceIdentifier,
+            tags: new Map(),
+          },
+          previous: undefined,
+        });
+
+      chainedBindings = false;
+    });
+
+    describe('when called, and binding.isSatisfiedBy() returns true', () => {
+      let planBindingNodeFixture: PlanBindingNode;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        planBindingNodeFixture = Symbol() as unknown as PlanBindingNode;
+
+        bindingMock.isSatisfiedBy.mockReturnValueOnce(true);
+
+        buildServiceNodeBindingsMock.mockReturnValueOnce([
+          planBindingNodeFixture,
+        ]);
+
+        result = addServiceNodeBindingIfContextFree(
+          paramsFixture,
+          lazyPlanServiceNodeFixture,
+          bindingMock,
+          bindingConstraintsListFixture,
+          chainedBindings,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call binding.isSatisfiedBy()', () => {
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+          new BindingConstraintsImplementation(
+            bindingConstraintsListFixture.last,
+          ),
+        );
+      });
+
+      it('should call buildServiceNodeBindings()', () => {
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledTimes(1);
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledWith(
+          paramsFixture,
+          bindingConstraintsListFixture,
+          [bindingMock],
+          lazyPlanServiceNodeFixture,
+          chainedBindings,
+        );
+      });
+
+      it('should return expected value', () => {
+        const expected: PlanServiceNodeBindingAddedResult = {
+          isContextFreeBinding:
+            !bindingConstraintsListFixture.last.elem.getAncestorsCalled,
+          shouldInvalidateServiceNode: true,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having a non lazy service node with single binding and bindingConstraintsList with elems with getAncestorsCalled false', () => {
+    let paramsFixture: BasePlanParams;
+    let planServiceNodeFixture: PlanServiceNode;
+    let bindingMock: Mocked<Binding<unknown>>;
+    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let chainedBindings: boolean;
+
+    beforeAll(() => {
+      paramsFixture = Symbol() as unknown as BasePlanParams;
+
+      const serviceIdentifier: ServiceIdentifier = Symbol();
+
+      planServiceNodeFixture = {
+        bindings: Symbol() as unknown as PlanBindingNode,
+        isContextFree: true,
+        serviceIdentifier: serviceIdentifier,
+      };
+
+      bindingMock = {
+        cache: {
+          isRight: false,
+          value: undefined,
+        },
+        id: 1,
+        isSatisfiedBy: vitest.fn(),
+        moduleId: undefined,
+        onActivation: vitest.fn(),
+        onDeactivation: vitest.fn(),
+        scope: bindingScopeValues.Singleton,
+        serviceIdentifier,
+        type: bindingTypeValues.ConstantValue,
+        value: Symbol(),
+      };
+
+      bindingConstraintsListFixture =
+        new SingleInmutableLinkedList<InternalBindingConstraints>({
+          elem: {
+            getAncestorsCalled: false,
+            name: undefined,
+            serviceIdentifier,
+            tags: new Map(),
+          },
+          previous: undefined,
+        });
+
+      chainedBindings = false;
+    });
+
+    describe('when called, and binding.isSatisfiedBy() returns true', () => {
+      let planBindingNodeFixture: PlanBindingNode;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        planBindingNodeFixture = Symbol() as unknown as PlanBindingNode;
+
+        bindingMock.isSatisfiedBy.mockReturnValueOnce(true);
+
+        buildServiceNodeBindingsMock.mockReturnValueOnce([
+          planBindingNodeFixture,
+        ]);
+
+        try {
+          addServiceNodeBindingIfContextFree(
+            paramsFixture,
+            planServiceNodeFixture,
+            bindingMock,
+            bindingConstraintsListFixture,
+            chainedBindings,
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call binding.isSatisfiedBy()', () => {
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+          new BindingConstraintsImplementation(
+            bindingConstraintsListFixture.last,
+          ),
+        );
+      });
+
+      it('should call buildServiceNodeBindings()', () => {
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledTimes(1);
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledWith(
+          paramsFixture,
+          bindingConstraintsListFixture,
+          [bindingMock],
+          planServiceNodeFixture,
+          chainedBindings,
+        );
+      });
+
+      it('should return expected error', () => {
+        const expectedErrorProperties: Partial<InversifyCoreError> = {
+          kind: InversifyCoreErrorKind.planning,
+          message:
+            'Unexpected non-lazy plan service node. This is likely a bug in the planning logic. Please, report this issue',
+        };
+
+        expect(result).toStrictEqual(
+          expect.objectContaining(expectedErrorProperties),
+        );
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/planning/actions/addServiceNodeBindingIfContextFree.ts
+++ b/packages/container/libraries/core/src/planning/actions/addServiceNodeBindingIfContextFree.ts
@@ -1,0 +1,155 @@
+import { Binding } from '../../binding/models/Binding';
+import { BindingConstraints } from '../../binding/models/BindingConstraints';
+import {
+  BindingConstraintsImplementation,
+  InternalBindingConstraints,
+} from '../../binding/models/BindingConstraintsImplementation';
+import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { InversifyCoreError } from '../../error/models/InversifyCoreError';
+import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
+import { ManagedClassElementMetadata } from '../../metadata/models/ManagedClassElementMetadata';
+import { PlanServiceNodeBindingAddedResult } from '../../metadata/models/PlanServiceNodeUpdateResult';
+import { ResolvedValueElementMetadata } from '../../metadata/models/ResolvedValueElementMetadata';
+import { BasePlanParams } from '../models/BasePlanParams';
+import { BindingNodeParent } from '../models/BindingNodeParent';
+import { LazyPlanServiceNode } from '../models/LazyPlanServiceNode';
+import { PlanBindingNode } from '../models/PlanBindingNode';
+import { PlanServiceNode } from '../models/PlanServiceNode';
+import { SubplanParams } from '../models/SubplanParams';
+import { curryBuildServiceNodeBindings } from './curryBuildServiceNodeBindings';
+import { curryLazyBuildPlanServiceNodeFromClassElementMetadata } from './curryLazyBuildPlanServiceNodeFromClassElementMetadata';
+import { curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata } from './curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata';
+import { currySubplan } from './currySubplan';
+import {
+  buildPlanServiceNodeFromClassElementMetadata,
+  buildPlanServiceNodeFromResolvedValueElementMetadata,
+} from './plan';
+
+const subplan: (
+  params: SubplanParams,
+  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+) => PlanBindingNode = currySubplan(
+  buildPlanServiceNodeFromClassElementMetadata,
+  buildPlanServiceNodeFromResolvedValueElementMetadata,
+  circularLazyBuildPlanServiceNodeFromClassElementMetadata,
+  circularLazyBuildPlanServiceNodeFromResolvedValueElementMetadata,
+);
+
+const buildServiceNodeBindings: (
+  params: BasePlanParams,
+  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  serviceBindings: Binding<unknown>[],
+  parentNode: BindingNodeParent,
+  chainedBindings: boolean,
+) => PlanBindingNode[] = curryBuildServiceNodeBindings(subplan);
+
+const lazyBuildPlanServiceNodeFromClassElementMetadata: (
+  params: SubplanParams,
+  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  elementMetadata: ManagedClassElementMetadata,
+) => PlanServiceNode | undefined =
+  curryLazyBuildPlanServiceNodeFromClassElementMetadata(
+    buildServiceNodeBindings,
+  );
+
+const lazyBuildPlanServiceNodeFromResolvedValueElementMetadata: (
+  params: SubplanParams,
+  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  elementMetadata: ResolvedValueElementMetadata,
+) => PlanServiceNode | undefined =
+  curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata(
+    buildServiceNodeBindings,
+  );
+
+function circularLazyBuildPlanServiceNodeFromClassElementMetadata(
+  params: SubplanParams,
+  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  elementMetadata: ManagedClassElementMetadata,
+): PlanServiceNode | undefined {
+  return lazyBuildPlanServiceNodeFromClassElementMetadata(
+    params,
+    bindingConstraintsList,
+    elementMetadata,
+  );
+}
+
+function circularLazyBuildPlanServiceNodeFromResolvedValueElementMetadata(
+  params: SubplanParams,
+  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  elementMetadata: ResolvedValueElementMetadata,
+): PlanServiceNode | undefined {
+  return lazyBuildPlanServiceNodeFromResolvedValueElementMetadata(
+    params,
+    bindingConstraintsList,
+    elementMetadata,
+  );
+}
+
+/**
+ * Attach a binding to a service node if the binding is context-free.
+ * @param params The plan parameters.
+ * @param serviceNode The service node to attach the binding to.
+ * @param binding The binding to attach.
+ * @returns True if the binding requires ancestor metadata, false otherwise.
+ */
+export function addServiceNodeBindingIfContextFree(
+  params: BasePlanParams,
+  serviceNode: PlanServiceNode,
+  binding: Binding<unknown>,
+  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  chainedBindings: boolean,
+): PlanServiceNodeBindingAddedResult {
+  if (LazyPlanServiceNode.is(serviceNode) && !serviceNode.isExpanded()) {
+    return {
+      isContextFreeBinding: true,
+      shouldInvalidateServiceNode: false,
+    };
+  }
+
+  const bindingConstraints: BindingConstraints =
+    new BindingConstraintsImplementation(bindingConstraintsList.last);
+
+  if (
+    !binding.isSatisfiedBy(bindingConstraints) ||
+    bindingConstraintsList.last.elem.getAncestorsCalled
+  ) {
+    return {
+      isContextFreeBinding:
+        !bindingConstraintsList.last.elem.getAncestorsCalled,
+      shouldInvalidateServiceNode: false,
+    };
+  }
+
+  const [serviceNodeBinding]: [PlanBindingNode] = buildServiceNodeBindings(
+    params,
+    bindingConstraintsList,
+    [binding],
+    serviceNode,
+    chainedBindings,
+  ) as [PlanBindingNode];
+
+  if (Array.isArray(serviceNode.bindings)) {
+    serviceNode.bindings.push(serviceNodeBinding);
+  } else {
+    if (serviceNode.bindings === undefined) {
+      serviceNode.bindings = serviceNodeBinding;
+    } else {
+      if (!LazyPlanServiceNode.is(serviceNode)) {
+        throw new InversifyCoreError(
+          InversifyCoreErrorKind.planning,
+          'Unexpected non-lazy plan service node. This is likely a bug in the planning logic. Please, report this issue',
+        );
+      }
+
+      return {
+        isContextFreeBinding: true,
+        shouldInvalidateServiceNode: true,
+      };
+    }
+  }
+
+  return {
+    isContextFreeBinding: true,
+    shouldInvalidateServiceNode: false,
+  };
+}

--- a/packages/container/libraries/core/src/planning/actions/curryLazyBuildPlanServiceNodeFromClassElementMetadata.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryLazyBuildPlanServiceNodeFromClassElementMetadata.spec.ts
@@ -1,0 +1,203 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  Mock,
+  vitest,
+} from 'vitest';
+
+vitest.mock('./curryBuildPlanServiceNodeFromClassElementMetadata');
+
+import { Binding } from '../../binding/models/Binding';
+import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
+import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { InversifyCoreError } from '../../error/models/InversifyCoreError';
+import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
+import { ClassElementMetadata } from '../../metadata/models/ClassElementMetadata';
+import { ManagedClassElementMetadata } from '../../metadata/models/ManagedClassElementMetadata';
+import { BasePlanParams } from '../models/BasePlanParams';
+import { BindingNodeParent } from '../models/BindingNodeParent';
+import { PlanBindingNode } from '../models/PlanBindingNode';
+import { PlanServiceNode } from '../models/PlanServiceNode';
+import { SubplanParams } from '../models/SubplanParams';
+import { curryBuildPlanServiceNodeFromClassElementMetadata } from './curryBuildPlanServiceNodeFromClassElementMetadata';
+import { curryLazyBuildPlanServiceNodeFromClassElementMetadata } from './curryLazyBuildPlanServiceNodeFromClassElementMetadata';
+
+describe(curryLazyBuildPlanServiceNodeFromClassElementMetadata, () => {
+  let buildServiceNodeBindingsFixture: Mock<
+    (
+      params: BasePlanParams,
+      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      serviceBindings: Binding<unknown>[],
+      parentNode: BindingNodeParent,
+      chainedBindings: boolean,
+    ) => PlanBindingNode[]
+  >;
+
+  let paramsFixture: SubplanParams;
+  let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+  let elementMetadataFixture: ManagedClassElementMetadata;
+
+  beforeAll(() => {
+    buildServiceNodeBindingsFixture = vitest.fn();
+
+    paramsFixture = Symbol() as unknown as SubplanParams;
+    bindingConstraintsListFixture =
+      Symbol() as unknown as SingleInmutableLinkedList<InternalBindingConstraints>;
+    elementMetadataFixture = Symbol() as unknown as ManagedClassElementMetadata;
+  });
+
+  describe('when called', () => {
+    let buildPlanServiceNodeFromClassElementMetadataMock: Mock<
+      (
+        params: SubplanParams,
+        bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+        elementMetadata: ClassElementMetadata,
+      ) => PlanServiceNode
+    >;
+
+    let planServiceNodeFixture: PlanServiceNode;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      planServiceNodeFixture = Symbol() as unknown as PlanServiceNode;
+
+      buildPlanServiceNodeFromClassElementMetadataMock = vitest
+        .fn()
+        .mockReturnValueOnce(planServiceNodeFixture);
+
+      vitest
+        .mocked(curryBuildPlanServiceNodeFromClassElementMetadata)
+        .mockReturnValueOnce(buildPlanServiceNodeFromClassElementMetadataMock);
+
+      result = curryLazyBuildPlanServiceNodeFromClassElementMetadata(
+        buildServiceNodeBindingsFixture,
+      )(paramsFixture, bindingConstraintsListFixture, elementMetadataFixture);
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call curryBuildPlanServiceNodeFromClassElementMetadata()', () => {
+      expect(
+        curryBuildPlanServiceNodeFromClassElementMetadata,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        curryBuildPlanServiceNodeFromClassElementMetadata,
+      ).toHaveBeenCalledWith(buildServiceNodeBindingsFixture);
+    });
+
+    it('should return a PlanServiceNode', () => {
+      expect(result).toBe(planServiceNodeFixture);
+    });
+  });
+
+  describe('when called, and buildPlanServiceNodeFromClassElementMetadata() throws an Error', () => {
+    let buildPlanServiceNodeFromClassElementMetadataMock: Mock<
+      (
+        params: SubplanParams,
+        bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+        elementMetadata: ClassElementMetadata,
+      ) => PlanServiceNode
+    >;
+
+    let errorFixture: Error;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      errorFixture = new Error('Test error');
+
+      buildPlanServiceNodeFromClassElementMetadataMock = vitest
+        .fn()
+        .mockImplementationOnce((): never => {
+          throw errorFixture;
+        });
+
+      vitest
+        .mocked(curryBuildPlanServiceNodeFromClassElementMetadata)
+        .mockReturnValueOnce(buildPlanServiceNodeFromClassElementMetadataMock);
+
+      try {
+        curryLazyBuildPlanServiceNodeFromClassElementMetadata(
+          buildServiceNodeBindingsFixture,
+        )(paramsFixture, bindingConstraintsListFixture, elementMetadataFixture);
+      } catch (error: unknown) {
+        result = error;
+      }
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call curryBuildPlanServiceNodeFromClassElementMetadata()', () => {
+      expect(
+        curryBuildPlanServiceNodeFromClassElementMetadata,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        curryBuildPlanServiceNodeFromClassElementMetadata,
+      ).toHaveBeenCalledWith(buildServiceNodeBindingsFixture);
+    });
+
+    it('should throw an Error', () => {
+      expect(result).toBe(errorFixture);
+    });
+  });
+
+  describe('when called, and buildPlanServiceNodeFromClassElementMetadata() throws an InversifyCoreError', () => {
+    let buildPlanServiceNodeFromClassElementMetadataMock: Mock<
+      (
+        params: SubplanParams,
+        bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+        elementMetadata: ClassElementMetadata,
+      ) => PlanServiceNode
+    >;
+
+    let errorFixture: InversifyCoreError;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      errorFixture = new InversifyCoreError(
+        InversifyCoreErrorKind.planning,
+        'Test error',
+      );
+
+      buildPlanServiceNodeFromClassElementMetadataMock = vitest
+        .fn()
+        .mockImplementationOnce((): never => {
+          throw errorFixture;
+        });
+
+      vitest
+        .mocked(curryBuildPlanServiceNodeFromClassElementMetadata)
+        .mockReturnValueOnce(buildPlanServiceNodeFromClassElementMetadataMock);
+
+      result = curryLazyBuildPlanServiceNodeFromClassElementMetadata(
+        buildServiceNodeBindingsFixture,
+      )(paramsFixture, bindingConstraintsListFixture, elementMetadataFixture);
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call curryBuildPlanServiceNodeFromClassElementMetadata()', () => {
+      expect(
+        curryBuildPlanServiceNodeFromClassElementMetadata,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        curryBuildPlanServiceNodeFromClassElementMetadata,
+      ).toHaveBeenCalledWith(buildServiceNodeBindingsFixture);
+    });
+
+    it('should return undefined', () => {
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/packages/container/libraries/core/src/planning/actions/curryLazyBuildPlanServiceNodeFromClassElementMetadata.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryLazyBuildPlanServiceNodeFromClassElementMetadata.ts
@@ -1,0 +1,56 @@
+import { Binding } from '../../binding/models/Binding';
+import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
+import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { InversifyCoreError } from '../../error/models/InversifyCoreError';
+import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
+import { ManagedClassElementMetadata } from '../../metadata/models/ManagedClassElementMetadata';
+import { BasePlanParams } from '../models/BasePlanParams';
+import { BindingNodeParent } from '../models/BindingNodeParent';
+import { PlanBindingNode } from '../models/PlanBindingNode';
+import { PlanServiceNode } from '../models/PlanServiceNode';
+import { SubplanParams } from '../models/SubplanParams';
+import { curryBuildPlanServiceNodeFromClassElementMetadata } from './curryBuildPlanServiceNodeFromClassElementMetadata';
+
+export function curryLazyBuildPlanServiceNodeFromClassElementMetadata(
+  buildServiceNodeBindings: (
+    params: BasePlanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    serviceBindings: Binding<unknown>[],
+    parentNode: BindingNodeParent,
+    chainedBindings: boolean,
+  ) => PlanBindingNode[],
+): (
+  params: SubplanParams,
+  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  elementMetadata: ManagedClassElementMetadata,
+) => PlanServiceNode | undefined {
+  const buildPlanServiceNodeFromClassElementMetadata: (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ManagedClassElementMetadata,
+  ) => PlanServiceNode = curryBuildPlanServiceNodeFromClassElementMetadata(
+    buildServiceNodeBindings,
+  );
+
+  return (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ManagedClassElementMetadata,
+  ): PlanServiceNode | undefined => {
+    try {
+      return buildPlanServiceNodeFromClassElementMetadata(
+        params,
+        bindingConstraintsList,
+        elementMetadata,
+      );
+    } catch (error: unknown) {
+      if (
+        InversifyCoreError.isErrorOfKind(error, InversifyCoreErrorKind.planning)
+      ) {
+        return undefined;
+      }
+
+      throw error;
+    }
+  };
+}

--- a/packages/container/libraries/core/src/planning/actions/curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata.spec.ts
@@ -1,0 +1,209 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  Mock,
+  vitest,
+} from 'vitest';
+
+vitest.mock('./curryBuildPlanServiceNodeFromResolvedValueElementMetadata');
+
+import { Binding } from '../../binding/models/Binding';
+import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
+import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { InversifyCoreError } from '../../error/models/InversifyCoreError';
+import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
+import { ResolvedValueElementMetadata } from '../../metadata/models/ResolvedValueElementMetadata';
+import { BasePlanParams } from '../models/BasePlanParams';
+import { BindingNodeParent } from '../models/BindingNodeParent';
+import { PlanBindingNode } from '../models/PlanBindingNode';
+import { PlanServiceNode } from '../models/PlanServiceNode';
+import { SubplanParams } from '../models/SubplanParams';
+import { curryBuildPlanServiceNodeFromResolvedValueElementMetadata } from './curryBuildPlanServiceNodeFromResolvedValueElementMetadata';
+import { curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata } from './curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata';
+
+describe(curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata, () => {
+  let buildServiceNodeBindingsFixture: Mock<
+    (
+      params: BasePlanParams,
+      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      serviceBindings: Binding<unknown>[],
+      parentNode: BindingNodeParent,
+      chainedBindings: boolean,
+    ) => PlanBindingNode[]
+  >;
+
+  let paramsFixture: SubplanParams;
+  let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+  let elementMetadataFixture: ResolvedValueElementMetadata;
+
+  beforeAll(() => {
+    buildServiceNodeBindingsFixture = vitest.fn();
+
+    paramsFixture = Symbol() as unknown as SubplanParams;
+    bindingConstraintsListFixture =
+      Symbol() as unknown as SingleInmutableLinkedList<InternalBindingConstraints>;
+    elementMetadataFixture =
+      Symbol() as unknown as ResolvedValueElementMetadata;
+  });
+
+  describe('when called', () => {
+    let buildPlanServiceNodeFromResolvedValueElementMetadataMock: Mock<
+      (
+        params: SubplanParams,
+        bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+        elementMetadata: ResolvedValueElementMetadata,
+      ) => PlanServiceNode
+    >;
+
+    let planServiceNodeFixture: PlanServiceNode;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      planServiceNodeFixture = Symbol() as unknown as PlanServiceNode;
+
+      buildPlanServiceNodeFromResolvedValueElementMetadataMock = vitest
+        .fn()
+        .mockReturnValueOnce(planServiceNodeFixture);
+
+      vitest
+        .mocked(curryBuildPlanServiceNodeFromResolvedValueElementMetadata)
+        .mockReturnValueOnce(
+          buildPlanServiceNodeFromResolvedValueElementMetadataMock,
+        );
+
+      result = curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata(
+        buildServiceNodeBindingsFixture,
+      )(paramsFixture, bindingConstraintsListFixture, elementMetadataFixture);
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call curryBuildPlanServiceNodeFromResolvedValueElementMetadata()', () => {
+      expect(
+        curryBuildPlanServiceNodeFromResolvedValueElementMetadata,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        curryBuildPlanServiceNodeFromResolvedValueElementMetadata,
+      ).toHaveBeenCalledWith(buildServiceNodeBindingsFixture);
+    });
+
+    it('should return a PlanServiceNode', () => {
+      expect(result).toBe(planServiceNodeFixture);
+    });
+  });
+
+  describe('when called, and buildPlanServiceNodeFromResolvedValueElementMetadata() throws an Error', () => {
+    let buildPlanServiceNodeFromResolvedValueElementMetadataMock: Mock<
+      (
+        params: SubplanParams,
+        bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+        elementMetadata: ResolvedValueElementMetadata,
+      ) => PlanServiceNode
+    >;
+
+    let errorFixture: Error;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      errorFixture = new Error('Test error');
+
+      buildPlanServiceNodeFromResolvedValueElementMetadataMock = vitest
+        .fn()
+        .mockImplementationOnce((): never => {
+          throw errorFixture;
+        });
+
+      vitest
+        .mocked(curryBuildPlanServiceNodeFromResolvedValueElementMetadata)
+        .mockReturnValueOnce(
+          buildPlanServiceNodeFromResolvedValueElementMetadataMock,
+        );
+
+      try {
+        curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata(
+          buildServiceNodeBindingsFixture,
+        )(paramsFixture, bindingConstraintsListFixture, elementMetadataFixture);
+      } catch (error: unknown) {
+        result = error;
+      }
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call curryBuildPlanServiceNodeFromResolvedValueElementMetadata()', () => {
+      expect(
+        curryBuildPlanServiceNodeFromResolvedValueElementMetadata,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        curryBuildPlanServiceNodeFromResolvedValueElementMetadata,
+      ).toHaveBeenCalledWith(buildServiceNodeBindingsFixture);
+    });
+
+    it('should throw an Error', () => {
+      expect(result).toBe(errorFixture);
+    });
+  });
+
+  describe('when called, and buildPlanServiceNodeFromResolvedValueElementMetadata() throws an InversifyCoreError', () => {
+    let buildPlanServiceNodeFromResolvedValueElementMetadataMock: Mock<
+      (
+        params: SubplanParams,
+        bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+        elementMetadata: ResolvedValueElementMetadata,
+      ) => PlanServiceNode
+    >;
+
+    let errorFixture: InversifyCoreError;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      errorFixture = new InversifyCoreError(
+        InversifyCoreErrorKind.planning,
+        'Test error',
+      );
+
+      buildPlanServiceNodeFromResolvedValueElementMetadataMock = vitest
+        .fn()
+        .mockImplementationOnce((): never => {
+          throw errorFixture;
+        });
+
+      vitest
+        .mocked(curryBuildPlanServiceNodeFromResolvedValueElementMetadata)
+        .mockReturnValueOnce(
+          buildPlanServiceNodeFromResolvedValueElementMetadataMock,
+        );
+
+      result = curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata(
+        buildServiceNodeBindingsFixture,
+      )(paramsFixture, bindingConstraintsListFixture, elementMetadataFixture);
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call curryBuildPlanServiceNodeFromResolvedValueElementMetadata()', () => {
+      expect(
+        curryBuildPlanServiceNodeFromResolvedValueElementMetadata,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        curryBuildPlanServiceNodeFromResolvedValueElementMetadata,
+      ).toHaveBeenCalledWith(buildServiceNodeBindingsFixture);
+    });
+
+    it('should return undefined', () => {
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/packages/container/libraries/core/src/planning/actions/curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata.ts
@@ -1,0 +1,57 @@
+import { Binding } from '../../binding/models/Binding';
+import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
+import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { InversifyCoreError } from '../../error/models/InversifyCoreError';
+import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
+import { ResolvedValueElementMetadata } from '../../metadata/models/ResolvedValueElementMetadata';
+import { BasePlanParams } from '../models/BasePlanParams';
+import { BindingNodeParent } from '../models/BindingNodeParent';
+import { PlanBindingNode } from '../models/PlanBindingNode';
+import { PlanServiceNode } from '../models/PlanServiceNode';
+import { SubplanParams } from '../models/SubplanParams';
+import { curryBuildPlanServiceNodeFromResolvedValueElementMetadata } from './curryBuildPlanServiceNodeFromResolvedValueElementMetadata';
+
+export function curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata(
+  buildServiceNodeBindings: (
+    params: BasePlanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    serviceBindings: Binding<unknown>[],
+    parentNode: BindingNodeParent,
+    chainedBindings: boolean,
+  ) => PlanBindingNode[],
+): (
+  params: SubplanParams,
+  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  elementMetadata: ResolvedValueElementMetadata,
+) => PlanServiceNode | undefined {
+  const buildPlanServiceNodeFromResolvedValueElementMetadata: (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ResolvedValueElementMetadata,
+  ) => PlanServiceNode | undefined =
+    curryBuildPlanServiceNodeFromResolvedValueElementMetadata(
+      buildServiceNodeBindings,
+    );
+
+  return (
+    params: SubplanParams,
+    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    elementMetadata: ResolvedValueElementMetadata,
+  ): PlanServiceNode | undefined => {
+    try {
+      return buildPlanServiceNodeFromResolvedValueElementMetadata(
+        params,
+        bindingConstraintsList,
+        elementMetadata,
+      );
+    } catch (error: unknown) {
+      if (
+        InversifyCoreError.isErrorOfKind(error, InversifyCoreErrorKind.planning)
+      ) {
+        return undefined;
+      }
+
+      throw error;
+    }
+  };
+}

--- a/packages/container/libraries/core/src/planning/actions/plan.ts
+++ b/packages/container/libraries/core/src/planning/actions/plan.ts
@@ -34,7 +34,7 @@ class LazyRootPlanServiceNode extends LazyPlanServiceNode {
   }
 }
 
-const buildPlanServiceNodeFromClassElementMetadata: (
+export const buildPlanServiceNodeFromClassElementMetadata: (
   params: SubplanParams,
   bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
   elementMetadata: ManagedClassElementMetadata,
@@ -42,7 +42,7 @@ const buildPlanServiceNodeFromClassElementMetadata: (
   circularBuildServiceNodeBindings,
 );
 
-const buildPlanServiceNodeFromResolvedValueElementMetadata: (
+export const buildPlanServiceNodeFromResolvedValueElementMetadata: (
   params: SubplanParams,
   bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
   elementMetadata: ResolvedValueElementMetadata,

--- a/packages/container/libraries/core/src/planning/models/LazyPlanServiceNode.spec.ts
+++ b/packages/container/libraries/core/src/planning/models/LazyPlanServiceNode.spec.ts
@@ -14,7 +14,7 @@ import { LazyPlanServiceNode } from './LazyPlanServiceNode';
 import { PlanBindingNode } from './PlanBindingNode';
 import { PlanServiceNode } from './PlanServiceNode';
 
-export class LazyPlanServiceNodeTest extends LazyPlanServiceNode {
+class LazyPlanServiceNodeTest extends LazyPlanServiceNode {
   readonly #buildPlanServiceNodeMock: Mock<() => PlanServiceNode>;
 
   constructor(


### PR DESCRIPTION
### Added
- Added `addRootServiceNodeBindingIfContextFree`.
- Added `addServiceNodeBindingIfContextFree`.
- Added `curryLazyBuildPlanServiceNodeFromClassElementMetadata`.
- Added `curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata`.
- Added `PlanServiceNodeBindingAddedResult`.