### PR TITLE
Update validation doc site with specific validator docs

### DIFF
--- a/packages/docs/services/inversify-http-site/docs/api/decorators.mdx
+++ b/packages/docs/services/inversify-http-site/docs/api/decorators.mdx
@@ -99,6 +99,24 @@ Next(): ParameterDecorator
   </TabItem>
 </Tabs>
 
+### UseErrorFilter
+
+Attaches one or more error filters to a controller class or method. Error filters handle exceptions that occur during request processing.
+
+```ts
+UseErrorFilter(...errorFilterList: Newable<ErrorFilter>[]): ClassDecorator & MethodDecorator
+```
+
+Parameters
+
+- errorFilterList: One or more error filter classes implementing `ErrorFilter`.
+
+Notes
+
+- Scope: Place on the controller class to affect all routes, or on a method to affect only that route.
+- Order: Error filters are processed in the order they are provided.
+- Exception handling: Error filters can catch, transform, or handle exceptions thrown during request processing.
+
 ### UseGuard
 
 Attaches one or more [guards](../../fundamentals/guard) to a controller class or method. All guards must allow for the request to continue.
@@ -116,6 +134,24 @@ Notes
 - Scope: Place on the controller class to affect all routes, or on a method to affect only that route.
 - Guard return values: `activate()` may return `true` (continue), `false` (reply with `403 Forbidden`), or throw an `ErrorHttpResponse` (replied as-is, e.g., `throw new ForbiddenHttpResponse('message')`).
 
+### UseInterceptor
+
+Attaches one or more interceptors to a controller class or method. Interceptors can modify requests before they reach the handler and responses before they are sent.
+
+```ts
+UseInterceptor(...interceptorList: Newable<Interceptor>[]): ClassDecorator & MethodDecorator
+```
+
+Parameters
+
+- interceptorList: One or more interceptor classes implementing `Interceptor`.
+
+Notes
+
+- Scope: Place on the controller class to affect all routes, or on a method to affect only that route.
+- Order: Interceptors are executed in the order they are provided.
+- Request/Response modification: Interceptors can transform both incoming requests and outgoing responses.
+- Timing: Interceptors run around the handler method, allowing both pre and post-processing.
 
 ## HTTP Request message abstraction
 

--- a/packages/docs/services/inversify-validation-site/docs/ajv/_category_.json
+++ b/packages/docs/services/inversify-validation-site/docs/ajv/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Ajv",
+  "position": 3
+}

--- a/packages/docs/services/inversify-validation-site/docs/ajv/api.mdx
+++ b/packages/docs/services/inversify-validation-site/docs/ajv/api.mdx
@@ -1,0 +1,109 @@
+---
+sidebar_position: 2
+title: API
+---
+import apiAjvValidationPipeSource from '@inversifyjs/validation-code-examples/generated/examples/v1/ajv/apiAjvValidationPipe.ts.txt';
+import apiAjvCompiledValidationPipeSource from '@inversifyjs/validation-code-examples/generated/examples/v1/ajv/apiAjvCompiledValidationPipe.ts.txt';
+import apiValidateAjvSchemaSource from '@inversifyjs/validation-code-examples/generated/examples/v1/ajv/apiValidateAjvSchema.ts.txt';
+import CodeBlock from '@theme/CodeBlock';
+
+## AjvValidationPipe
+
+Validates values using Ajv JSON Schema validator. Register it globally to validate incoming HTTP parameters (e.g., body) in your controllers.
+
+```ts
+constructor(ajv: Ajv, schemaList?: AnySchema[])
+```
+
+Parameters
+
+- **ajv** (Ajv): The Ajv instance to use for validation. You can configure it with custom formats, keywords, and options.
+- **schemaList** (optional AnySchema[]): One or more JSON schemas applied globally to every validated value. These run before any parameter-level schemas added via `@ValidateAjvSchema`.
+
+`AjvValidationPipe` can be registered as a global pipe: `adapter.useGlobalPipe(new AjvValidationPipe(ajv))`.
+This way, controller parameters decorated with `@ValidateAjvSchema` are automatically validated.
+
+### Example: register an AjvValidationPipe globally
+
+<CodeBlock language="ts">{apiAjvValidationPipeSource}</CodeBlock>
+
+## AjvCompiledValidationPipe
+
+An optimized version of `AjvValidationPipe` that uses compiled Ajv validation functions for better performance. Best suited for production environments where schemas don't change frequently.
+
+```ts
+constructor(ajv: Ajv, schemaList?: AnySchema[])
+```
+
+Parameters
+
+- **ajv** (Ajv): The Ajv instance to use for validation. Schemas must have an `$id` property to be compiled.
+- **schemaList** (optional AnySchema[]): One or more JSON schemas applied globally to every validated value.
+
+**Important**: When using `AjvCompiledValidationPipe`, all schemas must have an `$id` property. The pipe compiles and caches validation functions for better performance.
+
+### Example: register an AjvCompiledValidationPipe globally
+
+<CodeBlock language="ts">{apiAjvCompiledValidationPipeSource}</CodeBlock>
+
+## ValidateAjvSchema
+
+Attaches one or more JSON schemas to a specific parameter (e.g., `@Body()`), so the `AjvValidationPipe` or `AjvCompiledValidationPipe` can validate the value before your controller method runs.
+
+```ts
+ValidateAjvSchema(...schemaList: AnySchema[]): ParameterDecorator
+```
+
+Parameters
+
+- **schemaList**: One or more JSON Schema objects that define the expected structure and constraints for the parameter value.
+
+When multiple schemas are provided, they run in sequence. The value must pass all schema validations. Any schemas provided to `AjvValidationPipe` run first; parameter-level schemas run afterwards.
+
+On validation failure, an `InversifyValidationError` is thrown and can be converted to a Bad Request HTTP response by `ValidationErrorFilter`.
+
+### Example: validate request body with JSON Schema
+
+<CodeBlock language="ts">{apiValidateAjvSchemaSource}</CodeBlock>
+
+## JSON Schema Features
+
+Ajv supports the full JSON Schema specification, including:
+
+### Basic Types
+- `string`, `number`, `integer`, `boolean`, `array`, `object`, `null`
+
+### String Validation
+- `minLength`, `maxLength`: String length constraints
+- `pattern`: Regular expression validation
+- `format`: Built-in formats like `email`, `date`, `uri`, etc.
+
+### Number Validation
+- `minimum`, `maximum`: Value range constraints
+- `multipleOf`: Divisibility constraints
+
+### Array Validation
+- `minItems`, `maxItems`: Array length constraints
+- `items`: Schema for array items
+- `uniqueItems`: Ensure array elements are unique
+
+### Object Validation
+- `properties`: Define expected object properties
+- `required`: Specify required properties
+- `additionalProperties`: Control extra properties
+- `minProperties`, `maxProperties`: Object size constraints
+
+### Advanced Features
+- `$ref`: Schema references and reuse
+- `allOf`, `anyOf`, `oneOf`: Schema composition
+- `if`/`then`/`else`: Conditional validation
+- Custom keywords and formats
+
+### Error Handling
+
+When validation fails, Ajv provides detailed error information including:
+- Property path where validation failed
+- Expected vs actual values
+- Validation rule that was violated
+
+The `AjvValidationPipe` automatically converts these errors into user-friendly messages that can be returned as HTTP responses.

