### PR TITLE
refactor(http-core): refactor HttpResponse to let Exception use

### DIFF
--- a/packages/http/libraries/core/src/error/models/InversifyHttpAdapterErrorKind.ts
+++ b/packages/http/libraries/core/src/error/models/InversifyHttpAdapterErrorKind.ts
@@ -1,6 +1,5 @@
 export enum InversifyHttpAdapterErrorKind {
   invalidOperationAfterBuild,
   noControllerFound,
-  pipeError,
   requestParamIncorrectUse,
 }

--- a/packages/http/libraries/core/src/http/pipe/model/Pipe.ts
+++ b/packages/http/libraries/core/src/http/pipe/model/Pipe.ts
@@ -1,7 +1,5 @@
-import { HttpResponse } from '../../responses/HttpResponse';
 import { PipeMetadata } from './PipeMetadata';
 
 export interface Pipe<TInput = unknown, TOutput = unknown> {
   execute(input: TInput, metadata: PipeMetadata): Promise<TOutput> | TOutput;
-  getHttpResponse?(): HttpResponse;
 }

--- a/packages/http/libraries/core/src/http/responses/HttpResponse.ts
+++ b/packages/http/libraries/core/src/http/responses/HttpResponse.ts
@@ -2,25 +2,7 @@ import { Stream } from 'node:stream';
 
 import { HttpStatusCode } from './HttpStatusCode';
 
