### PR TITLE
Add schema decorator

### DIFF
--- a/.changeset/every-chefs-decide.md
+++ b/.changeset/every-chefs-decide.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/http-open-api": minor
+---
+
+Added `Schema` decorator

--- a/.changeset/fruity-teams-appear.md
+++ b/.changeset/fruity-teams-appear.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/http-open-api": minor
+---
+
+Added `ToSchemaFunction`

--- a/.changeset/modern-lands-travel.md
+++ b/.changeset/modern-lands-travel.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/http-open-api": minor
+---
+
+Added `BuildOpenApiBlockFunction`

--- a/.changeset/red-tools-relate.md
+++ b/.changeset/red-tools-relate.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/http-open-api": minor
+---
+
+Added `SchemaDecoratorOptions`

--- a/packages/http/libraries/open-api/src/index.ts
+++ b/packages/http/libraries/open-api/src/index.ts
@@ -6,6 +6,7 @@ export { SwaggerUiFastifyProvider } from './openApi/services/SwaggerUiFastifyPro
 export { SwaggerUiHonoProvider } from './openApi/services/SwaggerUiHonoProvider';
 
 export type { BuildOpenApiBlockFunction } from './metadata/models/BuildOpenApiBlockFunction';
+export type { SchemaDecoratorOptions } from './metadata/models/SchemaDecoratorOptions';
 export type { ToSchemaFunction } from './metadata/models/ToSchemaFunction';
 export type { SwaggerUiProviderOptions } from './openApi/models/SwaggerUiProviderOptions';
 export type { SwaggerUiProviderApiOptions } from './openApi/models/SwaggerUiProviderApiOptions';

--- a/packages/http/libraries/open-api/src/index.ts
+++ b/packages/http/libraries/open-api/src/index.ts
@@ -1,3 +1,4 @@
+export { Schema } from './metadata/decorators/Schema';
 export { Server } from './metadata/decorators/Server';
 export { Summary } from './metadata/decorators/Summary';
 export { SwaggerUiExpressProvider } from './openApi/services/SwaggerUiExpressProvider';

--- a/packages/http/libraries/open-api/src/index.ts
+++ b/packages/http/libraries/open-api/src/index.ts
@@ -8,3 +8,4 @@ export { SwaggerUiHonoProvider } from './openApi/services/SwaggerUiHonoProvider'
 export type { SwaggerUiProviderOptions } from './openApi/models/SwaggerUiProviderOptions';
 export type { SwaggerUiProviderApiOptions } from './openApi/models/SwaggerUiProviderApiOptions';
 export type { SwaggerUiProviderUiOptions } from './openApi/models/SwaggerUiProviderUiOptions';
+export type { ToSchemaFunction } from './metadata/models/ToSchemaFunction';

--- a/packages/http/libraries/open-api/src/index.ts
+++ b/packages/http/libraries/open-api/src/index.ts
@@ -5,7 +5,8 @@ export { SwaggerUiExpress4Provider } from './openApi/services/SwaggerUiExpress4P
 export { SwaggerUiFastifyProvider } from './openApi/services/SwaggerUiFastifyProvider';
 export { SwaggerUiHonoProvider } from './openApi/services/SwaggerUiHonoProvider';
 
+export type { BuildOpenApiBlockFunction } from './metadata/models/BuildOpenApiBlockFunction';
+export type { ToSchemaFunction } from './metadata/models/ToSchemaFunction';
 export type { SwaggerUiProviderOptions } from './openApi/models/SwaggerUiProviderOptions';
 export type { SwaggerUiProviderApiOptions } from './openApi/models/SwaggerUiProviderApiOptions';
 export type { SwaggerUiProviderUiOptions } from './openApi/models/SwaggerUiProviderUiOptions';
-export type { ToSchemaFunction } from './metadata/models/ToSchemaFunction';

