### PR TITLE
Remove Guard.getHttpResponse in favor of handling ErrorHttpResponse errors

### DIFF
--- a/packages/docs/services/inversify-http-site/docs/api/_category_.json
+++ b/packages/docs/services/inversify-http-site/docs/api/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "API",
-  "position": 2
+  "position": 3
 }

--- a/packages/docs/services/inversify-http-site/docs/api/decorators.mdx
+++ b/packages/docs/services/inversify-http-site/docs/api/decorators.mdx
@@ -27,7 +27,7 @@ This section covers Inversify HTTP decorators used to provide related metadata.
 
 Inversify HTTP decorators can be used to manage the lifecycle of HTTP requests, including middleware execution, request handling, and response generation. This allows for more modular and maintainable code.
 
-## ApplyMiddleware
+### ApplyMiddleware
 
 Attaches middleware to a controller class (applies to all its routes) or to a specific route method.
 
@@ -59,6 +59,24 @@ Notes
 #### Example: apply middleware to a single route
 
 <CodeBlock language="ts">{decoratorApiApplyMiddlewareRouteSource}</CodeBlock>
+
+### UseGuard
+
+Attaches one or more guards to a controller class or method. All guards must allow for the request to continue.
+
+```ts
+UseGuard(...guardList: Newable<Guard>[]): ClassDecorator & MethodDecorator
+```
+
+Parameters
+
+- guardList: One or more guard classes implementing `Guard<TRequest>`.
+
+Notes
+
+- Scope: Place on the controller class to affect all routes, or on a method to affect only that route.
+- Guard return values: `activate()` may return `true` (continue), `false` (reply with `403 Forbidden`), or a custom `HttpResponse` (replied as-is, e.g., `new ForbiddenHttpResponse('message')`).
+
 
 ## HTTP Request message abstraction
 

--- a/packages/docs/services/inversify-http-site/docs/api/decorators.mdx
+++ b/packages/docs/services/inversify-http-site/docs/api/decorators.mdx
@@ -62,7 +62,7 @@ Notes
 
 ### UseGuard
 
