### PR TITLE
Fix plan result cache service invalidation

### DIFF
--- a/.changeset/eager-hornets-prove.md
+++ b/.changeset/eager-hornets-prove.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": major
+---
+
+Removed `PlanResultCacheService.invalidateService` in favor of `invalidateServiceBinding`

--- a/packages/container/libraries/container/src/container/actions/resetDeactivationParams.spec.ts
+++ b/packages/container/libraries/container/src/container/actions/resetDeactivationParams.spec.ts
@@ -1,0 +1,68 @@
+import { beforeAll, describe, expect, it, vitest } from 'vitest';
+
+import { ServiceIdentifier } from '@inversifyjs/common';
+import {
+  Binding,
+  BindingDeactivation,
+  BindingService,
+  DeactivationParams,
+  DeactivationsService,
+} from '@inversifyjs/core';
+
+import { ServiceReferenceManager } from '../services/ServiceReferenceManager';
+import { resetDeactivationParams } from './resetDeactivationParams';
+
+describe(resetDeactivationParams, () => {
+  let serviceReferenceManager: ServiceReferenceManager;
+
+  beforeAll(() => {
+    serviceReferenceManager = {
+      bindingService: {
+        get: vitest.fn(),
+        getByModuleId: vitest.fn(),
+      } as Partial<BindingService> as BindingService,
+      deactivationService: {
+        get: vitest.fn(),
+      } as Partial<DeactivationsService> as DeactivationsService,
+    } as Partial<ServiceReferenceManager> as ServiceReferenceManager;
+  });
+
+  describe('when called', () => {
+    let deactivationParamsFixture: DeactivationParams;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      deactivationParamsFixture = {
+        getBindings: Symbol() as unknown as <TInstance>(
+          serviceIdentifier: ServiceIdentifier<TInstance>,
+        ) => Iterable<Binding<TInstance>> | undefined,
+        getBindingsFromModule: Symbol() as unknown as <TInstance>(
+          moduleId: number,
+        ) => Iterable<Binding<TInstance>> | undefined,
+        getDeactivations: Symbol() as unknown as <TActivated>(
+          serviceIdentifier: ServiceIdentifier<TActivated>,
+        ) => Iterable<BindingDeactivation<TActivated>> | undefined,
+      } as Partial<DeactivationParams> as DeactivationParams;
+
+      result = resetDeactivationParams(
+        serviceReferenceManager,
+        deactivationParamsFixture,
+      );
+    });
+
+    it('should return undefined', () => {
+      expect(result).toBeUndefined();
+    });
+
+    it('should reset deactivationParams property', () => {
+      expect(deactivationParamsFixture.getBindings).toBeInstanceOf(Function);
+      expect(deactivationParamsFixture.getBindingsFromModule).toBeInstanceOf(
+        Function,
+      );
+      expect(deactivationParamsFixture.getDeactivations).toBeInstanceOf(
+        Function,
+      );
+    });
+  });
+});

--- a/packages/container/libraries/container/src/container/actions/resetDeactivationParams.ts
+++ b/packages/container/libraries/container/src/container/actions/resetDeactivationParams.ts
@@ -1,0 +1,21 @@
+import { DeactivationParams } from '@inversifyjs/core';
+
+import { ServiceReferenceManager } from '../services/ServiceReferenceManager';
+
+export function resetDeactivationParams(
+  serviceReferenceManager: ServiceReferenceManager,
+  deactivationParams: DeactivationParams,
+): void {
+  deactivationParams.getBindings =
+    serviceReferenceManager.bindingService.get.bind(
+      serviceReferenceManager.bindingService,
+    );
+  deactivationParams.getBindingsFromModule =
+    serviceReferenceManager.bindingService.getByModuleId.bind(
+      serviceReferenceManager.bindingService,
+    );
+  deactivationParams.getDeactivations =
+    serviceReferenceManager.deactivationService.get.bind(
+      serviceReferenceManager.deactivationService,
+    );
+}

--- a/packages/container/libraries/container/src/container/models/CacheBindingInvalidation.ts
+++ b/packages/container/libraries/container/src/container/models/CacheBindingInvalidation.ts
@@ -1,0 +1,6 @@
+import { Binding, CacheBindingInvalidationKind } from '@inversifyjs/core';
+
+export interface CacheBindingInvalidation {
+  binding: Binding<unknown>;
+  kind: CacheBindingInvalidationKind;
+}

--- a/packages/container/libraries/container/src/container/services/Container.spec.ts
+++ b/packages/container/libraries/container/src/container/services/Container.spec.ts
@@ -28,9 +28,11 @@ import {
   PlanResultCacheService,
 } from '@inversifyjs/core';
 
-vitest.mock('../calculations/buildDeactivationParams');
 vitest.mock('./BindingManager');
 vitest.mock('./ContainerModuleManager');
+vitest.mock('./DeactivationParamsManager');
+vitest.mock('./PlanParamsOperationsManager');
+vitest.mock('./PlanResultCacheManager');
 vitest.mock('./PluginManager');
 vitest.mock('./ServiceReferenceManager');
 vitest.mock('./ServiceResolutionManager');
@@ -39,11 +41,13 @@ vitest.mock('./SnapshotManager');
 import { Plugin, PluginContext } from '@inversifyjs/plugin';
 
 import { BindToFluentSyntax } from '../../binding/models/BindingFluentSyntax';
-import { buildDeactivationParams } from '../calculations/buildDeactivationParams';
 import { ContainerModule } from '../models/ContainerModule';
 import { BindingManager } from './BindingManager';
 import { Container } from './Container';
 import { ContainerModuleManager } from './ContainerModuleManager';
+import { DeactivationParamsManager } from './DeactivationParamsManager';
+import { PlanParamsOperationsManager } from './PlanParamsOperationsManager';
+import { PlanResultCacheManager } from './PlanResultCacheManager';
 import { PluginManager } from './PluginManager';
 import { ServiceReferenceManager } from './ServiceReferenceManager';
 import { ServiceResolutionManager } from './ServiceResolutionManager';