-const isHttpResponseSymbol: unique symbol = Symbol.for(
-  '@inversifyjs/http-core/HttpResponse',
-);
-
-export class HttpResponse {
-  public [isHttpResponseSymbol]: true;
-
-  constructor(
-    public readonly statusCode: HttpStatusCode,
-    public body?: object | string | number | boolean | Stream,
-  ) {
-    this[isHttpResponseSymbol] = true;
-  }
-
-  public static is(value: unknown): value is HttpResponse {
-    return (
-      typeof value === 'object' &&
-      value !== null &&
-      (value as Record<string | symbol, unknown>)[isHttpResponseSymbol] === true
-    );
-  }
+export interface HttpResponse {
+  statusCode: HttpStatusCode;
+  body?: object | string | number | boolean | Stream | undefined;
 }

--- a/packages/http/libraries/core/src/http/responses/error/ErrorHttpResponse.ts
+++ b/packages/http/libraries/core/src/http/responses/error/ErrorHttpResponse.ts
@@ -1,4 +1,4 @@
-import { Stream } from 'stream';
+import { Stream } from 'node:stream';
 
 import { HttpResponse } from '../HttpResponse';
 import { HttpStatusCode } from '../HttpStatusCode';

--- a/packages/http/libraries/core/src/http/responses/error/ErrorHttpResponse.ts
+++ b/packages/http/libraries/core/src/http/responses/error/ErrorHttpResponse.ts
@@ -16,7 +16,7 @@ export class ErrorHttpResponse extends Error implements HttpResponse {
     error: string,
     message?: string,
   ) {
-    super();
+    super(message);
 
     this.body = { error, message, statusCode };
     this[isErrorHttpResponseSymbol] = true;

--- a/packages/http/libraries/core/src/http/responses/error/ErrorHttpResponse.ts
+++ b/packages/http/libraries/core/src/http/responses/error/ErrorHttpResponse.ts
@@ -1,8 +1,33 @@
+import { Stream } from 'stream';
+
 import { HttpResponse } from '../HttpResponse';
 import { HttpStatusCode } from '../HttpStatusCode';
 
-export class ErrorHttpResponse extends HttpResponse {
-  constructor(statusCode: HttpStatusCode, error: string, message?: string) {
-    super(statusCode, { error, message, statusCode });
+const isErrorHttpResponseSymbol: unique symbol = Symbol.for(
+  '@inversifyjs/http-core/ErrorHttpResponse',
+);
+
+export class ErrorHttpResponse extends Error implements HttpResponse {
+  public readonly [isErrorHttpResponseSymbol]: true;
+  public readonly body?: object | string | number | boolean | Stream;
+
+  constructor(
+    public readonly statusCode: HttpStatusCode,
+    error: string,
+    message?: string,
+  ) {
+    super();
+
+    this.body = { error, message, statusCode };
+    this[isErrorHttpResponseSymbol] = true;
+  }
+
+  public static is(value: unknown): value is ErrorHttpResponse {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      (value as Record<string | symbol, unknown>)[isErrorHttpResponseSymbol] ===
+        true
+    );
   }
 }

--- a/packages/http/libraries/core/src/http/responses/success/AcceptedHttpResponse.ts
+++ b/packages/http/libraries/core/src/http/responses/success/AcceptedHttpResponse.ts
@@ -1,7 +1,7 @@
-import { HttpResponse } from '../HttpResponse';
 import { HttpStatusCode } from '../HttpStatusCode';
+import { SuccessHttpResponse } from './SuccessHttpResponse';
 
-export class AcceptedHttpResponse extends HttpResponse {
+export class AcceptedHttpResponse extends SuccessHttpResponse {
   constructor(body?: object | string | number | boolean) {
     super(HttpStatusCode.ACCEPTED, body);
   }

--- a/packages/http/libraries/core/src/http/responses/success/AlreadyReportedHttpResponse.ts
+++ b/packages/http/libraries/core/src/http/responses/success/AlreadyReportedHttpResponse.ts
@@ -1,7 +1,7 @@
-import { HttpResponse } from '../HttpResponse';
 import { HttpStatusCode } from '../HttpStatusCode';
+import { SuccessHttpResponse } from './SuccessHttpResponse';
 
-export class AlreadyReportedHttpResponse extends HttpResponse {
+export class AlreadyReportedHttpResponse extends SuccessHttpResponse {
   constructor(body?: object | string | number | boolean) {
     super(HttpStatusCode.ALREADY_REPORTED, body);
   }

--- a/packages/http/libraries/core/src/http/responses/success/ContentDifferentHttpResponse.ts
+++ b/packages/http/libraries/core/src/http/responses/success/ContentDifferentHttpResponse.ts
@@ -1,7 +1,7 @@
-import { HttpResponse } from '../HttpResponse';
 import { HttpStatusCode } from '../HttpStatusCode';
+import { SuccessHttpResponse } from './SuccessHttpResponse';
 
-export class ContentDifferentHttpResponse extends HttpResponse {
+export class ContentDifferentHttpResponse extends SuccessHttpResponse {
   constructor(body?: object | string | number | boolean) {
     super(HttpStatusCode.CONTENT_DIFFERENT, body);
   }

--- a/packages/http/libraries/core/src/http/responses/success/CreatedHttpResponse.ts
+++ b/packages/http/libraries/core/src/http/responses/success/CreatedHttpResponse.ts
@@ -1,7 +1,7 @@
-import { HttpResponse } from '../HttpResponse';
 import { HttpStatusCode } from '../HttpStatusCode';
+import { SuccessHttpResponse } from './SuccessHttpResponse';
 
-export class CreatedHttpResponse extends HttpResponse {
+export class CreatedHttpResponse extends SuccessHttpResponse {
   constructor(body?: object | string | number | boolean) {
     super(HttpStatusCode.CREATED, body);
   }

--- a/packages/http/libraries/core/src/http/responses/success/MultiStatusHttpResponse.ts
+++ b/packages/http/libraries/core/src/http/responses/success/MultiStatusHttpResponse.ts
@@ -1,7 +1,7 @@
-import { HttpResponse } from '../HttpResponse';
 import { HttpStatusCode } from '../HttpStatusCode';
+import { SuccessHttpResponse } from './SuccessHttpResponse';
 
-export class MultiStatusHttpResponse extends HttpResponse {
+export class MultiStatusHttpResponse extends SuccessHttpResponse {
   constructor(body?: object | string | number | boolean) {
     super(HttpStatusCode.MULTI_STATUS, body);
   }

--- a/packages/http/libraries/core/src/http/responses/success/NoContentHttpResponse.ts
+++ b/packages/http/libraries/core/src/http/responses/success/NoContentHttpResponse.ts
@@ -1,7 +1,7 @@
-import { HttpResponse } from '../HttpResponse';
 import { HttpStatusCode } from '../HttpStatusCode';
+import { SuccessHttpResponse } from './SuccessHttpResponse';
 
-export class NoContentHttpResponse extends HttpResponse {
+export class NoContentHttpResponse extends SuccessHttpResponse {
   constructor() {
     super(HttpStatusCode.NO_CONTENT);
   }

--- a/packages/http/libraries/core/src/http/responses/success/NonAuthoritativeInformationHttpResponse.ts
+++ b/packages/http/libraries/core/src/http/responses/success/NonAuthoritativeInformationHttpResponse.ts
@@ -1,7 +1,7 @@
-import { HttpResponse } from '../HttpResponse';
 import { HttpStatusCode } from '../HttpStatusCode';
+import { SuccessHttpResponse } from './SuccessHttpResponse';
 
-export class NonAuthoritativeInformationHttpResponse extends HttpResponse {
+export class NonAuthoritativeInformationHttpResponse extends SuccessHttpResponse {
   constructor(body?: object | string | number | boolean) {
     super(HttpStatusCode.NON_AUTHORITATIVE_INFORMATION, body);
   }

--- a/packages/http/libraries/core/src/http/responses/success/OkHttpResponse.ts
+++ b/packages/http/libraries/core/src/http/responses/success/OkHttpResponse.ts
@@ -1,7 +1,7 @@
-import { HttpResponse } from '../HttpResponse';
 import { HttpStatusCode } from '../HttpStatusCode';
+import { SuccessHttpResponse } from './SuccessHttpResponse';
 
-export class OkHttpResponse extends HttpResponse {
+export class OkHttpResponse extends SuccessHttpResponse {
   constructor(body?: object | string | number | boolean) {
     super(HttpStatusCode.OK, body);
   }

--- a/packages/http/libraries/core/src/http/responses/success/PartialContentHttpResponse.ts
+++ b/packages/http/libraries/core/src/http/responses/success/PartialContentHttpResponse.ts
@@ -1,7 +1,7 @@
-import { HttpResponse } from '../HttpResponse';
 import { HttpStatusCode } from '../HttpStatusCode';
+import { SuccessHttpResponse } from './SuccessHttpResponse';
 
-export class PartialContentHttpResponse extends HttpResponse {
+export class PartialContentHttpResponse extends SuccessHttpResponse {
   constructor(body?: object | string | number | boolean) {
     super(HttpStatusCode.PARTIAL_CONTENT, body);
   }

--- a/packages/http/libraries/core/src/http/responses/success/ResetContentHttpResponse.ts
+++ b/packages/http/libraries/core/src/http/responses/success/ResetContentHttpResponse.ts
@@ -1,7 +1,7 @@
-import { HttpResponse } from '../HttpResponse';
 import { HttpStatusCode } from '../HttpStatusCode';
+import { SuccessHttpResponse } from './SuccessHttpResponse';
 
-export class ResetContentHttpResponse extends HttpResponse {
+export class ResetContentHttpResponse extends SuccessHttpResponse {
   constructor(body?: object | string | number | boolean) {
     super(HttpStatusCode.RESET_CONTENT, body);
   }

--- a/packages/http/libraries/core/src/http/responses/success/SuccessHttpResponse.ts
+++ b/packages/http/libraries/core/src/http/responses/success/SuccessHttpResponse.ts
@@ -1,4 +1,4 @@
-import { Stream } from 'stream';
+import { Stream } from 'node:stream';
 
 import { HttpResponse } from '../HttpResponse';
 import { HttpStatusCode } from '../HttpStatusCode';

--- a/packages/http/libraries/core/src/http/responses/success/SuccessHttpResponse.ts
+++ b/packages/http/libraries/core/src/http/responses/success/SuccessHttpResponse.ts
@@ -1,0 +1,29 @@
+import { Stream } from 'stream';
+
+import { HttpResponse } from '../HttpResponse';
+import { HttpStatusCode } from '../HttpStatusCode';
+
+const isSuccessHttpResponseSymbol: unique symbol = Symbol.for(
+  '@inversifyjs/http-core/SuccessHttpResponse',
+);
+
+export class SuccessHttpResponse implements HttpResponse {
+  public [isSuccessHttpResponseSymbol]: true;
+
+  constructor(
+    public readonly statusCode: HttpStatusCode,
+    public readonly body?: object | string | number | boolean | Stream,
+  ) {
+    this[isSuccessHttpResponseSymbol] = true;
+  }
+
+  public static is(value: unknown): value is SuccessHttpResponse {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      (value as Record<string | symbol, unknown>)[
+        isSuccessHttpResponseSymbol
+      ] === true
+    );
+  }
+}


### PR DESCRIPTION
### Changed
- Refactored HttpResponse in order to use abtractions with Error
- Refactored InversifyHttpAdapter to use ErrorHttpAdapter
- Refactored success HttpReponses to use SuccessHttpResponse

### Added
- Added SuccessHttpResponse
- Added ErrorHttpResponse

### Motivation
We are changing approach of api errors to get a clear form
