### PR TITLE
Fix "inmutable" typo

### DIFF
--- a/packages/container/libraries/core/src/binding/models/BindingConstraintsImplementation.ts
+++ b/packages/container/libraries/core/src/binding/models/BindingConstraintsImplementation.ts
@@ -1,6 +1,6 @@
 import { ServiceIdentifier } from '@inversifyjs/common';
 
-import { SingleInmutableLinkedListNode } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedListNode } from '../../common/models/SingleImmutableLinkedList';
 import { MetadataName } from '../../metadata/models/MetadataName';
 import { MetadataTag } from '../../metadata/models/MetadataTag';
 import { BindingConstraints } from './BindingConstraints';
@@ -13,9 +13,9 @@ export interface InternalBindingConstraints {
 }
 
 export class BindingConstraintsImplementation implements BindingConstraints {
-  readonly #node: SingleInmutableLinkedListNode<InternalBindingConstraints>;
+  readonly #node: SingleImmutableLinkedListNode<InternalBindingConstraints>;
 
-  constructor(node: SingleInmutableLinkedListNode<InternalBindingConstraints>) {
+  constructor(node: SingleImmutableLinkedListNode<InternalBindingConstraints>) {
     this.#node = node;
   }
 

--- a/packages/container/libraries/core/src/common/models/SingleImmutableLinkedList.spec.ts
+++ b/packages/container/libraries/core/src/common/models/SingleImmutableLinkedList.spec.ts
@@ -1,12 +1,12 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 
-import { SingleInmutableLinkedList } from './SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from './SingleImmutableLinkedList';
 
-describe(SingleInmutableLinkedList, () => {
-  let singleInmutableLinkedListFixture: SingleInmutableLinkedList<unknown>;
+describe(SingleImmutableLinkedList, () => {
+  let singleImmutableLinkedListFixture: SingleImmutableLinkedList<unknown>;
 
   beforeAll(() => {
-    singleInmutableLinkedListFixture = new SingleInmutableLinkedList({
+    singleImmutableLinkedListFixture = new SingleImmutableLinkedList({
       elem: Symbol(),
       previous: undefined,
     });
@@ -21,14 +21,14 @@ describe(SingleInmutableLinkedList, () => {
       beforeAll(() => {
         elementFixture = Symbol();
 
-        result = singleInmutableLinkedListFixture.concat(elementFixture);
+        result = singleImmutableLinkedListFixture.concat(elementFixture);
       });
 
       it('should return linked list', () => {
-        const expected: Partial<SingleInmutableLinkedList<unknown>> = {
+        const expected: Partial<SingleImmutableLinkedList<unknown>> = {
           last: {
             elem: elementFixture,
-            previous: singleInmutableLinkedListFixture.last,
+            previous: singleImmutableLinkedListFixture.last,
           },
         };
 
@@ -42,12 +42,12 @@ describe(SingleInmutableLinkedList, () => {
       let result: Iterable<unknown>;
 
       beforeAll(() => {
-        result = [...singleInmutableLinkedListFixture];
+        result = [...singleImmutableLinkedListFixture];
       });
 
       it('should return expected result', () => {
         expect(result).toStrictEqual([
-          singleInmutableLinkedListFixture.last.elem,
+          singleImmutableLinkedListFixture.last.elem,
         ]);
       });
     });

--- a/packages/container/libraries/core/src/common/models/SingleImmutableLinkedList.ts
+++ b/packages/container/libraries/core/src/common/models/SingleImmutableLinkedList.ts
@@ -1,20 +1,20 @@
-export interface SingleInmutableLinkedListNode<T> {
+export interface SingleImmutableLinkedListNode<T> {
   elem: T;
-  previous: SingleInmutableLinkedListNode<T> | undefined;
+  previous: SingleImmutableLinkedListNode<T> | undefined;
 }
 
-export class SingleInmutableLinkedList<T> implements Iterable<T> {
-  constructor(public readonly last: SingleInmutableLinkedListNode<T>) {}
+export class SingleImmutableLinkedList<T> implements Iterable<T> {
+  constructor(public readonly last: SingleImmutableLinkedListNode<T>) {}
 
-  public concat(elem: T): SingleInmutableLinkedList<T> {
-    return new SingleInmutableLinkedList({
+  public concat(elem: T): SingleImmutableLinkedList<T> {
+    return new SingleImmutableLinkedList({
       elem,
       previous: this.last,
     });
   }
 
   public [Symbol.iterator](): Iterator<T> {
-    let node: SingleInmutableLinkedListNode<T> | undefined = this.last;
+    let node: SingleImmutableLinkedListNode<T> | undefined = this.last;
 
     return {
       next: (): IteratorResult<T> => {

--- a/packages/container/libraries/core/src/planning/actions/addRootServiceNodeBindingIfContextFree.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/addRootServiceNodeBindingIfContextFree.spec.ts
@@ -18,7 +18,7 @@ import { Binding } from '../../binding/models/Binding';
 import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
 import { bindingScopeValues } from '../../binding/models/BindingScope';
 import { bindingTypeValues } from '../../binding/models/BindingType';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { PlanServiceNodeBindingAddedResult } from '../../metadata/models/PlanServiceNodeBindingAddedResult';
 import { buildPlanBindingConstraintsList } from '../calculations/buildPlanBindingConstraintsList';
 import { LazyPlanServiceNode } from '../models/LazyPlanServiceNode';
@@ -131,13 +131,13 @@ describe(addRootServiceNodeBindingIfContextFree, () => {
     });
 
     describe('when called', () => {
-      let buildPlanBindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let buildPlanBindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
       let planServiceNodeBindingAddedResultFixture: PlanServiceNodeBindingAddedResult;
 
       let result: unknown;
 
       beforeAll(() => {
-        buildPlanBindingConstraintsListFixture = new SingleInmutableLinkedList({
+        buildPlanBindingConstraintsListFixture = new SingleImmutableLinkedList({
           elem: Symbol() as unknown as InternalBindingConstraints,
           previous: undefined,
         });

--- a/packages/container/libraries/core/src/planning/actions/addRootServiceNodeBindingIfContextFree.ts
+++ b/packages/container/libraries/core/src/planning/actions/addRootServiceNodeBindingIfContextFree.ts
@@ -1,6 +1,6 @@
 import { Binding } from '../../binding/models/Binding';
 import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { PlanServiceNodeBindingAddedResult } from '../../metadata/models/PlanServiceNodeBindingAddedResult';
 import { buildPlanBindingConstraintsList } from '../calculations/buildPlanBindingConstraintsList';
 import { LazyPlanServiceNode } from '../models/LazyPlanServiceNode';
@@ -27,7 +27,7 @@ export function addRootServiceNodeBindingIfContextFree(
     };
   }
 
-  const bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints> =
+  const bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints> =
     buildPlanBindingConstraintsList(params);
 
   const chained: boolean =

--- a/packages/container/libraries/core/src/planning/actions/addServiceNodeBindingIfContextFree.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/addServiceNodeBindingIfContextFree.spec.ts
@@ -13,7 +13,7 @@ vitest.mock('./curryBuildServiceNodeBindings', () => {
   const buildServiceNodeBindingsMock: Mock<
     (
       params: BasePlanParams,
-      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
       serviceBindings: Binding<unknown>[],
       parentNode: BindingNodeParent,
       chainedBindings: boolean,
@@ -40,7 +40,7 @@ import {
 } from '../../binding/models/BindingConstraintsImplementation';
 import { bindingScopeValues } from '../../binding/models/BindingScope';
 import { bindingTypeValues } from '../../binding/models/BindingType';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { InversifyCoreError } from '../../error/models/InversifyCoreError';
 import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
 import { PlanServiceNodeBindingAddedResult } from '../../metadata/models/PlanServiceNodeBindingAddedResult';
@@ -74,7 +74,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
   let buildServiceNodeBindingsMock: Mock<
     (
       params: BasePlanParams,
-      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
       serviceBindings: Binding<unknown>[],
       parentNode: BindingNodeParent,
       chainedBindings: boolean,
@@ -106,7 +106,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
           Symbol() as unknown as BasePlanParams,
           lazyPlanServiceNodeFixture,
           Symbol() as unknown as Binding<unknown>,
-          Symbol() as unknown as SingleInmutableLinkedList<InternalBindingConstraints>,
+          Symbol() as unknown as SingleImmutableLinkedList<InternalBindingConstraints>,
           false,
         );
       });
@@ -130,7 +130,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
     let paramsFixture: BasePlanParams;
     let lazyPlanServiceNodeFixture: LazyPlanServiceNode;
     let bindingMock: Mocked<Binding<unknown>>;
-    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
     let chainedBindings: boolean;
 
     beforeAll(() => {
@@ -165,7 +165,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
       };
 
       bindingConstraintsListFixture =
-        new SingleInmutableLinkedList<InternalBindingConstraints>({
+        new SingleImmutableLinkedList<InternalBindingConstraints>({
           elem: {
             getAncestorsCalled: false,
             name: undefined,
@@ -280,7 +280,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
     let paramsFixture: BasePlanParams;
     let lazyPlanServiceNodeFixture: LazyPlanServiceNode;
     let bindingMock: Mocked<Binding<unknown>>;
-    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
     let chainedBindings: boolean;
 
     beforeAll(() => {
@@ -315,7 +315,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
       };
 
       bindingConstraintsListFixture =
-        new SingleInmutableLinkedList<InternalBindingConstraints>({
+        new SingleImmutableLinkedList<InternalBindingConstraints>({
           elem: {
             getAncestorsCalled: true,
             name: undefined,
@@ -372,7 +372,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
     let paramsFixture: BasePlanParams;
     let lazyPlanServiceNodeFixture: LazyPlanServiceNode;
     let bindingMock: Mocked<Binding<unknown>>;
-    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
     let chainedBindings: boolean;
 
     beforeAll(() => {
@@ -407,7 +407,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
       };
 
       bindingConstraintsListFixture =
-        new SingleInmutableLinkedList<InternalBindingConstraints>({
+        new SingleImmutableLinkedList<InternalBindingConstraints>({
           elem: {
             getAncestorsCalled: false,
             name: undefined,
@@ -483,7 +483,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
     let paramsFixture: BasePlanParams;
     let lazyPlanServiceNodeFixture: LazyPlanServiceNode;
     let bindingMock: Mocked<Binding<unknown>>;
-    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
     let chainedBindings: boolean;
 
     beforeAll(() => {
@@ -518,7 +518,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
       };
 
       bindingConstraintsListFixture =
-        new SingleInmutableLinkedList<InternalBindingConstraints>({
+        new SingleImmutableLinkedList<InternalBindingConstraints>({
           elem: {
             getAncestorsCalled: false,
             name: undefined,
@@ -594,7 +594,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
     let paramsFixture: BasePlanParams;
     let planServiceNodeFixture: PlanServiceNode;
     let bindingMock: Mocked<Binding<unknown>>;
-    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
     let chainedBindings: boolean;
 
     beforeAll(() => {
@@ -625,7 +625,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
       };
 
       bindingConstraintsListFixture =
-        new SingleInmutableLinkedList<InternalBindingConstraints>({
+        new SingleImmutableLinkedList<InternalBindingConstraints>({
           elem: {
             getAncestorsCalled: false,
             name: undefined,

--- a/packages/container/libraries/core/src/planning/actions/addServiceNodeBindingIfContextFree.ts
+++ b/packages/container/libraries/core/src/planning/actions/addServiceNodeBindingIfContextFree.ts
@@ -4,7 +4,7 @@ import {
   BindingConstraintsImplementation,
   InternalBindingConstraints,
 } from '../../binding/models/BindingConstraintsImplementation';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { InversifyCoreError } from '../../error/models/InversifyCoreError';
 import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
 import { ManagedClassElementMetadata } from '../../metadata/models/ManagedClassElementMetadata';
@@ -27,7 +27,7 @@ import {
 
 const subplan: (
   params: SubplanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
 ) => PlanBindingNode = currySubplan(
   buildPlanServiceNodeFromClassElementMetadata,
   buildPlanServiceNodeFromResolvedValueElementMetadata,
@@ -37,7 +37,7 @@ const subplan: (
 
 const buildServiceNodeBindings: (
   params: BasePlanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   serviceBindings: Binding<unknown>[],
   parentNode: BindingNodeParent,
   chainedBindings: boolean,
@@ -45,7 +45,7 @@ const buildServiceNodeBindings: (
 
 const lazyBuildPlanServiceNodeFromClassElementMetadata: (
   params: SubplanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   elementMetadata: ManagedClassElementMetadata,
 ) => PlanServiceNode | undefined =
   curryLazyBuildPlanServiceNodeFromClassElementMetadata(
@@ -54,7 +54,7 @@ const lazyBuildPlanServiceNodeFromClassElementMetadata: (
 
 const lazyBuildPlanServiceNodeFromResolvedValueElementMetadata: (
   params: SubplanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   elementMetadata: ResolvedValueElementMetadata,
 ) => PlanServiceNode | undefined =
   curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata(
@@ -63,7 +63,7 @@ const lazyBuildPlanServiceNodeFromResolvedValueElementMetadata: (
 
 function circularLazyBuildPlanServiceNodeFromClassElementMetadata(
   params: SubplanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   elementMetadata: ManagedClassElementMetadata,
 ): PlanServiceNode | undefined {
   return lazyBuildPlanServiceNodeFromClassElementMetadata(
@@ -75,7 +75,7 @@ function circularLazyBuildPlanServiceNodeFromClassElementMetadata(
 
 function circularLazyBuildPlanServiceNodeFromResolvedValueElementMetadata(
   params: SubplanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   elementMetadata: ResolvedValueElementMetadata,
 ): PlanServiceNode | undefined {
   return lazyBuildPlanServiceNodeFromResolvedValueElementMetadata(
@@ -98,7 +98,7 @@ export function addServiceNodeBindingIfContextFree(
   params: BasePlanParams,
   serviceNode: PlanServiceNode,
   binding: Binding<unknown>,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   chainedBindings: boolean,
 ): PlanServiceNodeBindingAddedResult {
   if (LazyPlanServiceNode.is(serviceNode) && !serviceNode.isExpanded()) {

--- a/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNode.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNode.spec.ts
@@ -17,7 +17,7 @@ import {
   BindingConstraintsImplementation,
   InternalBindingConstraints,
 } from '../../binding/models/BindingConstraintsImplementation';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { buildFilteredServiceBindings } from '../calculations/buildFilteredServiceBindings';
 import { buildPlanBindingConstraintsList } from '../calculations/buildPlanBindingConstraintsList';
 import { checkServiceNodeSingleInjectionBindings } from '../calculations/checkServiceNodeSingleInjectionBindings';
@@ -33,7 +33,7 @@ describe(curryBuildPlanServiceNode, () => {
   let buildServiceNodeBindingsMock: Mock<
     (
       params: BasePlanParams,
-      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
       serviceBindings: Binding<unknown>[],
       parentNode: BindingNodeParent,
       chainedBindings: boolean,
@@ -61,7 +61,7 @@ describe(curryBuildPlanServiceNode, () => {
     });
 
     describe('when called', () => {
-      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
       let bindingsFixture: Binding<unknown>[];
       let planBindingNodesFixture: PlanBindingNode[];
 
@@ -69,7 +69,7 @@ describe(curryBuildPlanServiceNode, () => {
 
       beforeAll(() => {
         bindingConstraintsListFixture =
-          new SingleInmutableLinkedList<InternalBindingConstraints>({
+          new SingleImmutableLinkedList<InternalBindingConstraints>({
             elem: Symbol() as unknown as InternalBindingConstraints,
             previous: undefined,
           });
@@ -163,7 +163,7 @@ describe(curryBuildPlanServiceNode, () => {
     });
 
     describe('when called', () => {
-      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
       let bindingsFixture: Binding<unknown>[];
       let planBindingNodeFixture: PlanBindingNode;
 
@@ -171,7 +171,7 @@ describe(curryBuildPlanServiceNode, () => {
 
       beforeAll(() => {
         bindingConstraintsListFixture =
-          new SingleInmutableLinkedList<InternalBindingConstraints>({
+          new SingleImmutableLinkedList<InternalBindingConstraints>({
             elem: Symbol() as unknown as InternalBindingConstraints,
             previous: undefined,
           });

--- a/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNode.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNode.ts
@@ -4,7 +4,7 @@ import {
   BindingConstraintsImplementation,
   InternalBindingConstraints,
 } from '../../binding/models/BindingConstraintsImplementation';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { buildFilteredServiceBindings } from '../calculations/buildFilteredServiceBindings';
 import { buildPlanBindingConstraintsList } from '../calculations/buildPlanBindingConstraintsList';
 import { checkServiceNodeSingleInjectionBindings } from '../calculations/checkServiceNodeSingleInjectionBindings';
@@ -17,14 +17,14 @@ import { PlanServiceNode } from '../models/PlanServiceNode';
 export function curryBuildPlanServiceNode(
   buildServiceNodeBindings: (
     params: BasePlanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     serviceBindings: Binding<unknown>[],
     parentNode: BindingNodeParent,
     chainedBindings: boolean,
   ) => PlanBindingNode[],
 ): (params: PlanParams) => PlanServiceNode {
   return (params: PlanParams): PlanServiceNode => {
-    const bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints> =
+    const bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints> =
       buildPlanBindingConstraintsList(params);
 
     const bindingConstraints: BindingConstraints =

--- a/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNodeFromClassElementMetadata.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNodeFromClassElementMetadata.spec.ts
@@ -19,9 +19,9 @@ import {
   InternalBindingConstraints,
 } from '../../binding/models/BindingConstraintsImplementation';
 import {
-  SingleInmutableLinkedList,
-  SingleInmutableLinkedListNode,
-} from '../../common/models/SingleInmutableLinkedList';
+  SingleImmutableLinkedList,
+  SingleImmutableLinkedListNode,
+} from '../../common/models/SingleImmutableLinkedList';
 import { MultipleInjectionManagedClassElementMetadataFixtures } from '../../metadata/fixtures/MultipleInjectionManagedClassElementMetadataFixtures';
 import { SingleInjectionManagedClassElementMetadataFixtures } from '../../metadata/fixtures/SingleInjectionManagedClassElementMetadataFixtures';
 import { MultipleInjectionManagedClassElementMetadata } from '../../metadata/models/MultipleInjectionManagedClassElementMetadata';
@@ -39,7 +39,7 @@ describe(curryBuildPlanServiceNodeFromClassElementMetadata, () => {
   let buildServiceNodeBindingsMock: Mock<
     (
       params: BasePlanParams,
-      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
       serviceBindings: Binding<unknown>[],
       parentNode: BindingNodeParent,
       chainedBindings: boolean,
@@ -52,12 +52,12 @@ describe(curryBuildPlanServiceNodeFromClassElementMetadata, () => {
 
   describe('having multiple injection class element metadata', () => {
     let paramsFixture: SubplanParams;
-    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
     let elementMetadataFixture: MultipleInjectionManagedClassElementMetadata;
 
     beforeAll(() => {
       paramsFixture = Symbol() as unknown as SubplanParams;
-      bindingConstraintsListFixture = new SingleInmutableLinkedList({
+      bindingConstraintsListFixture = new SingleImmutableLinkedList({
         elem: Symbol() as unknown as InternalBindingConstraints,
         previous: undefined,
       });
@@ -111,7 +111,7 @@ describe(curryBuildPlanServiceNodeFromClassElementMetadata, () => {
         expect(buildServiceNodeBindingsMock).toHaveBeenCalledTimes(1);
         expect(buildServiceNodeBindingsMock).toHaveBeenCalledWith(
           paramsFixture,
-          new SingleInmutableLinkedList({
+          new SingleImmutableLinkedList({
             elem: {
               getAncestorsCalled: false,
               name: elementMetadataFixture.name,
@@ -140,12 +140,12 @@ describe(curryBuildPlanServiceNodeFromClassElementMetadata, () => {
 
   describe('having single injection class element metadata', () => {
     let paramsFixture: SubplanParams;
-    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
     let elementMetadataFixture: SingleInjectionManagedClassElementMetadata;
 
     beforeAll(() => {
       paramsFixture = Symbol() as unknown as SubplanParams;
-      bindingConstraintsListFixture = new SingleInmutableLinkedList({
+      bindingConstraintsListFixture = new SingleImmutableLinkedList({
         elem: Symbol() as unknown as InternalBindingConstraints,
         previous: undefined,
       });
@@ -199,7 +199,7 @@ describe(curryBuildPlanServiceNodeFromClassElementMetadata, () => {
         expect(buildServiceNodeBindingsMock).toHaveBeenCalledTimes(1);
         expect(buildServiceNodeBindingsMock).toHaveBeenCalledWith(
           paramsFixture,
-          new SingleInmutableLinkedList({
+          new SingleImmutableLinkedList({
             elem: {
               getAncestorsCalled: false,
               name: elementMetadataFixture.name,
@@ -221,7 +221,7 @@ describe(curryBuildPlanServiceNodeFromClassElementMetadata, () => {
           serviceIdentifier: elementMetadataFixture.value as ServiceIdentifier,
         };
 
-        const expectedBindingConstraintsListNode: SingleInmutableLinkedListNode<InternalBindingConstraints> =
+        const expectedBindingConstraintsListNode: SingleImmutableLinkedListNode<InternalBindingConstraints> =
           {
             elem: {
               getAncestorsCalled: false,

--- a/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNodeFromClassElementMetadata.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNodeFromClassElementMetadata.ts
@@ -6,7 +6,7 @@ import {
   BindingConstraintsImplementation,
   InternalBindingConstraints,
 } from '../../binding/models/BindingConstraintsImplementation';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { ClassElementMetadataKind } from '../../metadata/models/ClassElementMetadataKind';
 import { ManagedClassElementMetadata } from '../../metadata/models/ManagedClassElementMetadata';
 import { buildFilteredServiceBindings } from '../calculations/buildFilteredServiceBindings';
@@ -21,25 +21,25 @@ import { SubplanParams } from '../models/SubplanParams';
 export function curryBuildPlanServiceNodeFromClassElementMetadata(
   buildServiceNodeBindings: (
     params: BasePlanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     serviceBindings: Binding<unknown>[],
     parentNode: BindingNodeParent,
     chainedBindings: boolean,
   ) => PlanBindingNode[],
 ): (
   params: SubplanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   elementMetadata: ManagedClassElementMetadata,
 ) => PlanServiceNode {
   return (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ManagedClassElementMetadata,
   ): PlanServiceNode => {
     const serviceIdentifier: ServiceIdentifier =
       getServiceFromMaybeLazyServiceIdentifier(elementMetadata.value);
 
-    const updatedBindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints> =
+    const updatedBindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints> =
       bindingConstraintsList.concat({
         getAncestorsCalled: false,
         name: elementMetadata.name,

--- a/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNodeFromResolvedValueElementMetadata.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNodeFromResolvedValueElementMetadata.spec.ts
@@ -19,9 +19,9 @@ import {
   InternalBindingConstraints,
 } from '../../binding/models/BindingConstraintsImplementation';
 import {
-  SingleInmutableLinkedList,
-  SingleInmutableLinkedListNode,
-} from '../../common/models/SingleInmutableLinkedList';
+  SingleImmutableLinkedList,
+  SingleImmutableLinkedListNode,
+} from '../../common/models/SingleImmutableLinkedList';
 import { MultipleInjectionResolvedValueElementMetadataFixtures } from '../../metadata/fixtures/MultipleInjectionResolvedValueElementMetadataFixtures';
 import { SingleInjectionResolvedValueElementMetadataFixtures } from '../../metadata/fixtures/SingleInjectionResolvedValueElementMetadataFixtures';
 import { MultipleInjectionResolvedValueElementMetadata } from '../../metadata/models/MultipleInjectionResolvedValueElementMetadata';
@@ -39,7 +39,7 @@ describe(curryBuildPlanServiceNodeFromResolvedValueElementMetadata, () => {
   let buildServiceNodeBindingsMock: Mock<
     (
       params: BasePlanParams,
-      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
       serviceBindings: Binding<unknown>[],
       parentNode: BindingNodeParent,
       chainedBindings: boolean,
@@ -52,12 +52,12 @@ describe(curryBuildPlanServiceNodeFromResolvedValueElementMetadata, () => {
 
   describe('having multiple injection class element metadata', () => {
     let paramsFixture: SubplanParams;
-    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
     let elementMetadataFixture: MultipleInjectionResolvedValueElementMetadata;
 
     beforeAll(() => {
       paramsFixture = Symbol() as unknown as SubplanParams;
-      bindingConstraintsListFixture = new SingleInmutableLinkedList({
+      bindingConstraintsListFixture = new SingleImmutableLinkedList({
         elem: Symbol() as unknown as InternalBindingConstraints,
         previous: undefined,
       });
@@ -111,7 +111,7 @@ describe(curryBuildPlanServiceNodeFromResolvedValueElementMetadata, () => {
         expect(buildServiceNodeBindingsMock).toHaveBeenCalledTimes(1);
         expect(buildServiceNodeBindingsMock).toHaveBeenCalledWith(
           paramsFixture,
-          new SingleInmutableLinkedList({
+          new SingleImmutableLinkedList({
             elem: {
               getAncestorsCalled: false,
               name: elementMetadataFixture.name,
@@ -140,12 +140,12 @@ describe(curryBuildPlanServiceNodeFromResolvedValueElementMetadata, () => {
 
   describe('having single injection class element metadata', () => {
     let paramsFixture: SubplanParams;
-    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
     let elementMetadataFixture: SingleInjectionResolvedValueElementMetadata;
 
     beforeAll(() => {
       paramsFixture = Symbol() as unknown as SubplanParams;
-      bindingConstraintsListFixture = new SingleInmutableLinkedList({
+      bindingConstraintsListFixture = new SingleImmutableLinkedList({
         elem: Symbol() as unknown as InternalBindingConstraints,
         previous: undefined,
       });
@@ -199,7 +199,7 @@ describe(curryBuildPlanServiceNodeFromResolvedValueElementMetadata, () => {
         expect(buildServiceNodeBindingsMock).toHaveBeenCalledTimes(1);
         expect(buildServiceNodeBindingsMock).toHaveBeenCalledWith(
           paramsFixture,
-          new SingleInmutableLinkedList({
+          new SingleImmutableLinkedList({
             elem: {
               getAncestorsCalled: false,
               name: elementMetadataFixture.name,
@@ -221,7 +221,7 @@ describe(curryBuildPlanServiceNodeFromResolvedValueElementMetadata, () => {
           serviceIdentifier: elementMetadataFixture.value as ServiceIdentifier,
         };
 
-        const expectedBindingConstraintsListNode: SingleInmutableLinkedListNode<InternalBindingConstraints> =
+        const expectedBindingConstraintsListNode: SingleImmutableLinkedListNode<InternalBindingConstraints> =
           {
             elem: {
               getAncestorsCalled: false,

--- a/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNodeFromResolvedValueElementMetadata.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNodeFromResolvedValueElementMetadata.ts
@@ -6,7 +6,7 @@ import {
   BindingConstraintsImplementation,
   InternalBindingConstraints,
 } from '../../binding/models/BindingConstraintsImplementation';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { ResolvedValueElementMetadata } from '../../metadata/models/ResolvedValueElementMetadata';
 import { ResolvedValueElementMetadataKind } from '../../metadata/models/ResolvedValueElementMetadataKind';
 import { buildFilteredServiceBindings } from '../calculations/buildFilteredServiceBindings';
@@ -21,25 +21,25 @@ import { SubplanParams } from '../models/SubplanParams';
 export function curryBuildPlanServiceNodeFromResolvedValueElementMetadata(
   buildServiceNodeBindings: (
     params: BasePlanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     serviceBindings: Binding<unknown>[],
     parentNode: BindingNodeParent,
     chainedBindings: boolean,
   ) => PlanBindingNode[],
 ): (
   params: SubplanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   elementMetadata: ResolvedValueElementMetadata,
 ) => PlanServiceNode {
   return (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ResolvedValueElementMetadata,
   ): PlanServiceNode => {
     const serviceIdentifier: ServiceIdentifier =
       getServiceFromMaybeLazyServiceIdentifier(elementMetadata.value);
 
-    const updatedBindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints> =
+    const updatedBindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints> =
       bindingConstraintsList.concat({
         getAncestorsCalled: false,
         name: elementMetadata.name,

--- a/packages/container/libraries/core/src/planning/actions/curryBuildServiceNodeBindings.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildServiceNodeBindings.spec.ts
@@ -23,7 +23,7 @@ import { bindingScopeValues } from '../../binding/models/BindingScope';
 import { InstanceBinding } from '../../binding/models/InstanceBinding';
 import { ResolvedValueBinding } from '../../binding/models/ResolvedValueBinding';
 import { ServiceRedirectionBinding } from '../../binding/models/ServiceRedirectionBinding';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { ClassMetadataFixtures } from '../../metadata/fixtures/ClassMetadataFixtures';
 import { ClassMetadata } from '../../metadata/models/ClassMetadata';
 import { buildFilteredServiceBindings } from '../calculations/buildFilteredServiceBindings';
@@ -38,7 +38,7 @@ describe(curryBuildServiceNodeBindings, () => {
   let subplanMock: Mock<
     (
       params: SubplanParams,
-      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     ) => PlanBindingNode
   >;
 
@@ -49,7 +49,7 @@ describe(curryBuildServiceNodeBindings, () => {
   describe('having serviceBindings with InstanceBinding and PlanServiceNode parent node', () => {
     let basePlanParamsMock: Mocked<BasePlanParams>;
     let instanceBindingFixture: InstanceBinding<unknown>;
-    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
     let parentNodeFixture: PlanServiceNode;
 
     beforeAll(() => {
@@ -66,7 +66,7 @@ describe(curryBuildServiceNodeBindings, () => {
       instanceBindingFixture = InstanceBindingFixtures.any;
 
       bindingConstraintsListFixture =
-        new SingleInmutableLinkedList<InternalBindingConstraints>({
+        new SingleImmutableLinkedList<InternalBindingConstraints>({
           elem: Symbol() as unknown as InternalBindingConstraints,
           previous: undefined,
         });
@@ -145,7 +145,7 @@ describe(curryBuildServiceNodeBindings, () => {
   describe('having serviceBindings with ResolvedValueBinding and PlanServiceNode parent node', () => {
     let basePlanParamsMock: Mocked<BasePlanParams>;
     let resolvedValueBindingFixture: ResolvedValueBinding<unknown>;
-    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
     let parentNodeFixture: PlanServiceNode;
 
     beforeAll(() => {
@@ -162,7 +162,7 @@ describe(curryBuildServiceNodeBindings, () => {
       resolvedValueBindingFixture = ResolvedValueBindingFixtures.any;
 
       bindingConstraintsListFixture =
-        new SingleInmutableLinkedList<InternalBindingConstraints>({
+        new SingleImmutableLinkedList<InternalBindingConstraints>({
           elem: Symbol() as unknown as InternalBindingConstraints,
           previous: undefined,
         });
@@ -224,7 +224,7 @@ describe(curryBuildServiceNodeBindings, () => {
   describe('having serviceBindings with ServiceRedirectionBinding and PlanServiceNode parent node', () => {
     let basePlanParamsMock: Mocked<BasePlanParams>;
     let serviceRedirectionBindingFixture: ServiceRedirectionBinding<unknown>;
-    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
     let parentNodeFixture: PlanServiceNode;
 
     beforeAll(() => {
@@ -241,7 +241,7 @@ describe(curryBuildServiceNodeBindings, () => {
       serviceRedirectionBindingFixture = ServiceRedirectionBindingFixtures.any;
 
       bindingConstraintsListFixture =
-        new SingleInmutableLinkedList<InternalBindingConstraints>({
+        new SingleImmutableLinkedList<InternalBindingConstraints>({
           elem: Symbol() as unknown as InternalBindingConstraints,
           previous: undefined,
         });

--- a/packages/container/libraries/core/src/planning/actions/curryBuildServiceNodeBindings.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildServiceNodeBindings.ts
@@ -10,7 +10,7 @@ import { bindingTypeValues } from '../../binding/models/BindingType';
 import { InstanceBinding } from '../../binding/models/InstanceBinding';
 import { ResolvedValueBinding } from '../../binding/models/ResolvedValueBinding';
 import { ServiceRedirectionBinding } from '../../binding/models/ServiceRedirectionBinding';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { ClassMetadata } from '../../metadata/models/ClassMetadata';
 import { buildFilteredServiceBindings } from '../calculations/buildFilteredServiceBindings';
 import { isPlanServiceRedirectionBindingNode } from '../calculations/isPlanServiceRedirectionBindingNode';
@@ -25,11 +25,11 @@ import { SubplanParams } from '../models/SubplanParams';
 export function curryBuildServiceNodeBindings(
   subplan: (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   ) => PlanBindingNode,
 ): (
   params: BasePlanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   serviceBindings: Binding<unknown>[],
   parentNode: BindingNodeParent,
   chainedBindings: boolean,
@@ -37,23 +37,23 @@ export function curryBuildServiceNodeBindings(
   const buildInstancePlanBindingNode: (
     params: BasePlanParams,
     binding: InstanceBinding<unknown>,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   ) => PlanBindingNode = curryBuildInstancePlanBindingNode(subplan);
   const buildResolvedValuePlanBindingNode: (
     params: BasePlanParams,
     binding: ResolvedValueBinding<unknown>,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   ) => PlanBindingNode = curryBuildResolvedValuePlanBindingNode(subplan);
 
   const buildServiceNodeBindings: (
     params: BasePlanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     serviceBindings: Binding<unknown>[],
     parentNode: BindingNodeParent,
     chainedBindings: boolean,
   ) => PlanBindingNode[] = (
     params: BasePlanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     serviceBindings: Binding<unknown>[],
     parentNode: BindingNodeParent,
     chainedBindings: boolean,
@@ -116,7 +116,7 @@ export function curryBuildServiceNodeBindings(
 
   const buildServiceRedirectionPlanBindingNode: (
     params: BasePlanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     binding: ServiceRedirectionBinding<unknown>,
     chainedBindings: boolean,
   ) => PlanBindingNode = curryBuildServiceRedirectionPlanBindingNode(
@@ -129,17 +129,17 @@ export function curryBuildServiceNodeBindings(
 function curryBuildInstancePlanBindingNode(
   subplan: (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   ) => PlanBindingNode,
 ): (
   params: BasePlanParams,
   binding: InstanceBinding<unknown>,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
 ) => PlanBindingNode {
   return (
     params: BasePlanParams,
     binding: InstanceBinding<unknown>,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   ): PlanBindingNode => {
     const classMetadata: ClassMetadata = params.operations.getClassMetadata(
       binding.implementationType,
@@ -166,17 +166,17 @@ function curryBuildInstancePlanBindingNode(
 function curryBuildResolvedValuePlanBindingNode(
   subplan: (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   ) => PlanBindingNode,
 ): (
   params: BasePlanParams,
   binding: ResolvedValueBinding<unknown>,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
 ) => PlanBindingNode {
   return (
     params: BasePlanParams,
     binding: ResolvedValueBinding<unknown>,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   ): PlanBindingNode => {
     const childNode: ResolvedValueBindingNode = {
       binding: binding,
@@ -197,20 +197,20 @@ function curryBuildResolvedValuePlanBindingNode(
 function curryBuildServiceRedirectionPlanBindingNode(
   buildServiceNodeBindings: (
     params: BasePlanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     serviceBindings: Binding<unknown>[],
     parentNode: BindingNodeParent,
     chainedBindings: boolean,
   ) => PlanBindingNode[],
 ): (
   params: BasePlanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   binding: ServiceRedirectionBinding<unknown>,
   chainedBindings: boolean,
 ) => PlanBindingNode {
   return (
     params: BasePlanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     binding: ServiceRedirectionBinding<unknown>,
     chainedBindings: boolean,
   ): PlanBindingNode => {

--- a/packages/container/libraries/core/src/planning/actions/curryLazyBuildPlanServiceNodeFromClassElementMetadata.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryLazyBuildPlanServiceNodeFromClassElementMetadata.spec.ts
@@ -12,7 +12,7 @@ vitest.mock('./curryBuildPlanServiceNodeFromClassElementMetadata');
 
 import { Binding } from '../../binding/models/Binding';
 import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { InversifyCoreError } from '../../error/models/InversifyCoreError';
 import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
 import { ClassElementMetadata } from '../../metadata/models/ClassElementMetadata';
@@ -29,7 +29,7 @@ describe(curryLazyBuildPlanServiceNodeFromClassElementMetadata, () => {
   let buildServiceNodeBindingsFixture: Mock<
     (
       params: BasePlanParams,
-      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
       serviceBindings: Binding<unknown>[],
       parentNode: BindingNodeParent,
       chainedBindings: boolean,
@@ -37,7 +37,7 @@ describe(curryLazyBuildPlanServiceNodeFromClassElementMetadata, () => {
   >;
 
   let paramsFixture: SubplanParams;
-  let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+  let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
   let elementMetadataFixture: ManagedClassElementMetadata;
 
   beforeAll(() => {
@@ -45,7 +45,7 @@ describe(curryLazyBuildPlanServiceNodeFromClassElementMetadata, () => {
 
     paramsFixture = Symbol() as unknown as SubplanParams;
     bindingConstraintsListFixture =
-      Symbol() as unknown as SingleInmutableLinkedList<InternalBindingConstraints>;
+      Symbol() as unknown as SingleImmutableLinkedList<InternalBindingConstraints>;
     elementMetadataFixture = Symbol() as unknown as ManagedClassElementMetadata;
   });
 
@@ -53,7 +53,7 @@ describe(curryLazyBuildPlanServiceNodeFromClassElementMetadata, () => {
     let buildPlanServiceNodeFromClassElementMetadataMock: Mock<
       (
         params: SubplanParams,
-        bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+        bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
         elementMetadata: ClassElementMetadata,
       ) => PlanServiceNode
     >;
@@ -100,7 +100,7 @@ describe(curryLazyBuildPlanServiceNodeFromClassElementMetadata, () => {
     let buildPlanServiceNodeFromClassElementMetadataMock: Mock<
       (
         params: SubplanParams,
-        bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+        bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
         elementMetadata: ClassElementMetadata,
       ) => PlanServiceNode
     >;
@@ -153,7 +153,7 @@ describe(curryLazyBuildPlanServiceNodeFromClassElementMetadata, () => {
     let buildPlanServiceNodeFromClassElementMetadataMock: Mock<
       (
         params: SubplanParams,
-        bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+        bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
         elementMetadata: ClassElementMetadata,
       ) => PlanServiceNode
     >;

--- a/packages/container/libraries/core/src/planning/actions/curryLazyBuildPlanServiceNodeFromClassElementMetadata.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryLazyBuildPlanServiceNodeFromClassElementMetadata.ts
@@ -1,6 +1,6 @@
 import { Binding } from '../../binding/models/Binding';
 import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { InversifyCoreError } from '../../error/models/InversifyCoreError';
 import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
 import { ManagedClassElementMetadata } from '../../metadata/models/ManagedClassElementMetadata';
@@ -14,19 +14,19 @@ import { curryBuildPlanServiceNodeFromClassElementMetadata } from './curryBuildP
 export function curryLazyBuildPlanServiceNodeFromClassElementMetadata(
   buildServiceNodeBindings: (
     params: BasePlanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     serviceBindings: Binding<unknown>[],
     parentNode: BindingNodeParent,
     chainedBindings: boolean,
   ) => PlanBindingNode[],
 ): (
   params: SubplanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   elementMetadata: ManagedClassElementMetadata,
 ) => PlanServiceNode | undefined {
   const buildPlanServiceNodeFromClassElementMetadata: (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ManagedClassElementMetadata,
   ) => PlanServiceNode = curryBuildPlanServiceNodeFromClassElementMetadata(
     buildServiceNodeBindings,
@@ -34,7 +34,7 @@ export function curryLazyBuildPlanServiceNodeFromClassElementMetadata(
 
   return (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ManagedClassElementMetadata,
   ): PlanServiceNode | undefined => {
     try {

--- a/packages/container/libraries/core/src/planning/actions/curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata.spec.ts
@@ -12,7 +12,7 @@ vitest.mock('./curryBuildPlanServiceNodeFromResolvedValueElementMetadata');
 
 import { Binding } from '../../binding/models/Binding';
 import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { InversifyCoreError } from '../../error/models/InversifyCoreError';
 import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
 import { ResolvedValueElementMetadata } from '../../metadata/models/ResolvedValueElementMetadata';
@@ -28,7 +28,7 @@ describe(curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata, () => {
   let buildServiceNodeBindingsFixture: Mock<
     (
       params: BasePlanParams,
-      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
       serviceBindings: Binding<unknown>[],
       parentNode: BindingNodeParent,
       chainedBindings: boolean,
@@ -36,7 +36,7 @@ describe(curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata, () => {
   >;
 
   let paramsFixture: SubplanParams;
-  let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+  let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
   let elementMetadataFixture: ResolvedValueElementMetadata;
 
   beforeAll(() => {
@@ -44,7 +44,7 @@ describe(curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata, () => {
 
     paramsFixture = Symbol() as unknown as SubplanParams;
     bindingConstraintsListFixture =
-      Symbol() as unknown as SingleInmutableLinkedList<InternalBindingConstraints>;
+      Symbol() as unknown as SingleImmutableLinkedList<InternalBindingConstraints>;
     elementMetadataFixture =
       Symbol() as unknown as ResolvedValueElementMetadata;
   });
@@ -53,7 +53,7 @@ describe(curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata, () => {
     let buildPlanServiceNodeFromResolvedValueElementMetadataMock: Mock<
       (
         params: SubplanParams,
-        bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+        bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
         elementMetadata: ResolvedValueElementMetadata,
       ) => PlanServiceNode
     >;
@@ -102,7 +102,7 @@ describe(curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata, () => {
     let buildPlanServiceNodeFromResolvedValueElementMetadataMock: Mock<
       (
         params: SubplanParams,
-        bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+        bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
         elementMetadata: ResolvedValueElementMetadata,
       ) => PlanServiceNode
     >;
@@ -157,7 +157,7 @@ describe(curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata, () => {
     let buildPlanServiceNodeFromResolvedValueElementMetadataMock: Mock<
       (
         params: SubplanParams,
-        bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+        bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
         elementMetadata: ResolvedValueElementMetadata,
       ) => PlanServiceNode
     >;

--- a/packages/container/libraries/core/src/planning/actions/curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata.ts
@@ -1,6 +1,6 @@
 import { Binding } from '../../binding/models/Binding';
 import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { InversifyCoreError } from '../../error/models/InversifyCoreError';
 import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
 import { ResolvedValueElementMetadata } from '../../metadata/models/ResolvedValueElementMetadata';
@@ -14,19 +14,19 @@ import { curryBuildPlanServiceNodeFromResolvedValueElementMetadata } from './cur
 export function curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata(
   buildServiceNodeBindings: (
     params: BasePlanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     serviceBindings: Binding<unknown>[],
     parentNode: BindingNodeParent,
     chainedBindings: boolean,
   ) => PlanBindingNode[],
 ): (
   params: SubplanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   elementMetadata: ResolvedValueElementMetadata,
 ) => PlanServiceNode | undefined {
   const buildPlanServiceNodeFromResolvedValueElementMetadata: (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ResolvedValueElementMetadata,
   ) => PlanServiceNode | undefined =
     curryBuildPlanServiceNodeFromResolvedValueElementMetadata(
@@ -35,7 +35,7 @@ export function curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata(
 
   return (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ResolvedValueElementMetadata,
   ): PlanServiceNode | undefined => {
     try {

--- a/packages/container/libraries/core/src/planning/actions/currySubplan.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/currySubplan.spec.ts
@@ -19,7 +19,7 @@ vitest.mock('./cacheNonRootPlanServiceNode');
 import { InstanceBindingFixtures } from '../../binding/fixtures/InstanceBindingFixtures';
 import { ResolvedValueBindingFixtures } from '../../binding/fixtures/ResolvedValueBindingFixtures';
 import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { ClassMetadataFixtures } from '../../metadata/fixtures/ClassMetadataFixtures';
 import { ManagedClassElementMetadata } from '../../metadata/models/ManagedClassElementMetadata';
 import { ResolvedValueElementMetadata } from '../../metadata/models/ResolvedValueElementMetadata';
@@ -40,28 +40,28 @@ describe(currySubplan, () => {
   let buildLazyPlanServiceNodeNodeFromClassElementMetadataMock: Mock<
     (
       params: SubplanParams,
-      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
       elementMetadata: ManagedClassElementMetadata,
     ) => PlanServiceNode
   >;
   let buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadataMock: Mock<
     (
       params: SubplanParams,
-      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
       elementMetadata: ResolvedValueElementMetadata,
     ) => PlanServiceNode
   >;
   let buildPlanServiceNodeFromClassElementMetadataMock: Mock<
     (
       params: SubplanParams,
-      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
       elementMetadata: ManagedClassElementMetadata,
     ) => PlanServiceNode | undefined
   >;
   let buildPlanServiceNodeFromResolvedValueElementMetadataMock: Mock<
     (
       params: SubplanParams,
-      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
       elementMetadata: ResolvedValueElementMetadata,
     ) => PlanServiceNode | undefined
   >;
@@ -98,13 +98,13 @@ describe(currySubplan, () => {
     });
 
     describe('when called, and tryBuildGetPlanOptionsFromManagedClassElementMetadata() returns undefined', () => {
-      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
 
       let result: unknown;
 
       beforeAll(() => {
         bindingConstraintsListFixture =
-          new SingleInmutableLinkedList<InternalBindingConstraints>({
+          new SingleImmutableLinkedList<InternalBindingConstraints>({
             elem: Symbol() as unknown as InternalBindingConstraints,
             previous: undefined,
           });
@@ -152,13 +152,13 @@ describe(currySubplan, () => {
     });
 
     describe('when called, and tryBuildGetPlanOptionsFromManagedClassElementMetadata() returns undefined', () => {
-      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
 
       let result: unknown;
 
       beforeAll(() => {
         bindingConstraintsListFixture =
-          new SingleInmutableLinkedList<InternalBindingConstraints>({
+          new SingleImmutableLinkedList<InternalBindingConstraints>({
             elem: Symbol() as unknown as InternalBindingConstraints,
             previous: undefined,
           });
@@ -223,14 +223,14 @@ describe(currySubplan, () => {
     });
 
     describe('when called, and tryBuildGetPlanOptionsFromManagedClassElementMetadata() returns GetPlanOptions and operations.getPlan() returns undefined', () => {
-      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
       let getPlanOptionsFixture: GetPlanOptions;
 
       let result: unknown;
 
       beforeAll(() => {
         bindingConstraintsListFixture =
-          new SingleInmutableLinkedList<InternalBindingConstraints>({
+          new SingleImmutableLinkedList<InternalBindingConstraints>({
             elem: Symbol() as unknown as InternalBindingConstraints,
             previous: undefined,
           });
@@ -304,7 +304,7 @@ describe(currySubplan, () => {
     });
 
     describe('when called, and tryBuildGetPlanOptionsFromManagedClassElementMetadata() returns GetPlanOptions and operations.getPlan() returns context free plan', () => {
-      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
       let getPlanOptionsFixture: GetPlanOptions;
       let planResultFixture: PlanResult;
 
@@ -312,7 +312,7 @@ describe(currySubplan, () => {
 
       beforeAll(() => {
         bindingConstraintsListFixture =
-          new SingleInmutableLinkedList<InternalBindingConstraints>({
+          new SingleImmutableLinkedList<InternalBindingConstraints>({
             elem: Symbol() as unknown as InternalBindingConstraints,
             previous: undefined,
           });
@@ -383,7 +383,7 @@ describe(currySubplan, () => {
     });
 
     describe('when called, and tryBuildGetPlanOptionsFromManagedClassElementMetadata() returns GetPlanOptions and operations.getPlan() returns non context free plan', () => {
-      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
       let getPlanOptionsFixture: GetPlanOptions;
       let planResultFixture: PlanResult;
 
@@ -391,7 +391,7 @@ describe(currySubplan, () => {
 
       beforeAll(() => {
         bindingConstraintsListFixture =
-          new SingleInmutableLinkedList<InternalBindingConstraints>({
+          new SingleImmutableLinkedList<InternalBindingConstraints>({
             elem: Symbol() as unknown as InternalBindingConstraints,
             previous: undefined,
           });
@@ -503,13 +503,13 @@ describe(currySubplan, () => {
     });
 
     describe('when called, and tryBuildGetPlanOptionsFromManagedClassElementMetadata() returns undefined', () => {
-      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
 
       let result: unknown;
 
       beforeAll(() => {
         bindingConstraintsListFixture =
-          new SingleInmutableLinkedList<InternalBindingConstraints>({
+          new SingleImmutableLinkedList<InternalBindingConstraints>({
             elem: Symbol() as unknown as InternalBindingConstraints,
             previous: undefined,
           });
@@ -582,14 +582,14 @@ describe(currySubplan, () => {
     });
 
     describe('when called, and tryBuildGetPlanOptionsFromManagedClassElementMetadata() returns GetPlanOptions and operations.getPlan() returns undefined', () => {
-      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
       let getPlanOptionsFixture: GetPlanOptions;
 
       let result: unknown;
 
       beforeAll(() => {
         bindingConstraintsListFixture =
-          new SingleInmutableLinkedList<InternalBindingConstraints>({
+          new SingleImmutableLinkedList<InternalBindingConstraints>({
             elem: Symbol() as unknown as InternalBindingConstraints,
             previous: undefined,
           });
@@ -671,7 +671,7 @@ describe(currySubplan, () => {
     });
 
     describe('when called, and tryBuildGetPlanOptionsFromManagedClassElementMetadata() returns GetPlanOptions and operations.getPlan() returns context free plan', () => {
-      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
       let getPlanOptionsFixture: GetPlanOptions;
       let planResultFixture: PlanResult;
 
@@ -679,7 +679,7 @@ describe(currySubplan, () => {
 
       beforeAll(() => {
         bindingConstraintsListFixture =
-          new SingleInmutableLinkedList<InternalBindingConstraints>({
+          new SingleImmutableLinkedList<InternalBindingConstraints>({
             elem: Symbol() as unknown as InternalBindingConstraints,
             previous: undefined,
           });
@@ -754,7 +754,7 @@ describe(currySubplan, () => {
     });
 
     describe('when called, and tryBuildGetPlanOptionsFromManagedClassElementMetadata() returns GetPlanOptions and operations.getPlan() returns non context free plan', () => {
-      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
       let getPlanOptionsFixture: GetPlanOptions;
       let planResultFixture: PlanResult;
 
@@ -762,7 +762,7 @@ describe(currySubplan, () => {
 
       beforeAll(() => {
         bindingConstraintsListFixture =
-          new SingleInmutableLinkedList<InternalBindingConstraints>({
+          new SingleImmutableLinkedList<InternalBindingConstraints>({
             elem: Symbol() as unknown as InternalBindingConstraints,
             previous: undefined,
           });
@@ -880,13 +880,13 @@ describe(currySubplan, () => {
     });
 
     describe('when called, and tryBuildGetPlanOptionsFromResolvedValueElementMetadata() returns undefined', () => {
-      let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
 
       let result: unknown;
 
       beforeAll(() => {
         bindingConstraintsListFixture =
-          new SingleInmutableLinkedList<InternalBindingConstraints>({
+          new SingleImmutableLinkedList<InternalBindingConstraints>({
             elem: Symbol() as unknown as InternalBindingConstraints,
             previous: undefined,
           });

--- a/packages/container/libraries/core/src/planning/actions/currySubplan.ts
+++ b/packages/container/libraries/core/src/planning/actions/currySubplan.ts
@@ -1,5 +1,5 @@
 import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { ClassElementMetadata } from '../../metadata/models/ClassElementMetadata';
 import { ClassElementMetadataKind } from '../../metadata/models/ClassElementMetadataKind';
 import { ClassMetadata } from '../../metadata/models/ClassMetadata';
@@ -25,20 +25,20 @@ class LazyManagedClassMetadataPlanServiceNode extends LazyPlanServiceNode {
   readonly #params: SubplanParams;
   readonly #buildLazyPlanServiceNodeNodeFromClassElementMetadata: (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ManagedClassElementMetadata,
   ) => PlanServiceNode;
-  readonly #bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>;
+  readonly #bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>;
   readonly #elementMetadata: ManagedClassElementMetadata;
 
   constructor(
     params: SubplanParams,
     buildLazyPlanServiceNodeNodeFromClassElementMetadata: (
       params: SubplanParams,
-      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
       elementMetadata: ManagedClassElementMetadata,
     ) => PlanServiceNode,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ManagedClassElementMetadata,
     serviceNode: PlanServiceNode | undefined,
   ) {
@@ -67,20 +67,20 @@ class LazyResolvedValueMetadataPlanServiceNode extends LazyPlanServiceNode {
   readonly #params: SubplanParams;
   readonly #buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadata: (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ResolvedValueElementMetadata,
   ) => PlanServiceNode;
-  readonly #bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>;
+  readonly #bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>;
   readonly #resolvedValueElementMetadata: ResolvedValueElementMetadata;
 
   constructor(
     params: SubplanParams,
     buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadata: (
       params: SubplanParams,
-      bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+      bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
       elementMetadata: ResolvedValueElementMetadata,
     ) => PlanServiceNode,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     resolvedValueElementMetadata: ResolvedValueElementMetadata,
     serviceNode: PlanServiceNode | undefined,
   ) {
@@ -110,32 +110,32 @@ class LazyResolvedValueMetadataPlanServiceNode extends LazyPlanServiceNode {
 export function currySubplan(
   buildLazyPlanServiceNodeNodeFromClassElementMetadata: (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ManagedClassElementMetadata,
   ) => PlanServiceNode,
   buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadata: (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ResolvedValueElementMetadata,
   ) => PlanServiceNode,
   buildPlanServiceNodeFromClassElementMetadata: (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ManagedClassElementMetadata,
   ) => PlanServiceNode | undefined,
   buildPlanServiceNodeFromResolvedValueElementMetadata: (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ResolvedValueElementMetadata,
   ) => PlanServiceNode | undefined,
 ): (
   params: SubplanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
 ) => PlanBindingNode {
   const subplanInstanceBindingNode: (
     params: SubplanParams,
     node: InstanceBindingNode,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   ) => PlanBindingNode = currySubplanInstanceBindingNode(
     buildLazyPlanServiceNodeNodeFromClassElementMetadata,
     buildPlanServiceNodeFromClassElementMetadata,
@@ -144,7 +144,7 @@ export function currySubplan(
   const subplanResolvedValueBindingNode: (
     params: SubplanParams,
     node: ResolvedValueBindingNode,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   ) => PlanBindingNode = currySubplanResolvedValueBindingNode(
     buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadata,
     buildPlanServiceNodeFromResolvedValueElementMetadata,
@@ -152,7 +152,7 @@ export function currySubplan(
 
   return (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   ): PlanBindingNode => {
     if (isInstanceBindingNode(params.node)) {
       return subplanInstanceBindingNode(
@@ -173,22 +173,22 @@ export function currySubplan(
 function currySubplanInstanceBindingNode(
   buildLazyPlanServiceNodeNodeFromClassElementMetadata: (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ManagedClassElementMetadata,
   ) => PlanServiceNode,
   buildPlanServiceNodeFromClassElementMetadata: (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ManagedClassElementMetadata,
   ) => PlanServiceNode | undefined,
 ): (
   params: SubplanParams,
   node: InstanceBindingNode,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
 ) => PlanBindingNode {
   const handlePlanServiceNodeBuildFromClassElementMetadata: (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ClassElementMetadata,
   ) => PlanServiceNode | undefined =
     curryHandlePlanServiceNodeBuildFromClassElementMetadata(
@@ -199,7 +199,7 @@ function currySubplanInstanceBindingNode(
   return (
     params: SubplanParams,
     node: InstanceBindingNode,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   ): PlanBindingNode => {
     const classMetadata: ClassMetadata = node.classMetadata;
 
@@ -235,22 +235,22 @@ function currySubplanInstanceBindingNode(
 function currySubplanResolvedValueBindingNode(
   buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadata: (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ResolvedValueElementMetadata,
   ) => PlanServiceNode,
   buildPlanServiceNodeFromResolvedValueElementMetadata: (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ResolvedValueElementMetadata,
   ) => PlanServiceNode | undefined,
 ): (
   params: SubplanParams,
   node: ResolvedValueBindingNode,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
 ) => PlanBindingNode {
   const handlePlanServiceNodeBuildFromResolvedValueElementMetadata: (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ResolvedValueElementMetadata,
   ) => PlanServiceNode =
     curryHandlePlanServiceNodeBuildFromResolvedValueElementMetadata(
@@ -261,7 +261,7 @@ function currySubplanResolvedValueBindingNode(
   return (
     params: SubplanParams,
     node: ResolvedValueBindingNode,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   ): PlanBindingNode => {
     const resolvedValueMetadata: ResolvedValueMetadata = node.binding.metadata;
 
@@ -284,22 +284,22 @@ function currySubplanResolvedValueBindingNode(
 function curryHandlePlanServiceNodeBuildFromClassElementMetadata(
   buildLazyPlanServiceNodeNodeFromClassElementMetadata: (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ManagedClassElementMetadata,
   ) => PlanServiceNode,
   buildPlanServiceNodeFromClassElementMetadata: (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ManagedClassElementMetadata,
   ) => PlanServiceNode | undefined,
 ): (
   params: SubplanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   elementMetadata: ClassElementMetadata,
 ) => PlanServiceNode | undefined {
   return (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ClassElementMetadata,
   ): PlanServiceNode | undefined => {
     if (elementMetadata.kind === ClassElementMetadataKind.unmanaged) {
@@ -354,22 +354,22 @@ function curryHandlePlanServiceNodeBuildFromClassElementMetadata(
 function curryHandlePlanServiceNodeBuildFromResolvedValueElementMetadata(
   buildLazyPlanServiceNodeNodeFromResolvedValueElementMetadata: (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ResolvedValueElementMetadata,
   ) => PlanServiceNode,
   buildPlanServiceNodeFromResolvedValueElementMetadata: (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ResolvedValueElementMetadata,
   ) => PlanServiceNode | undefined,
 ): (
   params: SubplanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   elementMetadata: ResolvedValueElementMetadata,
 ) => PlanServiceNode {
   return (
     params: SubplanParams,
-    bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+    bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     elementMetadata: ResolvedValueElementMetadata,
   ): PlanServiceNode => {
     const getPlanOptions: GetPlanOptions | undefined =

--- a/packages/container/libraries/core/src/planning/actions/plan.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/plan.spec.ts
@@ -23,7 +23,7 @@ vitest.mock('./curryBuildPlanServiceNode', () => {
 
 import { Binding } from '../../binding/models/Binding';
 import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { buildGetPlanOptionsFromPlanParams } from '../calculations/buildGetPlanOptionsFromPlanParams';
 import { BasePlanParams } from '../models/BasePlanParams';
 import { BindingNodeParent } from '../models/BindingNodeParent';
@@ -46,7 +46,7 @@ describe(plan, () => {
       curryBuildPlanServiceNode(
         Symbol() as unknown as (
           params: BasePlanParams,
-          bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+          bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
           serviceBindings: Binding<unknown>[],
           parentNode: BindingNodeParent,
           chainedBindings: boolean,

--- a/packages/container/libraries/core/src/planning/actions/plan.ts
+++ b/packages/container/libraries/core/src/planning/actions/plan.ts
@@ -1,6 +1,6 @@
 import { Binding } from '../../binding/models/Binding';
 import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { ManagedClassElementMetadata } from '../../metadata/models/ManagedClassElementMetadata';
 import { ResolvedValueElementMetadata } from '../../metadata/models/ResolvedValueElementMetadata';
 import { buildGetPlanOptionsFromPlanParams } from '../calculations/buildGetPlanOptionsFromPlanParams';
@@ -36,7 +36,7 @@ class LazyRootPlanServiceNode extends LazyPlanServiceNode {
 
 export const buildPlanServiceNodeFromClassElementMetadata: (
   params: SubplanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   elementMetadata: ManagedClassElementMetadata,
 ) => PlanServiceNode = curryBuildPlanServiceNodeFromClassElementMetadata(
   circularBuildServiceNodeBindings,
@@ -44,7 +44,7 @@ export const buildPlanServiceNodeFromClassElementMetadata: (
 
 export const buildPlanServiceNodeFromResolvedValueElementMetadata: (
   params: SubplanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   elementMetadata: ResolvedValueElementMetadata,
 ) => PlanServiceNode =
   curryBuildPlanServiceNodeFromResolvedValueElementMetadata(
@@ -53,7 +53,7 @@ export const buildPlanServiceNodeFromResolvedValueElementMetadata: (
 
 const subplan: (
   params: SubplanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
 ) => PlanBindingNode = currySubplan(
   buildPlanServiceNodeFromClassElementMetadata,
   buildPlanServiceNodeFromResolvedValueElementMetadata,
@@ -63,7 +63,7 @@ const subplan: (
 
 const buildServiceNodeBindings: (
   params: BasePlanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   serviceBindings: Binding<unknown>[],
   parentNode: BindingNodeParent,
   chainedBindings: boolean,
@@ -71,7 +71,7 @@ const buildServiceNodeBindings: (
 
 function circularBuildServiceNodeBindings(
   params: BasePlanParams,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   serviceBindings: Binding<unknown>[],
   parentNode: BindingNodeParent,
   chainedBindings: boolean,

--- a/packages/container/libraries/core/src/planning/actions/removeRootServiceNodeBindingIfContextFree.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/removeRootServiceNodeBindingIfContextFree.spec.ts
@@ -18,7 +18,7 @@ import { Binding } from '../../binding/models/Binding';
 import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
 import { bindingScopeValues } from '../../binding/models/BindingScope';
 import { bindingTypeValues } from '../../binding/models/BindingType';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { PlanServiceNodeBindingRemovedResult } from '../../metadata/models/PlanServiceNodeBindingRemovedResult';
 import { buildPlanBindingConstraintsList } from '../calculations/buildPlanBindingConstraintsList';
 import { LazyPlanServiceNode } from '../models/LazyPlanServiceNode';
@@ -131,13 +131,13 @@ describe(removeRootServiceNodeBindingIfContextFree, () => {
     });
 
     describe('when called', () => {
-      let buildPlanBindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+      let buildPlanBindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
       let planServiceNodeBindingRemovedResultFixture: PlanServiceNodeBindingRemovedResult;
 
       let result: unknown;
 
       beforeAll(() => {
-        buildPlanBindingConstraintsListFixture = new SingleInmutableLinkedList({
+        buildPlanBindingConstraintsListFixture = new SingleImmutableLinkedList({
           elem: Symbol() as unknown as InternalBindingConstraints,
           previous: undefined,
         });

--- a/packages/container/libraries/core/src/planning/actions/removeRootServiceNodeBindingIfContextFree.ts
+++ b/packages/container/libraries/core/src/planning/actions/removeRootServiceNodeBindingIfContextFree.ts
@@ -1,6 +1,6 @@
 import { Binding } from '../../binding/models/Binding';
 import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { PlanServiceNodeBindingRemovedResult } from '../../metadata/models/PlanServiceNodeBindingRemovedResult';
 import { buildPlanBindingConstraintsList } from '../calculations/buildPlanBindingConstraintsList';
 import { LazyPlanServiceNode } from '../models/LazyPlanServiceNode';
@@ -27,7 +27,7 @@ export function removeRootServiceNodeBindingIfContextFree(
     };
   }
 
-  const bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints> =
+  const bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints> =
     buildPlanBindingConstraintsList(params);
 
   return removeServiceNodeBindingIfContextFree(

--- a/packages/container/libraries/core/src/planning/actions/removeServiceNodeBindingIfContextFree.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/removeServiceNodeBindingIfContextFree.spec.ts
@@ -18,7 +18,7 @@ import {
 } from '../../binding/models/BindingConstraintsImplementation';
 import { bindingScopeValues } from '../../binding/models/BindingScope';
 import { bindingTypeValues } from '../../binding/models/BindingType';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { InversifyCoreError } from '../../error/models/InversifyCoreError';
 import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
 import { PlanServiceNodeBindingRemovedResult } from '../../metadata/models/PlanServiceNodeBindingRemovedResult';
@@ -64,7 +64,7 @@ describe(removeServiceNodeBindingIfContextFree, () => {
         result = removeServiceNodeBindingIfContextFree(
           lazyPlanServiceNodeFixture,
           Symbol() as unknown as Binding<unknown>,
-          Symbol() as unknown as SingleInmutableLinkedList<InternalBindingConstraints>,
+          Symbol() as unknown as SingleImmutableLinkedList<InternalBindingConstraints>,
           false,
         );
       });
@@ -88,7 +88,7 @@ describe(removeServiceNodeBindingIfContextFree, () => {
     let serviceIdentifierFixture: ServiceIdentifier;
     let bindingMock: Mocked<Binding<unknown>>;
     let planBindingNodeFixture: PlanBindingNode;
-    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
     let optionalBindings: boolean;
 
     beforeAll(() => {
@@ -115,7 +115,7 @@ describe(removeServiceNodeBindingIfContextFree, () => {
       } as PlanBindingNode;
 
       bindingConstraintsListFixture =
-        new SingleInmutableLinkedList<InternalBindingConstraints>({
+        new SingleImmutableLinkedList<InternalBindingConstraints>({
           elem: {
             getAncestorsCalled: false,
             name: undefined,
@@ -242,7 +242,7 @@ describe(removeServiceNodeBindingIfContextFree, () => {
   describe('having an expanded lazy service node with an array of bindings and bindingConstraintsList with elems with getAncestorsCalled true', () => {
     let lazyPlanServiceNodeFixture: LazyPlanServiceNode;
     let bindingMock: Mocked<Binding<unknown>>;
-    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
     let optionalBindings: boolean;
 
     beforeAll(() => {
@@ -275,7 +275,7 @@ describe(removeServiceNodeBindingIfContextFree, () => {
       };
 
       bindingConstraintsListFixture =
-        new SingleInmutableLinkedList<InternalBindingConstraints>({
+        new SingleImmutableLinkedList<InternalBindingConstraints>({
           elem: {
             getAncestorsCalled: true,
             name: undefined,
@@ -331,7 +331,7 @@ describe(removeServiceNodeBindingIfContextFree, () => {
     let serviceIdentifierFixture: ServiceIdentifier;
     let bindingMock: Mocked<Binding<unknown>>;
     let planBindingNodeFixture: PlanBindingNode;
-    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
     let optionalBindings: boolean;
 
     beforeAll(() => {
@@ -358,7 +358,7 @@ describe(removeServiceNodeBindingIfContextFree, () => {
       } as PlanBindingNode;
 
       bindingConstraintsListFixture =
-        new SingleInmutableLinkedList<InternalBindingConstraints>({
+        new SingleImmutableLinkedList<InternalBindingConstraints>({
           elem: {
             getAncestorsCalled: false,
             name: undefined,
@@ -430,7 +430,7 @@ describe(removeServiceNodeBindingIfContextFree, () => {
     let serviceIdentifierFixture: ServiceIdentifier;
     let bindingMock: Mocked<Binding<unknown>>;
     let planBindingNodeFixture: PlanBindingNode;
-    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
     let optionalBindings: boolean;
 
     beforeAll(() => {
@@ -457,7 +457,7 @@ describe(removeServiceNodeBindingIfContextFree, () => {
       } as PlanBindingNode;
 
       bindingConstraintsListFixture =
-        new SingleInmutableLinkedList<InternalBindingConstraints>({
+        new SingleImmutableLinkedList<InternalBindingConstraints>({
           elem: {
             getAncestorsCalled: false,
             name: undefined,
@@ -527,7 +527,7 @@ describe(removeServiceNodeBindingIfContextFree, () => {
     let serviceIdentifierFixture: ServiceIdentifier;
     let bindingMock: Mocked<Binding<unknown>>;
     let planBindingNodeFixture: PlanBindingNode;
-    let bindingConstraintsListFixture: SingleInmutableLinkedList<InternalBindingConstraints>;
+    let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
     let optionalBindings: boolean;
 
     beforeAll(() => {
@@ -554,7 +554,7 @@ describe(removeServiceNodeBindingIfContextFree, () => {
       } as PlanBindingNode;
 
       bindingConstraintsListFixture =
-        new SingleInmutableLinkedList<InternalBindingConstraints>({
+        new SingleImmutableLinkedList<InternalBindingConstraints>({
           elem: {
             getAncestorsCalled: false,
             name: undefined,

--- a/packages/container/libraries/core/src/planning/actions/removeServiceNodeBindingIfContextFree.ts
+++ b/packages/container/libraries/core/src/planning/actions/removeServiceNodeBindingIfContextFree.ts
@@ -4,7 +4,7 @@ import {
   BindingConstraintsImplementation,
   InternalBindingConstraints,
 } from '../../binding/models/BindingConstraintsImplementation';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { InversifyCoreError } from '../../error/models/InversifyCoreError';
 import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
 import { PlanServiceNodeBindingRemovedResult } from '../../metadata/models/PlanServiceNodeBindingRemovedResult';
@@ -23,7 +23,7 @@ import { PlanServiceNode } from '../models/PlanServiceNode';
 export function removeServiceNodeBindingIfContextFree(
   serviceNode: PlanServiceNode,
   binding: Binding<unknown>,
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>,
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   optionalBindings: boolean,
 ): PlanServiceNodeBindingRemovedResult {
   if (LazyPlanServiceNode.is(serviceNode) && !serviceNode.isExpanded()) {

--- a/packages/container/libraries/core/src/planning/calculations/buildPlanBindingConstraintsList.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildPlanBindingConstraintsList.spec.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 
 import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { PlanParams } from '../models/PlanParams';
 import { PlanParamsTagConstraint } from '../models/PlanParamsTagConstraint';
 import { buildPlanBindingConstraintsList } from './buildPlanBindingConstraintsList';
@@ -30,7 +30,7 @@ describe(buildPlanBindingConstraintsList, () => {
 
       it('should return expected value', () => {
         const expected: Partial<
-          SingleInmutableLinkedList<InternalBindingConstraints>
+          SingleImmutableLinkedList<InternalBindingConstraints>
         > = {
           last: {
             elem: {
@@ -76,7 +76,7 @@ describe(buildPlanBindingConstraintsList, () => {
 
       it('should return expected value', () => {
         const expected: Partial<
-          SingleInmutableLinkedList<InternalBindingConstraints>
+          SingleImmutableLinkedList<InternalBindingConstraints>
         > = {
           last: {
             elem: {

--- a/packages/container/libraries/core/src/planning/calculations/buildPlanBindingConstraintsList.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildPlanBindingConstraintsList.ts
@@ -1,18 +1,18 @@
 import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { MetadataTag } from '../../metadata/models/MetadataTag';
 import { PlanParams } from '../models/PlanParams';
 
 export function buildPlanBindingConstraintsList(
   params: PlanParams,
-): SingleInmutableLinkedList<InternalBindingConstraints> {
+): SingleImmutableLinkedList<InternalBindingConstraints> {
   const tags: Map<MetadataTag, unknown> = new Map();
 
   if (params.rootConstraints.tag !== undefined) {
     tags.set(params.rootConstraints.tag.key, params.rootConstraints.tag.value);
   }
 
-  return new SingleInmutableLinkedList({
+  return new SingleImmutableLinkedList({
     elem: {
       getAncestorsCalled: false,
       name: params.rootConstraints.name,

--- a/packages/container/libraries/core/src/planning/calculations/checkPlanServiceRedirectionBindingNodeSingleInjectionBindings.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/checkPlanServiceRedirectionBindingNodeSingleInjectionBindings.spec.ts
@@ -7,7 +7,7 @@ import { InternalBindingConstraints } from '../../binding/models/BindingConstrai
 import { bindingScopeValues } from '../../binding/models/BindingScope';
 import { bindingTypeValues } from '../../binding/models/BindingType';
 import { ServiceRedirectionBinding } from '../../binding/models/ServiceRedirectionBinding';
-import { SingleInmutableLinkedListNode } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedListNode } from '../../common/models/SingleImmutableLinkedList';
 import { MetadataTag } from '../../metadata/models/MetadataTag';
 import { PlanServiceRedirectionBindingNode } from '../models/PlanServiceRedirectionBindingNode';
 import { checkPlanServiceRedirectionBindingNodeSingleInjectionBindings } from './checkPlanServiceRedirectionBindingNodeSingleInjectionBindings';
@@ -18,7 +18,7 @@ describe(checkPlanServiceRedirectionBindingNodeSingleInjectionBindings, () => {
   describe('having a PlanServiceRedirectionBindingNode with no redirections', () => {
     let planServiceRedirectionBindingNodeFixture: PlanServiceRedirectionBindingNode;
     let isOptionalFixture: boolean;
-    let internalBindingConstraintsNodeFixture: SingleInmutableLinkedListNode<InternalBindingConstraints>;
+    let internalBindingConstraintsNodeFixture: SingleImmutableLinkedListNode<InternalBindingConstraints>;
 
     beforeAll(() => {
       planServiceRedirectionBindingNodeFixture = {
@@ -80,7 +80,7 @@ describe(checkPlanServiceRedirectionBindingNodeSingleInjectionBindings, () => {
   describe('having a PlanServiceRedirectionBindingNode with a single redirection to a leaf node', () => {
     let planServiceRedirectionBindingNodeFixture: PlanServiceRedirectionBindingNode;
     let isOptionalFixture: boolean;
-    let internalBindingConstraintsNodeFixture: SingleInmutableLinkedListNode<InternalBindingConstraints>;
+    let internalBindingConstraintsNodeFixture: SingleImmutableLinkedListNode<InternalBindingConstraints>;
 
     beforeAll(() => {
       planServiceRedirectionBindingNodeFixture = {
@@ -157,7 +157,7 @@ describe(checkPlanServiceRedirectionBindingNodeSingleInjectionBindings, () => {
     let planServiceRedirectionBindingNodeRedirectionFixture: PlanServiceRedirectionBindingNode;
     let planServiceRedirectionBindingNodeFixture: PlanServiceRedirectionBindingNode;
     let isOptionalFixture: boolean;
-    let internalBindingConstraintsNodeFixture: SingleInmutableLinkedListNode<InternalBindingConstraints>;
+    let internalBindingConstraintsNodeFixture: SingleImmutableLinkedListNode<InternalBindingConstraints>;
 
     beforeAll(() => {
       planServiceRedirectionBindingNodeRedirectionFixture = {

--- a/packages/container/libraries/core/src/planning/calculations/checkPlanServiceRedirectionBindingNodeSingleInjectionBindings.ts
+++ b/packages/container/libraries/core/src/planning/calculations/checkPlanServiceRedirectionBindingNodeSingleInjectionBindings.ts
@@ -1,7 +1,7 @@
 import { ServiceIdentifier } from '@inversifyjs/common';
 
 import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
-import { SingleInmutableLinkedListNode } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedListNode } from '../../common/models/SingleImmutableLinkedList';
 import { PlanBindingNode } from '../models/PlanBindingNode';
 import { PlanServiceRedirectionBindingNode } from '../models/PlanServiceRedirectionBindingNode';
 import { isPlanServiceRedirectionBindingNode } from './isPlanServiceRedirectionBindingNode';
@@ -12,7 +12,7 @@ const SINGLE_INJECTION_BINDINGS: number = 1;
 export function checkPlanServiceRedirectionBindingNodeSingleInjectionBindings(
   serviceRedirectionBindingNode: PlanServiceRedirectionBindingNode,
   isOptional: boolean,
-  bindingConstraintNode: SingleInmutableLinkedListNode<InternalBindingConstraints>,
+  bindingConstraintNode: SingleImmutableLinkedListNode<InternalBindingConstraints>,
   serviceRedirections: readonly ServiceIdentifier[],
 ): void {
   if (

--- a/packages/container/libraries/core/src/planning/calculations/checkServiceNodeSingleInjectionBindings.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/checkServiceNodeSingleInjectionBindings.spec.ts
@@ -7,7 +7,7 @@ vitest.mock('./throwErrorWhenUnexpectedBindingsAmountFound');
 import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
 import { bindingTypeValues } from '../../binding/models/BindingType';
 import { ServiceRedirectionBinding } from '../../binding/models/ServiceRedirectionBinding';
-import { SingleInmutableLinkedListNode } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedListNode } from '../../common/models/SingleImmutableLinkedList';
 import { MetadataTag } from '../../metadata/models/MetadataTag';
 import { PlanBindingNode } from '../models/PlanBindingNode';
 import { PlanServiceNode } from '../models/PlanServiceNode';
@@ -20,7 +20,7 @@ describe(checkServiceNodeSingleInjectionBindings, () => {
   describe('having a PlanServiceNode with no bindings', () => {
     let nodeFixture: PlanServiceNode;
     let isOptionalFixture: boolean;
-    let internalBindingConstraintsNodeFixture: SingleInmutableLinkedListNode<InternalBindingConstraints>;
+    let internalBindingConstraintsNodeFixture: SingleImmutableLinkedListNode<InternalBindingConstraints>;
 
     beforeAll(() => {
       nodeFixture = {
@@ -82,7 +82,7 @@ describe(checkServiceNodeSingleInjectionBindings, () => {
     let nodeFixtureBinding: PlanBindingNode;
     let nodeFixture: PlanServiceNode;
     let isOptionalFixture: boolean;
-    let internalBindingConstraintsNodeFixture: SingleInmutableLinkedListNode<InternalBindingConstraints>;
+    let internalBindingConstraintsNodeFixture: SingleImmutableLinkedListNode<InternalBindingConstraints>;
 
     beforeAll(() => {
       nodeFixtureBinding = {

--- a/packages/container/libraries/core/src/planning/calculations/checkServiceNodeSingleInjectionBindings.ts
+++ b/packages/container/libraries/core/src/planning/calculations/checkServiceNodeSingleInjectionBindings.ts
@@ -1,5 +1,5 @@
 import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
-import { SingleInmutableLinkedListNode } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedListNode } from '../../common/models/SingleImmutableLinkedList';
 import { PlanBindingNode } from '../models/PlanBindingNode';
 import { PlanServiceNode } from '../models/PlanServiceNode';
 import { checkPlanServiceRedirectionBindingNodeSingleInjectionBindings } from './checkPlanServiceRedirectionBindingNodeSingleInjectionBindings';
@@ -11,7 +11,7 @@ const SINGLE_INJECTION_BINDINGS: number = 1;
 export function checkServiceNodeSingleInjectionBindings(
   serviceNode: PlanServiceNode,
   isOptional: boolean,
-  bindingConstraintNode: SingleInmutableLinkedListNode<InternalBindingConstraints>,
+  bindingConstraintNode: SingleImmutableLinkedListNode<InternalBindingConstraints>,
 ): void {
   if (Array.isArray(serviceNode.bindings)) {
     if (serviceNode.bindings.length === SINGLE_INJECTION_BINDINGS) {

--- a/packages/container/libraries/core/src/planning/calculations/throwErrorWhenUnexpectedBindingsAmountFound.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/throwErrorWhenUnexpectedBindingsAmountFound.spec.ts
@@ -10,7 +10,7 @@ import { stringifyBinding } from '../../binding/calculations/stringifyBinding';
 import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
 import { bindingScopeValues } from '../../binding/models/BindingScope';
 import { bindingTypeValues } from '../../binding/models/BindingType';
-import { SingleInmutableLinkedListNode } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedListNode } from '../../common/models/SingleImmutableLinkedList';
 import { InversifyCoreError } from '../../error/models/InversifyCoreError';
 import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
 import { MetadataTag } from '../../metadata/models/MetadataTag';
@@ -21,7 +21,7 @@ describe(throwErrorWhenUnexpectedBindingsAmountFound, () => {
   describe('having undefined bindings and isOptional false', () => {
     let bindingsFixture: undefined;
     let isOptionalFixture: false;
-    let bindingConstraintsNodeFixture: SingleInmutableLinkedListNode<InternalBindingConstraints>;
+    let bindingConstraintsNodeFixture: SingleImmutableLinkedListNode<InternalBindingConstraints>;
 
     beforeAll(() => {
       bindingsFixture = undefined;
@@ -96,7 +96,7 @@ Binding constraints:
   describe('having bindings empty array and isOptional false', () => {
     let bindingsFixture: [];
     let isOptionalFixture: false;
-    let bindingConstraintsNodeFixture: SingleInmutableLinkedListNode<InternalBindingConstraints>;
+    let bindingConstraintsNodeFixture: SingleImmutableLinkedListNode<InternalBindingConstraints>;
 
     beforeAll(() => {
       bindingsFixture = [];
@@ -181,7 +181,7 @@ Binding constraints:
   describe('having bindings empty array and isOptional true', () => {
     let bindingsFixture: [];
     let isOptionalFixture: true;
-    let bindingConstraintsNodeFixture: SingleInmutableLinkedListNode<InternalBindingConstraints>;
+    let bindingConstraintsNodeFixture: SingleImmutableLinkedListNode<InternalBindingConstraints>;
 
     beforeAll(() => {
       bindingsFixture = [];
@@ -225,7 +225,7 @@ Binding constraints:
   describe('having multiple bindings', () => {
     let bindingsFixture: PlanBindingNode[];
     let isOptionalFixture: boolean;
-    let bindingConstraintsNodeFixture: SingleInmutableLinkedListNode<InternalBindingConstraints>;
+    let bindingConstraintsNodeFixture: SingleImmutableLinkedListNode<InternalBindingConstraints>;
 
     beforeAll(() => {
       bindingsFixture = [

--- a/packages/container/libraries/core/src/planning/calculations/throwErrorWhenUnexpectedBindingsAmountFound.ts
+++ b/packages/container/libraries/core/src/planning/calculations/throwErrorWhenUnexpectedBindingsAmountFound.ts
@@ -5,7 +5,7 @@ import {
 
 import { stringifyBinding } from '../../binding/calculations/stringifyBinding';
 import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
-import { SingleInmutableLinkedListNode } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedListNode } from '../../common/models/SingleImmutableLinkedList';
 import { InversifyCoreError } from '../../error/models/InversifyCoreError';
 import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKind';
 import { MetadataTag } from '../../metadata/models/MetadataTag';
@@ -14,7 +14,7 @@ import { PlanBindingNode } from '../models/PlanBindingNode';
 export function throwErrorWhenUnexpectedBindingsAmountFound(
   bindingNodes: PlanBindingNode[] | PlanBindingNode | undefined,
   isOptional: boolean,
-  bindingConstraintNode: SingleInmutableLinkedListNode<InternalBindingConstraints>,
+  bindingConstraintNode: SingleImmutableLinkedListNode<InternalBindingConstraints>,
   serviceRedirections: readonly ServiceIdentifier[],
 ): void {
   const serviceIdentifier: ServiceIdentifier =

--- a/packages/container/libraries/core/src/planning/models/NonCachedServiceNodeContext.ts
+++ b/packages/container/libraries/core/src/planning/models/NonCachedServiceNodeContext.ts
@@ -1,8 +1,8 @@
 import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 
 export interface NonCachedServiceNodeContext {
-  bindingConstraintsList: SingleInmutableLinkedList<InternalBindingConstraints>;
+  bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>;
   chainedBindings: boolean;
   optionalBindings: boolean;
 }

--- a/packages/container/libraries/core/src/planning/services/PlanResultCacheService.spec.ts
+++ b/packages/container/libraries/core/src/planning/services/PlanResultCacheService.spec.ts
@@ -16,7 +16,7 @@ import { Binding } from '../../binding/models/Binding';
 import { InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation';
 import { bindingScopeValues } from '../../binding/models/BindingScope';
 import { bindingTypeValues } from '../../binding/models/BindingType';
-import { SingleInmutableLinkedList } from '../../common/models/SingleInmutableLinkedList';
+import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList';
 import { ClassElementMetadataKind } from '../../metadata/models/ClassElementMetadataKind';
 import { PlanServiceNodeBindingAddedResult } from '../../metadata/models/PlanServiceNodeBindingAddedResult';
 import { ResolvedValueElementMetadataKind } from '../../metadata/models/ResolvedValueElementMetadataKind';
@@ -1537,7 +1537,7 @@ describe(PlanResultCacheService, () => {
                 childLazyPlanServiceNodeFixture,
                 {
                   bindingConstraintsList:
-                    Symbol() as unknown as SingleInmutableLinkedList<InternalBindingConstraints>,
+                    Symbol() as unknown as SingleImmutableLinkedList<InternalBindingConstraints>,
                   chainedBindings: false,
                   optionalBindings: false,
                 },
@@ -1764,7 +1764,7 @@ describe(PlanResultCacheService, () => {
                 childLazyPlanServiceNodeFixture,
                 {
                   bindingConstraintsList:
-                    Symbol() as unknown as SingleInmutableLinkedList<InternalBindingConstraints>,
+                    Symbol() as unknown as SingleImmutableLinkedList<InternalBindingConstraints>,
                   chainedBindings: false,
                   optionalBindings: false,
                 },
@@ -1996,7 +1996,7 @@ describe(PlanResultCacheService, () => {
                 childLazyPlanServiceNodeFixture,
                 {
                   bindingConstraintsList:
-                    Symbol() as unknown as SingleInmutableLinkedList<InternalBindingConstraints>,
+                    Symbol() as unknown as SingleImmutableLinkedList<InternalBindingConstraints>,
                   chainedBindings: false,
                   optionalBindings: false,
                 },
@@ -2091,7 +2091,7 @@ describe(PlanResultCacheService, () => {
 
           nonCachedServiceNodeContextFixture = {
             bindingConstraintsList:
-              Symbol() as unknown as SingleInmutableLinkedList<InternalBindingConstraints>,
+              Symbol() as unknown as SingleImmutableLinkedList<InternalBindingConstraints>,
             chainedBindings: false,
             optionalBindings: false,
           };
@@ -2188,7 +2188,7 @@ describe(PlanResultCacheService, () => {
 
           nonCachedServiceNodeContextFixture = {
             bindingConstraintsList:
-              Symbol() as unknown as SingleInmutableLinkedList<InternalBindingConstraints>,
+              Symbol() as unknown as SingleImmutableLinkedList<InternalBindingConstraints>,
             chainedBindings: false,
             optionalBindings: false,
           };


### PR DESCRIPTION
### Changed
- Renamed `SingleInmutableList` internal data structure to `SingleImmutableList`.