--- a/packages/http/libraries/open-api/src/metadata/actions/toSchema.ts
+++ b/packages/http/libraries/open-api/src/metadata/actions/toSchema.ts
@@ -1,0 +1,37 @@
+import { OpenApi3Dot1SchemaObject } from '@inversifyjs/open-api-types/v3Dot1';
+import { updateOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+
+import { schemaOpenApiMetadataReflectKey } from '../../reflectMetadata/data/schemaOpenApiMetadataReflectKey';
+import { buildDefaultSchemaMetadata } from '../calculations/buildDefaultSchemaMetadata';
+import { SchemaDecoratorOptions } from '../models/SchemaDecoratorOptions';
+import { SchemaMetadata } from '../models/SchemaMetadata';
+import { ToSchemaFunction } from '../models/ToSchemaFunction';
+
+export function toSchema(
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  target: Function,
+  options: SchemaDecoratorOptions | undefined,
+): ToSchemaFunction {
+  return (
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    type: Function,
+  ): OpenApi3Dot1SchemaObject => {
+    const name: string = options?.name ?? type.name;
+
+    updateOwnReflectMetadata(
+      target,
+      schemaOpenApiMetadataReflectKey,
+      buildDefaultSchemaMetadata,
+      (metadata: SchemaMetadata): SchemaMetadata => {
+        metadata.references.set(name, type);
+
+        return metadata;
+      },
+    );
+
+    return {
+      // TODO: Escape name in a way it's a valid JSON Pointer
+      $ref: `#/components/schemas/${name}`,
+    };
+  };
+}

--- a/packages/http/libraries/open-api/src/metadata/actions/updateSchemaMetadata.spec.ts
+++ b/packages/http/libraries/open-api/src/metadata/actions/updateSchemaMetadata.spec.ts
@@ -1,0 +1,276 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+import { OpenApi3Dot1SchemaObject } from '@inversifyjs/open-api-types/v3Dot1';
+
+import { SchemaDecoratorOptions } from '../models/SchemaDecoratorOptions';
+import { SchemaMetadata } from '../models/SchemaMetadata';
+import { updateSchemaMetadata } from './updateSchemaMetadata';
+
+describe(updateSchemaMetadata, () => {
+  let schemaFixture: OpenApi3Dot1SchemaObject;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  let targetFixture: Function;
+
+  beforeAll(() => {
+    schemaFixture = {
+      properties: {
+        id: { type: 'string' },
+      },
+      type: 'object',
+    };
+
+    targetFixture = function testClass() {};
+    Object.defineProperty(targetFixture, 'name', { value: 'TestClass' });
+  });
+
+  describe('having undefined options and metadata with undefined name', () => {
+    describe('when called', () => {
+      let metadataFixture: SchemaMetadata;
+      let optionsFixture: SchemaDecoratorOptions | undefined;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        metadataFixture = {
+          name: undefined,
+          properties: new Map(),
+          references: new Map(),
+          schema: undefined,
+        };
+
+        optionsFixture = undefined;
+
+        result = updateSchemaMetadata(
+          schemaFixture,
+          optionsFixture,
+          targetFixture,
+        )(metadataFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should set metadata.schema', () => {
+        expect(metadataFixture.schema).toBe(schemaFixture);
+      });
+
+      it('should not change metadata.name', () => {
+        expect(metadataFixture.name).toBeUndefined();
+      });
+
+      it('should return metadata', () => {
+        expect(result).toBe(metadataFixture);
+      });
+    });
+  });
+
+  describe('having undefined options and metadata with existing name', () => {
+    describe('when called', () => {
+      let metadataFixture: SchemaMetadata;
+      let optionsFixture: SchemaDecoratorOptions | undefined;
+      let existingNameFixture: string;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        existingNameFixture = 'ExistingName';
+
+        metadataFixture = {
+          name: existingNameFixture,
+          properties: new Map(),
+          references: new Map(),
+          schema: undefined,
+        };
+
+        optionsFixture = undefined;
+
+        result = updateSchemaMetadata(
+          schemaFixture,
+          optionsFixture,
+          targetFixture,
+        )(metadataFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should set metadata.schema', () => {
+        expect(metadataFixture.schema).toBe(schemaFixture);
+      });
+
+      it('should not change metadata.name', () => {
+        expect(metadataFixture.name).toBe(existingNameFixture);
+      });
+
+      it('should return metadata', () => {
+        expect(result).toBe(metadataFixture);
+      });
+    });
+  });
+
+  describe('having options with name and metadata with undefined name', () => {
+    describe('when called', () => {
+      let metadataFixture: SchemaMetadata;
+      let optionsFixture: SchemaDecoratorOptions;
+      let nameFixture: string;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        nameFixture = 'NewSchemaName';
+
+        metadataFixture = {
+          name: undefined,
+          properties: new Map(),
+          references: new Map(),
+          schema: undefined,
+        };
+
+        optionsFixture = {
+          name: nameFixture,
+        };
+
+        result = updateSchemaMetadata(
+          schemaFixture,
+          optionsFixture,
+          targetFixture,
+        )(metadataFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should set metadata.schema', () => {
+        expect(metadataFixture.schema).toBe(schemaFixture);
+      });
+
+      it('should set metadata.name', () => {
+        expect(metadataFixture.name).toBe(nameFixture);
+      });
+
+      it('should return metadata', () => {
+        expect(result).toBe(metadataFixture);
+      });
+    });
+  });
+
+  describe('having options with name and metadata with existing name', () => {
+    describe('when called', () => {
+      let metadataFixture: SchemaMetadata;
+      let optionsFixture: SchemaDecoratorOptions;
+      let nameFixture: string;
+      let existingNameFixture: string;
+
+      beforeAll(() => {
+        nameFixture = 'NewSchemaName';
+        existingNameFixture = 'ExistingSchemaName';
+
+        metadataFixture = {
+          name: existingNameFixture,
+          properties: new Map(),
+          references: new Map(),
+          schema: undefined,
+        };
+
+        optionsFixture = {
+          name: nameFixture,
+        };
+      });
+
+      it('should throw an Error', () => {
+        expect(() =>
+          updateSchemaMetadata(
+            schemaFixture,
+            optionsFixture,
+            targetFixture,
+          )(metadataFixture),
+        ).toThrow('Cannot redefine "TestClass" schema name');
+      });
+    });
+  });
+
+  describe('having undefined schema', () => {
+    describe('when called', () => {
+      let metadataFixture: SchemaMetadata;
+      let optionsFixture: SchemaDecoratorOptions | undefined;
+      let undefinedSchemaFixture: OpenApi3Dot1SchemaObject | undefined;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        metadataFixture = {
+          name: undefined,
+          properties: new Map(),
+          references: new Map(),
+          schema: schemaFixture,
+        };
+
+        optionsFixture = undefined;
+        undefinedSchemaFixture = undefined;
+
+        result = updateSchemaMetadata(
+          undefinedSchemaFixture,
+          optionsFixture,
+          targetFixture,
+        )(metadataFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should set metadata.schema to undefined', () => {
+        expect(metadataFixture.schema).toBeUndefined();
+      });
+
+      it('should return metadata', () => {
+        expect(result).toBe(metadataFixture);
+      });
+    });
+  });
+
+  describe('having options without name property and metadata with undefined name', () => {
+    describe('when called', () => {
+      let metadataFixture: SchemaMetadata;
+      let optionsFixture: SchemaDecoratorOptions;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        metadataFixture = {
+          name: undefined,
+          properties: new Map(),
+          references: new Map(),
+          schema: undefined,
+        };
+
+        optionsFixture = {};
+
+        result = updateSchemaMetadata(
+          schemaFixture,
+          optionsFixture,
+          targetFixture,
+        )(metadataFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should set metadata.schema', () => {
+        expect(metadataFixture.schema).toBe(schemaFixture);
+      });
+
+      it('should not change metadata.name', () => {
+        expect(metadataFixture.name).toBeUndefined();
+      });
+
+      it('should return metadata', () => {
+        expect(result).toBe(metadataFixture);
+      });
+    });
+  });
+});

