### PR TITLE
Fix injectFromHierarchy decorator

### DIFF
--- a/.changeset/curly-lions-smile.md
+++ b/.changeset/curly-lions-smile.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": patch
+---
+
+Fix `injectFromHierarchy` to ignore Object in prototype traversal, preventing missing metadata errors when extending undecorated Object.

--- a/packages/container/examples/plugin-example/package.json
+++ b/packages/container/examples/plugin-example/package.json
@@ -17,7 +17,7 @@
     "typescript": "5.9.2"
   },
   "peerDependencies": {
-    "inversify": "^7.7.1"
+    "inversify": "^7.8.0"
   },
   "homepage": "https://inversify.io",
   "keywords": [

--- a/packages/container/examples/plugin-usage-example/package.json
+++ b/packages/container/examples/plugin-usage-example/package.json
@@ -5,7 +5,7 @@
   },
   "description": "InversifyJs plugin example package",
   "dependencies": {
-    "inversify": "^7.7.1",
+    "inversify": "^7.8.0",
     "@inversifyjs/plugin-example": "workspace:*"
   },
   "devDependencies": {

--- a/packages/container/libraries/binding-decorators/package.json
+++ b/packages/container/libraries/binding-decorators/package.json
@@ -24,7 +24,7 @@
     "vitest": "3.2.4"
   },
   "peerDependencies": {
-    "inversify": "^7.7.1"
+    "inversify": "^7.8.0"
   },
   "homepage": "https://inversify.io",
   "keywords": [

--- a/packages/container/libraries/core/src/metadata/decorators/injectFromHierarchy.int.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/injectFromHierarchy.int.spec.ts
@@ -1,0 +1,105 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import 'reflect-metadata';
+
+import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+
+import { classMetadataReflectKey } from '../../reflectMetadata/data/classMetadataReflectKey';
+import { ClassElementMetadataKind } from '../models/ClassElementMetadataKind';
+import { ClassMetadata } from '../models/ClassMetadata';
+import { inject } from './inject';
+import { injectFromHierarchy } from './injectFromHierarchy';
+
+describe(injectFromHierarchy, () => {
+  describe('having a base class with constructor arguments', () => {
+    abstract class BaseSoldier {
+      constructor(@inject('Weapon') _weapon: unknown) {}
+    }
+
+    abstract class IntermediateSoldier extends BaseSoldier {}
+
+    @injectFromHierarchy({
+      extendConstructorArguments: true,
+      extendProperties: false,
+    })
+    class Soldier extends IntermediateSoldier {}
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = getOwnReflectMetadata(Soldier, classMetadataReflectKey);
+      });
+
+      it('should merge base constructor metadata without error (and not include Object)', () => {
+        const expected: ClassMetadata = {
+          constructorArguments: [
+            {
+              kind: ClassElementMetadataKind.singleInjection,
+              name: undefined,
+              optional: false,
+              tags: new Map(),
+              value: 'Weapon',
+            },
+          ],
+          lifecycle: {
+            postConstructMethodName: undefined,
+            preDestroyMethodName: undefined,
+          },
+          properties: new Map(),
+          scope: undefined,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having a base class with properties', () => {
+    abstract class BaseSoldier {
+      @inject('Shield')
+      public shield!: unknown;
+    }
+
+    abstract class IntermediateSoldier extends BaseSoldier {}
+
+    @injectFromHierarchy({
+      extendConstructorArguments: false,
+      extendProperties: true,
+    })
+    class Soldier extends IntermediateSoldier {}
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = getOwnReflectMetadata(Soldier, classMetadataReflectKey);
+      });
+
+      it('should merge base property metadata without error (and not include Object)', () => {
+        const expected: ClassMetadata = {
+          constructorArguments: [],
+          lifecycle: {
+            postConstructMethodName: undefined,
+            preDestroyMethodName: undefined,
+          },
+          properties: new Map([
+            [
+              'shield',
+              {
+                kind: ClassElementMetadataKind.singleInjection,
+                name: undefined,
+                optional: false,
+                tags: new Map(),
+                value: 'Shield',
+              },
+            ],
+          ]),
+          scope: undefined,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/metadata/decorators/injectFromHierarchy.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/injectFromHierarchy.ts
@@ -12,8 +12,7 @@ export function injectFromHierarchy(
     const chain: Newable[] = [];
 
     let current: Newable | undefined = getBaseType(target as Newable);
-
-    while (current !== undefined) {
+    while (current !== undefined && current !== Object) {
       const ancestor: Newable = current;
       chain.push(ancestor);
       current = getBaseType(ancestor);

--- a/packages/container/libraries/plugin-dispose/package.json
+++ b/packages/container/libraries/plugin-dispose/package.json
@@ -25,7 +25,7 @@
     "vitest": "3.2.4"
   },
   "peerDependencies": {
-    "inversify": "^7.7.1"
+    "inversify": "^7.8.0"
   },
   "homepage": "https://inversify.io",
   "keywords": [

--- a/packages/container/libraries/strongly-typed/package.json
+++ b/packages/container/libraries/strongly-typed/package.json
@@ -43,7 +43,7 @@
   },
   "name": "@inversifyjs/strongly-typed",
   "peerDependencies": {
-    "inversify": "^7.7.1"
+    "inversify": "^7.8.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/container/tools/container-benchmarks/package.json
+++ b/packages/container/tools/container-benchmarks/package.json
@@ -11,7 +11,7 @@
     "@nestjs/common": "11.1.6",
     "@nestjs/core": "11.1.6",
     "inversify6": "npm:inversify@6.2.2",
-    "inversify7": "npm:inversify@7.7.1",
+    "inversify7": "npm:inversify@7.8.0",
     "rxjs": "7.8.2",
     "tinybench": "5.0.0",
     "tsyringe": "4.10.0"

--- a/packages/docs/tools/binding-decorators-code-examples/package.json
+++ b/packages/docs/tools/binding-decorators-code-examples/package.json
@@ -6,7 +6,7 @@
   "description": "InversifyJs binding decorators docs code examples package",
   "dependencies": {
     "@inversifyjs/binding-decorators": "workspace:*",
-    "inversify": "npm:inversify@7.7.1"
+    "inversify": "7.8.0"
   },
   "devDependencies": {
     "@inversifyjs/code-examples-devkit": "workspace:*",

--- a/packages/docs/tools/inversify-code-examples/package.json
+++ b/packages/docs/tools/inversify-code-examples/package.json
@@ -6,7 +6,7 @@
   "description": "InversifyJs docs code examples package",
   "dependencies": {
     "inversify": "6.2.2",
-    "inversify7": "npm:inversify@7.7.1"
+    "inversify7": "npm:inversify@7.8.0"
   },
   "devDependencies": {
     "@inversifyjs/code-examples-devkit": "workspace:*",

--- a/packages/docs/tools/inversify-http-code-examples/package.json
+++ b/packages/docs/tools/inversify-http-code-examples/package.json
@@ -22,7 +22,7 @@
     "fastify": "5.5.0",
     "glob": "11.0.3",
     "hono": "4.9.2",
-    "inversify": "7.7.1",
+    "inversify": "7.8.0",
     "prettier": "3.6.2",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.0.1",

--- a/packages/http/libraries/core/package.json
+++ b/packages/http/libraries/core/package.json
@@ -50,7 +50,7 @@
   "name": "@inversifyjs/http-core",
   "private": "true",
   "peerDependencies": {
-    "inversify": "^7.7.1"
+    "inversify": "^7.8.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/http/libraries/express-v4/package.json
+++ b/packages/http/libraries/express-v4/package.json
@@ -52,7 +52,7 @@
   "name": "@inversifyjs/http-express-v4",
   "peerDependencies": {
     "express": "^4.21.2",
-    "inversify": "^7.7.1"
+    "inversify": "^7.8.0"
   },
   "private": true,
   "repository": {

--- a/packages/http/libraries/express/package.json
+++ b/packages/http/libraries/express/package.json
@@ -52,7 +52,7 @@
   "name": "@inversifyjs/http-express",
   "peerDependencies": {
     "express": "^5.1.0",
-    "inversify": "^7.7.1"
+    "inversify": "^7.8.0"
   },
   "private": true,
   "repository": {

--- a/packages/http/libraries/fastify/package.json
+++ b/packages/http/libraries/fastify/package.json
@@ -50,7 +50,7 @@
   "name": "@inversifyjs/http-fastify",
   "peerDependencies": {
     "fastify": "^5.5.0",
-    "inversify": "^7.7.1"
+    "inversify": "^7.8.0"
   },
   "private": true,
   "repository": {

--- a/packages/http/libraries/hono/package.json
+++ b/packages/http/libraries/hono/package.json
@@ -49,7 +49,7 @@
   "name": "@inversifyjs/http-hono",
   "peerDependencies": {
     "hono": "^4.9.2",
-    "inversify": "^7.7.1"
+    "inversify": "^7.8.0"
   },
   "private": true,
   "repository": {

--- a/packages/http/tools/e2e-tests/package.json
+++ b/packages/http/tools/e2e-tests/package.json
@@ -16,7 +16,7 @@
     "express4": "npm:express@4.21.2",
     "fastify": "^5.5.0",
     "hono": "^4.9.2",
-    "inversify": "7.7.1"
+    "inversify": "7.8.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.3",

--- a/packages/http/tools/http-benchmarks/package.json
+++ b/packages/http/tools/http-benchmarks/package.json
@@ -20,7 +20,7 @@
     "express4": "npm:express@4.21.2",
     "fastify": "5.5.0",
     "hono": "4.9.2",
-    "inversify": "7.7.1",
+    "inversify": "7.8.0",
     "rxjs": "7.8.2"
   },
   "devDependencies": {


### PR DESCRIPTION
### Changed
- Updated `injectFromHierarchy` to not to traverse `Object` class.