-Attaches one or more guards to a controller class or method. All guards must allow for the request to continue.
+Attaches one or more [guards](../../fundamentals/guard) to a controller class or method. All guards must allow for the request to continue.
 
 ```ts
 UseGuard(...guardList: Newable<Guard>[]): ClassDecorator & MethodDecorator
@@ -75,7 +75,7 @@ Parameters
 Notes
 
 - Scope: Place on the controller class to affect all routes, or on a method to affect only that route.
-- Guard return values: `activate()` may return `true` (continue), `false` (reply with `403 Forbidden`), or a custom `HttpResponse` (replied as-is, e.g., `new ForbiddenHttpResponse('message')`).
+- Guard return values: `activate()` may return `true` (continue), `false` (reply with `403 Forbidden`), or throw an `ErrorHttpResponse` (replied as-is, e.g., `throw new ForbiddenHttpResponse('message')`).
 
 
 ## HTTP Request message abstraction

--- a/packages/docs/services/inversify-http-site/docs/fundamentals/_category_.json
+++ b/packages/docs/services/inversify-http-site/docs/fundamentals/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Fundamentals",
-  "position": 3
+  "position": 2
 }

--- a/packages/docs/services/inversify-http-site/docs/fundamentals/guard.mdx
+++ b/packages/docs/services/inversify-http-site/docs/fundamentals/guard.mdx
@@ -16,12 +16,12 @@ import TabItem from '@theme/TabItem';
 
 # Guard
 
-Guards decide whether a request can continue. They run before middleware and handlers. If a guard returns `false`, the request is short-circuited with a `403 Forbidden` by default. A guard can also return an `HttpResponse` (for example `ForbiddenHttpResponse`), which will be sent as-is.
+Guards decide whether a request can continue. They run before middleware and handlers. If a guard returns `false`, the request is short-circuited with a `403 Forbidden` by default. A guard can also throw an `ErrorHttpResponse` (for example `ForbiddenHttpResponse`), which will be sent as-is.
 
 Key points
 
-- Implement the `Guard<TRequest>` interface: `activate(request) => boolean | HttpResponse | Promise<boolean | HttpResponse>`
-- Returning `true` calls the next guard/handler; returning `false` replies with `403 Forbidden` by default; returning an `HttpResponse` replies with that response
+- Implement the `Guard<TRequest>` interface: `activate(request) => boolean | Promise<boolean>` and optionally throw an `ErrorHttpResponse` to short-circuit
+- Returning `true` calls the next guard/handler; returning `false` replies with `403 Forbidden` by default; throwing an `ErrorHttpResponse` replies with that response
 - Attach guards with `UseGuard(GuardClass)` at class or method level
 
 ## Adapter-specific examples
@@ -43,9 +43,9 @@ Each adapter has its own request type. Below is a minimal “allow” guard for 
 	</TabItem>
 </Tabs>
 
-### Deny with a custom response
+### Deny with a custom error response
 
-Below are minimal “deny” guards that return a `ForbiddenHttpResponse` directly.
+Below are minimal “deny” guards that throw a `ForbiddenHttpResponse` directly.
 
 <Tabs>
 	<TabItem value="express4-deny" label="Express 4">

--- a/packages/docs/services/inversify-http-site/docs/fundamentals/guard.mdx
+++ b/packages/docs/services/inversify-http-site/docs/fundamentals/guard.mdx
@@ -1,0 +1,67 @@
+---
+sidebar_position: 1
+title: Guard
+---
+import guardApiExpressSource from '@inversifyjs/http-code-examples/generated/examples/v0/guardApiExpressAllow.ts.txt';
+import guardApiExpress4Source from '@inversifyjs/http-code-examples/generated/examples/v0/guardApiExpress4Allow.ts.txt';
+import guardApiFastifySource from '@inversifyjs/http-code-examples/generated/examples/v0/guardApiFastifyAllow.ts.txt';
+import guardApiHonoSource from '@inversifyjs/http-code-examples/generated/examples/v0/guardApiHonoAllow.ts.txt';
+import guardApiExpressDenySource from '@inversifyjs/http-code-examples/generated/examples/v0/guardApiExpressDeny.ts.txt';
+import guardApiExpress4DenySource from '@inversifyjs/http-code-examples/generated/examples/v0/guardApiExpress4Deny.ts.txt';
+import guardApiFastifyDenySource from '@inversifyjs/http-code-examples/generated/examples/v0/guardApiFastifyDeny.ts.txt';
+import guardApiHonoDenySource from '@inversifyjs/http-code-examples/generated/examples/v0/guardApiHonoDeny.ts.txt';
+import CodeBlock from '@theme/CodeBlock';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Guard
+
+Guards decide whether a request can continue. They run before middleware and handlers. If a guard returns `false`, the request is short-circuited with a `403 Forbidden` by default. A guard can also return an `HttpResponse` (for example `ForbiddenHttpResponse`), which will be sent as-is.
+
+Key points
+
+- Implement the `Guard<TRequest>` interface: `activate(request) => boolean | HttpResponse | Promise<boolean | HttpResponse>`
+- Returning `true` calls the next guard/handler; returning `false` replies with `403 Forbidden` by default; returning an `HttpResponse` replies with that response
+- Attach guards with `UseGuard(GuardClass)` at class or method level
+
+## Adapter-specific examples
+
+Each adapter has its own request type. Below is a minimal “allow” guard for each adapter.
+
+<Tabs>
+	<TabItem value="express4" label="Express 4">
+		<CodeBlock language="ts">{guardApiExpress4Source}</CodeBlock>
+	</TabItem>
+	<TabItem value="express5" label="Express 5">
+		<CodeBlock language="ts">{guardApiExpressSource}</CodeBlock>
+	</TabItem>
+	<TabItem value="fastify" label="Fastify">
+		<CodeBlock language="ts">{guardApiFastifySource}</CodeBlock>
+	</TabItem>
+	<TabItem value="hono" label="Hono">
+		<CodeBlock language="ts">{guardApiHonoSource}</CodeBlock>
+	</TabItem>
+</Tabs>
+
+### Deny with a custom response
+
+Below are minimal “deny” guards that return a `ForbiddenHttpResponse` directly.
+
+<Tabs>
+	<TabItem value="express4-deny" label="Express 4">
+		<CodeBlock language="ts">{guardApiExpress4DenySource}</CodeBlock>
+	</TabItem>
+	<TabItem value="express5-deny" label="Express 5">
+		<CodeBlock language="ts">{guardApiExpressDenySource}</CodeBlock>
+	</TabItem>
+	<TabItem value="fastify-deny" label="Fastify">
+		<CodeBlock language="ts">{guardApiFastifyDenySource}</CodeBlock>
+	</TabItem>
+	<TabItem value="hono-deny" label="Hono">
+		<CodeBlock language="ts">{guardApiHonoDenySource}</CodeBlock>
+	</TabItem>
+</Tabs>
+
+## Attaching guard
+
+Use [UseGuard](../../api/decorators#useguard) decorator at the controller (applies to all routes) or method level (applies to one route).

--- a/packages/docs/services/inversify-http-site/docs/fundamentals/middleware.mdx
+++ b/packages/docs/services/inversify-http-site/docs/fundamentals/middleware.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 2
 title: Middleware
 ---
 import middlewareApiExpressSource from '@inversifyjs/http-code-examples/generated/examples/v0/middlewareApiExpressSetHeader.ts.txt';

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiExpress4Allow.int.spec.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiExpress4Allow.int.spec.ts
@@ -1,0 +1,43 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { Controller, Get, UseGuard } from '@inversifyjs/http-core';
+import { Container } from 'inversify';
+
+import { buildExpress4Server } from '../../server/adapter/express4/actions/buildExpress4Server';
+import { Server } from '../../server/models/Server';
+import { Express4AllowGuard } from './guardApiExpress4Allow';
+
+describe('Guard API (Express 4)', () => {
+  let server: Server;
+
+  beforeAll(async () => {
+    @Controller('/ping')
+    class PingController {
+      @UseGuard(Express4AllowGuard)
+      @Get()
+      public async get(): Promise<string> {
+        return 'pong';
+      }
+    }
+
+    const container: Container = new Container();
+    container.bind(Express4AllowGuard).toSelf().inSingletonScope();
+    container.bind(PingController).toSelf().inSingletonScope();
+
+    server = await buildExpress4Server(container);
+  });
+
+  afterAll(async () => {
+    await server.shutdown();
+  });
+
+  it('should allow request and return pong', async () => {
+    const response: Response = await fetch(
+      `http://${server.host}:${server.port.toString()}/ping`,
+    );
+    const body: string = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toBe('pong');
+  });
+});

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiExpress4Allow.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiExpress4Allow.ts
@@ -1,0 +1,10 @@
+import { Guard } from '@inversifyjs/http-core';
+import { Request } from 'express4';
+
+// Begin-example
+export class Express4AllowGuard implements Guard<Request> {
+  public async activate(_request: Request): Promise<boolean> {
+    return true;
+  }
+}
+// End-example

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiExpress4Deny.int.spec.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiExpress4Deny.int.spec.ts
@@ -1,0 +1,47 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { Controller, Get, UseGuard } from '@inversifyjs/http-core';
+import { Container } from 'inversify';
+
+import { buildExpress4Server } from '../../server/adapter/express4/actions/buildExpress4Server';
+import { Server } from '../../server/models/Server';
+import { Express4DenyGuard } from './guardApiExpress4Deny';
+
+describe('Guard API deny (Express 4)', () => {
+  let server: Server;
+
+  beforeAll(async () => {
+    @Controller('/ping')
+    class PingController {
+      @UseGuard(Express4DenyGuard)
+      @Get()
+      public async get(): Promise<string> {
+        return 'pong';
+      }
+    }
+
+    const container: Container = new Container();
+    container.bind(Express4DenyGuard).toSelf().inSingletonScope();
+    container.bind(PingController).toSelf().inSingletonScope();
+
+    server = await buildExpress4Server(container);
+  });
+
+  afterAll(async () => {
+    await server.shutdown();
+  });
+
+  it('should block request with 403 Forbidden', async () => {
+    const response: Response = await fetch(
+      `http://${server.host}:${server.port.toString()}/ping`,
+    );
+    const body: unknown = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body).toMatchObject({
+      error: 'Forbidden',
+      message: 'Missing or invalid credentials',
+      statusCode: 403,
+    });
+  });
+});

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiExpress4Deny.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiExpress4Deny.ts
@@ -1,0 +1,14 @@
+import {
+  ForbiddenHttpResponse,
+  Guard,
+  HttpResponse,
+} from '@inversifyjs/http-core';
+import { Request } from 'express4';
+
+// Begin-example
+export class Express4DenyGuard implements Guard<Request> {
+  public activate(_request: Request): HttpResponse {
+    return new ForbiddenHttpResponse('Missing or invalid credentials');
+  }
+}
+// End-example

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiExpress4Deny.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiExpress4Deny.ts
@@ -1,14 +1,10 @@
-import {
-  ForbiddenHttpResponse,
-  Guard,
-  HttpResponse,
-} from '@inversifyjs/http-core';
+import { ForbiddenHttpResponse, Guard } from '@inversifyjs/http-core';
 import { Request } from 'express4';
 
 // Begin-example
 export class Express4DenyGuard implements Guard<Request> {
-  public activate(_request: Request): HttpResponse {
-    return new ForbiddenHttpResponse('Missing or invalid credentials');
+  public activate(_request: Request): boolean {
+    throw new ForbiddenHttpResponse('Missing or invalid credentials');
   }
 }
 // End-example

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiExpressAllow.int.spec.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiExpressAllow.int.spec.ts
@@ -1,0 +1,43 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { Controller, Get, UseGuard } from '@inversifyjs/http-core';
+import { Container } from 'inversify';
+
+import { buildExpressServer } from '../../server/adapter/express/actions/buildExpressServer';
+import { Server } from '../../server/models/Server';
+import { ExpressAllowGuard } from './guardApiExpressAllow';
+
+describe('Guard API (Express 5)', () => {
+  let server: Server;
+
+  beforeAll(async () => {
+    @Controller('/ping')
+    class PingController {
+      @UseGuard(ExpressAllowGuard)
+      @Get()
+      public async get(): Promise<string> {
+        return 'pong';
+      }
+    }
+
+    const container: Container = new Container();
+    container.bind(ExpressAllowGuard).toSelf().inSingletonScope();
+    container.bind(PingController).toSelf().inSingletonScope();
+
+    server = await buildExpressServer(container);
+  });
+
+  afterAll(async () => {
+    await server.shutdown();
+  });
+
+  it('should allow request and return pong', async () => {
+    const response: Response = await fetch(
+      `http://${server.host}:${server.port.toString()}/ping`,
+    );
+    const body: string = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toBe('pong');
+  });
+});

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiExpressAllow.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiExpressAllow.ts
@@ -1,0 +1,10 @@
+import { Guard } from '@inversifyjs/http-core';
+import { Request } from 'express';
+
+// Begin-example
+export class ExpressAllowGuard implements Guard<Request> {
+  public async activate(_request: Request): Promise<boolean> {
+    return true;
+  }
+}
+// End-example

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiExpressDeny.int.spec.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiExpressDeny.int.spec.ts
@@ -1,0 +1,47 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { Controller, Get, UseGuard } from '@inversifyjs/http-core';
+import { Container } from 'inversify';
+
+import { buildExpressServer } from '../../server/adapter/express/actions/buildExpressServer';
+import { Server } from '../../server/models/Server';
+import { ExpressDenyGuard } from './guardApiExpressDeny';
+
+describe('Guard API deny (Express 5)', () => {
+  let server: Server;
+
+  beforeAll(async () => {
+    @Controller('/ping')
+    class PingController {
+      @UseGuard(ExpressDenyGuard)
+      @Get()
+      public async get(): Promise<string> {
+        return 'pong';
+      }
+    }
+
+    const container: Container = new Container();
+    container.bind(ExpressDenyGuard).toSelf().inSingletonScope();
+    container.bind(PingController).toSelf().inSingletonScope();
+
+    server = await buildExpressServer(container);
+  });
+
+  afterAll(async () => {
+    await server.shutdown();
+  });
+
+  it('should block request with 403 Forbidden', async () => {
+    const response: Response = await fetch(
+      `http://${server.host}:${server.port.toString()}/ping`,
+    );
+    const body: unknown = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body).toMatchObject({
+      error: 'Forbidden',
+      message: 'Missing or invalid credentials',
+      statusCode: 403,
+    });
+  });
+});

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiExpressDeny.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiExpressDeny.ts
@@ -1,0 +1,14 @@
+import {
+  ForbiddenHttpResponse,
+  Guard,
+  HttpResponse,
+} from '@inversifyjs/http-core';
+import { Request } from 'express';
+
+// Begin-example
+export class ExpressDenyGuard implements Guard<Request> {
+  public activate(_request: Request): HttpResponse {
+    return new ForbiddenHttpResponse('Missing or invalid credentials');
+  }
+}
+// End-example

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiExpressDeny.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiExpressDeny.ts
@@ -1,14 +1,10 @@
-import {
-  ForbiddenHttpResponse,
-  Guard,
-  HttpResponse,
-} from '@inversifyjs/http-core';
+import { ForbiddenHttpResponse, Guard } from '@inversifyjs/http-core';
 import { Request } from 'express';
 
 // Begin-example
 export class ExpressDenyGuard implements Guard<Request> {
-  public activate(_request: Request): HttpResponse {
-    return new ForbiddenHttpResponse('Missing or invalid credentials');
+  public activate(_request: Request): boolean {
+    throw new ForbiddenHttpResponse('Missing or invalid credentials');
   }
 }
 // End-example

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiFastifyAllow.int.spec.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiFastifyAllow.int.spec.ts
@@ -1,0 +1,43 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { Controller, Get, UseGuard } from '@inversifyjs/http-core';
+import { Container } from 'inversify';
+
+import { buildFastifyServer } from '../../server/adapter/fastify/actions/buildFastifyServer';
+import { Server } from '../../server/models/Server';
+import { FastifyAllowGuard } from './guardApiFastifyAllow';
+
+describe('Guard API (Fastify)', () => {
+  let server: Server;
+
+  beforeAll(async () => {
+    @Controller('/ping')
+    class PingController {
+      @UseGuard(FastifyAllowGuard)
+      @Get()
+      public async get(): Promise<string> {
+        return 'pong';
+      }
+    }
+
+    const container: Container = new Container();
+    container.bind(FastifyAllowGuard).toSelf().inSingletonScope();
+    container.bind(PingController).toSelf().inSingletonScope();
+
+    server = await buildFastifyServer(container);
+  });
+
+  afterAll(async () => {
+    await server.shutdown();
+  });
+
+  it('should allow request and return pong', async () => {
+    const response: Response = await fetch(
+      `http://${server.host}:${server.port.toString()}/ping`,
+    );
+    const body: string = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toBe('pong');
+  });
+});

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiFastifyAllow.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiFastifyAllow.ts
@@ -1,0 +1,10 @@
+import { Guard } from '@inversifyjs/http-core';
+import { FastifyRequest } from 'fastify';
+
+// Begin-example
+export class FastifyAllowGuard implements Guard<FastifyRequest> {
+  public async activate(_request: FastifyRequest): Promise<boolean> {
+    return true;
+  }
+}
+// End-example

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiFastifyDeny.int.spec.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiFastifyDeny.int.spec.ts
@@ -1,0 +1,47 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { Controller, Get, UseGuard } from '@inversifyjs/http-core';
+import { Container } from 'inversify';
+
+import { buildFastifyServer } from '../../server/adapter/fastify/actions/buildFastifyServer';
+import { Server } from '../../server/models/Server';
+import { FastifyDenyGuard } from './guardApiFastifyDeny';
+
+describe('Guard API deny (Fastify)', () => {
+  let server: Server;
+
+  beforeAll(async () => {
+    @Controller('/ping')
+    class PingController {
+      @UseGuard(FastifyDenyGuard)
+      @Get()
+      public async get(): Promise<string> {
+        return 'pong';
+      }
+    }
+
+    const container: Container = new Container();
+    container.bind(FastifyDenyGuard).toSelf().inSingletonScope();
+    container.bind(PingController).toSelf().inSingletonScope();
+
+    server = await buildFastifyServer(container);
+  });
+
+  afterAll(async () => {
+    await server.shutdown();
+  });
+
+  it('should block request with 403 Forbidden', async () => {
+    const response: Response = await fetch(
+      `http://${server.host}:${server.port.toString()}/ping`,
+    );
+    const body: unknown = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body).toMatchObject({
+      error: 'Forbidden',
+      message: 'Missing or invalid credentials',
+      statusCode: 403,
+    });
+  });
+});

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiFastifyDeny.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiFastifyDeny.ts
@@ -1,0 +1,14 @@
+import {
+  ForbiddenHttpResponse,
+  Guard,
+  HttpResponse,
+} from '@inversifyjs/http-core';
+import { FastifyRequest } from 'fastify';
+
+// Begin-example
+export class FastifyDenyGuard implements Guard<FastifyRequest> {
+  public activate(_request: FastifyRequest): HttpResponse {
+    return new ForbiddenHttpResponse('Missing or invalid credentials');
+  }
+}
+// End-example

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiFastifyDeny.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiFastifyDeny.ts
@@ -1,14 +1,10 @@
-import {
-  ForbiddenHttpResponse,
-  Guard,
-  HttpResponse,
-} from '@inversifyjs/http-core';
+import { ForbiddenHttpResponse, Guard } from '@inversifyjs/http-core';
 import { FastifyRequest } from 'fastify';
 
 // Begin-example
 export class FastifyDenyGuard implements Guard<FastifyRequest> {
-  public activate(_request: FastifyRequest): HttpResponse {
-    return new ForbiddenHttpResponse('Missing or invalid credentials');
+  public activate(_request: FastifyRequest): boolean {
+    throw new ForbiddenHttpResponse('Missing or invalid credentials');
   }
 }
 // End-example

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiHonoAllow.int.spec.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiHonoAllow.int.spec.ts
@@ -1,0 +1,43 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { Controller, Get, UseGuard } from '@inversifyjs/http-core';
+import { Container } from 'inversify';
+
+import { buildHonoServer } from '../../server/adapter/hono/actions/buildHonoServer';
+import { Server } from '../../server/models/Server';
+import { HonoAllowGuard } from './guardApiHonoAllow';
+
+describe('Guard API (Hono)', () => {
+  let server: Server;
+
+  beforeAll(async () => {
+    @Controller('/ping')
+    class PingController {
+      @UseGuard(HonoAllowGuard)
+      @Get()
+      public async get(): Promise<string> {
+        return 'pong';
+      }
+    }
+
+    const container: Container = new Container();
+    container.bind(HonoAllowGuard).toSelf().inSingletonScope();
+    container.bind(PingController).toSelf().inSingletonScope();
+
+    server = await buildHonoServer(container);
+  });
+
+  afterAll(async () => {
+    await server.shutdown();
+  });
+
+  it('should allow request and return pong', async () => {
+    const response: Response = await fetch(
+      `http://${server.host}:${server.port.toString()}/ping`,
+    );
+    const body: string = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toBe('pong');
+  });
+});

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiHonoAllow.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiHonoAllow.ts
@@ -1,0 +1,10 @@
+import { Guard } from '@inversifyjs/http-core';
+import { HonoRequest } from 'hono';
+
+// Begin-example
+export class HonoAllowGuard implements Guard<HonoRequest> {
+  public async activate(_request: HonoRequest): Promise<boolean> {
+    return true;
+  }
+}
+// End-example

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiHonoDeny.int.spec.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiHonoDeny.int.spec.ts
@@ -1,0 +1,47 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { Controller, Get, UseGuard } from '@inversifyjs/http-core';
+import { Container } from 'inversify';
+
+import { buildHonoServer } from '../../server/adapter/hono/actions/buildHonoServer';
+import { Server } from '../../server/models/Server';
+import { HonoDenyGuard } from './guardApiHonoDeny';
+
+describe('Guard API deny (Hono)', () => {
+  let server: Server;
+
+  beforeAll(async () => {
+    @Controller('/ping')
+    class PingController {
+      @UseGuard(HonoDenyGuard)
+      @Get()
+      public async get(): Promise<string> {
+        return 'pong';
+      }
+    }
+
+    const container: Container = new Container();
+    container.bind(HonoDenyGuard).toSelf().inSingletonScope();
+    container.bind(PingController).toSelf().inSingletonScope();
+
+    server = await buildHonoServer(container);
+  });
+
+  afterAll(async () => {
+    await server.shutdown();
+  });
+
+  it('should block request with 403 Forbidden', async () => {
+    const response: Response = await fetch(
+      `http://${server.host}:${server.port.toString()}/ping`,
+    );
+    const body: unknown = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body).toMatchObject({
+      error: 'Forbidden',
+      message: 'Missing or invalid credentials',
+      statusCode: 403,
+    });
+  });
+});

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiHonoDeny.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiHonoDeny.ts
@@ -1,14 +1,10 @@
-import {
-  ForbiddenHttpResponse,
-  Guard,
-  HttpResponse,
-} from '@inversifyjs/http-core';
+import { ForbiddenHttpResponse, Guard } from '@inversifyjs/http-core';
 import { HonoRequest } from 'hono';
 
 // Begin-example
 export class HonoDenyGuard implements Guard<HonoRequest> {
-  public activate(_request: HonoRequest): HttpResponse {
-    return new ForbiddenHttpResponse('Missing or invalid credentials');
+  public activate(_request: HonoRequest): boolean {
+    throw new ForbiddenHttpResponse('Missing or invalid credentials');
   }
 }
 // End-example

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiHonoDeny.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/guardApiHonoDeny.ts
@@ -1,0 +1,14 @@
+import {
+  ForbiddenHttpResponse,
+  Guard,
+  HttpResponse,
+} from '@inversifyjs/http-core';
+import { HonoRequest } from 'hono';
+
+// Begin-example
+export class HonoDenyGuard implements Guard<HonoRequest> {
+  public activate(_request: HonoRequest): HttpResponse {
+    return new ForbiddenHttpResponse('Missing or invalid credentials');
+  }
+}
+// End-example

--- a/packages/http/libraries/core/src/http/guard/model/Guard.ts
+++ b/packages/http/libraries/core/src/http/guard/model/Guard.ts
@@ -1,8 +1,4 @@
-import { HttpResponse } from '../../responses/HttpResponse';
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface Guard<TRequest = any> {
-  activate(
-    request: TRequest,
-  ): Promise<boolean | HttpResponse> | boolean | HttpResponse;
+  activate(request: TRequest): Promise<boolean> | boolean;
 }

--- a/packages/http/libraries/core/src/http/guard/model/Guard.ts
+++ b/packages/http/libraries/core/src/http/guard/model/Guard.ts
@@ -2,6 +2,7 @@ import { HttpResponse } from '../../responses/HttpResponse';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface Guard<TRequest = any> {
-  activate(request: TRequest): Promise<boolean> | boolean;
-  getHttpResponse?(): HttpResponse;
+  activate(
+    request: TRequest,
+  ): Promise<boolean | HttpResponse> | boolean | HttpResponse;
 }

--- a/packages/http/libraries/core/src/index.ts
+++ b/packages/http/libraries/core/src/index.ts
@@ -36,6 +36,7 @@ import { Pipe } from './http/pipe/model/Pipe';
 import { BadGatewayHttpResponse } from './http/responses/error/BadGatewayHttpResponse';
 import { BadRequestHttpResponse } from './http/responses/error/BadRequestHttpResponse';
 import { ConflictHttpResponse } from './http/responses/error/ConflictHttpResponse';
+import { ErrorHttpResponse } from './http/responses/error/ErrorHttpResponse';
 import { ForbiddenHttpResponse } from './http/responses/error/ForbiddenHttpResponse';
 import { GatewayTimeoutHttpResponse } from './http/responses/error/GatewayTimeoutHttpResponse';
 import { GoneHttpResponse } from './http/responses/error/GoneHttpResponse';
@@ -94,6 +95,7 @@ export {
   Get,
   GoneHttpResponse,
   Guard,
+  ErrorHttpResponse,
   Head,
   Headers,
   HttpResponse,


### PR DESCRIPTION
### Added
- Added `Guard` and `UseGuard` code examples.

### Changed
- Updated `InversifyHttpAdapter` to handle `ErrorHttpResponse` errors.

### Removed
- Removed `Guard.getHttpResponse`.