### PR TITLE
Update mergeOpenApiTypeSchema to infer design types from prototypes

### DIFF
--- a/packages/framework/http/libraries/open-api/src/openApi/actions/mergeOpenApiTypeSchema.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/actions/mergeOpenApiTypeSchema.spec.ts
@@ -555,7 +555,7 @@ describe(mergeOpenApiTypeSchema, () => {
         it('should call getOwnReflectMetadata()', () => {
           expect(getOwnReflectMetadataMock).toHaveBeenCalledTimes(1);
           expect(getOwnReflectMetadataMock).toHaveBeenCalledWith(
-            typeFixture,
+            typeFixture.prototype,
             'design:type',
             'unknownProperty',
           );
@@ -564,7 +564,7 @@ describe(mergeOpenApiTypeSchema, () => {
         it('should throw an Error', () => {
           expect(result).toBeInstanceOf(Error);
           expect((result as Error).message).toBe(
-            'Unable to determine type for property "Type.unknownProperty"',
+            '[@inversifyjs/http-open-api] Unable to determine type for property "Type.unknownProperty". Are you enabling "emitDecoratorMetadata" and "experimentalDecorators" TypeScript compiler options?',
           );
         });
 
@@ -623,7 +623,7 @@ describe(mergeOpenApiTypeSchema, () => {
         it('should call getOwnReflectMetadata()', () => {
           expect(getOwnReflectMetadataMock).toHaveBeenCalledTimes(1);
           expect(getOwnReflectMetadataMock).toHaveBeenCalledWith(
-            typeFixture,
+            typeFixture.prototype,
             'design:type',
             'stringProperty',
           );
@@ -724,7 +724,7 @@ describe(mergeOpenApiTypeSchema, () => {
         it('should call getOwnReflectMetadata()', () => {
           expect(getOwnReflectMetadataMock).toHaveBeenCalledTimes(1);
           expect(getOwnReflectMetadataMock).toHaveBeenCalledWith(
-            typeFixture,
+            typeFixture.prototype,
             'design:type',
             'customProperty',
           );
@@ -834,7 +834,7 @@ describe(mergeOpenApiTypeSchema, () => {
         it('should call getOwnReflectMetadata()', () => {
           expect(getOwnReflectMetadataMock).toHaveBeenCalledTimes(1);
           expect(getOwnReflectMetadataMock).toHaveBeenCalledWith(
-            typeFixture,
+            typeFixture.prototype,
             'design:type',
             'customProperty',
           );

--- a/packages/framework/http/libraries/open-api/src/openApi/actions/mergeOpenApiTypeSchema.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/actions/mergeOpenApiTypeSchema.ts
@@ -40,14 +40,15 @@ export function mergeOpenApiTypeSchema(
     if (propertySchema.schema === undefined) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
       const typescriptDesignType: Function | undefined = getOwnReflectMetadata(
-        type,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        type.prototype,
         'design:type',
         propertyKey,
       );
 
       if (typescriptDesignType === undefined) {
         throw new Error(
-          `Unable to determine type for property "${type.name}.${propertyKey}"`,
+          `[@inversifyjs/http-open-api] Unable to determine type for property "${type.name}.${propertyKey}". Are you enabling "emitDecoratorMetadata" and "experimentalDecorators" TypeScript compiler options?`,
         );
       }
 


### PR DESCRIPTION
### Changed
- Updated `mergeOpenApiTypeSchema` to infer `design:types` from `prototypes`.