--- a/packages/docs/services/inversify-validation-site/docs/ajv/introduction.mdx
+++ b/packages/docs/services/inversify-validation-site/docs/ajv/introduction.mdx
@@ -1,0 +1,48 @@
+---
+sidebar_position: 1
+title: Introduction
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import apiIntroductionSource from '@inversifyjs/validation-code-examples/generated/examples/v1/ajv/apiIntroduction.ts.txt';
+import CodeBlock from '@theme/CodeBlock';
+
+[Ajv](https://ajv.js.org/) (Another JSON Schema Validator) is a popular, fast JSON Schema validator for Node.js and browser. It validates data against JSON Schema and is commonly used for API request/response validation.
+
+Inversify Validation's Ajv package provides seamless integration with Ajv, allowing you to validate data in your Inversify applications using JSON Schema definitions. The package includes both standard and compiled validation pipes for optimal performance.
+
+## Install dependencies
+
+In order to use the package, install it along with Ajv:
+
+<Tabs>
+  <TabItem value="npm" label="npm">
+
+```bash
+npm install ajv @inversifyjs/ajv-validation
+```
+
+  </TabItem>
+  <TabItem value="yarn" label="yarn">
+
+```bash
+yarn add ajv @inversifyjs/ajv-validation
+```
+
+  </TabItem>
+  <TabItem value="pnpm" label="pnpm">
+
+```bash
+pnpm install ajv @inversifyjs/ajv-validation
+```
+
+  </TabItem>
+</Tabs>
+
+## Quick Start
+
+Here's a simple example of how to use Ajv validation in your Inversify application:
+
+<CodeBlock language="ts">{apiIntroductionSource}</CodeBlock>
+
+This example sets up Ajv validation for a user creation endpoint, ensuring that the request body matches the defined JSON schema before the controller method executes.

--- a/packages/docs/services/inversify-validation-site/docs/class-validator/_category_.json
+++ b/packages/docs/services/inversify-validation-site/docs/class-validator/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Class Validator",
-  "position": 3
+  "position": 4
 }

--- a/packages/docs/services/inversify-validation-site/docs/class-validator/_category_.json
+++ b/packages/docs/services/inversify-validation-site/docs/class-validator/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Class Validator",
+  "position": 3
+}

--- a/packages/docs/services/inversify-validation-site/docs/class-validator/api.mdx
+++ b/packages/docs/services/inversify-validation-site/docs/class-validator/api.mdx
@@ -13,12 +13,6 @@ Validates values using class-validator decorators and class-transformer for type
 `ClassValidationPipe` can be registered as a global pipe: `adapter.useGlobalPipe(new ClassValidationPipe())`.
 This way, controller parameters with decorated classes are automatically validated.
 
-The pipe performs the following operations:
-1. Extracts TypeScript type metadata for the parameter
-2. Transforms the plain input object into a class instance using `class-transformer`
-3. Validates the instance using `class-validator` with strict validation options
-4. Returns the validated and transformed instance
-
 ### Example: register a ClassValidationPipe globally
 
 <CodeBlock language="ts">{apiClassValidationPipeSource}</CodeBlock>

