### PR TITLE
Update InversifyHonoHttpAdapter._replyText

### DIFF
--- a/packages/http/libraries/hono/src/adapter/InversifyHonoHttpAdapter.ts
+++ b/packages/http/libraries/hono/src/adapter/InversifyHonoHttpAdapter.ts
@@ -148,7 +148,7 @@ export class InversifyHonoHttpAdapter extends InversifyHttpAdapter<
     response: Context,
     value: string,
   ): Response {
-    return response.text(value);
+    return response.body(value);
   }
 
   protected _replyJson(


### PR DESCRIPTION
### Changed

Update `InversifyHonoHttpAdapter._replyText` to rely on  `response.body`.

### Context

`response.text` forces `text/plain` Content-Type header, which is incorrect. Users might be interested in setting different text mime types, such as `text/html`.