--- a/packages/http/libraries/open-api/src/metadata/actions/updateSchemaMetadata.ts
+++ b/packages/http/libraries/open-api/src/metadata/actions/updateSchemaMetadata.ts
@@ -1,0 +1,25 @@
+import { OpenApi3Dot1SchemaObject } from '@inversifyjs/open-api-types/v3Dot1';
+
+import { SchemaDecoratorOptions } from '../models/SchemaDecoratorOptions';
+import { SchemaMetadata } from '../models/SchemaMetadata';
+
+export function updateSchemaMetadata(
+  schema: OpenApi3Dot1SchemaObject | undefined,
+  options: SchemaDecoratorOptions | undefined,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  target: Function,
+): (metadata: SchemaMetadata) => SchemaMetadata {
+  return (metadata: SchemaMetadata): SchemaMetadata => {
+    metadata.schema = schema;
+
+    if (options?.name !== undefined) {
+      if (metadata.name !== undefined) {
+        throw new Error(`Cannot redefine "${target.name}" schema name`);
+      }
+
+      metadata.name = options.name;
+    }
+
+    return metadata;
+  };
+}

--- a/packages/http/libraries/open-api/src/metadata/calculations/buildDefaultSchemaMetadata.spec.ts
+++ b/packages/http/libraries/open-api/src/metadata/calculations/buildDefaultSchemaMetadata.spec.ts
@@ -1,0 +1,25 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { SchemaMetadata } from '../models/SchemaMetadata';
+import { buildDefaultSchemaMetadata } from './buildDefaultSchemaMetadata';
+
+describe(buildDefaultSchemaMetadata, () => {
+  describe('when called', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      result = buildDefaultSchemaMetadata();
+    });
+
+    it('should return the expected result', () => {
+      const expected: SchemaMetadata = {
+        name: undefined,
+        properties: new Map(),
+        references: new Map(),
+        schema: undefined,
+      };
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/http/libraries/open-api/src/metadata/calculations/buildDefaultSchemaMetadata.ts
+++ b/packages/http/libraries/open-api/src/metadata/calculations/buildDefaultSchemaMetadata.ts
@@ -1,0 +1,10 @@
+import { SchemaMetadata } from '../models/SchemaMetadata';
+
+export function buildDefaultSchemaMetadata(): SchemaMetadata {
+  return {
+    name: undefined,
+    properties: new Map(),
+    references: new Map(),
+    schema: undefined,
+  };
+}

--- a/packages/http/libraries/open-api/src/metadata/decorators/Schema.spec.ts
+++ b/packages/http/libraries/open-api/src/metadata/decorators/Schema.spec.ts
@@ -1,0 +1,395 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  Mock,
+  vitest,
+} from 'vitest';
+
+vitest.mock('@inversifyjs/reflect-metadata-utils');
+
+import { updateOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+
+vitest.mock('../actions/toSchema');
+vitest.mock('../actions/updateSchemaMetadata');
+
+import { OpenApi3Dot1SchemaObject } from '@inversifyjs/open-api-types/v3Dot1';
+
+import { schemaOpenApiMetadataReflectKey } from '../../reflectMetadata/data/schemaOpenApiMetadataReflectKey';
+import { toSchema } from '../actions/toSchema';
+import { updateSchemaMetadata } from '../actions/updateSchemaMetadata';
+import { buildDefaultSchemaMetadata } from '../calculations/buildDefaultSchemaMetadata';
+import { BuildOpenApiBlockFunction } from '../models/BuildOpenApiBlockFunction';
+import { SchemaDecoratorOptions } from '../models/SchemaDecoratorOptions';
+import { SchemaMetadata } from '../models/SchemaMetadata';
+import { ToSchemaFunction } from '../models/ToSchemaFunction';
+import { Schema } from './Schema';
+
+describe(Schema, () => {
+  describe('having no schema parameter', () => {
+    describe('when called', () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+      let targetTypeFixture: Function;
+      let updateSchemaMetadataResultMock: Mock<
+        (metadata: SchemaMetadata) => SchemaMetadata
+      >;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        targetTypeFixture = function testClass() {};
+
+        updateSchemaMetadataResultMock = vitest.fn();
+
+        vitest
+          .mocked(updateSchemaMetadata)
+          .mockReturnValueOnce(updateSchemaMetadataResultMock);
+
+        result = Schema()(targetTypeFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call updateSchemaMetadata()', () => {
+        expect(updateSchemaMetadata).toHaveBeenCalledTimes(1);
+        expect(updateSchemaMetadata).toHaveBeenCalledWith(
+          undefined,
+          undefined,
+          targetTypeFixture,
+        );
+      });
+
+      it('should call updateOwnReflectMetadata()', () => {
+        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
+        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+          targetTypeFixture,
+          schemaOpenApiMetadataReflectKey,
+          buildDefaultSchemaMetadata,
+          updateSchemaMetadataResultMock,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a schema object parameter', () => {
+    let schemaFixture: OpenApi3Dot1SchemaObject;
+
+    beforeAll(() => {
+      schemaFixture = {
+        description: 'Test schema',
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' },
+        },
+        required: ['id', 'name'],
+        type: 'object',
+      };
+    });
+
+    describe('when called', () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+      let targetTypeFixture: Function;
+      let updateSchemaMetadataResultMock: Mock<
+        (metadata: SchemaMetadata) => SchemaMetadata
+      >;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        targetTypeFixture = function testClass() {};
+
+        updateSchemaMetadataResultMock = vitest.fn();
+
+        vitest
+          .mocked(updateSchemaMetadata)
+          .mockReturnValueOnce(updateSchemaMetadataResultMock);
+
+        result = Schema(schemaFixture)(targetTypeFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call updateSchemaMetadata()', () => {
+        expect(updateSchemaMetadata).toHaveBeenCalledTimes(1);
+        expect(updateSchemaMetadata).toHaveBeenCalledWith(
+          schemaFixture,
+          undefined,
+          targetTypeFixture,
+        );
+      });
+
+      it('should call updateOwnReflectMetadata()', () => {
+        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
+        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+          targetTypeFixture,
+          schemaOpenApiMetadataReflectKey,
+          buildDefaultSchemaMetadata,
+          updateSchemaMetadataResultMock,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a schema object parameter and options', () => {
+    let schemaFixture: OpenApi3Dot1SchemaObject;
+    let optionsFixture: SchemaDecoratorOptions;
+
+    beforeAll(() => {
+      schemaFixture = {
+        description: 'Test schema',
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' },
+        },
+        required: ['id', 'name'],
+        type: 'object',
+      };
+
+      optionsFixture = {
+        name: 'CustomSchemaName',
+      };
+    });
+
+    describe('when called', () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+      let targetTypeFixture: Function;
+      let updateSchemaMetadataResultMock: Mock<
+        (metadata: SchemaMetadata) => SchemaMetadata
+      >;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        targetTypeFixture = function testClass() {};
+
+        updateSchemaMetadataResultMock = vitest.fn();
+
+        vitest
+          .mocked(updateSchemaMetadata)
+          .mockReturnValueOnce(updateSchemaMetadataResultMock);
+
+        result = Schema(schemaFixture, optionsFixture)(targetTypeFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call updateSchemaMetadata()', () => {
+        expect(updateSchemaMetadata).toHaveBeenCalledTimes(1);
+        expect(updateSchemaMetadata).toHaveBeenCalledWith(
+          schemaFixture,
+          optionsFixture,
+          targetTypeFixture,
+        );
+      });
+
+      it('should call updateOwnReflectMetadata()', () => {
+        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
+        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+          targetTypeFixture,
+          schemaOpenApiMetadataReflectKey,
+          buildDefaultSchemaMetadata,
+          updateSchemaMetadataResultMock,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a build function parameter', () => {
+    let buildFunctionFixture: BuildOpenApiBlockFunction<OpenApi3Dot1SchemaObject>;
+    let toSchemaFunctionMock: Mock<ToSchemaFunction>;
+    let builtSchemaFixture: OpenApi3Dot1SchemaObject;
+
+    beforeAll(() => {
+      builtSchemaFixture = {
+        description: 'Built schema',
+        properties: {
+          value: { type: 'number' },
+        },
+        required: ['value'],
+        type: 'object',
+      };
+
+      toSchemaFunctionMock = vitest.fn();
+
+      buildFunctionFixture = vitest
+        .fn()
+        .mockReturnValueOnce(builtSchemaFixture);
+
+      vitest.mocked(toSchema).mockReturnValueOnce(toSchemaFunctionMock);
+    });
+
+    describe('when called', () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+      let targetTypeFixture: Function;
+      let updateSchemaMetadataResultMock: Mock<
+        (metadata: SchemaMetadata) => SchemaMetadata
+      >;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        targetTypeFixture = function testClass() {};
+
+        updateSchemaMetadataResultMock = vitest.fn();
+
+        vitest
+          .mocked(updateSchemaMetadata)
+          .mockReturnValueOnce(updateSchemaMetadataResultMock);
+
+        result = Schema(buildFunctionFixture)(targetTypeFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call toSchema()', () => {
+        expect(toSchema).toHaveBeenCalledTimes(1);
+        expect(toSchema).toHaveBeenCalledWith(targetTypeFixture, undefined);
+      });
+
+      it('should call build function with toSchema result', () => {
+        expect(buildFunctionFixture).toHaveBeenCalledTimes(1);
+        expect(buildFunctionFixture).toHaveBeenCalledWith(toSchemaFunctionMock);
+      });
+
+      it('should call updateSchemaMetadata()', () => {
+        expect(updateSchemaMetadata).toHaveBeenCalledTimes(1);
+        expect(updateSchemaMetadata).toHaveBeenCalledWith(
+          builtSchemaFixture,
+          undefined,
+          targetTypeFixture,
+        );
+      });
+
+      it('should call updateOwnReflectMetadata()', () => {
+        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
+        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+          targetTypeFixture,
+          schemaOpenApiMetadataReflectKey,
+          buildDefaultSchemaMetadata,
+          updateSchemaMetadataResultMock,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a build function parameter and options', () => {
+    let buildFunctionFixture: BuildOpenApiBlockFunction<OpenApi3Dot1SchemaObject>;
+    let optionsFixture: SchemaDecoratorOptions;
+    let toSchemaFunctionMock: Mock<ToSchemaFunction>;
+    let builtSchemaFixture: OpenApi3Dot1SchemaObject;
+
+    beforeAll(() => {
+      builtSchemaFixture = {
+        description: 'Built schema with options',
+        properties: {
+          data: { type: 'string' },
+        },
+        required: ['data'],
+        type: 'object',
+      };
+
+      optionsFixture = {
+        name: 'BuildFunctionSchemaName',
+      };
+
+      toSchemaFunctionMock = vitest.fn();
+
+      buildFunctionFixture = vitest
+        .fn()
+        .mockReturnValueOnce(builtSchemaFixture);
+
+      vitest.mocked(toSchema).mockReturnValueOnce(toSchemaFunctionMock);
+    });
+
+    describe('when called', () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+      let targetTypeFixture: Function;
+      let updateSchemaMetadataResultMock: Mock<
+        (metadata: SchemaMetadata) => SchemaMetadata
+      >;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        targetTypeFixture = function testClass() {};
+
+        updateSchemaMetadataResultMock = vitest.fn();
+
+        vitest
+          .mocked(updateSchemaMetadata)
+          .mockReturnValueOnce(updateSchemaMetadataResultMock);
+
+        result = Schema(
+          buildFunctionFixture,
+          optionsFixture,
+        )(targetTypeFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call toSchema()', () => {
+        expect(toSchema).toHaveBeenCalledTimes(1);
+        expect(toSchema).toHaveBeenCalledWith(
+          targetTypeFixture,
+          optionsFixture,
+        );
+      });
+
+      it('should call build function with toSchema result', () => {
+        expect(buildFunctionFixture).toHaveBeenCalledTimes(1);
+        expect(buildFunctionFixture).toHaveBeenCalledWith(toSchemaFunctionMock);
+      });
+
+      it('should call updateSchemaMetadata()', () => {
+        expect(updateSchemaMetadata).toHaveBeenCalledTimes(1);
+        expect(updateSchemaMetadata).toHaveBeenCalledWith(
+          builtSchemaFixture,
+          optionsFixture,
+          targetTypeFixture,
+        );
+      });
+
+      it('should call updateOwnReflectMetadata()', () => {
+        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
+        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+          targetTypeFixture,
+          schemaOpenApiMetadataReflectKey,
+          buildDefaultSchemaMetadata,
+          updateSchemaMetadataResultMock,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+});

--- a/packages/http/libraries/open-api/src/metadata/decorators/Schema.ts
+++ b/packages/http/libraries/open-api/src/metadata/decorators/Schema.ts
@@ -1,0 +1,30 @@
+import { OpenApi3Dot1SchemaObject } from '@inversifyjs/open-api-types/v3Dot1';
+import { updateOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+
+import { schemaOpenApiMetadataReflectKey } from '../../reflectMetadata/data/schemaOpenApiMetadataReflectKey';
+import { toSchema } from '../actions/toSchema';
+import { updateSchemaMetadata } from '../actions/updateSchemaMetadata';
+import { buildDefaultSchemaMetadata } from '../calculations/buildDefaultSchemaMetadata';
+import { BuildOpenApiBlockFunction } from '../models/BuildOpenApiBlockFunction';
+import { SchemaDecoratorOptions } from '../models/SchemaDecoratorOptions';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function Schema(
+  schema?:
+    | OpenApi3Dot1SchemaObject
+    | BuildOpenApiBlockFunction<OpenApi3Dot1SchemaObject>,
+  options?: SchemaDecoratorOptions,
+): ClassDecorator {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  return (target: Function): void => {
+    const schemaResult: OpenApi3Dot1SchemaObject | undefined =
+      typeof schema === 'function' ? schema(toSchema(target, options)) : schema;
+
+    updateOwnReflectMetadata(
+      target,
+      schemaOpenApiMetadataReflectKey,
+      buildDefaultSchemaMetadata,
+      updateSchemaMetadata(schemaResult, options, target),
+    );
+  };
+}

--- a/packages/http/libraries/open-api/src/metadata/models/BuildOpenApiBlockFunction.ts
+++ b/packages/http/libraries/open-api/src/metadata/models/BuildOpenApiBlockFunction.ts
@@ -1,0 +1,5 @@
+import { ToSchemaFunction } from './ToSchemaFunction';
+
+export type BuildOpenApiBlockFunction<TBlock> = (
+  toSchema: ToSchemaFunction,
+) => TBlock;

--- a/packages/http/libraries/open-api/src/metadata/models/ReferencedSchemaMetadata.ts
+++ b/packages/http/libraries/open-api/src/metadata/models/ReferencedSchemaMetadata.ts
@@ -1,0 +1,7 @@
+import { OpenApi3Dot1SchemaObject } from '@inversifyjs/open-api-types/v3Dot1';
+
+export interface ReferencedSchemaMetadata {
+  schema: OpenApi3Dot1SchemaObject | undefined;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  references: Map<string, Function>;
+}

--- a/packages/http/libraries/open-api/src/metadata/models/SchemaDecoratorOptions.ts
+++ b/packages/http/libraries/open-api/src/metadata/models/SchemaDecoratorOptions.ts
@@ -1,0 +1,3 @@
+export interface SchemaDecoratorOptions {
+  name?: string;
+}

--- a/packages/http/libraries/open-api/src/metadata/models/SchemaMetadata.ts
+++ b/packages/http/libraries/open-api/src/metadata/models/SchemaMetadata.ts
@@ -1,0 +1,6 @@
+import { ReferencedSchemaMetadata } from './ReferencedSchemaMetadata';
+
+export interface SchemaMetadata extends ReferencedSchemaMetadata {
+  name: string | undefined;
+  properties: Map<string, ReferencedSchemaMetadata>;
+}

--- a/packages/http/libraries/open-api/src/metadata/models/ToSchemaFunction.ts
+++ b/packages/http/libraries/open-api/src/metadata/models/ToSchemaFunction.ts
@@ -1,0 +1,4 @@
+import { OpenApi3Dot1SchemaObject } from '@inversifyjs/open-api-types/v3Dot1';
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+export type ToSchemaFunction = (type: Function) => OpenApi3Dot1SchemaObject;

--- a/packages/http/libraries/open-api/src/reflectMetadata/data/schemaOpenApiMetadataReflectKey.ts
+++ b/packages/http/libraries/open-api/src/reflectMetadata/data/schemaOpenApiMetadataReflectKey.ts
@@ -1,0 +1,2 @@
+export const schemaOpenApiMetadataReflectKey: string =
+  '@inversifyjs/http-open-api/schemaOpenApiMetadataReflectKey';


### PR DESCRIPTION
### Added
- Added `Schema` decorator.
- Added `SchemaMetadata` models.

### Pending
- [ ] Rely on JSON Schema pointer library to build proper json schema ref pointes.
- [ ] Implement `toSchema` tests.
- [ ] Add `SchemaProperty`decorator.