@@ -54,8 +58,10 @@ describe(Container, () => {
   let bindingManagerMock: Mocked<BindingManager>;
   let bindingServiceMock: Mocked<BindingService>;
   let containerModuleManagerMock: Mocked<ContainerModuleManager>;
-  let deactivationParamsFixture: DeactivationParams;
+  let deactivationParamsManagerMock: Mocked<DeactivationParamsManager>;
   let deactivationServiceMock: Mocked<DeactivationsService>;
+  let planParamsOperationsManagerMock: Mocked<PlanParamsOperationsManager>;
+  let planResultCacheManagerMock: Mocked<PlanResultCacheManager>;
   let planResultCacheServiceMock: Mocked<PlanResultCacheService>;
   let pluginManagerMock: Mocked<PluginManager>;
   let serviceReferenceManagerMock: Mocked<ServiceReferenceManager>;
@@ -93,13 +99,35 @@ describe(Container, () => {
     } as Partial<
       Mocked<ContainerModuleManager>
     > as Mocked<ContainerModuleManager>;
-    deactivationParamsFixture = Symbol() as unknown as DeactivationParams;
+    deactivationParamsManagerMock = {
+      deactivationParams: Symbol() as unknown as DeactivationParams,
+    } as Partial<
+      Mocked<DeactivationParamsManager>
+    > as Mocked<DeactivationParamsManager>;
     deactivationServiceMock = {
       add: vitest.fn(),
       clone: vitest.fn().mockReturnThis(),
       removeAllByModuleId: vitest.fn(),
       removeAllByServiceId: vitest.fn(),
     } as Partial<Mocked<DeactivationsService>> as Mocked<DeactivationsService>;
+    planParamsOperationsManagerMock = {
+      planParamsOperations: {
+        getBindings: vitest.fn(),
+        getBindingsChained: vitest.fn(),
+        getClassMetadata: vitest.fn(),
+        getPlan: vitest.fn(),
+        setBinding: vitest.fn(),
+        setNonCachedServiceNode: vitest.fn(),
+        setPlan: vitest.fn(),
+      },
+    } as Partial<
+      Mocked<PlanParamsOperationsManager>
+    > as Mocked<PlanParamsOperationsManager>;
+    planResultCacheManagerMock = {
+      invalidateService: vitest.fn(),
+    } as Partial<
+      Mocked<PlanResultCacheManager>
+    > as Mocked<PlanResultCacheManager>;
     planResultCacheServiceMock = {
       get: vitest.fn(),
       set: vitest.fn(),
@@ -114,6 +142,7 @@ describe(Container, () => {
       activationService: activationServiceMock,
       bindingService: bindingServiceMock,
       deactivationService: deactivationServiceMock,
+      onReset: vitest.fn(),
       planResultCacheService: planResultCacheServiceMock,
     } as Partial<
       Mocked<ServiceReferenceManager>
@@ -132,10 +161,6 @@ describe(Container, () => {
     } as Partial<Mocked<SnapshotManager>> as Mocked<SnapshotManager>;
 
     vitest
-      .mocked(buildDeactivationParams)
-      .mockReturnValue(deactivationParamsFixture);
-
-    vitest
       .mocked(ActivationsService.build)
       .mockReturnValue(activationServiceMock);
 
@@ -148,8 +173,20 @@ describe(Container, () => {
       .mockReturnValue(containerModuleManagerMock);
 
     vitest
+      .mocked(DeactivationParamsManager)
+      .mockReturnValue(deactivationParamsManagerMock);
+
+    vitest
       .mocked(DeactivationsService.build)
       .mockReturnValue(deactivationServiceMock);
+
+    vitest
+      .mocked(PlanParamsOperationsManager)
+      .mockReturnValue(planParamsOperationsManagerMock);
+
+    vitest
+      .mocked(PlanResultCacheManager)
+      .mockReturnValue(planResultCacheManagerMock);
 
     vitest
       .mocked(PlanResultCacheService)

--- a/packages/container/libraries/container/src/container/services/ContainerModuleManager.spec.ts
+++ b/packages/container/libraries/container/src/container/services/ContainerModuleManager.spec.ts
@@ -32,12 +32,14 @@ import {
 import { IsBoundOptions } from '../models/isBoundOptions';
 import { BindingManager } from './BindingManager';
 import { ContainerModuleManager } from './ContainerModuleManager';
+import { PlanResultCacheManager } from './PlanResultCacheManager';
 import { ServiceReferenceManager } from './ServiceReferenceManager';
 
 describe(ContainerModuleManager, () => {
   let bindingManagerMock: Mocked<BindingManager>;
   let deactivationParamsFixture: DeactivationParams;
   let defaultScopeFixture: BindingScope;
+  let planResultCacheManagerMock: Mocked<PlanResultCacheManager>;
   let serviceReferenceManagerMock: Mocked<ServiceReferenceManager>;
 
   beforeAll(() => {
@@ -53,6 +55,11 @@ describe(ContainerModuleManager, () => {
     } as Partial<Mocked<BindingManager>> as Mocked<BindingManager>;
     deactivationParamsFixture = Symbol() as unknown as DeactivationParams;
     defaultScopeFixture = bindingScopeValues.Singleton;
+    planResultCacheManagerMock = {
+      invalidateService: vitest.fn(),
+    } as Partial<
+      Mocked<PlanResultCacheManager>
+    > as Mocked<PlanResultCacheManager>;
     serviceReferenceManagerMock = {
       activationService: {} as Partial<
         Mocked<ActivationsService>
@@ -93,6 +100,7 @@ describe(ContainerModuleManager, () => {
           bindingManagerMock,
           deactivationParamsFixture,
           defaultScopeFixture,
+          planResultCacheManagerMock,
           serviceReferenceManagerMock,
         ).load(asyncContainerModuleMock);
       });
@@ -149,6 +157,7 @@ describe(ContainerModuleManager, () => {
           bindingManagerMock,
           deactivationParamsFixture,
           defaultScopeFixture,
+          planResultCacheManagerMock,
           serviceReferenceManagerMock,
         ).load(syncContainerModuleMock);
       });
@@ -220,6 +229,7 @@ describe(ContainerModuleManager, () => {
           bindingManagerMock,
           deactivationParamsFixture,
           defaultScopeFixture,
+          planResultCacheManagerMock,
           serviceReferenceManagerMock,
         ).loadSync(syncContainerModuleMock);
       });
@@ -277,6 +287,7 @@ describe(ContainerModuleManager, () => {
             bindingManagerMock,
             deactivationParamsFixture,
             defaultScopeFixture,
+            planResultCacheManagerMock,
             serviceReferenceManagerMock,
           ).loadSync(asyncContainerModuleMock);
         } catch (error: unknown) {

--- a/packages/container/libraries/container/src/container/services/DeactivationParamsManager.ts
+++ b/packages/container/libraries/container/src/container/services/DeactivationParamsManager.ts
@@ -1,0 +1,17 @@
+import { DeactivationParams } from '@inversifyjs/core';
+
+import { resetDeactivationParams } from '../actions/resetDeactivationParams';
+import { buildDeactivationParams } from '../calculations/buildDeactivationParams';
+import { ServiceReferenceManager } from './ServiceReferenceManager';
+
+export class DeactivationParamsManager {
+  public readonly deactivationParams: DeactivationParams;
+
+  constructor(serviceReferenceManager: ServiceReferenceManager) {
+    this.deactivationParams = buildDeactivationParams(serviceReferenceManager);
+
+    serviceReferenceManager.onReset((): void => {
+      resetDeactivationParams(serviceReferenceManager, this.deactivationParams);
+    });
+  }
+}

--- a/packages/container/libraries/container/src/container/services/PlanParamsOperationsManager.ts
+++ b/packages/container/libraries/container/src/container/services/PlanParamsOperationsManager.ts
@@ -1,0 +1,66 @@
+import {
+  Binding,
+  CacheBindingInvalidationKind,
+  getClassMetadata,
+  PlanParamsOperations,
+} from '@inversifyjs/core';
+
+import { ServiceReferenceManager } from './ServiceReferenceManager';
+
+export class PlanParamsOperationsManager {
+  public readonly planParamsOperations: PlanParamsOperations;
+  readonly #serviceReferenceManager: ServiceReferenceManager;
+
+  constructor(serviceReferenceManager: ServiceReferenceManager) {
+    this.#serviceReferenceManager = serviceReferenceManager;
+
+    this.planParamsOperations = {
+      getBindings: this.#serviceReferenceManager.bindingService.get.bind(
+        this.#serviceReferenceManager.bindingService,
+      ),
+      getBindingsChained:
+        this.#serviceReferenceManager.bindingService.getChained.bind(
+          this.#serviceReferenceManager.bindingService,
+        ),
+      getClassMetadata,
+      getPlan: this.#serviceReferenceManager.planResultCacheService.get.bind(
+        this.#serviceReferenceManager.planResultCacheService,
+      ),
+      setBinding: this.#setBinding.bind(this),
+      setNonCachedServiceNode:
+        this.#serviceReferenceManager.planResultCacheService.setNonCachedServiceNode.bind(
+          this.#serviceReferenceManager.planResultCacheService,
+        ),
+      setPlan: this.#serviceReferenceManager.planResultCacheService.set.bind(
+        this.#serviceReferenceManager.planResultCacheService,
+      ),
+    };
+
+    this.#serviceReferenceManager.onReset(() => {
+      this.#resetComputedProperties();
+    });
+  }
+
+  #resetComputedProperties(): void {
+    this.planParamsOperations.getBindings =
+      this.#serviceReferenceManager.bindingService.get.bind(
+        this.#serviceReferenceManager.bindingService,
+      );
+    this.planParamsOperations.getBindingsChained =
+      this.#serviceReferenceManager.bindingService.getChained.bind(
+        this.#serviceReferenceManager.bindingService,
+      );
+    this.planParamsOperations.setBinding = this.#setBinding.bind(this);
+  }
+
+  #setBinding(binding: Binding): void {
+    this.#serviceReferenceManager.bindingService.set(binding);
+    this.#serviceReferenceManager.planResultCacheService.invalidateServiceBinding(
+      {
+        binding: binding as Binding<unknown>,
+        kind: CacheBindingInvalidationKind.bindingAdded,
+        operations: this.planParamsOperations,
+      },
+    );
+  }
+}

--- a/packages/container/libraries/container/src/container/services/PlanResultCacheManager.spec.ts
+++ b/packages/container/libraries/container/src/container/services/PlanResultCacheManager.spec.ts
@@ -1,0 +1,82 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  Mocked,
+  vitest,
+} from 'vitest';
+
+import {
+  Binding,
+  CacheBindingInvalidationKind,
+  PlanParamsOperations,
+  PlanResultCacheService,
+} from '@inversifyjs/core';
+
+import { CacheBindingInvalidation } from '../models/CacheBindingInvalidation';
+import { PlanParamsOperationsManager } from './PlanParamsOperationsManager';
+import { PlanResultCacheManager } from './PlanResultCacheManager';
+import { ServiceReferenceManager } from './ServiceReferenceManager';
+
+describe(PlanResultCacheManager, () => {
+  let planParamsOperationsManagerFixture: PlanParamsOperationsManager;
+  let serviceReferenceManagerMock: Mocked<ServiceReferenceManager>;
+
+  let planResultCacheManager: PlanResultCacheManager;
+
+  beforeAll(() => {
+    planParamsOperationsManagerFixture = {
+      planParamsOperations: Symbol() as unknown as PlanParamsOperations,
+    } as Partial<PlanParamsOperationsManager> as PlanParamsOperationsManager;
+
+    serviceReferenceManagerMock = {
+      planResultCacheService: {
+        invalidateServiceBinding: vitest.fn(),
+      } as Partial<
+        Mocked<PlanResultCacheService>
+      > as Mocked<PlanResultCacheService>,
+    } as Partial<ServiceReferenceManager> as Mocked<ServiceReferenceManager>;
+
+    planResultCacheManager = new PlanResultCacheManager(
+      planParamsOperationsManagerFixture,
+      serviceReferenceManagerMock,
+    );
+  });
+
+  describe('.invalidateService', () => {
+    describe('when called', () => {
+      let invalidationFixture: CacheBindingInvalidation;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        invalidationFixture = {
+          binding: Symbol() as unknown as Binding<unknown>,
+          kind: CacheBindingInvalidationKind.bindingAdded,
+        };
+
+        result = planResultCacheManager.invalidateService(invalidationFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call planResultCacheService.invalidateServiceBinding with the correct parameters', () => {
+        expect(
+          serviceReferenceManagerMock.planResultCacheService
+            .invalidateServiceBinding,
+        ).toHaveBeenCalledWith({
+          ...invalidationFixture,
+          operations: planParamsOperationsManagerFixture.planParamsOperations,
+        });
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+});

--- a/packages/container/libraries/container/src/container/services/PlanResultCacheManager.ts
+++ b/packages/container/libraries/container/src/container/services/PlanResultCacheManager.ts
@@ -1,0 +1,25 @@
+import { CacheBindingInvalidation } from '../models/CacheBindingInvalidation';
+import { PlanParamsOperationsManager } from './PlanParamsOperationsManager';
+import { ServiceReferenceManager } from './ServiceReferenceManager';
+
+export class PlanResultCacheManager {
+  readonly #planParamsOperationsManager: PlanParamsOperationsManager;
+  readonly #serviceReferenceManager: ServiceReferenceManager;
+
+  constructor(
+    planParamsOperationsManager: PlanParamsOperationsManager,
+    serviceReferenceManager: ServiceReferenceManager,
+  ) {
+    this.#planParamsOperationsManager = planParamsOperationsManager;
+    this.#serviceReferenceManager = serviceReferenceManager;
+  }
+
+  public invalidateService(invalidation: CacheBindingInvalidation): void {
+    this.#serviceReferenceManager.planResultCacheService.invalidateServiceBinding(
+      {
+        ...invalidation,
+        operations: this.#planParamsOperationsManager.planParamsOperations,
+      },
+    );
+  }
+}

--- a/packages/container/libraries/container/src/container/services/ServiceResolutionManager.spec.ts
+++ b/packages/container/libraries/container/src/container/services/ServiceResolutionManager.spec.ts
@@ -14,22 +14,20 @@ vitest.mock('@inversifyjs/core');
 import { ServiceIdentifier } from '@inversifyjs/common';
 import {
   ActivationsService,
-  Binding,
   BindingActivation,
   BindingScope,
   bindingScopeValues,
   BindingService,
   DeactivationsService,
   GetAllOptions,
-  getClassMetadata,
   GetOptions,
   GetOptionsTagConstraint,
   GetPlanOptions,
   plan,
   PlanParams,
+  PlanParamsOperations,
   PlanResult,
   PlanResultCacheService,
-  PlanServiceNode,
   ResolutionContext,
   ResolutionParams,
   resolve,
@@ -37,17 +35,22 @@ import {
 
 import { InversifyContainerError } from '../../error/models/InversifyContainerError';
 import { InversifyContainerErrorKind } from '../../error/models/InversifyContainerErrorKind';
+import { PlanParamsOperationsManager } from './PlanParamsOperationsManager';
 import { ServiceReferenceManager } from './ServiceReferenceManager';
 import { ServiceResolutionManager } from './ServiceResolutionManager';
 
 describe(ServiceResolutionManager, () => {
   let autobindFixture: boolean;
   let defaultScopeFixture: BindingScope;
+  let planParamsOperationsManagerFixture: PlanParamsOperationsManager;
   let serviceReferenceManagerMock: Mocked<ServiceReferenceManager>;
 
   beforeAll(() => {
     autobindFixture = false;
     defaultScopeFixture = bindingScopeValues.Singleton;
+    planParamsOperationsManagerFixture = {
+      planParamsOperations: Symbol() as unknown as PlanParamsOperations,
+    } as Partial<PlanParamsOperationsManager> as PlanParamsOperationsManager;
     serviceReferenceManagerMock = {
       activationService: {} as Partial<
         Mocked<ActivationsService>
@@ -78,6 +81,7 @@ describe(ServiceResolutionManager, () => {
 
       beforeAll(() => {
         serviceResolutionManager = new ServiceResolutionManager(
+          planParamsOperationsManagerFixture,
           serviceReferenceManagerMock,
           autobindFixture,
           defaultScopeFixture,
@@ -143,30 +147,7 @@ describe(ServiceResolutionManager, () => {
         it('should call plan()', () => {
           const expectedPlanParams: PlanParams = {
             autobindOptions: undefined,
-            operations: {
-              getBindings: expect.any(Function) as unknown as <TInstance>(
-                serviceIdentifier: ServiceIdentifier<TInstance>,
-              ) => Binding<TInstance>[] | undefined,
-              getBindingsChained: expect.any(Function) as unknown as <
-                TInstance,
-              >(
-                serviceIdentifier: ServiceIdentifier<TInstance>,
-              ) => Generator<Binding<TInstance>>,
-              getClassMetadata,
-              getPlan: expect.any(Function) as unknown as (
-                options: GetPlanOptions,
-              ) => PlanResult | undefined,
-              setBinding: expect.any(Function) as unknown as <TInstance>(
-                binding: Binding<TInstance>,
-              ) => void,
-              setNonCachedServiceNode: expect.any(Function) as unknown as (
-                node: PlanServiceNode,
-              ) => void,
-              setPlan: expect.any(Function) as unknown as (
-                options: GetPlanOptions,
-                planResult: PlanResult,
-              ) => void,
-            },
+            operations: planParamsOperationsManagerFixture.planParamsOperations,
             rootConstraints: {
               isMultiple: false,
               isOptional: getOptionsFixture.optional as true,
@@ -268,30 +249,7 @@ describe(ServiceResolutionManager, () => {
         it('should call plan()', () => {
           const expectedPlanParams: PlanParams = {
             autobindOptions: undefined,
-            operations: {
-              getBindings: expect.any(Function) as unknown as <TInstance>(
-                serviceIdentifier: ServiceIdentifier<TInstance>,
-              ) => Binding<TInstance>[] | undefined,
-              getBindingsChained: expect.any(Function) as unknown as <
-                TInstance,
-              >(
-                serviceIdentifier: ServiceIdentifier<TInstance>,
-              ) => Generator<Binding<TInstance>>,
-              getClassMetadata,
-              getPlan: expect.any(Function) as unknown as (
-                options: GetPlanOptions,
-              ) => PlanResult | undefined,
-              setBinding: expect.any(Function) as unknown as <TInstance>(
-                binding: Binding<TInstance>,
-              ) => void,
-              setNonCachedServiceNode: expect.any(Function) as unknown as (
-                node: PlanServiceNode,
-              ) => void,
-              setPlan: expect.any(Function) as unknown as (
-                options: GetPlanOptions,
-                planResult: PlanResult,
-              ) => void,
-            },
+            operations: planParamsOperationsManagerFixture.planParamsOperations,
             rootConstraints: {
               isMultiple: false,
               isOptional: getOptionsFixture.optional as true,
@@ -401,30 +359,7 @@ describe(ServiceResolutionManager, () => {
         it('should call plan()', () => {
           const expectedPlanParams: PlanParams = {
             autobindOptions: undefined,
-            operations: {
-              getBindings: expect.any(Function) as unknown as <TInstance>(
-                serviceIdentifier: ServiceIdentifier<TInstance>,
-              ) => Binding<TInstance>[] | undefined,
-              getBindingsChained: expect.any(Function) as unknown as <
-                TInstance,
-              >(
-                serviceIdentifier: ServiceIdentifier<TInstance>,
-              ) => Generator<Binding<TInstance>>,
-              getClassMetadata,
-              getPlan: expect.any(Function) as unknown as (
-                options: GetPlanOptions,
-              ) => PlanResult | undefined,
-              setBinding: expect.any(Function) as unknown as <TInstance>(
-                binding: Binding<TInstance>,
-              ) => void,
-              setNonCachedServiceNode: expect.any(Function) as unknown as (
-                node: PlanServiceNode,
-              ) => void,
-              setPlan: expect.any(Function) as unknown as (
-                options: GetPlanOptions,
-                planResult: PlanResult,
-              ) => void,
-            },
+            operations: planParamsOperationsManagerFixture.planParamsOperations,
             rootConstraints: {
               isMultiple: false,
               isOptional: getOptionsFixture.optional as true,
@@ -487,6 +422,7 @@ describe(ServiceResolutionManager, () => {
       beforeAll(() => {
         defaultScopeFixture = bindingScopeValues.Singleton;
         serviceResolutionManager = new ServiceResolutionManager(
+          planParamsOperationsManagerFixture,
           serviceReferenceManagerMock,
           true,
           defaultScopeFixture,
@@ -554,30 +490,7 @@ describe(ServiceResolutionManager, () => {
             autobindOptions: {
               scope: defaultScopeFixture,
             },
-            operations: {
-              getBindings: expect.any(Function) as unknown as <TInstance>(
-                serviceIdentifier: ServiceIdentifier<TInstance>,
-              ) => Binding<TInstance>[] | undefined,
-              getBindingsChained: expect.any(Function) as unknown as <
-                TInstance,
-              >(
-                serviceIdentifier: ServiceIdentifier<TInstance>,
-              ) => Generator<Binding<TInstance>>,
-              getClassMetadata,
-              getPlan: expect.any(Function) as unknown as (
-                options: GetPlanOptions,
-              ) => PlanResult | undefined,
-              setBinding: expect.any(Function) as unknown as <TInstance>(
-                binding: Binding<TInstance>,
-              ) => void,
-              setNonCachedServiceNode: expect.any(Function) as unknown as (
-                node: PlanServiceNode,
-              ) => void,
-              setPlan: expect.any(Function) as unknown as (
-                options: GetPlanOptions,
-                planResult: PlanResult,
-              ) => void,
-            },
+            operations: planParamsOperationsManagerFixture.planParamsOperations,
             rootConstraints: {
               isMultiple: false,
               isOptional: getOptionsFixture.optional as true,
@@ -624,6 +537,7 @@ describe(ServiceResolutionManager, () => {
       beforeAll(() => {
         defaultScopeFixture = bindingScopeValues.Singleton;
         serviceResolutionManager = new ServiceResolutionManager(
+          planParamsOperationsManagerFixture,
           serviceReferenceManagerMock,
           false,
           defaultScopeFixture,
@@ -692,30 +606,7 @@ describe(ServiceResolutionManager, () => {
             autobindOptions: {
               scope: defaultScopeFixture,
             },
-            operations: {
-              getBindings: expect.any(Function) as unknown as <TInstance>(
-                serviceIdentifier: ServiceIdentifier<TInstance>,
-              ) => Binding<TInstance>[] | undefined,
-              getBindingsChained: expect.any(Function) as unknown as <
-                TInstance,
-              >(
-                serviceIdentifier: ServiceIdentifier<TInstance>,
-              ) => Generator<Binding<TInstance>>,
-              getClassMetadata,
-              getPlan: expect.any(Function) as unknown as (
-                options: GetPlanOptions,
-              ) => PlanResult | undefined,
-              setBinding: expect.any(Function) as unknown as <TInstance>(
-                binding: Binding<TInstance>,
-              ) => void,
-              setNonCachedServiceNode: expect.any(Function) as unknown as (
-                node: PlanServiceNode,
-              ) => void,
-              setPlan: expect.any(Function) as unknown as (
-                options: GetPlanOptions,
-                planResult: PlanResult,
-              ) => void,
-            },
+            operations: planParamsOperationsManagerFixture.planParamsOperations,
             rootConstraints: {
               isMultiple: false,
               isOptional: getOptionsFixture.optional as true,
@@ -771,6 +662,7 @@ describe(ServiceResolutionManager, () => {
       beforeAll(() => {
         defaultScopeFixture = bindingScopeValues.Singleton;
         serviceResolutionManager = new ServiceResolutionManager(
+          planParamsOperationsManagerFixture,
           serviceReferenceManagerMock,
           false,
           defaultScopeFixture,
@@ -879,6 +771,7 @@ describe(ServiceResolutionManager, () => {
           vitest.mocked(resolve).mockReturnValueOnce([resolvedValueFixture]);
 
           result = new ServiceResolutionManager(
+            planParamsOperationsManagerFixture,
             serviceReferenceManagerMock,
             autobindFixture,
             defaultScopeFixture,
@@ -910,30 +803,7 @@ describe(ServiceResolutionManager, () => {
         it('should call plan()', () => {
           const expectedPlanParams: PlanParams = {
             autobindOptions: undefined,
-            operations: {
-              getBindings: expect.any(Function) as unknown as <TInstance>(
-                serviceIdentifier: ServiceIdentifier<TInstance>,
-              ) => Binding<TInstance>[] | undefined,
-              getBindingsChained: expect.any(Function) as unknown as <
-                TInstance,
-              >(
-                serviceIdentifier: ServiceIdentifier<TInstance>,
-              ) => Generator<Binding<TInstance>>,
-              getClassMetadata,
-              getPlan: expect.any(Function) as unknown as (
-                options: GetPlanOptions,
-              ) => PlanResult | undefined,
-              setBinding: expect.any(Function) as unknown as <TInstance>(
-                binding: Binding<TInstance>,
-              ) => void,
-              setNonCachedServiceNode: expect.any(Function) as unknown as (
-                node: PlanServiceNode,
-              ) => void,
-              setPlan: expect.any(Function) as unknown as (
-                options: GetPlanOptions,
-                planResult: PlanResult,
-              ) => void,
-            },
+            operations: planParamsOperationsManagerFixture.planParamsOperations,
             rootConstraints: {
               chained: true,
               isMultiple: true,
@@ -1001,6 +871,7 @@ describe(ServiceResolutionManager, () => {
         vitest.mocked(resolve).mockReturnValueOnce([resolvedValueFixture]);
 
         result = new ServiceResolutionManager(
+          planParamsOperationsManagerFixture,
           serviceReferenceManagerMock,
           autobindFixture,
           defaultScopeFixture,
@@ -1032,28 +903,7 @@ describe(ServiceResolutionManager, () => {
       it('should call plan()', () => {
         const expectedPlanParams: PlanParams = {
           autobindOptions: undefined,
-          operations: {
-            getBindings: expect.any(Function) as unknown as <TInstance>(
-              serviceIdentifier: ServiceIdentifier<TInstance>,
-            ) => Binding<TInstance>[] | undefined,
-            getBindingsChained: expect.any(Function) as unknown as <TInstance>(
-              serviceIdentifier: ServiceIdentifier<TInstance>,
-            ) => Generator<Binding<TInstance>>,
-            getClassMetadata,
-            getPlan: expect.any(Function) as unknown as (
-              options: GetPlanOptions,
-            ) => PlanResult | undefined,
-            setBinding: expect.any(Function) as unknown as <TInstance>(
-              binding: Binding<TInstance>,
-            ) => void,
-            setNonCachedServiceNode: expect.any(Function) as unknown as (
-              node: PlanServiceNode,
-            ) => void,
-            setPlan: expect.any(Function) as unknown as (
-              options: GetPlanOptions,
-              planResult: PlanResult,
-            ) => void,
-          },
+          operations: planParamsOperationsManagerFixture.planParamsOperations,
           rootConstraints: {
             chained: false,
             isMultiple: true,
@@ -1124,6 +974,7 @@ describe(ServiceResolutionManager, () => {
 
         try {
           new ServiceResolutionManager(
+            planParamsOperationsManagerFixture,
             serviceReferenceManagerMock,
             autobindFixture,
             defaultScopeFixture,
@@ -1158,28 +1009,7 @@ describe(ServiceResolutionManager, () => {
       it('should call plan()', () => {
         const expectedPlanParams: PlanParams = {
           autobindOptions: undefined,
-          operations: {
-            getBindings: expect.any(Function) as unknown as <TInstance>(
-              serviceIdentifier: ServiceIdentifier<TInstance>,
-            ) => Binding<TInstance>[] | undefined,
-            getBindingsChained: expect.any(Function) as unknown as <TInstance>(
-              serviceIdentifier: ServiceIdentifier<TInstance>,
-            ) => Generator<Binding<TInstance>>,
-            getClassMetadata,
-            getPlan: expect.any(Function) as unknown as (
-              options: GetPlanOptions,
-            ) => PlanResult | undefined,
-            setBinding: expect.any(Function) as unknown as <TInstance>(
-              binding: Binding<TInstance>,
-            ) => void,
-            setNonCachedServiceNode: expect.any(Function) as unknown as (
-              node: PlanServiceNode,
-            ) => void,
-            setPlan: expect.any(Function) as unknown as (
-              options: GetPlanOptions,
-              planResult: PlanResult,
-            ) => void,
-          },
+          operations: planParamsOperationsManagerFixture.planParamsOperations,
           rootConstraints: {
             chained: false,
             isMultiple: true,
@@ -1259,6 +1089,7 @@ describe(ServiceResolutionManager, () => {
         vitest.mocked(resolve).mockReturnValueOnce([resolvedValueFixture]);
 
         result = await new ServiceResolutionManager(
+          planParamsOperationsManagerFixture,
           serviceReferenceManagerMock,
           autobindFixture,
           defaultScopeFixture,
@@ -1290,28 +1121,7 @@ describe(ServiceResolutionManager, () => {
       it('should call plan()', () => {
         const expectedPlanParams: PlanParams = {
           autobindOptions: undefined,
-          operations: {
-            getBindings: expect.any(Function) as unknown as <TInstance>(
-              serviceIdentifier: ServiceIdentifier<TInstance>,
-            ) => Binding<TInstance>[] | undefined,
-            getBindingsChained: expect.any(Function) as unknown as <TInstance>(
-              serviceIdentifier: ServiceIdentifier<TInstance>,
-            ) => Generator<Binding<TInstance>>,
-            getClassMetadata,
-            getPlan: expect.any(Function) as unknown as (
-              options: GetPlanOptions,
-            ) => PlanResult | undefined,
-            setBinding: expect.any(Function) as unknown as <TInstance>(
-              binding: Binding<TInstance>,
-            ) => void,
-            setNonCachedServiceNode: expect.any(Function) as unknown as (
-              node: PlanServiceNode,
-            ) => void,
-            setPlan: expect.any(Function) as unknown as (
-              options: GetPlanOptions,
-              planResult: PlanResult,
-            ) => void,
-          },
+          operations: planParamsOperationsManagerFixture.planParamsOperations,
           rootConstraints: {
             chained: false,
             isMultiple: true,
@@ -1383,6 +1193,7 @@ describe(ServiceResolutionManager, () => {
         vitest.mocked(resolve).mockReturnValueOnce(resolvedValueFixture);
 
         result = await new ServiceResolutionManager(
+          planParamsOperationsManagerFixture,
           serviceReferenceManagerMock,
           autobindFixture,
           defaultScopeFixture,
@@ -1413,28 +1224,7 @@ describe(ServiceResolutionManager, () => {
       it('should call plan()', () => {
         const expectedPlanParams: PlanParams = {
           autobindOptions: undefined,
-          operations: {
-            getBindings: expect.any(Function) as unknown as <TInstance>(
-              serviceIdentifier: ServiceIdentifier<TInstance>,
-            ) => Binding<TInstance>[] | undefined,
-            getBindingsChained: expect.any(Function) as unknown as <TInstance>(
-              serviceIdentifier: ServiceIdentifier<TInstance>,
-            ) => Generator<Binding<TInstance>>,
-            getClassMetadata,
-            getPlan: expect.any(Function) as unknown as (
-              options: GetPlanOptions,
-            ) => PlanResult | undefined,
-            setBinding: expect.any(Function) as unknown as <TInstance>(
-              binding: Binding<TInstance>,
-            ) => void,
-            setNonCachedServiceNode: expect.any(Function) as unknown as (
-              node: PlanServiceNode,
-            ) => void,
-            setPlan: expect.any(Function) as unknown as (
-              options: GetPlanOptions,
-              planResult: PlanResult,
-            ) => void,
-          },
+          operations: planParamsOperationsManagerFixture.planParamsOperations,
           rootConstraints: {
             isMultiple: false,
             isOptional: getOptionsFixture.optional as true,

--- a/packages/container/libraries/container/src/issues/inversify-InversifyJs-issue-1864-unbindCallShouldNotTrowPlanningErrorsint.spec.ts
+++ b/packages/container/libraries/container/src/issues/inversify-InversifyJs-issue-1864-unbindCallShouldNotTrowPlanningErrorsint.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import 'reflect-metadata';
+
+import { inject } from '@inversifyjs/core';
+
+import { Container } from '../container/services/Container';
+
+describe('inversify/InversifyJS#1864', () => {
+  it('Container unbind request should not throw planning errors', () => {
+    class Foo {
+      constructor(@inject('bar') _bar: string) {}
+    }
+
+    const container: Container = new Container();
+    container.bind(Foo).toSelf();
+    container.bind('bar').toConstantValue('bar');
+
+    container.get(Foo);
+
+    expect(() => {
+      container.unbindSync('bar');
+      container.unbindSync(Foo);
+      container.unbindSync(Foo);
+    }).not.toThrow();
+  });
+});

--- a/packages/container/libraries/container/src/issues/inversify-InversifyJs-issue-1864-unbindCallShouldNotTrowPlanningErrorsint.spec.ts
+++ b/packages/container/libraries/container/src/issues/inversify-InversifyJs-issue-1864-unbindCallShouldNotTrowPlanningErrorsint.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import 'reflect-metadata';
 
-import { inject } from '@inversifyjs/core';
+import { inject, multiInject } from '@inversifyjs/core';
 
 import { Container } from '../container/services/Container';
 
@@ -23,5 +23,47 @@ describe('inversify/InversifyJS#1864', () => {
       container.unbindSync(Foo);
       container.unbindSync(Foo);
     }).not.toThrow();
+  });
+
+  it('Container leaf bind request should not throw planning errors', () => {
+    class Foo {
+      constructor(@multiInject('bar') _bar: string[]) {}
+    }
+
+    const container: Container = new Container();
+    container.bind(Foo).toSelf();
+    container.bind('bar').toConstantValue('bar');
+
+    container.get(Foo);
+
+    expect(() => {
+      container.bind('bar').toConstantValue('bar');
+    }).not.toThrow();
+  });
+
+  it('Container non leaf bind request should not throw planning errors', () => {
+    class Foo {
+      constructor(@multiInject('bar') _bar: unknown[]) {}
+    }
+
+    class Bar {
+      constructor(@inject('baz') _baz: string) {}
+    }
+
+    const container: Container = new Container();
+    container.bind(Foo).toSelf();
+    container.bind('bar').toConstantValue('bar');
+
+    container.get(Foo);
+
+    expect(() => {
+      container.bind('bar').to(Bar);
+    }).not.toThrow();
+
+    container.bind('baz').toConstantValue('baz');
+
+    const foo: Foo = container.get(Foo);
+
+    expect(foo).toStrictEqual(new Foo(['bar', new Bar('baz')]));
   });
 });

--- a/packages/container/libraries/core/src/index.ts
+++ b/packages/container/libraries/core/src/index.ts
@@ -76,6 +76,7 @@ import { PlanParamsConstraint } from './planning/models/PlanParamsConstraint';
 import { PlanParamsOperations } from './planning/models/PlanParamsOperations';
 import { PlanParamsTagConstraint } from './planning/models/PlanParamsTagConstraint';
 import { PlanResult } from './planning/models/PlanResult';
+import { PlanResultCacheServiceInvalidationKind } from './planning/models/PlanResultCacheServiceInvalidationKind';
 import { PlanServiceNode } from './planning/models/PlanServiceNode';
 import { PlanServiceNodeParent } from './planning/models/PlanServiceNodeParent';
 import { PlanServiceRedirectionBindingNode } from './planning/models/PlanServiceRedirectionBindingNode';
@@ -193,5 +194,6 @@ export {
   tagged,
   unmanaged,
   MultipleBindingPlanParamsConstraint,
+  PlanResultCacheServiceInvalidationKind,
   SingleBindingPlanParamsConstraint,
 };

--- a/packages/container/libraries/core/src/index.ts
+++ b/packages/container/libraries/core/src/index.ts
@@ -62,6 +62,8 @@ import { plan } from './planning/actions/plan';
 import { BaseBindingNode } from './planning/models/BaseBindingNode';
 import { BaseGetPlanOptions } from './planning/models/BaseGetPlanOptions';
 import { BasePlanParams } from './planning/models/BasePlanParams';
+import { CacheBindingInvalidation } from './planning/models/CacheBindingInvalidation';
+import { CacheBindingInvalidationKind } from './planning/models/CacheBindingInvalidationKind';
 import { GetMultipleServicePlanOptions } from './planning/models/GetMultipleServicePlanOptions';
 import { GetPlanOptions } from './planning/models/GetPlanOptions';
 import { GetPlanOptionsTagConstraint } from './planning/models/GetPlanOptionsTagConstraint';
@@ -76,7 +78,6 @@ import { PlanParamsConstraint } from './planning/models/PlanParamsConstraint';
 import { PlanParamsOperations } from './planning/models/PlanParamsOperations';
 import { PlanParamsTagConstraint } from './planning/models/PlanParamsTagConstraint';
 import { PlanResult } from './planning/models/PlanResult';
-import { PlanResultCacheServiceInvalidationKind } from './planning/models/PlanResultCacheServiceInvalidationKind';
 import { PlanServiceNode } from './planning/models/PlanServiceNode';
 import { PlanServiceNodeParent } from './planning/models/PlanServiceNodeParent';
 import { PlanServiceRedirectionBindingNode } from './planning/models/PlanServiceRedirectionBindingNode';
@@ -112,6 +113,7 @@ export type {
   BindingConstraints,
   BindingScope,
   BindingType,
+  CacheBindingInvalidation,
   ClassElementMetadata,
   ClassMetadata,
   ClassMetadataLifecycle,
@@ -171,6 +173,7 @@ export {
   bindingScopeValues,
   BindingService,
   bindingTypeValues,
+  CacheBindingInvalidationKind,
   ClassElementMetadataKind,
   DeactivationsService,
   decorate,
@@ -194,6 +197,5 @@ export {
   tagged,
   unmanaged,
   MultipleBindingPlanParamsConstraint,
-  PlanResultCacheServiceInvalidationKind,
   SingleBindingPlanParamsConstraint,
 };

--- a/packages/container/libraries/core/src/planning/actions/cacheNonRootPlanServiceNode.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/cacheNonRootPlanServiceNode.spec.ts
@@ -4,16 +4,38 @@ import {
   describe,
   expect,
   it,
+  Mock,
   Mocked,
   vitest,
 } from 'vitest';
 
+import { ServiceIdentifier } from '@inversifyjs/common';
+
 import { GetPlanOptionsFixtures } from '../fixtures/GetPlanOptionsFixtures';
 import { GetPlanOptions } from '../models/GetPlanOptions';
+import { LazyPlanServiceNode } from '../models/LazyPlanServiceNode';
 import { NonCachedServiceNodeContext } from '../models/NonCachedServiceNodeContext';
 import { PlanParamsOperations } from '../models/PlanParamsOperations';
 import { PlanServiceNode } from '../models/PlanServiceNode';
 import { cacheNonRootPlanServiceNode } from './cacheNonRootPlanServiceNode';
+
+class LazyPlanServiceNodeTest extends LazyPlanServiceNode {
+  readonly #buildPlanServiceNodeMock: Mock<() => PlanServiceNode>;
+
+  constructor(
+    serviceNode: PlanServiceNode | undefined,
+    serviceIdentifier: ServiceIdentifier,
+    buildPlanServiceNode: Mock<() => PlanServiceNode>,
+  ) {
+    super(serviceNode, serviceIdentifier);
+
+    this.#buildPlanServiceNodeMock = buildPlanServiceNode;
+  }
+
+  protected _buildPlanServiceNode(): PlanServiceNode {
+    return this.#buildPlanServiceNodeMock();
+  }
+}
 
 describe(cacheNonRootPlanServiceNode, () => {
   let operationsMock: Mocked<PlanParamsOperations>;
@@ -121,6 +143,55 @@ describe(cacheNonRootPlanServiceNode, () => {
         isContextFree: true,
         serviceIdentifier: Symbol(),
       };
+      contextFixture = Symbol() as unknown as NonCachedServiceNodeContext;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = cacheNonRootPlanServiceNode(
+          getPlanOptionsFixture,
+          operationsMock,
+          planServiceNodeFixture,
+          contextFixture,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call operations.setPlan()', () => {
+        expect(operationsMock.setPlan).toHaveBeenCalledTimes(1);
+        expect(operationsMock.setPlan).toHaveBeenCalledWith(
+          getPlanOptionsFixture,
+          {
+            tree: {
+              root: planServiceNodeFixture,
+            },
+          },
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having non expanded LazyPlanServiceNode', () => {
+    let getPlanOptionsFixture: GetPlanOptions;
+    let planServiceNodeFixture: PlanServiceNode;
+    let contextFixture: NonCachedServiceNodeContext;
+
+    beforeAll(() => {
+      getPlanOptionsFixture = GetPlanOptionsFixtures.any;
+      planServiceNodeFixture = new LazyPlanServiceNodeTest(
+        undefined,
+        Symbol(),
+        vitest.fn(),
+      );
       contextFixture = Symbol() as unknown as NonCachedServiceNodeContext;
     });
 

--- a/packages/container/libraries/core/src/planning/actions/cacheNonRootPlanServiceNode.ts
+++ b/packages/container/libraries/core/src/planning/actions/cacheNonRootPlanServiceNode.ts
@@ -1,4 +1,5 @@
 import { GetPlanOptions } from '../models/GetPlanOptions';
+import { LazyPlanServiceNode } from '../models/LazyPlanServiceNode';
 import { NonCachedServiceNodeContext } from '../models/NonCachedServiceNodeContext';
 import { PlanParamsOperations } from '../models/PlanParamsOperations';
 import { PlanResult } from '../models/PlanResult';
@@ -10,7 +11,12 @@ export function cacheNonRootPlanServiceNode(
   planServiceNode: PlanServiceNode,
   context: NonCachedServiceNodeContext,
 ): void {
-  if (getPlanOptions !== undefined && planServiceNode.isContextFree) {
+  if (
+    getPlanOptions !== undefined &&
+    ((LazyPlanServiceNode.is(planServiceNode) &&
+      !planServiceNode.isExpanded()) ||
+      planServiceNode.isContextFree)
+  ) {
     const planResult: PlanResult = {
       tree: {
         root: planServiceNode,

--- a/packages/container/libraries/core/src/planning/models/CacheBindingInvalidation.ts
+++ b/packages/container/libraries/core/src/planning/models/CacheBindingInvalidation.ts
@@ -1,0 +1,9 @@
+import { Binding } from '../../binding/models/Binding';
+import { CacheBindingInvalidationKind } from './CacheBindingInvalidationKind';
+import { PlanParamsOperations } from './PlanParamsOperations';
+
+export interface CacheBindingInvalidation {
+  binding: Binding<unknown>;
+  kind: CacheBindingInvalidationKind;
+  operations: PlanParamsOperations;
+}

--- a/packages/container/libraries/core/src/planning/models/CacheBindingInvalidationKind.ts
+++ b/packages/container/libraries/core/src/planning/models/CacheBindingInvalidationKind.ts
@@ -1,4 +1,4 @@
-export enum PlanResultCacheServiceInvalidationKind {
+export enum CacheBindingInvalidationKind {
   bindingAdded = 'bindingAdded',
   bindingRemoved = 'bindingRemoved',
 }

--- a/packages/container/libraries/core/src/planning/models/PlanResultCacheServiceInvalidation.ts
+++ b/packages/container/libraries/core/src/planning/models/PlanResultCacheServiceInvalidation.ts
@@ -1,9 +1,0 @@
-import { Binding } from '../../binding/models/Binding';
-import { PlanParamsOperations } from './PlanParamsOperations';
-import { PlanResultCacheServiceInvalidationKind } from './PlanResultCacheServiceInvalidationKind';
-
-export interface PlanResultCacheServiceInvalidation {
-  binding: Binding<unknown>;
-  kind: PlanResultCacheServiceInvalidationKind;
-  operations: PlanParamsOperations;
-}

--- a/packages/container/libraries/core/src/planning/models/PlanResultCacheServiceInvalidation.ts
+++ b/packages/container/libraries/core/src/planning/models/PlanResultCacheServiceInvalidation.ts
@@ -1,0 +1,9 @@
+import { Binding } from '../../binding/models/Binding';
+import { PlanParamsOperations } from './PlanParamsOperations';
+import { PlanResultCacheServiceInvalidationKind } from './PlanResultCacheServiceInvalidationKind';
+
+export interface PlanResultCacheServiceInvalidation {
+  binding: Binding<unknown>;
+  kind: PlanResultCacheServiceInvalidationKind;
+  operations: PlanParamsOperations;
+}

--- a/packages/container/libraries/core/src/planning/models/PlanResultCacheServiceInvalidationKind.ts
+++ b/packages/container/libraries/core/src/planning/models/PlanResultCacheServiceInvalidationKind.ts
@@ -1,0 +1,4 @@
+export enum PlanResultCacheServiceInvalidationKind {
+  bindingAdded = 'bindingAdded',
+  bindingRemoved = 'bindingRemoved',
+}

--- a/packages/http/libraries/hono/package.json
+++ b/packages/http/libraries/hono/package.json
@@ -48,7 +48,7 @@
   },
   "name": "@inversifyjs/http-hono",
   "peerDependencies": {
-    "hono": "^4.8.12",
+    "hono": "^4.9.0",
     "inversify": "^7.7.0"
   },
   "private": true,


### PR DESCRIPTION
### Added
- Added `PlanResultCacheManager`.
- Added `DeactivationParamsManager`.
- Added `PlanParamsOperationsManager`.
- Added `CacheBindingInvalidation` models.

### Changed
- Updated `PlanResultCacheService` to invalidate at binding level.
- Updated `Container` to rely on extracted managers.

### Context

After reveral refactors accomplished in previous PR, this PR fixes inversify/InversifyJS#1864, improving the cache service invalidation in order to avoid triggering LazyServiceNode binding expansion, fixing some invalid service invalidation in edge cases involving ancestor binding constraints and improving memory usage with some more aggresive optimizations.