--- a/packages/docs/services/inversify-validation-site/docs/class-validator/api.mdx
+++ b/packages/docs/services/inversify-validation-site/docs/class-validator/api.mdx
@@ -1,0 +1,38 @@
+---
+sidebar_position: 2
+title: API
+---
+import apiClassValidationPipeSource from '@inversifyjs/validation-code-examples/generated/examples/v1/classValidator/apiClassValidationPipe.ts.txt';
+import gettingStartedSource from '@inversifyjs/validation-code-examples/generated/examples/v1/classValidator/gettingStarted.ts.txt';
+import CodeBlock from '@theme/CodeBlock';
+
+## ClassValidationPipe
+
+Validates values using class-validator decorators and class-transformer for type conversion. The pipe automatically extracts parameter type metadata and validates incoming data against the decorated class properties.
+
+`ClassValidationPipe` can be registered as a global pipe: `adapter.useGlobalPipe(new ClassValidationPipe())`.
+This way, controller parameters with decorated classes are automatically validated.
+
+The pipe performs the following operations:
+1. Extracts TypeScript type metadata for the parameter
+2. Transforms the plain input object into a class instance using `class-transformer`
+3. Validates the instance using `class-validator` with strict validation options
+4. Returns the validated and transformed instance
+
+### Example: register a ClassValidationPipe globally
+
+<CodeBlock language="ts">{apiClassValidationPipeSource}</CodeBlock>
+
+## Using class-validator decorators
+
+To validate request parameters, create classes with class-validator decorators and use them as parameter types in your controller methods. The `ClassValidationPipe` will automatically validate and transform the data.
+
+On validation failure, an `InversifyValidationError` is thrown and can be converted to a Bad Request HTTP response by `InversifyValidationErrorFilter`.
+
+### Example: validate request body with class-validator
+
+<CodeBlock language="ts">{gettingStartedSource}</CodeBlock>
+
+### Available Validation Decorators
+
+Class-validator provides many built-in validation decorators. For a complete list of available decorators, see the [class-validator documentation](https://github.com/typestack/class-validator#validation-decorators).

--- a/packages/docs/services/inversify-validation-site/docs/class-validator/introduction.mdx
+++ b/packages/docs/services/inversify-validation-site/docs/class-validator/introduction.mdx
@@ -1,0 +1,51 @@
+---
+sidebar_position: 1
+title: Introduction
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+[Class-validator](https://github.com/typestack/class-validator) is a TypeScript library that uses decorators to validate classes and their properties. It provides a declarative way to validate data using annotations directly on class properties.
+
+Inversify Validation's Class Validation Pipe integrates seamlessly with class-validator, allowing you to validate incoming HTTP parameters (e.g., request body) using decorated classes in your controllers.
+
+## Install dependencies
+
+In order to use the package, install it along with the required peer dependencies:
+
+<Tabs>
+  <TabItem value="npm" label="npm">
+
+```bash
+npm install class-validator class-transformer @inversifyjs/class-validation
+```
+
+  </TabItem>
+  <TabItem value="yarn" label="yarn">
+
+```bash
+yarn add class-validator class-transformer @inversifyjs/class-validation
+```
+
+  </TabItem>
+  <TabItem value="pnpm" label="pnpm">
+
+```bash
+pnpm install class-validator class-transformer @inversifyjs/class-validation
+```
+
+  </TabItem>
+</Tabs>
+
+## TypeScript Configuration
+
+Class-validator requires specific TypeScript compiler options to function properly. Make sure your `tsconfig.json` includes:
+
+```json
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  }
+}
+```

--- a/packages/docs/services/inversify-validation-site/docs/introduction/getting-started.mdx
+++ b/packages/docs/services/inversify-validation-site/docs/introduction/getting-started.mdx
@@ -63,7 +63,27 @@ Validation tools are designed to work outside HTTP context. In order to use them
 
 ## Configure server
 
-After installing the packages, create a server to listen for incoming requests. Below is a basic example of setting up a controller to validate a request body.
+In order to enable validation in your application, you need to configure the server:
+
+1. Use the specific validator error pipe. If we take the previous example, we need to use a `StandardSchemaValidationPipe`, for Zod is integrated via Standard Schema integration.
+2. Use the `ValidationErrorFilter` to handle validation errors. This error filter provided by the `@inversifyjs/http-validation` package catches validation errors in order to send Bad Request HTTP responses on top of them.
+
+```ts
+  const adapter: InversifyExpressHttpAdapter = new InversifyExpressHttpAdapter(
+    container,
+    {
+      logger: true,
+      useCookies: true,
+    },
+  );
+
+  adapter.useGlobalFilters(ValidationErrorFilter);
+  adapter.useGlobalPipe(new StandardSchemaValidationPipe());
+```
+
+## Configure controller
+
+After configuring the server, just apply the validation decorators to your controller routes. Below is a basic example of setting up a controller to validate a request body.
 
 <CodeBlock language="typescript">{gettingStartedSource}</CodeBlock>
 

--- a/packages/docs/services/inversify-validation-site/docs/standard-schema/_category_.json
+++ b/packages/docs/services/inversify-validation-site/docs/standard-schema/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Standard Schema",
+  "position": 2
+}

--- a/packages/docs/services/inversify-validation-site/docs/standard-schema/api.mdx
+++ b/packages/docs/services/inversify-validation-site/docs/standard-schema/api.mdx
@@ -1,0 +1,46 @@
+---
+sidebar_position: 2
+title: API
+---
+import apiStandardSchemaValidationPipeSource from '@inversifyjs/validation-code-examples/generated/examples/v1/standardSchema/apiStandardSchemaValidationPipe.ts.txt';
+import apiValidateStandardSchemaV1Source from '@inversifyjs/validation-code-examples/generated/examples/v1/standardSchema/apiValidateStandardSchemaV1.ts.txt';
+import CodeBlock from '@theme/CodeBlock';
+
+## StandardSchemaValidationPipe
+
+Validates values using any schema that implements the Standard Schema v1 spec. Register it globally to validate incoming HTTP parameters (e.g., body) in your controllers.
+
+```ts
+constructor(schemaList?: StandardSchemaV1[])
+```
+
+Parameters
+
+- schemaList (optional StandardSchemaV1[]): One or more Standard Schema schemas applied globally to every validated value. These run before any parameter-level schemas added via `@ValidateStandardSchemaV1`.
+
+`StandardSchemaValidationPipe` can be registered as a global pipe: `adapter.useGlobalPipe(new StandardSchemaValidationPipe())`.
+This way, controller parameters decorated `@ValidateStandardSchemaV1` are automatically validated.
+
+### Example: register a StandardSchemaValidationPipe globally
+
+<CodeBlock language="ts">{apiStandardSchemaValidationPipeSource}</CodeBlock>
+
+## ValidateStandardSchemaV1
+
+Attaches one or more Standard Schema v1 schemas to a specific parameter (e.g., `@Body()`), so the `StandardSchemaValidationPipe` can validate and (optionally) transform the value before your controller method runs.
+
+```ts
+ValidateStandardSchemaV1(...schemaList: StandardSchemaV1[]): ParameterDecorator
+```
+
+Parameters
+
+- schemaList: One or more schemas from any library that implements the Standard Schema v1 spec (e.g., Zod, Valibot, Arktype).
+
+When multiple schemas are provided, they run in order. The output of one becomes the input of the next. Any schemas provided to `StandardSchemaValidationPipe` run first; parameter-level schemas run afterwards. If a schema transforms the value (e.g., parsing/coercion), the controller receives the transformed value.
+
+On failure, an `InversifyValidationError` is thrown and can be converted to a Bad Request HTTP response by `ValidationErrorFilter`.
+
+Example: validate request body with Zod
+
+<CodeBlock language="ts">{apiValidateStandardSchemaV1Source}</CodeBlock>

--- a/packages/docs/services/inversify-validation-site/docs/standard-schema/introduction.mdx
+++ b/packages/docs/services/inversify-validation-site/docs/standard-schema/introduction.mdx
@@ -1,0 +1,40 @@
+---
+sidebar_position: 1
+title: Introduction
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+[Standard Schema](https://standardschema.dev/) is a common interface designed to be implemented by JavaScript and TypeScript schema libraries.
+
+Any schema library that implements the Standard Schema interface can be used with Inversify Validation's Standard Schema Validation Pipe. This allows you to use this pipe with popular schema libraries like [Zod](https://zod.dev/), [Valibot](https://valibot.dev/), [Arktype](https://arktype.io/) and [others](https://standardschema.dev/#what-schema-libraries-implement-the-spec).
+
+## Install dependencies
+
+In order to use the package, install it along with the validation library of your choice:
+
+
+
+<Tabs>
+  <TabItem value="npm" label="npm">
+
+```bash
+  npm install zod @inversifyjs/standard-schema-validation
+```
+
+  </TabItem>
+  <TabItem value="yarn" label="yarn">
+
+```bash
+  yarn add zod @inversifyjs/standard-schema-validation
+```
+
+  </TabItem>
+  <TabItem value="pnpm" label="pnpm">
+
+```bash
+  pnpm install zod @inversifyjs/standard-schema-validation
+```
+
+  </TabItem>
+</Tabs>

--- a/packages/docs/tools/inversify-validation-code-examples/package.json
+++ b/packages/docs/tools/inversify-validation-code-examples/package.json
@@ -5,6 +5,7 @@
   },
   "description": "InversifyJS validation docs code examples package",
   "devDependencies": {
+    "@inversifyjs/ajv-validation": "workspace:*",
     "@inversifyjs/class-validation": "workspace:*",
     "@inversifyjs/code-examples-devkit": "workspace:*",
     "@inversifyjs/http-core": "workspace:*",
@@ -15,6 +16,8 @@
     "@types/express": "5.0.3",
     "@types/node": "22.18.4",
     "@vitest/coverage-v8": "3.2.4",
+    "ajv": "8.17.1",
+    "ajv-formats": "3.0.1",
     "class-transformer": "~0.5.1",
     "class-validator": "~0.14.2",
     "eslint": "9.35.0",

--- a/packages/docs/tools/inversify-validation-code-examples/package.json
+++ b/packages/docs/tools/inversify-validation-code-examples/package.json
@@ -5,6 +5,7 @@
   },
   "description": "InversifyJS validation docs code examples package",
   "devDependencies": {
+    "@inversifyjs/class-validation": "workspace:*",
     "@inversifyjs/code-examples-devkit": "workspace:*",
     "@inversifyjs/http-core": "workspace:*",
     "@inversifyjs/http-express": "workspace:*",
@@ -14,6 +15,8 @@
     "@types/express": "5.0.3",
     "@types/node": "22.18.4",
     "@vitest/coverage-v8": "3.2.4",
+    "class-transformer": "~0.5.1",
+    "class-validator": "~0.14.2",
     "eslint": "9.35.0",
     "express": "5.1.0",
     "glob": "11.0.3",

--- a/packages/docs/tools/inversify-validation-code-examples/package.json
+++ b/packages/docs/tools/inversify-validation-code-examples/package.json
@@ -8,6 +8,7 @@
     "@inversifyjs/code-examples-devkit": "workspace:*",
     "@inversifyjs/http-core": "workspace:*",
     "@inversifyjs/http-express": "workspace:*",
+    "@inversifyjs/http-validation": "workspace:*",
     "@inversifyjs/standard-schema-validation": "workspace:*",
     "@inversifyjs/validation-common": "workspace:*",
     "@types/express": "5.0.3",

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/ajv/apiAjvCompiledValidationPipe.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/ajv/apiAjvCompiledValidationPipe.ts
@@ -1,0 +1,16 @@
+import { AjvCompiledValidationPipe } from '@inversifyjs/ajv-validation';
+import { InversifyExpressHttpAdapter } from '@inversifyjs/http-express';
+import { InversifyValidationErrorFilter } from '@inversifyjs/http-validation';
+import Ajv from 'ajv';
+import { Container } from 'inversify';
+
+const container: Container = new Container();
+
+const ajv: Ajv = new Ajv();
+
+const adapter: InversifyExpressHttpAdapter = new InversifyExpressHttpAdapter(
+  container,
+  { logger: true },
+);
+adapter.useGlobalFilters(InversifyValidationErrorFilter);
+adapter.useGlobalPipe(new AjvCompiledValidationPipe(ajv));

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/ajv/apiAjvValidationPipe.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/ajv/apiAjvValidationPipe.ts
@@ -1,0 +1,16 @@
+import { AjvValidationPipe } from '@inversifyjs/ajv-validation';
+import { InversifyExpressHttpAdapter } from '@inversifyjs/http-express';
+import { InversifyValidationErrorFilter } from '@inversifyjs/http-validation';
+import Ajv from 'ajv';
+import { Container } from 'inversify';
+
+const container: Container = new Container();
+
+const ajv: Ajv = new Ajv();
+
+const adapter: InversifyExpressHttpAdapter = new InversifyExpressHttpAdapter(
+  container,
+  { logger: true },
+);
+adapter.useGlobalFilters(InversifyValidationErrorFilter);
+adapter.useGlobalPipe(new AjvValidationPipe(ajv));

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/ajv/apiIntroduction.int.spec.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/ajv/apiIntroduction.int.spec.ts
@@ -1,0 +1,205 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { AjvValidationPipe } from '@inversifyjs/ajv-validation';
+import {
+  BadRequestHttpResponse,
+  CatchError,
+  ErrorFilter,
+} from '@inversifyjs/http-core';
+import { InversifyValidationError } from '@inversifyjs/validation-common';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import { Container } from 'inversify';
+
+import { buildExpressServer } from '../../../server/adapter/express/actions/buildExpressServer';
+import { Server } from '../../../server/models/Server';
+import { UserController } from './apiIntroduction';
+
+@CatchError(InversifyValidationError)
+class ValidationErrorFilter implements ErrorFilter<InversifyValidationError> {
+  public catch(error: InversifyValidationError): never {
+    throw new BadRequestHttpResponse(error.message, undefined, {
+      cause: error,
+    });
+  }
+}
+
+describe('API Introduction (AJV)', () => {
+  describe('having an AjvValidationPipe in an HTTP server with Quick Start user validation', () => {
+    let server: Server;
+
+    beforeAll(async () => {
+      const container: Container = new Container();
+      const ajv: Ajv = new Ajv();
+      addFormats(ajv);
+
+      container.bind(ValidationErrorFilter).toSelf().inSingletonScope();
+      container.bind(UserController).toSelf().inSingletonScope();
+
+      server = await buildExpressServer(
+        container,
+        [ValidationErrorFilter],
+        [new AjvValidationPipe(ajv)],
+      );
+    });
+
+    afterAll(async () => {
+      await server.shutdown();
+    });
+
+    describe('when a valid POST /users request is made', () => {
+      let response: Response;
+
+      beforeAll(async () => {
+        response = await fetch(
+          `http://${server.host}:${server.port.toString()}/users`,
+          {
+            body: JSON.stringify({
+              age: 30,
+              email: 'jane.doe@example.com',
+              name: 'Jane Doe',
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+          },
+        );
+      });
+
+      it('should return expected Response', async () => {
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toStrictEqual(
+          expect.stringContaining('text/html'),
+        );
+        await expect(response.text()).resolves.toBe('Created user: Jane Doe');
+      });
+    });
+
+    describe('when a valid POST /users request is made (without optional age)', () => {
+      let response: Response;
+
+      beforeAll(async () => {
+        response = await fetch(
+          `http://${server.host}:${server.port.toString()}/users`,
+          {
+            body: JSON.stringify({
+              email: 'john.smith@example.com',
+              name: 'John Smith',
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+          },
+        );
+      });
+
+      it('should return expected Response', async () => {
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toStrictEqual(
+          expect.stringContaining('text/html'),
+        );
+        await expect(response.text()).resolves.toBe('Created user: John Smith');
+      });
+    });
+
+    describe('when an invalid POST /users request is made (missing name)', () => {
+      let response: Response;
+
+      beforeAll(async () => {
+        response = await fetch(
+          `http://${server.host}:${server.port.toString()}/users`,
+          {
+            body: JSON.stringify({
+              email: 'test@example.com',
+              // Missing required name field
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+          },
+        );
+      });
+
+      it('should return expected Response', async () => {
+        expect(response.status).toBe(400);
+        expect(response.headers.get('content-type')).toStrictEqual(
+          expect.stringContaining('application/json'),
+        );
+
+        await expect(response.json()).resolves.toStrictEqual({
+          error: 'Bad Request',
+          message: expect.stringContaining('name'),
+          statusCode: 400,
+        });
+      });
+    });
+
+    describe('when an invalid POST /users request is made (invalid email)', () => {
+      let response: Response;
+
+      beforeAll(async () => {
+        response = await fetch(
+          `http://${server.host}:${server.port.toString()}/users`,
+          {
+            body: JSON.stringify({
+              email: 'not-an-email',
+              name: 'Test User',
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+          },
+        );
+      });
+
+      it('should return expected Response', async () => {
+        expect(response.status).toBe(400);
+        expect(response.headers.get('content-type')).toStrictEqual(
+          expect.stringContaining('application/json'),
+        );
+        await expect(response.json()).resolves.toStrictEqual({
+          error: 'Bad Request',
+          message: expect.stringContaining('format'),
+          statusCode: 400,
+        });
+      });
+    });
+
+    describe('when an invalid POST /users request is made (negative age)', () => {
+      let response: Response;
+
+      beforeAll(async () => {
+        response = await fetch(
+          `http://${server.host}:${server.port.toString()}/users`,
+          {
+            body: JSON.stringify({
+              age: -5,
+              email: 'test@example.com',
+              name: 'Test User',
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+          },
+        );
+      });
+
+      it('should return expected Response', async () => {
+        expect(response.status).toBe(400);
+        expect(response.headers.get('content-type')).toStrictEqual(
+          expect.stringContaining('application/json'),
+        );
+        await expect(response.json()).resolves.toStrictEqual({
+          error: 'Bad Request',
+          message: expect.stringContaining('minimum'),
+          statusCode: 400,
+        });
+      });
+    });
+  });
+});

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/ajv/apiIntroduction.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/ajv/apiIntroduction.ts
@@ -1,0 +1,49 @@
+// Begin-example
+import {
+  AjvValidationPipe,
+  ValidateAjvSchema,
+} from '@inversifyjs/ajv-validation';
+import { Body, Controller, Post } from '@inversifyjs/http-core';
+import { InversifyExpressHttpAdapter } from '@inversifyjs/http-express';
+import { InversifyValidationErrorFilter } from '@inversifyjs/http-validation';
+import { AnySchema } from 'ajv';
+import Ajv from 'ajv';
+import { Container } from 'inversify';
+
+const container: Container = new Container();
+const ajv: Ajv = new Ajv();
+
+// Create HTTP adapter
+const adapter: InversifyExpressHttpAdapter = new InversifyExpressHttpAdapter(
+  container,
+);
+
+// Register global AJV validation pipe
+adapter.useGlobalPipe(new AjvValidationPipe(ajv));
+adapter.useGlobalFilters(InversifyValidationErrorFilter);
+
+// Define a JSON schema
+const userSchema: AnySchema = {
+  additionalProperties: false,
+  properties: {
+    age: { minimum: 0, type: 'number' },
+    email: { format: 'email', type: 'string' },
+    name: { minLength: 1, type: 'string' },
+  },
+  required: ['name', 'email'],
+  type: 'object',
+};
+
+interface User {
+  age?: number;
+  email: string;
+  name: string;
+}
+
+@Controller('/users')
+export class UserController {
+  @Post('/')
+  public createUser(@ValidateAjvSchema(userSchema) @Body() user: User): string {
+    return `Created user: ${user.name}`;
+  }
+}

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/ajv/apiValidateAjvSchema.int.spec.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/ajv/apiValidateAjvSchema.int.spec.ts
@@ -1,0 +1,147 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { AjvValidationPipe } from '@inversifyjs/ajv-validation';
+import {
+  BadRequestHttpResponse,
+  CatchError,
+  ErrorFilter,
+} from '@inversifyjs/http-core';
+import { InversifyValidationError } from '@inversifyjs/validation-common';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import { Container } from 'inversify';
+
+import { buildExpressServer } from '../../../server/adapter/express/actions/buildExpressServer';
+import { Server } from '../../../server/models/Server';
+import { UserController } from './apiValidateAjvSchema';
+
+@CatchError(InversifyValidationError)
+class ValidationErrorFilter implements ErrorFilter<InversifyValidationError> {
+  public catch(error: InversifyValidationError): never {
+    throw new BadRequestHttpResponse(error.message, undefined, {
+      cause: error,
+    });
+  }
+}
+
+describe('ValidateAjvSchema API', () => {
+  describe('having an AjvValidationPipe in an HTTP server with ValidateAjvSchema decorated endpoints', () => {
+    let server: Server;
+
+    beforeAll(async () => {
+      const container: Container = new Container();
+      const ajv: Ajv = new Ajv();
+      addFormats(ajv);
+
+      container.bind(ValidationErrorFilter).toSelf().inSingletonScope();
+      container.bind(UserController).toSelf().inSingletonScope();
+
+      server = await buildExpressServer(
+        container,
+        [ValidationErrorFilter],
+        [new AjvValidationPipe(ajv)],
+      );
+    });
+
+    afterAll(async () => {
+      await server.shutdown();
+    });
+
+    describe('when a valid POST /users request is made', () => {
+      let response: Response;
+
+      beforeAll(async () => {
+        response = await fetch(
+          `http://${server.host}:${server.port.toString()}/users`,
+          {
+            body: JSON.stringify({
+              age: 25,
+              email: 'john.doe@example.com',
+              name: 'John Doe',
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+          },
+        );
+      });
+
+      it('should return expected Response', async () => {
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toStrictEqual(
+          expect.stringContaining('application/json'),
+        );
+        await expect(response.json()).resolves.toStrictEqual({
+          age: 25,
+          email: 'john.doe@example.com',
+          name: 'John Doe',
+        });
+      });
+    });
+
+    describe('when an invalid POST /users request is made (missing required field)', () => {
+      let response: Response;
+
+      beforeAll(async () => {
+        response = await fetch(
+          `http://${server.host}:${server.port.toString()}/users`,
+          {
+            body: JSON.stringify({
+              name: 'John Doe',
+              // Missing required email field
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+          },
+        );
+      });
+
+      it('should return expected Response', async () => {
+        expect(response.status).toBe(400);
+        expect(response.headers.get('content-type')).toStrictEqual(
+          expect.stringContaining('application/json'),
+        );
+        await expect(response.json()).resolves.toStrictEqual({
+          error: 'Bad Request',
+          message: expect.stringContaining('email'),
+          statusCode: 400,
+        });
+      });
+    });
+
+    describe('when an invalid POST /users request is made (invalid email format)', () => {
+      let response: Response;
+
+      beforeAll(async () => {
+        response = await fetch(
+          `http://${server.host}:${server.port.toString()}/users`,
+          {
+            body: JSON.stringify({
+              email: 'invalid-email',
+              name: 'John Doe',
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+          },
+        );
+      });
+
+      it('should return expected Response', async () => {
+        expect(response.status).toBe(400);
+        expect(response.headers.get('content-type')).toStrictEqual(
+          expect.stringContaining('application/json'),
+        );
+        await expect(response.json()).resolves.toStrictEqual({
+          error: 'Bad Request',
+          message: expect.stringContaining('format'),
+          statusCode: 400,
+        });
+      });
+    });
+  });
+});

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/ajv/apiValidateAjvSchema.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/ajv/apiValidateAjvSchema.ts
@@ -1,0 +1,33 @@
+// Begin-example
+import { ValidateAjvSchema } from '@inversifyjs/ajv-validation';
+import { Body, Controller, Post } from '@inversifyjs/http-core';
+import { AnySchema } from 'ajv';
+
+interface User {
+  name: string;
+  email: string;
+  age?: number;
+}
+
+const userSchema: AnySchema = {
+  additionalProperties: false,
+  properties: {
+    age: { minimum: 0, type: 'number' },
+    email: { format: 'email', type: 'string' },
+    name: { minLength: 1, type: 'string' },
+  },
+  required: ['name', 'email'],
+  type: 'object',
+};
+
+@Controller('/users')
+export class UserController {
+  @Post()
+  public async createUser(
+    @Body()
+    @ValidateAjvSchema(userSchema)
+    user: User,
+  ): Promise<User> {
+    return user;
+  }
+}

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/classValidator/apiClassValidationPipe.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/classValidator/apiClassValidationPipe.ts
@@ -1,0 +1,15 @@
+// Begin-example
+import { ClassValidationPipe } from '@inversifyjs/class-validation';
+import { InversifyExpressHttpAdapter } from '@inversifyjs/http-express';
+import { InversifyValidationErrorFilter } from '@inversifyjs/http-validation';
+import { Container } from 'inversify';
+
+const container: Container = new Container();
+
+const adapter: InversifyExpressHttpAdapter = new InversifyExpressHttpAdapter(
+  container,
+  { logger: true },
+);
+adapter.useGlobalFilters(InversifyValidationErrorFilter);
+adapter.useGlobalPipe(new ClassValidationPipe());
+// End-example

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/classValidator/gettingStarted.int.spec.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/classValidator/gettingStarted.int.spec.ts
@@ -1,0 +1,98 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { ClassValidationPipe } from '@inversifyjs/class-validation';
+import {
+  BadRequestHttpResponse,
+  CatchError,
+  ErrorFilter,
+} from '@inversifyjs/http-core';
+import { InversifyValidationError } from '@inversifyjs/validation-common';
+import { Container } from 'inversify';
+
+import { buildExpressServer } from '../../../server/adapter/express/actions/buildExpressServer';
+import { Server } from '../../../server/models/Server';
+import { MessageController } from './gettingStarted';
+
+@CatchError(InversifyValidationError)
+class ValidationErrorFilter implements ErrorFilter<InversifyValidationError> {
+  public catch(error: InversifyValidationError): never {
+    throw new BadRequestHttpResponse(error.message, undefined, {
+      cause: error,
+    });
+  }
+}
+
+describe('Getting started', () => {
+  describe('having a ClassValidationPipe in an HTTP server with validated endpoints', () => {
+    let server: Server;
+
+    beforeAll(async () => {
+      const container: Container = new Container();
+
+      container.bind(ValidationErrorFilter).toSelf().inSingletonScope();
+      container.bind(MessageController).toSelf().inSingletonScope();
+
+      server = await buildExpressServer(
+        container,
+        [ValidationErrorFilter],
+        [new ClassValidationPipe()],
+      );
+    });
+
+    afterAll(async () => {
+      await server.shutdown();
+    });
+
+    describe('when a valid POST /messages request is made', () => {
+      let response: Response;
+
+      beforeAll(async () => {
+        response = await fetch(
+          `http://${server.host}:${server.port.toString()}/messages`,
+          {
+            body: JSON.stringify({
+              content: 'Hello, world!',
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+          },
+        );
+      });
+
+      it('should return expected Response', async () => {
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toStrictEqual(
+          expect.stringContaining('application/json'),
+        );
+        await expect(response.json()).resolves.toStrictEqual({
+          content: 'Hello, world!',
+        });
+      });
+    });
+
+    describe('when an invalid POST /messages request is made', () => {
+      let response: Response;
+
+      beforeAll(async () => {
+        response = await fetch(
+          `http://${server.host}:${server.port.toString()}/messages`,
+          {
+            body: JSON.stringify({
+              content: 123, // Should be a string
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+          },
+        );
+      });
+
+      it('should return a Bad Request response', async () => {
+        expect(response.status).toBe(400);
+      });
+    });
+  });
+});

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/classValidator/gettingStarted.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/classValidator/gettingStarted.ts
@@ -1,0 +1,20 @@
+// Begin-example
+import { Body, Controller, Post } from '@inversifyjs/http-core';
+import { IsString } from 'class-validator';
+
+class Message {
+  @IsString()
+  public readonly content!: string;
+}
+
+@Controller('/messages')
+export class MessageController {
+  @Post()
+  public async createMessage(
+    @Body()
+    message: Message,
+  ): Promise<Message> {
+    return message;
+  }
+}
+// End-example

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/standardSchema/apiStandardSchemaValidationPipe.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/standardSchema/apiStandardSchemaValidationPipe.ts
@@ -1,0 +1,13 @@
+import { InversifyExpressHttpAdapter } from '@inversifyjs/http-express';
+import { InversifyValidationErrorFilter } from '@inversifyjs/http-validation';
+import { StandardSchemaValidationPipe } from '@inversifyjs/standard-schema-validation';
+import { Container } from 'inversify';
+
+const container: Container = new Container();
+
+const adapter: InversifyExpressHttpAdapter = new InversifyExpressHttpAdapter(
+  container,
+  { logger: true },
+);
+adapter.useGlobalFilters(InversifyValidationErrorFilter);
+adapter.useGlobalPipe(new StandardSchemaValidationPipe());

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/standardSchema/apiValidateStandardSchemaV1.int.spec.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/standardSchema/apiValidateStandardSchemaV1.int.spec.ts
@@ -1,0 +1,109 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  BadRequestHttpResponse,
+  CatchError,
+  ErrorFilter,
+} from '@inversifyjs/http-core';
+import { StandardSchemaValidationPipe } from '@inversifyjs/standard-schema-validation';
+import { InversifyValidationError } from '@inversifyjs/validation-common';
+import { Container } from 'inversify';
+
+import { buildExpressServer } from '../../../server/adapter/express/actions/buildExpressServer';
+import { Server } from '../../../server/models/Server';
+import { MessageController } from './gettingStarted';
+
+@CatchError(InversifyValidationError)
+class ValidationErrorFilter implements ErrorFilter<InversifyValidationError> {
+  public catch(error: InversifyValidationError): never {
+    throw new BadRequestHttpResponse(error.message, undefined, {
+      cause: error,
+    });
+  }
+}
+
+describe('Getting started', () => {
+  describe('having a StandardSchemaValidationPipe in an HTTP server with validated endpoints', () => {
+    let server: Server;
+
+    beforeAll(async () => {
+      const container: Container = new Container();
+
+      container.bind(ValidationErrorFilter).toSelf().inSingletonScope();
+      container.bind(MessageController).toSelf().inSingletonScope();
+
+      server = await buildExpressServer(
+        container,
+        [ValidationErrorFilter],
+        [new StandardSchemaValidationPipe()],
+      );
+    });
+
+    afterAll(async () => {
+      await server.shutdown();
+    });
+
+    describe('when a valid POST /messages request is made', () => {
+      let response: Response;
+
+      beforeAll(async () => {
+        response = await fetch(
+          `http://${server.host}:${server.port.toString()}/messages`,
+          {
+            body: JSON.stringify({
+              content: 'Hello, world!',
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+          },
+        );
+      });
+
+      it('should return expected Response', async () => {
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toStrictEqual(
+          expect.stringContaining('application/json'),
+        );
+        await expect(response.json()).resolves.toStrictEqual({
+          content: 'Hello, world!',
+        });
+      });
+    });
+
+    describe('when an invalid POST /messages request is made', () => {
+      let response: Response;
+
+      beforeAll(async () => {
+        response = await fetch(
+          `http://${server.host}:${server.port.toString()}/messages`,
+          {
+            body: JSON.stringify({
+              content: 'Hello, world!',
+              someExtraProperty: 'This should not be here',
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+          },
+        );
+      });
+
+      it('should return expected Response', async () => {
+        expect(response.status).toBe(400);
+        expect(response.headers.get('content-type')).toStrictEqual(
+          expect.stringContaining('application/json'),
+        );
+        await expect(response.json()).resolves.toStrictEqual({
+          error: 'Bad Request',
+          message: expect.stringContaining(
+            'Unrecognized key: "someExtraProperty"',
+          ),
+          statusCode: 400,
+        });
+      });
+    });
+  });
+});

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/standardSchema/apiValidateStandardSchemaV1.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/standardSchema/apiValidateStandardSchemaV1.ts
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+
+// Begin-example
+import { Body, Controller, Post } from '@inversifyjs/http-core';
+import { ValidateStandardSchemaV1 } from '@inversifyjs/standard-schema-validation';
+import zod from 'zod';
+
+interface Message {
+  content: string;
+}
+
+@Controller('/messages')
+export class MessageController {
+  @Post()
+  public async createMessage(
+    @Body()
+    @ValidateStandardSchemaV1(
+      zod.object({ content: zod.string().max(100) }).strict(),
+    )
+    message: Message,
+  ): Promise<Message> {
+    return message;
+  }
+}


### PR DESCRIPTION
### Changed
- Updated http decorator docs with missing `UseErrorFilter` and `UseInterceptor` decorator docs.
- Updated validation docs with:
  - [x] A better introduction.
  - [x] Standard Schema docs.
  - [x] Class validator docs.
  - [x] Ajv docs.