### PR TITLE
[HTTP] Update services to be injectable by service identifiers

### DIFF
--- a/packages/docs/services/inversify-http-site/docs/api/decorators.mdx
+++ b/packages/docs/services/inversify-http-site/docs/api/decorators.mdx
@@ -37,6 +37,18 @@ import TabItem from '@theme/TabItem';
 
 This section covers Inversify HTTP decorators used to provide related metadata.
 
+:::info Service Identifiers
+
+Many decorators in this framework accept `ServiceIdentifier` types for dependency injection. A `ServiceIdentifier<T>` can be:
+- A class constructor (e.g., `MyMiddleware`)
+- A string token (e.g., `'my-middleware'`)
+- A symbol (e.g., `Symbol.for('my-middleware')`)
+- An abstract class reference
+
+This allows for flexible dependency resolution through the InversifyJS container.
+
+:::
+
 ## HTTP Request lifecycle
 
 Inversify HTTP decorators can be used to manage the lifecycle of HTTP requests, including middleware execution, request handling, and response generation. This allows for more modular and maintainable code.
@@ -47,22 +59,20 @@ Attaches middleware to a controller class (applies to all its routes) or to a sp
 
 ```ts
 ApplyMiddleware(
-  ...middlewareList: (Newable<Middleware> | ApplyMiddlewareOptions)[],
+  ...middlewareList: (ServiceIdentifier<Middleware> | ApplyMiddlewareOptions)[],
 ): ClassDecorator & MethodDecorator
 ```
 
 Parameters
 
-- `middlewareList`
-  - `Newable<Middleware>`: One or more middleware classes. When passed directly, they run in the `PreHandler` phase.
-  - `ApplyMiddlewareOptions`: Object form to control the execution phase and group multiple middleware.
-    - phase (`MiddlewarePhase`): Either `PreHandler` or `PostHandler`.
-    - middleware (`Newable<Middleware>` | `Newable<Middleware>`[]): One or many middleware classes.
+- `middlewareList`: One or more middleware service identifiers or options objects.
+  - `ServiceIdentifier<Middleware>`: A middleware class, string token, symbol, or abstract class that can be resolved by the DI container.
+  - `ApplyMiddlewareOptions`: Configuration object with middleware and phase settings.
 
 Notes
 
 - Scope: Place the decorator on the controller class to affect all routes, or on a method to affect only that route.
-- Phase: When passing middleware classes directly (not the options object), they run in the `PreHandler` phase by default.
+- Phase: When passing middleware service identifiers directly (not the options object), they run in the `PreHandler` phase by default.
 - Order: Within the same phase, middleware execute in the order they are provided.
 - See also: [Middleware fundamentals](../../fundamentals/middleware) for adapter-specific request/response types and tips.
 
@@ -122,36 +132,24 @@ Notes
 Attaches one or more [guards](../../fundamentals/guard) to a controller class or method. All guards must allow for the request to continue.
 
 ```ts
-UseGuard(...guardList: Newable<Guard>[]): ClassDecorator & MethodDecorator
+UseGuard(...guardList: ServiceIdentifier<Guard>[]): ClassDecorator & MethodDecorator
 ```
 
 Parameters
 
-- `guardList`: One or more guard classes implementing `Guard<TRequest>`.
-
-Notes
-
-- Scope: Place on the controller class to affect all routes, or on a method to affect only that route.
-- Guard return values: `activate()` may return `true` (continue), `false` (reply with `403 Forbidden`), or throw an `ErrorHttpResponse` (replied as-is, e.g., `throw new ForbiddenHttpResponse('message')`).
+- `guardList`: One or more guard service identifiers that can be resolved by the DI container.
 
 ### UseInterceptor
 
 Attaches one or more interceptors to a controller class or method. Interceptors can modify requests before they reach the handler and responses before they are sent.
 
 ```ts
-UseInterceptor(...interceptorList: Newable<Interceptor>[]): ClassDecorator & MethodDecorator
+UseInterceptor(...interceptorList: ServiceIdentifier<Interceptor>[]): ClassDecorator & MethodDecorator
 ```
 
 Parameters
 
-- `interceptorList`: One or more interceptor classes implementing `Interceptor`.
-
-Notes
-
-- Scope: Place on the controller class to affect all routes, or on a method to affect only that route.
-- Order: Interceptors are executed in the order they are provided.
-- Request/Response modification: Interceptors can transform both incoming requests and outgoing responses.
-- Timing: Interceptors run around the handler method, allowing both pre and post-processing.
+- `interceptorList`: One or more interceptor service identifiers that can be resolved by the DI container.
 
 ## HTTP Request message abstraction
 
@@ -162,12 +160,16 @@ Inversify HTTP decorators can be used to abstract HTTP request details, such as 
 Reads the HTTP request body, or a specific property of it when a name is provided.
 
 ```ts
-Body(parameterName?: string): ParameterDecorator
+Body(
+  optionsOrPipe?: RouteParameterOptions | (ServiceIdentifier<Pipe> | Pipe),
+  ...parameterPipeList: (ServiceIdentifier<Pipe> | Pipe)[]
+): ParameterDecorator
 ```
 
 Parameters
 
-- `parameterName` (optional string): When provided, extracts the named property from the body. When omitted, injects the entire body object.
+- `optionsOrPipe` (optional): Either route parameter options or a pipe. When this is `RouteParameterOptions`, it contains configuration like `parameterName`. When it's a pipe (service identifier or instance), it's the first pipe in the pipeline.
+- `parameterPipeList`: Additional pipes to apply to the parameter for transformation and validation.
 
 #### Example: reading a request body
 
@@ -178,12 +180,16 @@ Parameters
 Reads HTTP request headers, or a specific header when a name is provided.
 
 ```ts
-Headers(name?: string): ParameterDecorator
+Headers(
+  optionsOrPipe?: RouteParameterOptions | (ServiceIdentifier<Pipe> | Pipe),
+  ...parameterPipeList: (ServiceIdentifier<Pipe> | Pipe)[]
+): ParameterDecorator
 ```
 
 Parameters
 
-- `name` (optional string): Header name to extract. When omitted, injects all headers as an object. Header names are case-insensitive.
+- `optionsOrPipe` (optional): Either route parameter options or a pipe. When this is `RouteParameterOptions`, it contains configuration like header `name`. When it's a pipe (service identifier or instance), it's the first pipe in the pipeline.
+- `parameterPipeList`: Additional pipes to apply to the parameter for transformation and validation.
 
 #### Example: reading the User-Agent header
 
@@ -200,29 +206,44 @@ Remember to enable `useCookies` option when using `express` or `fastify` adapter
 :::
 
 ```ts
-Cookies(name?: string): ParameterDecorator
+Cookies(
+  optionsOrPipe?: RouteParameterOptions | (ServiceIdentifier<Pipe> | Pipe),
+  ...parameterPipeList: (ServiceIdentifier<Pipe> | Pipe)[]
+): ParameterDecorator
 ```
 
 Parameters
 
-- `name` (optional string): Cookie name to extract. When omitted, injects a key-value map of all cookies.
+- `optionsOrPipe` (optional): Either route parameter options or a pipe. When this is `RouteParameterOptions`, it contains configuration like cookie `name`. When it's a pipe (service identifier or instance), it's the first pipe in the pipeline.
+- `parameterPipeList`: Additional pipes to apply to the parameter for transformation and validation.
 
 #### Example: reading a session cookie
 
 <CodeBlock language="ts">{decoratorApiCookiesSource}</CodeBlock>
+
+### Params
+
+Reads HTTP route parameters (path parameters), or a specific parameter when a name is provided.
+
+```ts
+Params(
+  optionsOrPipe?: RouteParameterOptions | (ServiceIdentifier<Pipe> | Pipe),
+  ...parameterPipeList: (ServiceIdentifier<Pipe> | Pipe)[]
+): ParameterDecorator
+```
+
+Parameters
+
+- `optionsOrPipe` (optional): Either route parameter options or a pipe. When this is `RouteParameterOptions`, it contains configuration like parameter `name`. When it's a pipe (service identifier or instance), it's the first pipe in the pipeline.
+- `parameterPipeList`: Additional pipes to apply to the parameter for transformation and validation.
 
 ### Request
 
 Retrieves the native request object of the current adapter. Useful when you need full access to the underlying framework request.
 
 ```ts
-Request(...pipeList: (Newable<Pipe> | Pipe)[]): ParameterDecorator
+Request(...pipeList: (ServiceIdentifier<Pipe> | Pipe)[]): ParameterDecorator
 ```
-
-Notes
-
-- Type-safe: Type the parameter with the adapter's request type for intellisense and safety.
-- Pipes: You can attach pipes to the parameter if you need to transform or validate it.
 
 #### Example: accessing the native request per adapter
 
@@ -241,6 +262,22 @@ Notes
   </TabItem>
 </Tabs>
 
+### Query
+
+Reads HTTP query parameters, or a specific query parameter when a name is provided.
+
+```ts
+Query(
+  optionsOrPipe?: RouteParameterOptions | (ServiceIdentifier<Pipe> | Pipe),
+  ...parameterPipeList: (ServiceIdentifier<Pipe> | Pipe)[]
+): ParameterDecorator
+```
+
+Parameters
+
+- `optionsOrPipe` (optional): Either route parameter options or a pipe. When this is `RouteParameterOptions`, it contains configuration like parameter `name`. When it's a pipe (service identifier or instance), it's the first pipe in the pipeline.
+- `parameterPipeList`: Additional pipes to apply to the parameter for transformation and validation.
+
 ## HTTP Response message abstraction
 
 Inversify HTTP decorators can also be used to abstract HTTP response details, such as status codes and headers. This allows for more consistent and maintainable response handling across controllers.
@@ -250,7 +287,7 @@ Inversify HTTP decorators can also be used to abstract HTTP response details, su
 Injects the native response object of the current adapter. Use it when you want to write directly to the underlying framework response.
 
 ```ts
-Response(...pipeList: (Newable<Pipe> | Pipe)[]): ParameterDecorator
+Response(...pipeList: (ServiceIdentifier<Pipe> | Pipe)[]): ParameterDecorator
 ```
 
 Notes

--- a/packages/docs/services/inversify-http-site/docs/fundamentals/pipe.mdx
+++ b/packages/docs/services/inversify-http-site/docs/fundamentals/pipe.mdx
@@ -29,9 +29,6 @@ A simple pipe that parses the input into a number and rejects invalid values wit
 
 Use parameter decorators to attach pipes where you need them. `Body`, `Params`, `Query`, `Headers`, `Cookies`, `Request`, and `Response` all accept pipes.
 
-- Named parameter: `@Params('id', ParseNumberPipe) id: number`
-- Whole object: `@Query(ParseNumberPipe) query: QueryObject`
-
 The adapter applies global pipes first, then parameter-level pipes, before calling your controller method.
 
 Global pipes can be registered using the [InversifyHttpAdapter](../../api/inversify-http-adapter#useglobalpipe).

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/decoratorApiCookies.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/decoratorApiCookies.ts
@@ -9,7 +9,10 @@ export interface CookiesResult {
 export class CookiesController {
   @Get()
   public async getCookie(
-    @Cookies('sessionId') sessionId: string | undefined,
+    @Cookies({
+      name: 'sessionId',
+    })
+    sessionId: string | undefined,
   ): Promise<CookiesResult> {
     return {
       sessionId,

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/decoratorApiHeaders.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/decoratorApiHeaders.ts
@@ -9,7 +9,10 @@ export interface HeadersResult {
 export class HeadersController {
   @Get()
   public async getUserAgent(
-    @Headers('x-client') userAgent: string | undefined,
+    @Headers({
+      name: 'x-client',
+    })
+    userAgent: string | undefined,
   ): Promise<HeadersResult> {
     return {
       agent: userAgent,

--- a/packages/docs/tools/inversify-http-code-examples/src/examples/v0/pipeApiParseNumber.int.spec.ts
+++ b/packages/docs/tools/inversify-http-code-examples/src/examples/v0/pipeApiParseNumber.int.spec.ts
@@ -29,15 +29,33 @@ describe.each<[(container: Container) => Promise<Server>]>([
       class MathController {
         @Get('/sum/:a/:b')
         public async sum(
-          @Params('a', ParseNumberPipe) a: number,
-          @Params('b', ParseNumberPipe) b: number,
+          @Params(
+            {
+              name: 'a',
+            },
+            ParseNumberPipe,
+          )
+          a: number,
+          @Params(
+            {
+              name: 'b',
+            },
+            ParseNumberPipe,
+          )
+          b: number,
         ): Promise<SumResult> {
           return { sum: a + b };
         }
 
         @Get('/double')
         public async double(
-          @Query('v', ParseNumberPipe) v: number,
+          @Query(
+            {
+              name: 'v',
+            },
+            ParseNumberPipe,
+          )
+          v: number,
         ): Promise<SumResult> {
           return { sum: v * 2 };
         }

--- a/packages/framework/core/src/error-filter/decorators/UseErrorFilter.spec.ts
+++ b/packages/framework/core/src/error-filter/decorators/UseErrorFilter.spec.ts
@@ -24,11 +24,11 @@ import { UseErrorFilter } from './UseErrorFilter';
 
 describe(UseErrorFilter, () => {
   describe('having a target', () => {
-    let middlewareFixture: Newable<ErrorFilter>;
+    let errorFilterFixture: Newable<ErrorFilter>;
     let targetFixture: NewableFunction;
 
     beforeAll(() => {
-      middlewareFixture = Symbol() as unknown as Newable<ErrorFilter>;
+      errorFilterFixture = Symbol() as unknown as Newable<ErrorFilter>;
       targetFixture = class TestController {};
     });
 
@@ -46,7 +46,7 @@ describe(UseErrorFilter, () => {
           .mocked(updateSetMetadataWithList)
           .mockReturnValueOnce(updateSetMetadataWithListResultFixture);
 
-        result = UseErrorFilter(middlewareFixture)(targetFixture);
+        result = UseErrorFilter(errorFilterFixture)(targetFixture);
       });
 
       afterAll(() => {
@@ -56,7 +56,7 @@ describe(UseErrorFilter, () => {
       it('should call updateSetMetadataWithList()', () => {
         expect(updateSetMetadataWithList).toHaveBeenCalledTimes(1);
         expect(updateSetMetadataWithList).toHaveBeenCalledWith([
-          middlewareFixture,
+          errorFilterFixture,
         ]);
       });
 
@@ -78,13 +78,13 @@ describe(UseErrorFilter, () => {
   });
 
   describe('having a target and a key', () => {
-    let middlewareFixture: Newable<ErrorFilter>;
+    let errorFilterFixture: Newable<ErrorFilter>;
     let targetFixture: NewableFunction;
     let methodKeyFixture: string | symbol;
     let descriptorFixture: PropertyDescriptor;
 
     beforeAll(() => {
-      middlewareFixture = Symbol() as unknown as Newable<ErrorFilter>;
+      errorFilterFixture = Symbol() as unknown as Newable<ErrorFilter>;
       targetFixture = class TestController {};
       methodKeyFixture = 'testMethod';
       descriptorFixture = {
@@ -106,7 +106,7 @@ describe(UseErrorFilter, () => {
           .mocked(updateSetMetadataWithList)
           .mockReturnValueOnce(updateSetMetadataWithListResultFixture);
 
-        result = UseErrorFilter(middlewareFixture)(
+        result = UseErrorFilter(errorFilterFixture)(
           // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
           targetFixture.prototype,
           methodKeyFixture,
@@ -117,7 +117,7 @@ describe(UseErrorFilter, () => {
       it('should call updateSetMetadataWithList()', () => {
         expect(updateSetMetadataWithList).toHaveBeenCalledTimes(1);
         expect(updateSetMetadataWithList).toHaveBeenCalledWith([
-          middlewareFixture,
+          errorFilterFixture,
         ]);
       });
 

--- a/packages/framework/core/src/guard/calculations/getClassGuardList.spec.ts
+++ b/packages/framework/core/src/guard/calculations/getClassGuardList.spec.ts
@@ -3,8 +3,10 @@ import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
 vitest.mock('@inversifyjs/reflect-metadata-utils');
 
 import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+import { ServiceIdentifier } from 'inversify';
 
 import { classGuardMetadataReflectKey } from '../../reflectMetadata/data/classGuardMetadataReflectKey';
+import { Guard } from '../models/Guard';
 import { getClassGuardList } from './getClassGuardList';
 
 describe(getClassGuardList, () => {
@@ -37,7 +39,7 @@ describe(getClassGuardList, () => {
 
   describe('when called, and getOwnReflectMetadata() returns an array', () => {
     let classFixture: NewableFunction;
-    let classGuardFixtures: NewableFunction[];
+    let classGuardFixtures: ServiceIdentifier<Guard>[];
     let result: unknown;
 
     beforeAll(() => {

--- a/packages/framework/core/src/guard/calculations/getClassGuardList.ts
+++ b/packages/framework/core/src/guard/calculations/getClassGuardList.ts
@@ -1,5 +1,5 @@
 import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
-import { Newable } from 'inversify';
+import { ServiceIdentifier } from 'inversify';
 
 import { classGuardMetadataReflectKey } from '../../reflectMetadata/data/classGuardMetadataReflectKey';
 import { Guard } from '../models/Guard';
@@ -7,7 +7,7 @@ import { Guard } from '../models/Guard';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function getClassGuardList<TRequest = any>(
   classConstructor: NewableFunction,
-): Newable<Guard<TRequest>>[] {
+): ServiceIdentifier<Guard<TRequest>>[] {
   return (
     getOwnReflectMetadata(classConstructor, classGuardMetadataReflectKey) ?? []
   );

--- a/packages/framework/core/src/guard/calculations/getClassMethodGuardList.spec.ts
+++ b/packages/framework/core/src/guard/calculations/getClassMethodGuardList.spec.ts
@@ -3,8 +3,10 @@ import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
 vitest.mock('@inversifyjs/reflect-metadata-utils');
 
 import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+import { ServiceIdentifier } from 'inversify';
 
 import { classMethodGuardMetadataReflectKey } from '../../reflectMetadata/data/classMethodGuardMetadataReflectKey';
+import { Guard } from '../models/Guard';
 import { getClassMethodGuardList } from './getClassMethodGuardList';
 
 describe(getClassMethodGuardList, () => {
@@ -41,7 +43,7 @@ describe(getClassMethodGuardList, () => {
   describe('when called, and getOwnReflectMetadata() returns an array', () => {
     let classFixture: NewableFunction;
     let classMethodKeyFixture: string | symbol;
-    let classMethodGuardFixtures: NewableFunction[];
+    let classMethodGuardFixtures: ServiceIdentifier<Guard>[];
     let result: unknown;
 
     beforeAll(() => {

--- a/packages/framework/core/src/guard/calculations/getClassMethodGuardList.ts
+++ b/packages/framework/core/src/guard/calculations/getClassMethodGuardList.ts
@@ -1,5 +1,5 @@
 import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
-import { Newable } from 'inversify';
+import { ServiceIdentifier } from 'inversify';
 
 import { classMethodGuardMetadataReflectKey } from '../../reflectMetadata/data/classMethodGuardMetadataReflectKey';
 import { Guard } from '../models/Guard';
@@ -8,7 +8,7 @@ import { Guard } from '../models/Guard';
 export function getClassMethodGuardList<TRequest = any>(
   classConstructor: NewableFunction,
   methodKey: string | symbol,
-): Newable<Guard<TRequest>>[] {
+): ServiceIdentifier<Guard<TRequest>>[] {
   return (
     getOwnReflectMetadata(
       classConstructor,

--- a/packages/framework/core/src/guard/decorators/UseGuard.spec.ts
+++ b/packages/framework/core/src/guard/decorators/UseGuard.spec.ts
@@ -7,7 +7,7 @@ import {
   buildEmptyArrayMetadata,
   updateOwnReflectMetadata,
 } from '@inversifyjs/reflect-metadata-utils';
-import { Newable } from 'inversify';
+import { ServiceIdentifier } from 'inversify';
 
 import { classGuardMetadataReflectKey } from '../../reflectMetadata/data/classGuardMetadataReflectKey';
 import { classMethodGuardMetadataReflectKey } from '../../reflectMetadata/data/classMethodGuardMetadataReflectKey';
@@ -17,12 +17,12 @@ import { UseGuard } from './UseGuard';
 describe(UseGuard, () => {
   describe('having a ClassDecorator', () => {
     describe('when called', () => {
-      let middlewareFixture: Newable<Guard>;
+      let guardServiceIdentifierFixture: ServiceIdentifier<Guard>;
       let targetFixture: NewableFunction;
       let callbackFixture: (arrayMetadata: unknown[]) => unknown[];
 
       beforeAll(() => {
-        middlewareFixture = {} as Newable<Guard>;
+        guardServiceIdentifierFixture = Symbol();
         targetFixture = class TestController {};
         callbackFixture = (arrayMetadata: unknown[]): unknown[] =>
           arrayMetadata;
@@ -31,7 +31,7 @@ describe(UseGuard, () => {
           .mocked(buildArrayMetadataWithArray)
           .mockReturnValueOnce(callbackFixture);
 
-        UseGuard(middlewareFixture)(targetFixture);
+        UseGuard(guardServiceIdentifierFixture)(targetFixture);
       });
 
       afterAll(() => {
@@ -41,7 +41,7 @@ describe(UseGuard, () => {
       it('should call buildArrayMetadataWithArray()', () => {
         expect(buildArrayMetadataWithArray).toHaveBeenCalledTimes(1);
         expect(buildArrayMetadataWithArray).toHaveBeenCalledWith([
-          middlewareFixture,
+          guardServiceIdentifierFixture,
         ]);
       });
 
@@ -62,14 +62,14 @@ describe(UseGuard, () => {
     describe('when called', () => {
       let targetFixture: NewableFunction;
       let methodKeyFixture: string | symbol;
-      let middlewareFixture: Newable<Guard>;
+      let guardServiceIdentifierFixture: ServiceIdentifier<Guard>;
       let descriptorFixture: PropertyDescriptor;
       let callbackFixture: (arrayMetadata: unknown[]) => unknown[];
 
       beforeAll(() => {
         targetFixture = class TestController {};
         methodKeyFixture = 'testMethod';
-        middlewareFixture = {} as Newable<Guard>;
+        guardServiceIdentifierFixture = Symbol();
         descriptorFixture = {
           value: 'value-descriptor-example',
         } as PropertyDescriptor;
@@ -80,7 +80,7 @@ describe(UseGuard, () => {
           .mocked(buildArrayMetadataWithArray)
           .mockReturnValueOnce(callbackFixture);
 
-        UseGuard(middlewareFixture)(
+        UseGuard(guardServiceIdentifierFixture)(
           targetFixture,
           methodKeyFixture,
           descriptorFixture,
@@ -90,7 +90,7 @@ describe(UseGuard, () => {
       it('should call buildArrayMetadataWithArray()', () => {
         expect(buildArrayMetadataWithArray).toHaveBeenCalledTimes(1);
         expect(buildArrayMetadataWithArray).toHaveBeenCalledWith([
-          middlewareFixture,
+          guardServiceIdentifierFixture,
         ]);
       });
 

--- a/packages/framework/core/src/guard/decorators/UseGuard.ts
+++ b/packages/framework/core/src/guard/decorators/UseGuard.ts
@@ -3,7 +3,7 @@ import {
   buildEmptyArrayMetadata,
   updateOwnReflectMetadata,
 } from '@inversifyjs/reflect-metadata-utils';
-import { Newable } from 'inversify';
+import { ServiceIdentifier } from 'inversify';
 
 import { classGuardMetadataReflectKey } from '../../reflectMetadata/data/classGuardMetadataReflectKey';
 import { classMethodGuardMetadataReflectKey } from '../../reflectMetadata/data/classMethodGuardMetadataReflectKey';
@@ -11,7 +11,7 @@ import { Guard } from '../models/Guard';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function UseGuard(
-  ...guardList: Newable<Guard>[]
+  ...guardList: ServiceIdentifier<Guard>[]
 ): ClassDecorator & MethodDecorator {
   return (target: object, key?: string | symbol): void => {
     let classTarget: object;

--- a/packages/framework/core/src/interceptor/calculations/getClassInterceptorList.spec.ts
+++ b/packages/framework/core/src/interceptor/calculations/getClassInterceptorList.spec.ts
@@ -3,8 +3,10 @@ import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
 vitest.mock('@inversifyjs/reflect-metadata-utils');
 
 import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+import { ServiceIdentifier } from 'inversify';
 
 import { classInterceptorMetadataReflectKey } from '../../reflectMetadata/data/classInterceptorMetadataReflectKey';
+import { Interceptor } from '../models/Interceptor';
 import { getClassInterceptorList } from './getClassInterceptorList';
 
 describe(getClassInterceptorList, () => {
@@ -37,7 +39,7 @@ describe(getClassInterceptorList, () => {
 
   describe('when called, and getOwnReflectMetadata() returns an array', () => {
     let classFixture: NewableFunction;
-    let classInterceptorFixtures: NewableFunction[];
+    let classInterceptorFixtures: ServiceIdentifier<Interceptor>[];
     let result: unknown;
 
     beforeAll(() => {

--- a/packages/framework/core/src/interceptor/calculations/getClassInterceptorList.ts
+++ b/packages/framework/core/src/interceptor/calculations/getClassInterceptorList.ts
@@ -1,12 +1,12 @@
 import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
-import { Newable } from 'inversify';
+import { ServiceIdentifier } from 'inversify';
 
 import { classInterceptorMetadataReflectKey } from '../../reflectMetadata/data/classInterceptorMetadataReflectKey';
 import { Interceptor } from '../models/Interceptor';
 
 export function getClassInterceptorList(
   classConstructor: NewableFunction,
-): Newable<Interceptor>[] {
+): ServiceIdentifier<Interceptor>[] {
   return (
     getOwnReflectMetadata(
       classConstructor,

--- a/packages/framework/core/src/interceptor/calculations/getClassMethodInterceptorList.spec.ts
+++ b/packages/framework/core/src/interceptor/calculations/getClassMethodInterceptorList.spec.ts
@@ -3,8 +3,10 @@ import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
 vitest.mock('@inversifyjs/reflect-metadata-utils');
 
 import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+import { ServiceIdentifier } from 'inversify';
 
 import { classMethodInterceptorMetadataReflectKey } from '../../reflectMetadata/data/classMethodInterceptorMetadataReflectKey';
+import { Interceptor } from '../models/Interceptor';
 import { getClassMethodInterceptorList } from './getClassMethodInterceptorList';
 
 describe(getClassMethodInterceptorList, () => {
@@ -44,7 +46,7 @@ describe(getClassMethodInterceptorList, () => {
   describe('when called, and getOwnReflectMetadata() returns an array', () => {
     let classFixture: NewableFunction;
     let classMethodKeyFixture: string | symbol;
-    let classMethodInterceptorFixtures: NewableFunction[];
+    let classMethodInterceptorFixtures: ServiceIdentifier<Interceptor>[];
     let result: unknown;
 
     beforeAll(() => {

--- a/packages/framework/core/src/interceptor/calculations/getClassMethodInterceptorList.ts
+++ b/packages/framework/core/src/interceptor/calculations/getClassMethodInterceptorList.ts
@@ -1,5 +1,5 @@
 import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
-import { Newable } from 'inversify';
+import { ServiceIdentifier } from 'inversify';
 
 import { classMethodInterceptorMetadataReflectKey } from '../../reflectMetadata/data/classMethodInterceptorMetadataReflectKey';
 import { Interceptor } from '../models/Interceptor';
@@ -7,7 +7,7 @@ import { Interceptor } from '../models/Interceptor';
 export function getClassMethodInterceptorList(
   classConstructor: NewableFunction,
   methodKey: string | symbol,
-): Newable<Interceptor>[] {
+): ServiceIdentifier<Interceptor>[] {
   return (
     getOwnReflectMetadata(
       classConstructor,

--- a/packages/framework/core/src/interceptor/decorators/UseInterceptor.spec.ts
+++ b/packages/framework/core/src/interceptor/decorators/UseInterceptor.spec.ts
@@ -7,7 +7,7 @@ import {
   buildEmptyArrayMetadata,
   updateOwnReflectMetadata,
 } from '@inversifyjs/reflect-metadata-utils';
-import { Newable } from 'inversify';
+import { ServiceIdentifier } from 'inversify';
 
 import { classInterceptorMetadataReflectKey } from '../../reflectMetadata/data/classInterceptorMetadataReflectKey';
 import { classMethodInterceptorMetadataReflectKey } from '../../reflectMetadata/data/classMethodInterceptorMetadataReflectKey';
@@ -17,12 +17,12 @@ import { UseInterceptor } from './UseInterceptor';
 describe(UseInterceptor, () => {
   describe('having a ClassDecorator', () => {
     describe('when called', () => {
-      let middlewareFixture: Newable<Interceptor>;
+      let interceptorServiceIdentifier: ServiceIdentifier<Interceptor>;
       let targetFixture: NewableFunction;
       let callbackFixture: (arrayMetadata: unknown[]) => unknown[];
 
       beforeAll(() => {
-        middlewareFixture = {} as Newable<Interceptor>;
+        interceptorServiceIdentifier = Symbol();
         targetFixture = class TestController {};
         callbackFixture = (arrayMetadata: unknown[]): unknown[] =>
           arrayMetadata;
@@ -31,7 +31,7 @@ describe(UseInterceptor, () => {
           .mocked(buildArrayMetadataWithArray)
           .mockReturnValueOnce(callbackFixture);
 
-        UseInterceptor(middlewareFixture)(targetFixture);
+        UseInterceptor(interceptorServiceIdentifier)(targetFixture);
       });
 
       afterAll(() => {
@@ -41,7 +41,7 @@ describe(UseInterceptor, () => {
       it('should call buildArrayMetadataWithArray()', () => {
         expect(buildArrayMetadataWithArray).toHaveBeenCalledTimes(1);
         expect(buildArrayMetadataWithArray).toHaveBeenCalledWith([
-          middlewareFixture,
+          interceptorServiceIdentifier,
         ]);
       });
 
@@ -62,14 +62,14 @@ describe(UseInterceptor, () => {
     describe('when called', () => {
       let targetFixture: NewableFunction;
       let methodKeyFixture: string | symbol;
-      let middlewareFixture: Newable<Interceptor>;
+      let interceptorServiceIdentifier: ServiceIdentifier<Interceptor>;
       let descriptorFixture: PropertyDescriptor;
       let callbackFixture: (arrayMetadata: unknown[]) => unknown[];
 
       beforeAll(() => {
         targetFixture = class TestController {};
         methodKeyFixture = 'testMethod';
-        middlewareFixture = {} as Newable<Interceptor>;
+        interceptorServiceIdentifier = Symbol();
         descriptorFixture = {
           value: 'value-descriptor-example',
         } as PropertyDescriptor;
@@ -80,7 +80,7 @@ describe(UseInterceptor, () => {
           .mocked(buildArrayMetadataWithArray)
           .mockReturnValueOnce(callbackFixture);
 
-        UseInterceptor(middlewareFixture)(
+        UseInterceptor(interceptorServiceIdentifier)(
           targetFixture,
           methodKeyFixture,
           descriptorFixture,
@@ -90,7 +90,7 @@ describe(UseInterceptor, () => {
       it('should call buildArrayMetadataWithArray()', () => {
         expect(buildArrayMetadataWithArray).toHaveBeenCalledTimes(1);
         expect(buildArrayMetadataWithArray).toHaveBeenCalledWith([
-          middlewareFixture,
+          interceptorServiceIdentifier,
         ]);
       });
 

--- a/packages/framework/core/src/interceptor/decorators/UseInterceptor.ts
+++ b/packages/framework/core/src/interceptor/decorators/UseInterceptor.ts
@@ -3,7 +3,7 @@ import {
   buildEmptyArrayMetadata,
   updateOwnReflectMetadata,
 } from '@inversifyjs/reflect-metadata-utils';
-import { Newable } from 'inversify';
+import { ServiceIdentifier } from 'inversify';
 
 import { classInterceptorMetadataReflectKey } from '../../reflectMetadata/data/classInterceptorMetadataReflectKey';
 import { classMethodInterceptorMetadataReflectKey } from '../../reflectMetadata/data/classMethodInterceptorMetadataReflectKey';
@@ -11,7 +11,7 @@ import { Interceptor } from '../models/Interceptor';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function UseInterceptor(
-  ...interceptorList: Newable<Interceptor>[]
+  ...interceptorList: ServiceIdentifier<Interceptor>[]
 ): ClassDecorator & MethodDecorator {
   return (target: object, key?: string | symbol): void => {
     let classTarget: object;

--- a/packages/framework/core/src/middleware/calculations/buildMiddlewareOptionsFromApplyMiddlewareOptions.spec.ts
+++ b/packages/framework/core/src/middleware/calculations/buildMiddlewareOptionsFromApplyMiddlewareOptions.spec.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 
-import { Newable } from 'inversify';
+import { Newable, ServiceIdentifier } from 'inversify';
 
 import { ApplyMiddlewareOptions } from '../models/ApplyMiddlewareOptions';
 import { Middleware } from '../models/Middleware';
@@ -9,9 +9,9 @@ import { MiddlewarePhase } from '../models/MiddlewarePhase';
 import { buildMiddlewareOptionsFromApplyMiddlewareOptions } from './buildMiddlewareOptionsFromApplyMiddlewareOptions';
 
 describe(buildMiddlewareOptionsFromApplyMiddlewareOptions, () => {
-  describe('having applyMiddlewareOptionsList with NewableFunction', () => {
-    let firstApplyMiddlewareOptionsFixture: NewableFunction;
-    let secondApplyMiddlewareOptionsFixture: NewableFunction;
+  describe('having applyMiddlewareOptionsList with ServiceIdentifier<Middleware>', () => {
+    let firstApplyMiddlewareOptionsFixture: ServiceIdentifier<Middleware>;
+    let secondApplyMiddlewareOptionsFixture: ServiceIdentifier<Middleware>;
 
     beforeAll(() => {
       firstApplyMiddlewareOptionsFixture = class FirstMiddlewareFixture {};

--- a/packages/framework/core/src/middleware/calculations/buildMiddlewareOptionsFromApplyMiddlewareOptions.ts
+++ b/packages/framework/core/src/middleware/calculations/buildMiddlewareOptionsFromApplyMiddlewareOptions.ts
@@ -1,10 +1,16 @@
+import { ServiceIdentifier } from 'inversify';
+
 import { ApplyMiddlewareOptions } from '../models/ApplyMiddlewareOptions';
+import { Middleware } from '../models/Middleware';
 import { MiddlewareOptions } from '../models/MiddlewareOptions';
 import { MiddlewarePhase } from '../models/MiddlewarePhase';
 import { isApplyMiddlewareOptions } from '../typeguard/isApplyMiddlewareOptions';
 
 export function buildMiddlewareOptionsFromApplyMiddlewareOptions(
-  applyMiddlewareOptionsList: (NewableFunction | ApplyMiddlewareOptions)[],
+  applyMiddlewareOptionsList: (
+    | ServiceIdentifier<Middleware>
+    | ApplyMiddlewareOptions
+  )[],
 ): MiddlewareOptions {
   const middlewareOptions: MiddlewareOptions = {
     postHandlerMiddlewareList: [],
@@ -13,18 +19,15 @@ export function buildMiddlewareOptionsFromApplyMiddlewareOptions(
 
   for (const applyMiddlewareOptions of applyMiddlewareOptionsList) {
     if (isApplyMiddlewareOptions(applyMiddlewareOptions)) {
-      const middlewareList: NewableFunction[] = [];
+      const middlewareList: ServiceIdentifier<Middleware>[] =
+        applyMiddlewareOptions.phase === MiddlewarePhase.PostHandler
+          ? middlewareOptions.postHandlerMiddlewareList
+          : middlewareOptions.preHandlerMiddlewareList;
 
       if (Array.isArray(applyMiddlewareOptions.middleware)) {
         middlewareList.push(...applyMiddlewareOptions.middleware);
       } else {
         middlewareList.push(applyMiddlewareOptions.middleware);
-      }
-
-      if (applyMiddlewareOptions.phase === MiddlewarePhase.PostHandler) {
-        middlewareOptions.postHandlerMiddlewareList.push(...middlewareList);
-      } else {
-        middlewareOptions.preHandlerMiddlewareList.push(...middlewareList);
       }
     } else {
       middlewareOptions.preHandlerMiddlewareList.push(applyMiddlewareOptions);

--- a/packages/framework/core/src/middleware/calculations/getClassMethodMiddlewareList.spec.ts
+++ b/packages/framework/core/src/middleware/calculations/getClassMethodMiddlewareList.spec.ts
@@ -3,8 +3,10 @@ import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
 vitest.mock('@inversifyjs/reflect-metadata-utils');
 
 import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+import { ServiceIdentifier } from 'inversify';
 
 import { classMethodMiddlewareMetadataReflectKey } from '../../reflectMetadata/data/classMethodMiddlewareMetadataReflectKey';
+import { Middleware } from '../models/Middleware';
 import { getClassMethodMiddlewareList } from './getClassMethodMiddlewareList';
 
 describe(getClassMethodMiddlewareList, () => {
@@ -44,17 +46,17 @@ describe(getClassMethodMiddlewareList, () => {
   describe('when called, and getOwnReflectMetadata() returns an array', () => {
     let classFixture: NewableFunction;
     let classMethodKeyFixture: string | symbol;
-    let middlewareFixtures: NewableFunction[];
+    let middlewareServiceIdentifierListFixture: ServiceIdentifier<Middleware>[];
     let result: unknown;
 
     beforeAll(() => {
       classFixture = class Test {};
       classMethodKeyFixture = 'testMethod';
-      middlewareFixtures = [];
+      middlewareServiceIdentifierListFixture = [Symbol()];
 
       vitest
         .mocked(getOwnReflectMetadata)
-        .mockReturnValueOnce(middlewareFixtures);
+        .mockReturnValueOnce(middlewareServiceIdentifierListFixture);
 
       result = getClassMethodMiddlewareList(
         classFixture,
@@ -76,7 +78,7 @@ describe(getClassMethodMiddlewareList, () => {
     });
 
     it('should return an array', () => {
-      expect(result).toBe(middlewareFixtures);
+      expect(result).toBe(middlewareServiceIdentifierListFixture);
     });
   });
 });

--- a/packages/framework/core/src/middleware/calculations/getClassMethodMiddlewareList.ts
+++ b/packages/framework/core/src/middleware/calculations/getClassMethodMiddlewareList.ts
@@ -1,12 +1,14 @@
 import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+import { ServiceIdentifier } from 'inversify';
 
 import { classMethodMiddlewareMetadataReflectKey } from '../../reflectMetadata/data/classMethodMiddlewareMetadataReflectKey';
 import { ApplyMiddlewareOptions } from '../models/ApplyMiddlewareOptions';
+import { Middleware } from '../models/Middleware';
 
 export function getClassMethodMiddlewareList(
   classConstructor: NewableFunction,
   methodKey: string | symbol,
-): (NewableFunction | ApplyMiddlewareOptions)[] {
+): (ServiceIdentifier<Middleware> | ApplyMiddlewareOptions)[] {
   return (
     getOwnReflectMetadata(
       classConstructor,

--- a/packages/framework/core/src/middleware/calculations/getClassMiddlewareList.spec.ts
+++ b/packages/framework/core/src/middleware/calculations/getClassMiddlewareList.spec.ts
@@ -3,8 +3,10 @@ import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
 vitest.mock('@inversifyjs/reflect-metadata-utils');
 
 import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+import { ServiceIdentifier } from 'inversify';
 
 import { classMiddlewareMetadataReflectKey } from '../../reflectMetadata/data/classMiddlewareMetadataReflectKey';
+import { Middleware } from '../models/Middleware';
 import { getClassMiddlewareList } from './getClassMiddlewareList';
 
 describe(getClassMiddlewareList, () => {
@@ -37,16 +39,16 @@ describe(getClassMiddlewareList, () => {
 
   describe('when called, and getOwnReflectMetadata() returns an array', () => {
     let targetFixture: NewableFunction;
-    let middlewareFixtures: NewableFunction[];
+    let middlewareServiceIdentifierListFixture: ServiceIdentifier<Middleware>[];
     let result: unknown;
 
     beforeAll(() => {
       targetFixture = class Test {};
-      middlewareFixtures = [];
+      middlewareServiceIdentifierListFixture = [];
 
       vitest
         .mocked(getOwnReflectMetadata)
-        .mockReturnValueOnce(middlewareFixtures);
+        .mockReturnValueOnce(middlewareServiceIdentifierListFixture);
 
       result = getClassMiddlewareList(targetFixture);
     });
@@ -64,7 +66,7 @@ describe(getClassMiddlewareList, () => {
     });
 
     it('should return an array', () => {
-      expect(result).toBe(middlewareFixtures);
+      expect(result).toBe(middlewareServiceIdentifierListFixture);
     });
   });
 });

--- a/packages/framework/core/src/middleware/calculations/getClassMiddlewareList.ts
+++ b/packages/framework/core/src/middleware/calculations/getClassMiddlewareList.ts
@@ -1,10 +1,13 @@
 import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+import { ServiceIdentifier } from 'inversify';
 
 import { classMiddlewareMetadataReflectKey } from '../../reflectMetadata/data/classMiddlewareMetadataReflectKey';
+import { ApplyMiddlewareOptions } from '../models/ApplyMiddlewareOptions';
+import { Middleware } from '../models/Middleware';
 
 export function getClassMiddlewareList(
   classConstructor: NewableFunction,
-): NewableFunction[] {
+): (ServiceIdentifier<Middleware> | ApplyMiddlewareOptions)[] {
   return (
     getOwnReflectMetadata(
       classConstructor,

--- a/packages/framework/core/src/middleware/decorators/ApplyMiddleware.spec.ts
+++ b/packages/framework/core/src/middleware/decorators/ApplyMiddleware.spec.ts
@@ -7,7 +7,7 @@ import {
   buildEmptyArrayMetadata,
   updateOwnReflectMetadata,
 } from '@inversifyjs/reflect-metadata-utils';
-import { Newable } from 'inversify';
+import { ServiceIdentifier } from 'inversify';
 
 import { classMethodMiddlewareMetadataReflectKey } from '../../reflectMetadata/data/classMethodMiddlewareMetadataReflectKey';
 import { classMiddlewareMetadataReflectKey } from '../../reflectMetadata/data/classMiddlewareMetadataReflectKey';
@@ -17,12 +17,12 @@ import { ApplyMiddleware } from './ApplyMiddleware';
 describe(ApplyMiddleware, () => {
   describe('having a ClassDecorator', () => {
     describe('when called', () => {
-      let middlewareFixture: Newable<Middleware>;
+      let middlewareServiceIdentifierFixture: ServiceIdentifier<Middleware>;
       let callbackFixture: (arrayMetadata: unknown[]) => unknown[];
       let targetFixture: NewableFunction;
 
       beforeAll(() => {
-        middlewareFixture = {} as Newable<Middleware>;
+        middlewareServiceIdentifierFixture = Symbol();
         callbackFixture = (arrayMetadata: unknown[]): unknown[] =>
           arrayMetadata;
         targetFixture = class TestController {};
@@ -31,7 +31,7 @@ describe(ApplyMiddleware, () => {
           .mocked(buildArrayMetadataWithArray)
           .mockReturnValueOnce(callbackFixture);
 
-        ApplyMiddleware(middlewareFixture)(targetFixture);
+        ApplyMiddleware(middlewareServiceIdentifierFixture)(targetFixture);
       });
 
       afterAll(() => {
@@ -41,7 +41,7 @@ describe(ApplyMiddleware, () => {
       it('should call buildArrayMetadataWithArray()', () => {
         expect(buildArrayMetadataWithArray).toHaveBeenCalledTimes(1);
         expect(buildArrayMetadataWithArray).toHaveBeenCalledWith([
-          middlewareFixture,
+          middlewareServiceIdentifierFixture,
         ]);
       });
 
@@ -64,14 +64,14 @@ describe(ApplyMiddleware, () => {
       let controllerMethodKeyFixture: string | symbol;
       let callbackFixture: (arrayMetadata: unknown[]) => unknown[];
       let descriptorFixture: PropertyDescriptor;
-      let middlewareFixture: Newable<Middleware>;
+      let middlewareServiceIdentifierFixture: ServiceIdentifier<Middleware>;
 
       beforeAll(() => {
         controllerFixture = class Test {};
         controllerMethodKeyFixture = 'testMethod';
         callbackFixture = (arrayMetadata: unknown[]): unknown[] =>
           arrayMetadata;
-        middlewareFixture = {} as Newable<Middleware>;
+        middlewareServiceIdentifierFixture = Symbol();
         descriptorFixture = {
           value: 'value-descriptor-example',
         } as PropertyDescriptor;
@@ -80,7 +80,7 @@ describe(ApplyMiddleware, () => {
           .mocked(buildArrayMetadataWithArray)
           .mockReturnValueOnce(callbackFixture);
 
-        ApplyMiddleware(middlewareFixture)(
+        ApplyMiddleware(middlewareServiceIdentifierFixture)(
           controllerFixture,
           controllerMethodKeyFixture,
           descriptorFixture,
@@ -90,7 +90,7 @@ describe(ApplyMiddleware, () => {
       it('should call buildArrayMetadataWithArray()', () => {
         expect(buildArrayMetadataWithArray).toHaveBeenCalledTimes(1);
         expect(buildArrayMetadataWithArray).toHaveBeenCalledWith([
-          middlewareFixture,
+          middlewareServiceIdentifierFixture,
         ]);
       });
 

--- a/packages/framework/core/src/middleware/decorators/ApplyMiddleware.ts
+++ b/packages/framework/core/src/middleware/decorators/ApplyMiddleware.ts
@@ -3,7 +3,7 @@ import {
   buildEmptyArrayMetadata,
   updateOwnReflectMetadata,
 } from '@inversifyjs/reflect-metadata-utils';
-import { Newable } from 'inversify';
+import { ServiceIdentifier } from 'inversify';
 
 import { classMethodMiddlewareMetadataReflectKey } from '../../reflectMetadata/data/classMethodMiddlewareMetadataReflectKey';
 import { classMiddlewareMetadataReflectKey } from '../../reflectMetadata/data/classMiddlewareMetadataReflectKey';
@@ -12,7 +12,7 @@ import { Middleware } from '../models/Middleware';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function ApplyMiddleware(
-  ...middlewareList: (Newable<Middleware> | ApplyMiddlewareOptions)[]
+  ...middlewareList: (ServiceIdentifier<Middleware> | ApplyMiddlewareOptions)[]
 ): ClassDecorator & MethodDecorator {
   return (target: object, key?: string | symbol): void => {
     let classTarget: object;

--- a/packages/framework/core/src/middleware/models/ApplyMiddlewareOptions.ts
+++ b/packages/framework/core/src/middleware/models/ApplyMiddlewareOptions.ts
@@ -1,9 +1,9 @@
-import { Newable } from 'inversify';
+import { ServiceIdentifier } from 'inversify';
 
 import { Middleware } from './Middleware';
 import { MiddlewarePhase } from './MiddlewarePhase';
 
 export interface ApplyMiddlewareOptions {
   phase: MiddlewarePhase;
-  middleware: Newable<Middleware> | Newable<Middleware>[];
+  middleware: ServiceIdentifier<Middleware> | ServiceIdentifier<Middleware>[];
 }

--- a/packages/framework/core/src/middleware/models/MiddlewareOptions.ts
+++ b/packages/framework/core/src/middleware/models/MiddlewareOptions.ts
@@ -1,4 +1,8 @@
+import { ServiceIdentifier } from 'inversify';
+
+import { Middleware } from './Middleware';
+
 export interface MiddlewareOptions {
-  postHandlerMiddlewareList: NewableFunction[];
-  preHandlerMiddlewareList: NewableFunction[];
+  postHandlerMiddlewareList: ServiceIdentifier<Middleware>[];
+  preHandlerMiddlewareList: ServiceIdentifier<Middleware>[];
 }

--- a/packages/framework/http/libraries/core/src/http/actions/setErrorFilterToErrorFilterMap.ts
+++ b/packages/framework/http/libraries/core/src/http/actions/setErrorFilterToErrorFilterMap.ts
@@ -5,10 +5,7 @@ import {
 import { Newable } from 'inversify';
 
 export function setErrorFilterToErrorFilterMap(
-  errorTypeToGlobalErrorFilterMap: Map<
-    Newable<Error> | null,
-    Newable<ErrorFilter>
-  >,
+  errorTypeToErrorFilterMap: Map<Newable<Error> | null, Newable<ErrorFilter>>,
   errorFilter: Newable<ErrorFilter>,
 ): void {
   const errorTypes: Set<Newable<Error> | null> =
@@ -16,10 +13,10 @@ export function setErrorFilterToErrorFilterMap(
 
   for (const errorType of errorTypes) {
     const existingErrorFilter: Newable<ErrorFilter> | undefined =
-      errorTypeToGlobalErrorFilterMap.get(errorType);
+      errorTypeToErrorFilterMap.get(errorType);
 
     if (existingErrorFilter === undefined) {
-      errorTypeToGlobalErrorFilterMap.set(errorType, errorFilter);
+      errorTypeToErrorFilterMap.set(errorType, errorFilter);
     }
   }
 }

--- a/packages/framework/http/libraries/core/src/http/calculations/buildInterceptedHandler.ts
+++ b/packages/framework/http/libraries/core/src/http/calculations/buildInterceptedHandler.ts
@@ -2,7 +2,7 @@ import {
   Interceptor,
   InterceptorTransformObject,
 } from '@inversifyjs/framework-core';
-import { Container, Newable } from 'inversify';
+import { Container, ServiceIdentifier } from 'inversify';
 
 import { RouterExplorerControllerMethodMetadata } from '../../routerExplorer/model/RouterExplorerControllerMethodMetadata';
 import { Controller } from '../models/Controller';
@@ -100,7 +100,7 @@ export function buildInterceptedHandler<
             await container.getAsync(
               routerExplorerControllerMethodMetadata.interceptorList[
                 index
-              ] as Newable<Interceptor<TRequest, TResponse>>,
+              ] as ServiceIdentifier<Interceptor<TRequest, TResponse>>,
             );
 
           await interceptor.intercept(

--- a/packages/framework/http/libraries/core/src/http/calculations/buildRouteParameterDecorator.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/calculations/buildRouteParameterDecorator.spec.ts
@@ -5,22 +5,26 @@ vitest.mock('./requestParam');
 import { Pipe } from '@inversifyjs/framework-core';
 import { Newable } from 'inversify';
 
+import { ControllerMethodParameterMetadata } from '../../routerExplorer/model/ControllerMethodParameterMetadata';
 import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
-import { buildRequestParameterDecorator } from './buildRequestParameterDecorator';
+import { RouteParamOptions } from '../models/RouteParamOptions';
+import { buildRouteParameterDecorator } from './buildRouteParameterDecorator';
 import { requestParam } from './requestParam';
 
-describe(buildRequestParameterDecorator, () => {
-  describe('having a parameterNameOrPipe with type string', () => {
+describe(buildRouteParameterDecorator, () => {
+  describe('having a RouteParameterOptions parameterNameOrPipe', () => {
     describe('when called', () => {
       let parameterTypeFixture: RequestMethodParameterType;
-      let parameterNameOrPipeFixture: string;
+      let parameterNameOrPipeFixture: RouteParamOptions;
       let parameterPipeListFixture: (Newable<Pipe> | Pipe)[];
       let parameterDecoratorFixture: ParameterDecorator;
       let result: unknown;
 
       beforeAll(() => {
         parameterTypeFixture = RequestMethodParameterType.Query;
-        parameterNameOrPipeFixture = 'parameterName';
+        parameterNameOrPipeFixture = {
+          name: 'parameterName',
+        };
         parameterPipeListFixture = [];
         parameterDecoratorFixture = {} as ParameterDecorator;
 
@@ -28,7 +32,7 @@ describe(buildRequestParameterDecorator, () => {
           .mocked(requestParam)
           .mockReturnValueOnce(parameterDecoratorFixture);
 
-        result = buildRequestParameterDecorator(
+        result = buildRouteParameterDecorator(
           parameterTypeFixture,
           parameterPipeListFixture,
           parameterNameOrPipeFixture,
@@ -39,13 +43,15 @@ describe(buildRequestParameterDecorator, () => {
         vitest.clearAllMocks();
       });
 
-      it('should call requestParam', () => {
-        expect(requestParam).toHaveBeenCalledTimes(1);
-        expect(requestParam).toHaveBeenCalledWith({
-          parameterName: parameterNameOrPipeFixture,
+      it('should call requestParam()', () => {
+        const expected: ControllerMethodParameterMetadata = {
+          parameterName: parameterNameOrPipeFixture.name,
           parameterType: parameterTypeFixture,
           pipeList: parameterPipeListFixture,
-        });
+        };
+
+        expect(requestParam).toHaveBeenCalledTimes(1);
+        expect(requestParam).toHaveBeenCalledWith(expected);
       });
 
       it('should return a ParameterDecorator', () => {
@@ -72,7 +78,7 @@ describe(buildRequestParameterDecorator, () => {
           .mocked(requestParam)
           .mockReturnValueOnce(parameterDecoratorFixture);
 
-        result = buildRequestParameterDecorator(
+        result = buildRouteParameterDecorator(
           parameterTypeFixture,
           parameterPipeListFixture,
           parameterNameOrPipeFixture,
@@ -83,12 +89,14 @@ describe(buildRequestParameterDecorator, () => {
         vitest.clearAllMocks();
       });
 
-      it('should call requestParam', () => {
-        expect(requestParam).toHaveBeenCalledTimes(1);
-        expect(requestParam).toHaveBeenCalledWith({
+      it('should call requestParam()', () => {
+        const expected: ControllerMethodParameterMetadata = {
           parameterType: parameterTypeFixture,
           pipeList: [parameterNameOrPipeFixture],
-        });
+        };
+
+        expect(requestParam).toHaveBeenCalledTimes(1);
+        expect(requestParam).toHaveBeenCalledWith(expected);
       });
 
       it('should return a ParameterDecorator', () => {
@@ -97,17 +105,19 @@ describe(buildRequestParameterDecorator, () => {
     });
   });
 
-  describe('having a parameterNameOrPipe with type string and parameterPipeList length greater than 0', () => {
+  describe('having a RouteParameterOptions parameterNameOrPipe and parameterPipeList length greater than 0', () => {
     describe('when called', () => {
       let parameterTypeFixture: RequestMethodParameterType;
-      let parameterNameOrPipeFixture: string;
+      let parameterNameOrPipeFixture: RouteParamOptions;
       let parameterPipeListFixture: (Newable<Pipe> | Pipe)[];
       let parameterDecoratorFixture: ParameterDecorator;
       let result: unknown;
 
       beforeAll(() => {
         parameterTypeFixture = RequestMethodParameterType.Query;
-        parameterNameOrPipeFixture = 'parameterName';
+        parameterNameOrPipeFixture = {
+          name: 'parameterName',
+        };
         parameterPipeListFixture = [{ execute: () => {} }];
         parameterDecoratorFixture = {} as ParameterDecorator;
 
@@ -115,7 +125,7 @@ describe(buildRequestParameterDecorator, () => {
           .mocked(requestParam)
           .mockReturnValueOnce(parameterDecoratorFixture);
 
-        result = buildRequestParameterDecorator(
+        result = buildRouteParameterDecorator(
           parameterTypeFixture,
           parameterPipeListFixture,
           parameterNameOrPipeFixture,
@@ -126,13 +136,15 @@ describe(buildRequestParameterDecorator, () => {
         vitest.clearAllMocks();
       });
 
-      it('should call requestParam', () => {
-        expect(requestParam).toHaveBeenCalledTimes(1);
-        expect(requestParam).toHaveBeenCalledWith({
-          parameterName: parameterNameOrPipeFixture,
+      it('should call requestParam()', () => {
+        const expected: ControllerMethodParameterMetadata = {
+          parameterName: parameterNameOrPipeFixture.name,
           parameterType: parameterTypeFixture,
           pipeList: parameterPipeListFixture,
-        });
+        };
+
+        expect(requestParam).toHaveBeenCalledTimes(1);
+        expect(requestParam).toHaveBeenCalledWith(expected);
       });
 
       it('should return a ParameterDecorator', () => {

--- a/packages/framework/http/libraries/core/src/http/calculations/buildRouteParameterDecorator.ts
+++ b/packages/framework/http/libraries/core/src/http/calculations/buildRouteParameterDecorator.ts
@@ -1,23 +1,27 @@
-import { Pipe } from '@inversifyjs/framework-core';
-import { Newable } from 'inversify';
+import { isPipe, Pipe } from '@inversifyjs/framework-core';
+import { ServiceIdentifier } from 'inversify';
 
 import { ControllerMethodParameterMetadata } from '../../routerExplorer/model/ControllerMethodParameterMetadata';
 import { CustomParameterDecoratorHandler } from '../models/CustomParameterDecoratorHandler';
 import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
+import { RouteParamOptions } from '../models/RouteParamOptions';
 import { requestParam } from './requestParam';
 
-export function buildRequestParameterDecorator(
+export function buildRouteParameterDecorator(
   parameterType: RequestMethodParameterType,
-  parameterPipeList: (Newable<Pipe> | Pipe)[],
-  parameterNameOrPipe?: string | (Newable<Pipe> | Pipe),
+  parameterPipeList: (ServiceIdentifier<Pipe> | Pipe)[],
+  parameterNameOrPipe?: RouteParamOptions | (ServiceIdentifier<Pipe> | Pipe),
   customParameterDecoratorHandler?: CustomParameterDecoratorHandler,
 ): ParameterDecorator {
   let parameterName: string | undefined = undefined;
-  const pipeList: (Newable<Pipe> | Pipe)[] = [];
+  const pipeList: (ServiceIdentifier<Pipe> | Pipe)[] = [];
 
   if (parameterNameOrPipe !== undefined) {
-    if (typeof parameterNameOrPipe === 'string') {
-      parameterName = parameterNameOrPipe;
+    if (
+      typeof parameterNameOrPipe === 'object' &&
+      !isPipe(parameterNameOrPipe)
+    ) {
+      parameterName = parameterNameOrPipe.name;
     } else {
       pipeList.push(parameterNameOrPipe);
     }

--- a/packages/framework/http/libraries/core/src/http/calculations/createCustomParameterDecorator.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/calculations/createCustomParameterDecorator.spec.ts
@@ -1,27 +1,35 @@
 import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
 
-vitest.mock('../calculations/buildRequestParameterDecorator');
+vitest.mock('../calculations/buildRouteParameterDecorator');
+
+import { Pipe } from '@inversifyjs/framework-core';
+import { ServiceIdentifier } from 'inversify';
 
 import { CustomParameterDecoratorHandler } from '../models/CustomParameterDecoratorHandler';
 import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
-import { buildRequestParameterDecorator } from './buildRequestParameterDecorator';
+import { buildRouteParameterDecorator } from './buildRouteParameterDecorator';
 import { createCustomParameterDecorator } from './createCustomParameterDecorator';
 
 describe(createCustomParameterDecorator, () => {
   describe('when called', () => {
     let handlerFixture: CustomParameterDecoratorHandler;
+    let parameterPipeListFixture: (ServiceIdentifier<Pipe> | Pipe)[];
     let parameterDecoratorFixture: ParameterDecorator;
     let result: unknown;
 
     beforeAll(() => {
-      handlerFixture = {} as CustomParameterDecoratorHandler;
-      parameterDecoratorFixture = {} as ParameterDecorator;
+      handlerFixture = Symbol() as unknown as CustomParameterDecoratorHandler;
+      parameterPipeListFixture = [Symbol()];
+      parameterDecoratorFixture = Symbol() as unknown as ParameterDecorator;
 
       vitest
-        .mocked(buildRequestParameterDecorator)
+        .mocked(buildRouteParameterDecorator)
         .mockReturnValueOnce(parameterDecoratorFixture);
 
-      result = createCustomParameterDecorator(handlerFixture);
+      result = createCustomParameterDecorator(
+        handlerFixture,
+        ...parameterPipeListFixture,
+      );
     });
 
     afterAll(() => {
@@ -29,10 +37,10 @@ describe(createCustomParameterDecorator, () => {
     });
 
     it('should call requestParamFactory', () => {
-      expect(buildRequestParameterDecorator).toHaveBeenCalledTimes(1);
-      expect(buildRequestParameterDecorator).toHaveBeenCalledWith(
+      expect(buildRouteParameterDecorator).toHaveBeenCalledTimes(1);
+      expect(buildRouteParameterDecorator).toHaveBeenCalledWith(
         RequestMethodParameterType.Custom,
-        [],
+        parameterPipeListFixture,
         undefined,
         handlerFixture,
       );

--- a/packages/framework/http/libraries/core/src/http/calculations/createCustomParameterDecorator.ts
+++ b/packages/framework/http/libraries/core/src/http/calculations/createCustomParameterDecorator.ts
@@ -1,15 +1,15 @@
 import { Pipe } from '@inversifyjs/framework-core';
-import { Newable } from 'inversify';
+import { ServiceIdentifier } from 'inversify';
 
 import { CustomParameterDecoratorHandler } from '../models/CustomParameterDecoratorHandler';
 import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
-import { buildRequestParameterDecorator } from './buildRequestParameterDecorator';
+import { buildRouteParameterDecorator } from './buildRouteParameterDecorator';
 
 export function createCustomParameterDecorator<TRequest, TResponse, TResult>(
   handler: CustomParameterDecoratorHandler<TRequest, TResponse, TResult>,
-  ...parameterPipeList: (Newable<Pipe> | Pipe)[]
+  ...parameterPipeList: (ServiceIdentifier<Pipe> | Pipe)[]
 ): ParameterDecorator {
-  return buildRequestParameterDecorator(
+  return buildRouteParameterDecorator(
     RequestMethodParameterType.Custom,
     parameterPipeList,
     undefined,

--- a/packages/framework/http/libraries/core/src/http/decorators/Body.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Body.spec.ts
@@ -1,38 +1,44 @@
 import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
 
-vitest.mock('../calculations/buildRequestParameterDecorator');
+vitest.mock('../calculations/buildRouteParameterDecorator');
 
-import { buildRequestParameterDecorator } from '../calculations/buildRequestParameterDecorator';
+import { Pipe } from '@inversifyjs/framework-core';
+import { ServiceIdentifier } from 'inversify';
+
+import { buildRouteParameterDecorator } from '../calculations/buildRouteParameterDecorator';
 import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
+import { RouteParamOptions } from '../models/RouteParamOptions';
 import { Body } from './Body';
 
 describe(Body, () => {
   describe('when called', () => {
-    let parameterNameFixture: string | undefined;
+    let optionsFixture: RouteParamOptions | undefined;
+    let parameterPipeListFixture: (ServiceIdentifier<Pipe> | Pipe)[];
     let parameterDecoratorFixture: ParameterDecorator;
     let result: unknown;
 
     beforeAll(() => {
-      parameterNameFixture = undefined;
+      optionsFixture = undefined;
+      parameterPipeListFixture = [Symbol()];
       parameterDecoratorFixture = {} as ParameterDecorator;
 
       vitest
-        .mocked(buildRequestParameterDecorator)
+        .mocked(buildRouteParameterDecorator)
         .mockReturnValueOnce(parameterDecoratorFixture);
 
-      result = Body(parameterNameFixture);
+      result = Body(optionsFixture, ...parameterPipeListFixture);
     });
 
     afterAll(() => {
       vitest.clearAllMocks();
     });
 
-    it('should call requestParamFactory', () => {
-      expect(buildRequestParameterDecorator).toHaveBeenCalledTimes(1);
-      expect(buildRequestParameterDecorator).toHaveBeenCalledWith(
+    it('should call buildRouteParameterDecorator()', () => {
+      expect(buildRouteParameterDecorator).toHaveBeenCalledTimes(1);
+      expect(buildRouteParameterDecorator).toHaveBeenCalledWith(
         RequestMethodParameterType.Body,
-        [],
-        parameterNameFixture,
+        parameterPipeListFixture,
+        optionsFixture,
       );
     });
 

--- a/packages/framework/http/libraries/core/src/http/decorators/Body.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Body.ts
@@ -1,17 +1,18 @@
 import { Pipe } from '@inversifyjs/framework-core';
-import { Newable } from 'inversify';
+import { ServiceIdentifier } from 'inversify';
 
-import { buildRequestParameterDecorator } from '../calculations/buildRequestParameterDecorator';
+import { buildRouteParameterDecorator } from '../calculations/buildRouteParameterDecorator';
 import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
+import { RouteParamOptions } from '../models/RouteParamOptions';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function Body(
-  parameterNameOrPipe?: string | (Newable<Pipe> | Pipe),
-  ...parameterPipeList: (Newable<Pipe> | Pipe)[]
+  optionsOrPipe?: RouteParamOptions | (ServiceIdentifier<Pipe> | Pipe),
+  ...parameterPipeList: (ServiceIdentifier<Pipe> | Pipe)[]
 ): ParameterDecorator {
-  return buildRequestParameterDecorator(
+  return buildRouteParameterDecorator(
     RequestMethodParameterType.Body,
     parameterPipeList,
-    parameterNameOrPipe,
+    optionsOrPipe,
   );
 }

--- a/packages/framework/http/libraries/core/src/http/decorators/Cookies.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Cookies.spec.ts
@@ -1,38 +1,43 @@
 import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
 
-vitest.mock('../calculations/buildRequestParameterDecorator');
+vitest.mock('../calculations/buildRouteParameterDecorator');
 
-import { buildRequestParameterDecorator } from '../calculations/buildRequestParameterDecorator';
+import { Pipe } from '@inversifyjs/framework-core';
+import { ServiceIdentifier } from 'inversify';
+
+import { buildRouteParameterDecorator } from '../calculations/buildRouteParameterDecorator';
 import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
 import { Cookies } from './Cookies';
 
 describe(Cookies, () => {
   describe('when called', () => {
-    let parameterNameFixture: undefined;
+    let optionsFixture: undefined;
+    let parameterPipeListFixture: (ServiceIdentifier<Pipe> | Pipe)[];
     let parameterDecoratorFixture: ParameterDecorator;
     let result: unknown;
 
     beforeAll(() => {
-      parameterNameFixture = undefined;
+      optionsFixture = undefined;
+      parameterPipeListFixture = [Symbol()];
       parameterDecoratorFixture = {} as ParameterDecorator;
 
       vitest
-        .mocked(buildRequestParameterDecorator)
+        .mocked(buildRouteParameterDecorator)
         .mockReturnValueOnce(parameterDecoratorFixture);
 
-      result = Cookies(parameterNameFixture);
+      result = Cookies(optionsFixture, ...parameterPipeListFixture);
     });
 
     afterAll(() => {
       vitest.clearAllMocks();
     });
 
-    it('should call requestParamFactory', () => {
-      expect(buildRequestParameterDecorator).toHaveBeenCalledTimes(1);
-      expect(buildRequestParameterDecorator).toHaveBeenCalledWith(
+    it('should call buildRouteParameterDecorator()', () => {
+      expect(buildRouteParameterDecorator).toHaveBeenCalledTimes(1);
+      expect(buildRouteParameterDecorator).toHaveBeenCalledWith(
         RequestMethodParameterType.Cookies,
-        [],
-        parameterNameFixture,
+        parameterPipeListFixture,
+        optionsFixture,
       );
     });
 

--- a/packages/framework/http/libraries/core/src/http/decorators/Cookies.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Cookies.ts
@@ -1,17 +1,18 @@
 import { Pipe } from '@inversifyjs/framework-core';
-import { Newable } from 'inversify';
+import { ServiceIdentifier } from 'inversify';
 
-import { buildRequestParameterDecorator } from '../calculations/buildRequestParameterDecorator';
+import { buildRouteParameterDecorator } from '../calculations/buildRouteParameterDecorator';
 import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
+import { RouteParamOptions } from '../models/RouteParamOptions';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function Cookies(
-  parameterNameOrPipe?: string | (Newable<Pipe> | Pipe),
-  ...parameterPipeList: (Newable<Pipe> | Pipe)[]
+  optionsOrPipe?: RouteParamOptions | (ServiceIdentifier<Pipe> | Pipe),
+  ...parameterPipeList: (ServiceIdentifier<Pipe> | Pipe)[]
 ): ParameterDecorator {
-  return buildRequestParameterDecorator(
+  return buildRouteParameterDecorator(
     RequestMethodParameterType.Cookies,
     parameterPipeList,
-    parameterNameOrPipe,
+    optionsOrPipe,
   );
 }

--- a/packages/framework/http/libraries/core/src/http/decorators/Headers.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Headers.spec.ts
@@ -1,38 +1,44 @@
 import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
 
-vitest.mock('../calculations/buildRequestParameterDecorator');
+vitest.mock('../calculations/buildRouteParameterDecorator');
 
-import { buildRequestParameterDecorator } from '../calculations/buildRequestParameterDecorator';
+import { Pipe } from '@inversifyjs/framework-core';
+import { ServiceIdentifier } from 'inversify';
+
+import { buildRouteParameterDecorator } from '../calculations/buildRouteParameterDecorator';
 import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
+import { RouteParamOptions } from '../models/RouteParamOptions';
 import { Headers } from './Headers';
 
 describe(Headers, () => {
   describe('when called', () => {
-    let parameterNameFixture: string | undefined;
+    let optionsFixture: RouteParamOptions | undefined;
+    let parameterPipeListFixture: (ServiceIdentifier<Pipe> | Pipe)[];
     let parameterDecoratorFixture: ParameterDecorator;
     let result: unknown;
 
     beforeAll(() => {
-      parameterNameFixture = undefined;
+      optionsFixture = undefined;
+      parameterPipeListFixture = [Symbol()];
       parameterDecoratorFixture = {} as ParameterDecorator;
 
       vitest
-        .mocked(buildRequestParameterDecorator)
+        .mocked(buildRouteParameterDecorator)
         .mockReturnValueOnce(parameterDecoratorFixture);
 
-      result = Headers(parameterNameFixture);
+      result = Headers(optionsFixture, ...parameterPipeListFixture);
     });
 
     afterAll(() => {
       vitest.clearAllMocks();
     });
 
-    it('should call requestParamFactory', () => {
-      expect(buildRequestParameterDecorator).toHaveBeenCalledTimes(1);
-      expect(buildRequestParameterDecorator).toHaveBeenCalledWith(
+    it('should call buildRouteParameterDecorator()', () => {
+      expect(buildRouteParameterDecorator).toHaveBeenCalledTimes(1);
+      expect(buildRouteParameterDecorator).toHaveBeenCalledWith(
         RequestMethodParameterType.Headers,
-        [],
-        parameterNameFixture,
+        parameterPipeListFixture,
+        optionsFixture,
       );
     });
 

--- a/packages/framework/http/libraries/core/src/http/decorators/Headers.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Headers.ts
@@ -1,17 +1,18 @@
 import { Pipe } from '@inversifyjs/framework-core';
-import { Newable } from 'inversify';
+import { ServiceIdentifier } from 'inversify';
 
-import { buildRequestParameterDecorator } from '../calculations/buildRequestParameterDecorator';
+import { buildRouteParameterDecorator } from '../calculations/buildRouteParameterDecorator';
 import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
+import { RouteParamOptions } from '../models/RouteParamOptions';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function Headers(
-  parameterNameOrPipe?: string | (Newable<Pipe> | Pipe),
-  ...parameterPipeList: (Newable<Pipe> | Pipe)[]
+  optionsOrPipe?: RouteParamOptions | (ServiceIdentifier<Pipe> | Pipe),
+  ...parameterPipeList: (ServiceIdentifier<Pipe> | Pipe)[]
 ): ParameterDecorator {
-  return buildRequestParameterDecorator(
+  return buildRouteParameterDecorator(
     RequestMethodParameterType.Headers,
     parameterPipeList,
-    parameterNameOrPipe,
+    optionsOrPipe,
   );
 }

--- a/packages/framework/http/libraries/core/src/http/decorators/Next.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Next.spec.ts
@@ -1,8 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
 
-vitest.mock('../calculations/buildRequestParameterDecorator');
+vitest.mock('../calculations/buildRouteParameterDecorator');
 
-import { buildRequestParameterDecorator } from '../calculations/buildRequestParameterDecorator';
+import { buildRouteParameterDecorator } from '../calculations/buildRouteParameterDecorator';
 import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
 import { Next } from './Next';
 
@@ -15,7 +15,7 @@ describe(Next, () => {
       parameterDecoratorFixture = {} as ParameterDecorator;
 
       vitest
-        .mocked(buildRequestParameterDecorator)
+        .mocked(buildRouteParameterDecorator)
         .mockReturnValueOnce(parameterDecoratorFixture);
 
       result = Next();
@@ -25,9 +25,9 @@ describe(Next, () => {
       vitest.clearAllMocks();
     });
 
-    it('should call requestParamFactory', () => {
-      expect(buildRequestParameterDecorator).toHaveBeenCalledTimes(1);
-      expect(buildRequestParameterDecorator).toHaveBeenCalledWith(
+    it('should call buildRouteParameterDecorator()', () => {
+      expect(buildRouteParameterDecorator).toHaveBeenCalledTimes(1);
+      expect(buildRouteParameterDecorator).toHaveBeenCalledWith(
         RequestMethodParameterType.Next,
         [],
       );

--- a/packages/framework/http/libraries/core/src/http/decorators/Next.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Next.ts
@@ -1,7 +1,7 @@
-import { buildRequestParameterDecorator } from '../calculations/buildRequestParameterDecorator';
+import { buildRouteParameterDecorator } from '../calculations/buildRouteParameterDecorator';
 import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function Next(): ParameterDecorator {
-  return buildRequestParameterDecorator(RequestMethodParameterType.Next, []);
+  return buildRouteParameterDecorator(RequestMethodParameterType.Next, []);
 }

--- a/packages/framework/http/libraries/core/src/http/decorators/Params.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Params.spec.ts
@@ -1,38 +1,43 @@
 import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
 
-vitest.mock('../calculations/buildRequestParameterDecorator');
+vitest.mock('../calculations/buildRouteParameterDecorator');
 
-import { buildRequestParameterDecorator } from '../calculations/buildRequestParameterDecorator';
+import { Pipe } from '@inversifyjs/framework-core';
+import { ServiceIdentifier } from 'inversify';
+
+import { buildRouteParameterDecorator } from '../calculations/buildRouteParameterDecorator';
 import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
 import { Params } from './Params';
 
 describe(Params, () => {
   describe('when called', () => {
-    let parameterFixture: undefined;
+    let optionsFixture: undefined;
+    let parameterPipeListFixture: (ServiceIdentifier<Pipe> | Pipe)[];
     let parameterDecoratorFixture: ParameterDecorator;
     let result: unknown;
 
     beforeAll(() => {
-      parameterFixture = undefined;
+      optionsFixture = undefined;
+      parameterPipeListFixture = [Symbol()];
       parameterDecoratorFixture = {} as ParameterDecorator;
 
       vitest
-        .mocked(buildRequestParameterDecorator)
+        .mocked(buildRouteParameterDecorator)
         .mockReturnValueOnce(parameterDecoratorFixture);
 
-      result = Params(parameterFixture);
+      result = Params(optionsFixture, ...parameterPipeListFixture);
     });
 
     afterAll(() => {
       vitest.clearAllMocks();
     });
 
-    it('should call requestParamFactory', () => {
-      expect(buildRequestParameterDecorator).toHaveBeenCalledTimes(1);
-      expect(buildRequestParameterDecorator).toHaveBeenCalledWith(
+    it('should call buildRouteParameterDecorator()', () => {
+      expect(buildRouteParameterDecorator).toHaveBeenCalledTimes(1);
+      expect(buildRouteParameterDecorator).toHaveBeenCalledWith(
         RequestMethodParameterType.Params,
-        [],
-        parameterFixture,
+        parameterPipeListFixture,
+        optionsFixture,
       );
     });
 

--- a/packages/framework/http/libraries/core/src/http/decorators/Params.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Params.ts
@@ -1,17 +1,18 @@
 import { Pipe } from '@inversifyjs/framework-core';
-import { Newable } from 'inversify';
+import { ServiceIdentifier } from 'inversify';
 
-import { buildRequestParameterDecorator } from '../calculations/buildRequestParameterDecorator';
+import { buildRouteParameterDecorator } from '../calculations/buildRouteParameterDecorator';
 import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
+import { RouteParamOptions } from '../models/RouteParamOptions';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function Params(
-  parameterNameOrPipe?: string | (Newable<Pipe> | Pipe),
-  ...parameterPipeList: (Newable<Pipe> | Pipe)[]
+  optionsOrPipe?: RouteParamOptions | (ServiceIdentifier<Pipe> | Pipe),
+  ...parameterPipeList: (ServiceIdentifier<Pipe> | Pipe)[]
 ): ParameterDecorator {
-  return buildRequestParameterDecorator(
+  return buildRouteParameterDecorator(
     RequestMethodParameterType.Params,
     parameterPipeList,
-    parameterNameOrPipe,
+    optionsOrPipe,
   );
 }

--- a/packages/framework/http/libraries/core/src/http/decorators/Query.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Query.spec.ts
@@ -1,37 +1,42 @@
 import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
 
-vitest.mock('../calculations/buildRequestParameterDecorator');
+vitest.mock('../calculations/buildRouteParameterDecorator');
 
-import { buildRequestParameterDecorator } from '../calculations/buildRequestParameterDecorator';
+import { Pipe } from '@inversifyjs/framework-core';
+import { ServiceIdentifier } from 'inversify';
+
+import { buildRouteParameterDecorator } from '../calculations/buildRouteParameterDecorator';
 import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
 import { Query } from './Query';
 
 describe(Query, () => {
   describe('when called', () => {
     let parameterFixture: undefined;
+    let parameterPipeListFixture: (ServiceIdentifier<Pipe> | Pipe)[];
     let parameterDecoratorFixture: ParameterDecorator;
     let result: unknown;
 
     beforeAll(() => {
       parameterFixture = undefined;
+      parameterPipeListFixture = [Symbol()];
       parameterDecoratorFixture = {} as ParameterDecorator;
 
       vitest
-        .mocked(buildRequestParameterDecorator)
+        .mocked(buildRouteParameterDecorator)
         .mockReturnValueOnce(parameterDecoratorFixture);
 
-      result = Query(parameterFixture);
+      result = Query(parameterFixture, ...parameterPipeListFixture);
     });
 
     afterAll(() => {
       vitest.clearAllMocks();
     });
 
-    it('should call requestParam', () => {
-      expect(buildRequestParameterDecorator).toHaveBeenCalledTimes(1);
-      expect(buildRequestParameterDecorator).toHaveBeenCalledWith(
+    it('should call buildRouteParameterDecorator()', () => {
+      expect(buildRouteParameterDecorator).toHaveBeenCalledTimes(1);
+      expect(buildRouteParameterDecorator).toHaveBeenCalledWith(
         RequestMethodParameterType.Query,
-        [],
+        parameterPipeListFixture,
         parameterFixture,
       );
     });

--- a/packages/framework/http/libraries/core/src/http/decorators/Query.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Query.ts
@@ -1,17 +1,18 @@
 import { Pipe } from '@inversifyjs/framework-core';
-import { Newable } from 'inversify';
+import { ServiceIdentifier } from 'inversify';
 
-import { buildRequestParameterDecorator } from '../calculations/buildRequestParameterDecorator';
+import { buildRouteParameterDecorator } from '../calculations/buildRouteParameterDecorator';
 import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
+import { RouteParamOptions } from '../models/RouteParamOptions';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function Query(
-  parameterNameOrPipe?: string | (Newable<Pipe> | Pipe),
-  ...parameterPipeList: (Newable<Pipe> | Pipe)[]
+  optionsOrPipe?: RouteParamOptions | (ServiceIdentifier<Pipe> | Pipe),
+  ...parameterPipeList: (ServiceIdentifier<Pipe> | Pipe)[]
 ): ParameterDecorator {
-  return buildRequestParameterDecorator(
+  return buildRouteParameterDecorator(
     RequestMethodParameterType.Query,
     parameterPipeList,
-    parameterNameOrPipe,
+    optionsOrPipe,
   );
 }

--- a/packages/framework/http/libraries/core/src/http/decorators/Request.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Request.spec.ts
@@ -1,35 +1,40 @@
 import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
 
-vitest.mock('../calculations/buildRequestParameterDecorator');
+vitest.mock('../calculations/buildRouteParameterDecorator');
 
-import { buildRequestParameterDecorator } from '../calculations/buildRequestParameterDecorator';
+import { Pipe } from '@inversifyjs/framework-core';
+import { ServiceIdentifier } from 'inversify';
+
+import { buildRouteParameterDecorator } from '../calculations/buildRouteParameterDecorator';
 import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
 import { Request } from './Request';
 
 describe(Request, () => {
   describe('when called', () => {
+    let parameterPipeListFixture: (ServiceIdentifier<Pipe> | Pipe)[];
     let parameterDecoratorFixture: ParameterDecorator;
     let result: unknown;
 
     beforeAll(() => {
+      parameterPipeListFixture = [Symbol()];
       parameterDecoratorFixture = {} as ParameterDecorator;
 
       vitest
-        .mocked(buildRequestParameterDecorator)
+        .mocked(buildRouteParameterDecorator)
         .mockReturnValueOnce(parameterDecoratorFixture);
 
-      result = Request();
+      result = Request(...parameterPipeListFixture);
     });
 
     afterAll(() => {
       vitest.clearAllMocks();
     });
 
-    it('should call RequestParamFactory', () => {
-      expect(buildRequestParameterDecorator).toHaveBeenCalledTimes(1);
-      expect(buildRequestParameterDecorator).toHaveBeenCalledWith(
+    it('should call buildRouteParameterDecorator()', () => {
+      expect(buildRouteParameterDecorator).toHaveBeenCalledTimes(1);
+      expect(buildRouteParameterDecorator).toHaveBeenCalledWith(
         RequestMethodParameterType.Request,
-        [],
+        parameterPipeListFixture,
       );
     });
 

--- a/packages/framework/http/libraries/core/src/http/decorators/Request.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Request.ts
@@ -1,14 +1,14 @@
 import { Pipe } from '@inversifyjs/framework-core';
-import { Newable } from 'inversify';
+import { ServiceIdentifier } from 'inversify';
 
-import { buildRequestParameterDecorator } from '../calculations/buildRequestParameterDecorator';
+import { buildRouteParameterDecorator } from '../calculations/buildRouteParameterDecorator';
 import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function Request(
-  ...parameterPipeList: (Newable<Pipe> | Pipe)[]
+  ...parameterPipeList: (ServiceIdentifier<Pipe> | Pipe)[]
 ): ParameterDecorator {
-  return buildRequestParameterDecorator(
+  return buildRouteParameterDecorator(
     RequestMethodParameterType.Request,
     parameterPipeList,
   );

--- a/packages/framework/http/libraries/core/src/http/decorators/Response.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Response.spec.ts
@@ -1,35 +1,40 @@
 import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
 
-vitest.mock('../calculations/buildRequestParameterDecorator');
+vitest.mock('../calculations/buildRouteParameterDecorator');
 
-import { buildRequestParameterDecorator } from '../calculations/buildRequestParameterDecorator';
+import { Pipe } from '@inversifyjs/framework-core';
+import { ServiceIdentifier } from 'inversify';
+
+import { buildRouteParameterDecorator } from '../calculations/buildRouteParameterDecorator';
 import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
 import { Response } from './Response';
 
 describe(Response, () => {
   describe('when called', () => {
+    let parameterPipeListFixture: (ServiceIdentifier<Pipe> | Pipe)[];
     let parameterDecoratorFixture: ParameterDecorator;
     let result: unknown;
 
     beforeAll(() => {
+      parameterPipeListFixture = [Symbol()];
       parameterDecoratorFixture = {} as ParameterDecorator;
 
       vitest
-        .mocked(buildRequestParameterDecorator)
+        .mocked(buildRouteParameterDecorator)
         .mockReturnValueOnce(parameterDecoratorFixture);
 
-      result = Response();
+      result = Response(...parameterPipeListFixture);
     });
 
     afterAll(() => {
       vitest.clearAllMocks();
     });
 
-    it('should call requestParamFactory', () => {
-      expect(buildRequestParameterDecorator).toHaveBeenCalledTimes(1);
-      expect(buildRequestParameterDecorator).toHaveBeenCalledWith(
+    it('should call buildRouteParameterDecorator()', () => {
+      expect(buildRouteParameterDecorator).toHaveBeenCalledTimes(1);
+      expect(buildRouteParameterDecorator).toHaveBeenCalledWith(
         RequestMethodParameterType.Response,
-        [],
+        parameterPipeListFixture,
       );
     });
 

--- a/packages/framework/http/libraries/core/src/http/decorators/Response.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Response.ts
@@ -1,14 +1,14 @@
 import { Pipe } from '@inversifyjs/framework-core';
-import { Newable } from 'inversify';
+import { ServiceIdentifier } from 'inversify';
 
-import { buildRequestParameterDecorator } from '../calculations/buildRequestParameterDecorator';
+import { buildRouteParameterDecorator } from '../calculations/buildRouteParameterDecorator';
 import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function Response(
-  ...parameterPipeList: (Newable<Pipe> | Pipe)[]
+  ...parameterPipeList: (ServiceIdentifier<Pipe> | Pipe)[]
 ): ParameterDecorator {
-  return buildRequestParameterDecorator(
+  return buildRouteParameterDecorator(
     RequestMethodParameterType.Response,
     parameterPipeList,
   );

--- a/packages/framework/http/libraries/core/src/http/models/RouteParamOptions.ts
+++ b/packages/framework/http/libraries/core/src/http/models/RouteParamOptions.ts
@@ -1,0 +1,3 @@
+export interface RouteParamOptions {
+  name?: string | undefined;
+}

--- a/packages/framework/http/libraries/core/src/index.ts
+++ b/packages/framework/http/libraries/core/src/index.ts
@@ -44,6 +44,7 @@ import { RequestHandler } from './http/models/RequestHandler';
 import { RequestMethodParameterType } from './http/models/RequestMethodParameterType';
 import { RequestMethodType } from './http/models/RequestMethodType';
 import { RequiredOptions } from './http/models/RequiredOptions';
+import { RouteParamOptions } from './http/models/RouteParamOptions';
 import { RouteParams } from './http/models/RouteParams';
 import { RouterParams } from './http/models/RouterParams';
 import { isHttpResponse } from './httpResponse/calculations/isHttpResponse';
@@ -97,6 +98,7 @@ export type {
   PipeMetadata,
   RequestHandler,
   RequiredOptions,
+  RouteParamOptions,
   RouteParams,
   RouterParams,
 };

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMetadata.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMetadata.spec.ts
@@ -8,8 +8,10 @@ vitest.mock('./buildRouterExplorerControllerMethodMetadataList');
 import {
   buildMiddlewareOptionsFromApplyMiddlewareOptions,
   getClassMiddlewareList,
+  Middleware,
   MiddlewareOptions,
 } from '@inversifyjs/framework-core';
+import { ServiceIdentifier } from 'inversify';
 
 import { ControllerMetadata } from '../model/ControllerMetadata';
 import { ControllerMethodMetadata } from '../model/ControllerMethodMetadata';
@@ -23,7 +25,7 @@ describe(buildRouterExplorerControllerMetadata, () => {
   describe('when called', () => {
     let controllerMetadataFixture: ControllerMetadata;
     let controllerMethodMetadataListFixture: ControllerMethodMetadata[];
-    let controllerMiddlewareListFixture: NewableFunction[];
+    let controllerMiddlewareListFixture: ServiceIdentifier<Middleware>[];
     let middlewareOptionsFixture: MiddlewareOptions;
     let routerExplorerControllerMethodMetadataListFixture: RouterExplorerControllerMethodMetadata[];
     let result: unknown;

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMetadata.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMetadata.ts
@@ -1,8 +1,11 @@
 import {
+  ApplyMiddlewareOptions,
   buildMiddlewareOptionsFromApplyMiddlewareOptions,
   getClassMiddlewareList,
+  Middleware,
   MiddlewareOptions,
 } from '@inversifyjs/framework-core';
+import { ServiceIdentifier } from 'inversify';
 
 import { ControllerMetadata } from '../model/ControllerMetadata';
 import { ControllerMethodMetadata } from '../model/ControllerMethodMetadata';
@@ -20,9 +23,11 @@ export function buildRouterExplorerControllerMetadata<
   const controllerMethodMetadataList: ControllerMethodMetadata[] =
     getControllerMethodMetadataList(controllerMetadata.target);
 
-  const controllerMiddlewareList: NewableFunction[] = getClassMiddlewareList(
-    controllerMetadata.target,
-  );
+  const controllerMiddlewareList: (
+    | // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ServiceIdentifier<Middleware<TRequest, TResponse, any, TResult>>
+    | ApplyMiddlewareOptions
+  )[] = getClassMiddlewareList(controllerMetadata.target);
 
   const middlewareOptions: MiddlewareOptions =
     buildMiddlewareOptionsFromApplyMiddlewareOptions(controllerMiddlewareList);

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadata.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadata.spec.ts
@@ -18,9 +18,10 @@ import {
   getClassMethodMiddlewareList,
   Guard,
   Interceptor,
+  Middleware,
   MiddlewareOptions,
 } from '@inversifyjs/framework-core';
-import { Newable } from 'inversify';
+import { Newable, ServiceIdentifier } from 'inversify';
 
 import { RequestMethodType } from '../../http/models/RequestMethodType';
 import { ControllerMethodMetadata } from '../model/ControllerMethodMetadata';
@@ -48,7 +49,7 @@ describe(buildRouterExplorerControllerMethodMetadata, () => {
     let classMethodInterceptorListFixture: Newable<Interceptor>[];
     let controllerMethodGuardListFixture: Newable<Guard>[];
     let controllerMethodInterceptorListFixture: Newable<Interceptor>[];
-    let controllerMethodMiddlewareListFixture: NewableFunction[];
+    let controllerMethodMiddlewareListFixture: ServiceIdentifier<Middleware>[];
     let middlewareOptionsFixture: MiddlewareOptions;
     let headerMetadataListFixture: [string, string][];
     let useNativeHandlerFixture: boolean;

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadata.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadata.ts
@@ -9,9 +9,10 @@ import {
   getClassMethodMiddlewareList,
   Guard,
   Interceptor,
+  Middleware,
   MiddlewareOptions,
 } from '@inversifyjs/framework-core';
-import { Newable } from 'inversify';
+import { Newable, ServiceIdentifier } from 'inversify';
 
 import { HttpStatusCode } from '../../http/models/HttpStatusCode';
 import { ControllerMethodMetadata } from '../model/ControllerMethodMetadata';
@@ -45,12 +46,12 @@ export function buildRouterExplorerControllerMethodMetadata<
       controllerMethodMetadata.methodKey,
     );
 
-  const controllerMethodGuardList: Newable<Guard<TRequest>>[] = [
+  const controllerMethodGuardList: ServiceIdentifier<Guard<TRequest>>[] = [
     ...getClassGuardList(controller),
     ...getClassMethodGuardList(controller, controllerMethodMetadata.methodKey),
   ];
 
-  const controllerMethodInterceptorList: Newable<
+  const controllerMethodInterceptorList: ServiceIdentifier<
     Interceptor<TRequest, TResponse>
   >[] = [
     ...getClassInterceptorList(controller),
@@ -61,7 +62,8 @@ export function buildRouterExplorerControllerMethodMetadata<
   ];
 
   const controllerMethodMiddlewareList: (
-    | NewableFunction
+    | // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ServiceIdentifier<Middleware<TRequest, TResponse, any, TResult>>
     | ApplyMiddlewareOptions
   )[] = getClassMethodMiddlewareList(
     controller,

--- a/packages/framework/http/libraries/core/src/routerExplorer/model/ControllerMethodParameterMetadata.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/model/ControllerMethodParameterMetadata.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Pipe } from '@inversifyjs/framework-core';
-import { Newable } from 'inversify';
+import { ServiceIdentifier } from 'inversify';
 
 import { CustomParameterDecoratorHandler } from '../../http/models/CustomParameterDecoratorHandler';
 import { RequestMethodParameterType } from '../../http/models/RequestMethodParameterType';
@@ -15,5 +15,5 @@ export interface ControllerMethodParameterMetadata<
     | undefined;
   parameterType: RequestMethodParameterType;
   parameterName?: string | undefined;
-  pipeList: (Newable<Pipe> | Pipe)[];
+  pipeList: (ServiceIdentifier<Pipe> | Pipe)[];
 }

--- a/packages/framework/http/libraries/core/src/routerExplorer/model/RouterExplorerControllerMetadata.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/model/RouterExplorerControllerMetadata.ts
@@ -1,5 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { Middleware } from '@inversifyjs/framework-core';
+import { ServiceIdentifier } from 'inversify';
+
 import { RouterExplorerControllerMethodMetadata } from './RouterExplorerControllerMethodMetadata';
 
 export interface RouterExplorerControllerMetadata<
@@ -13,7 +16,11 @@ export interface RouterExplorerControllerMetadata<
     TResult
   >[];
   readonly path: string;
-  readonly postHandlerMiddlewareList: NewableFunction[];
-  readonly preHandlerMiddlewareList: NewableFunction[];
+  readonly postHandlerMiddlewareList: ServiceIdentifier<
+    Middleware<TRequest, TResponse, any, TResult>
+  >[];
+  readonly preHandlerMiddlewareList: ServiceIdentifier<
+    Middleware<TRequest, TResponse, any, TResult>
+  >[];
   readonly target: NewableFunction;
 }

--- a/packages/framework/http/libraries/core/src/routerExplorer/model/RouterExplorerControllerMethodMetadata.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/model/RouterExplorerControllerMethodMetadata.ts
@@ -1,5 +1,10 @@
-import { ErrorFilter, Guard, Interceptor } from '@inversifyjs/framework-core';
-import { Newable } from 'inversify';
+import {
+  ErrorFilter,
+  Guard,
+  Interceptor,
+  Middleware,
+} from '@inversifyjs/framework-core';
+import { Newable, ServiceIdentifier } from 'inversify';
 
 import { HttpStatusCode } from '../../http/models/HttpStatusCode';
 import { RequestMethodType } from '../../http/models/RequestMethodType';
@@ -14,17 +19,23 @@ export interface RouterExplorerControllerMethodMetadata<
     Newable<Error> | null,
     Newable<ErrorFilter>
   >;
-  readonly guardList: Newable<Guard<TRequest>>[];
+  readonly guardList: ServiceIdentifier<Guard<TRequest>>[];
   readonly headerMetadataList: [string, string][];
-  readonly interceptorList: Newable<Interceptor<TRequest>>[];
+  readonly interceptorList: ServiceIdentifier<Interceptor<TRequest>>[];
   readonly methodKey: string | symbol;
   readonly parameterMetadataList: (
     | ControllerMethodParameterMetadata<TRequest, TResponse, TResult>
     | undefined
   )[];
   readonly path: string;
-  readonly postHandlerMiddlewareList: NewableFunction[];
-  readonly preHandlerMiddlewareList: NewableFunction[];
+  readonly postHandlerMiddlewareList: ServiceIdentifier<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Middleware<TRequest, TResponse, any, TResult>
+  >[];
+  readonly preHandlerMiddlewareList: ServiceIdentifier<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Middleware<TRequest, TResponse, any, TResult>
+  >[];
   readonly requestMethodType: RequestMethodType;
   readonly statusCode: HttpStatusCode | undefined;
   readonly useNativeHandler: boolean;

--- a/packages/framework/http/libraries/open-api/src/openApi/calculations/buildSwaggerUiExpress4Controller.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/calculations/buildSwaggerUiExpress4Controller.ts
@@ -44,7 +44,10 @@ export function buildSwaggerUiExpress4Controller(
 
     @Get('/resources/:resource')
     public override getSwaggerUiResource(
-      @Params('resource') resource: string,
+      @Params({
+        name: 'resource',
+      })
+      resource: string,
       @Response()
       response: express.Response,
     ): void {

--- a/packages/framework/http/libraries/open-api/src/openApi/calculations/buildSwaggerUiExpressController.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/calculations/buildSwaggerUiExpressController.ts
@@ -44,7 +44,10 @@ export function buildSwaggerUiExpressController(
 
     @Get('/resources/:resource')
     public override getSwaggerUiResource(
-      @Params('resource') resource: string,
+      @Params({
+        name: 'resource',
+      })
+      resource: string,
       @Response()
       response: express.Response,
     ): void {

--- a/packages/framework/http/libraries/open-api/src/openApi/calculations/buildSwaggerUiFastifyController.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/calculations/buildSwaggerUiFastifyController.ts
@@ -48,7 +48,10 @@ export function buildSwaggerUiFastifyController(
 
     @Get('/resources/:resource')
     public override async getSwaggerUiResource(
-      @Params('resource') resource: string,
+      @Params({
+        name: 'resource',
+      })
+      resource: string,
       @Response()
       response: FastifyReply,
     ): Promise<void> {

--- a/packages/framework/http/libraries/open-api/src/openApi/calculations/buildSwaggerUiHonoController.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/calculations/buildSwaggerUiHonoController.ts
@@ -51,7 +51,10 @@ export function buildSwaggerUiHonoController(
 
     @Get('/resources/:resource')
     public override getSwaggerUiResource(
-      @Params('resource') resource: string,
+      @Params({
+        name: 'resource',
+      })
+      resource: string,
       @Response()
       context: Context,
     ): Response | undefined {

--- a/packages/framework/http/tools/e2e-tests/src/warrior/body/controllers/WarriorsDeleteBodyNamedController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/body/controllers/WarriorsDeleteBodyNamedController.ts
@@ -7,7 +7,10 @@ import { WarriorCreationResponseType } from '../models/WarriorCreationResponseTy
 export class WarriorsDeleteBodyNamedController {
   @Delete()
   public async deleteWarrior(
-    @Body('name') name: string,
+    @Body({
+      name: 'name',
+    })
+    name: string,
   ): Promise<WarriorCreationResponse> {
     return {
       damage: 10,

--- a/packages/framework/http/tools/e2e-tests/src/warrior/body/controllers/WarriorsOptionsBodyNamedController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/body/controllers/WarriorsOptionsBodyNamedController.ts
@@ -7,7 +7,10 @@ import { WarriorCreationResponseType } from '../models/WarriorCreationResponseTy
 export class WarriorsOptionsBodyNamedController {
   @Options()
   public async optionsWarrior(
-    @Body('name') name: string,
+    @Body({
+      name: 'name',
+    })
+    name: string,
   ): Promise<WarriorCreationResponse> {
     return {
       damage: 10,

--- a/packages/framework/http/tools/e2e-tests/src/warrior/body/controllers/WarriorsPatchBodyNamedController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/body/controllers/WarriorsPatchBodyNamedController.ts
@@ -7,7 +7,10 @@ import { WarriorCreationResponseType } from '../models/WarriorCreationResponseTy
 export class WarriorsPatchBodyNamedController {
   @Patch()
   public async updateWarrior(
-    @Body('name') name: string,
+    @Body({
+      name: 'name',
+    })
+    name: string,
   ): Promise<WarriorCreationResponse> {
     return {
       damage: 10,

--- a/packages/framework/http/tools/e2e-tests/src/warrior/body/controllers/WarriorsPostBodyNamedController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/body/controllers/WarriorsPostBodyNamedController.ts
@@ -7,7 +7,10 @@ import { WarriorCreationResponseType } from '../models/WarriorCreationResponseTy
 export class WarriorsPostBodyNamedController {
   @Post()
   public async createWarrior(
-    @Body('name') name: string,
+    @Body({
+      name: 'name',
+    })
+    name: string,
   ): Promise<WarriorCreationResponse> {
     return {
       damage: 10,

--- a/packages/framework/http/tools/e2e-tests/src/warrior/body/controllers/WarriorsPutBodyNamedController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/body/controllers/WarriorsPutBodyNamedController.ts
@@ -7,7 +7,10 @@ import { WarriorCreationResponseType } from '../models/WarriorCreationResponseTy
 export class WarriorsPutBodyNamedController {
   @Put()
   public async updateWarrior(
-    @Body('name') name: string,
+    @Body({
+      name: 'name',
+    })
+    name: string,
   ): Promise<WarriorCreationResponse> {
     return {
       damage: 10,

--- a/packages/framework/http/tools/e2e-tests/src/warrior/headers/controllers/WarriorsDeleteHeadersNamedController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/headers/controllers/WarriorsDeleteHeadersNamedController.ts
@@ -4,7 +4,10 @@ import { Controller, Delete, Headers } from '@inversifyjs/http-core';
 export class WarriorsDeleteHeadersNamedController {
   @Delete()
   public async deleteWarrior(
-    @Headers('x-test-header') testHeader: string,
+    @Headers({
+      name: 'x-test-header',
+    })
+    testHeader: string,
   ): Promise<Record<string, string>> {
     return {
       'x-test-header': testHeader,

--- a/packages/framework/http/tools/e2e-tests/src/warrior/headers/controllers/WarriorsGetHeadersNamedController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/headers/controllers/WarriorsGetHeadersNamedController.ts
@@ -4,7 +4,10 @@ import { Controller, Get, Headers } from '@inversifyjs/http-core';
 export class WarriorsGetHeadersNamedController {
   @Get()
   public async getWarrior(
-    @Headers('x-test-header') testHeader: string,
+    @Headers({
+      name: 'x-test-header',
+    })
+    testHeader: string,
   ): Promise<Record<string, string>> {
     return {
       'x-test-header': testHeader,

--- a/packages/framework/http/tools/e2e-tests/src/warrior/headers/controllers/WarriorsOptionsHeadersNamedController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/headers/controllers/WarriorsOptionsHeadersNamedController.ts
@@ -4,7 +4,10 @@ import { Controller, Headers, Options } from '@inversifyjs/http-core';
 export class WarriorsOptionsHeadersNamedController {
   @Options()
   public async optionsWarrior(
-    @Headers('x-test-header') testHeader: string,
+    @Headers({
+      name: 'x-test-header',
+    })
+    testHeader: string,
   ): Promise<Record<string, string>> {
     return {
       'x-test-header': testHeader,

--- a/packages/framework/http/tools/e2e-tests/src/warrior/headers/controllers/WarriorsPatchHeadersNamedController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/headers/controllers/WarriorsPatchHeadersNamedController.ts
@@ -4,7 +4,10 @@ import { Controller, Headers, Patch } from '@inversifyjs/http-core';
 export class WarriorsPatchHeadersNamedController {
   @Patch()
   public async patchWarrior(
-    @Headers('x-test-header') testHeader: string,
+    @Headers({
+      name: 'x-test-header',
+    })
+    testHeader: string,
   ): Promise<Record<string, string>> {
     return {
       'x-test-header': testHeader,

--- a/packages/framework/http/tools/e2e-tests/src/warrior/headers/controllers/WarriorsPostHeadersNamedController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/headers/controllers/WarriorsPostHeadersNamedController.ts
@@ -4,7 +4,10 @@ import { Controller, Headers, Post } from '@inversifyjs/http-core';
 export class WarriorsPostHeadersNamedController {
   @Post()
   public async postWarrior(
-    @Headers('x-test-header') testHeader: string,
+    @Headers({
+      name: 'x-test-header',
+    })
+    testHeader: string,
   ): Promise<Record<string, string>> {
     return {
       'x-test-header': testHeader,

--- a/packages/framework/http/tools/e2e-tests/src/warrior/headers/controllers/WarriorsPutHeadersNamedController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/headers/controllers/WarriorsPutHeadersNamedController.ts
@@ -4,7 +4,10 @@ import { Controller, Headers, Put } from '@inversifyjs/http-core';
 export class WarriorsPutHeadersNamedController {
   @Put()
   public async putWarrior(
-    @Headers('x-test-header') testHeader: string,
+    @Headers({
+      name: 'x-test-header',
+    })
+    testHeader: string,
   ): Promise<Record<string, string>> {
     return {
       'x-test-header': testHeader,

--- a/packages/framework/http/tools/e2e-tests/src/warrior/params/controllers/WarriorsDeleteParamsNamedController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/params/controllers/WarriorsDeleteParamsNamedController.ts
@@ -5,7 +5,12 @@ import { WarriorWithId } from '../models/WarriorWithId';
 @Controller('/warriors')
 export class WarriorsDeleteParamsNamedController {
   @Delete('/:id')
-  public async deleteWarrior(@Params('id') id: string): Promise<WarriorWithId> {
+  public async deleteWarrior(
+    @Params({
+      name: 'id',
+    })
+    id: string,
+  ): Promise<WarriorWithId> {
     return {
       damage: 10,
       health: 100,

--- a/packages/framework/http/tools/e2e-tests/src/warrior/params/controllers/WarriorsGetParamsNamedController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/params/controllers/WarriorsGetParamsNamedController.ts
@@ -5,7 +5,12 @@ import { WarriorWithId } from '../models/WarriorWithId';
 @Controller('/warriors')
 export class WarriorsGetParamsNamedController {
   @Get('/:id')
-  public async getWarrior(@Params('id') id: string): Promise<WarriorWithId> {
+  public async getWarrior(
+    @Params({
+      name: 'id',
+    })
+    id: string,
+  ): Promise<WarriorWithId> {
     return {
       damage: 10,
       health: 100,

--- a/packages/framework/http/tools/e2e-tests/src/warrior/params/controllers/WarriorsPatchParamsNamedController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/params/controllers/WarriorsPatchParamsNamedController.ts
@@ -5,7 +5,12 @@ import { WarriorWithId } from '../models/WarriorWithId';
 @Controller('/warriors')
 export class WarriorsPatchParamsNamedController {
   @Patch('/:id')
-  public async updateWarrior(@Params('id') id: string): Promise<WarriorWithId> {
+  public async updateWarrior(
+    @Params({
+      name: 'id',
+    })
+    id: string,
+  ): Promise<WarriorWithId> {
     return {
       damage: 10,
       health: 100,

--- a/packages/framework/http/tools/e2e-tests/src/warrior/params/controllers/WarriorsPostParamsNamedController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/params/controllers/WarriorsPostParamsNamedController.ts
@@ -5,7 +5,12 @@ import { WarriorWithId } from '../models/WarriorWithId';
 @Controller('/warriors')
 export class WarriorsPostParamsNamedController {
   @Post('/:id')
-  public async createWarrior(@Params('id') id: string): Promise<WarriorWithId> {
+  public async createWarrior(
+    @Params({
+      name: 'id',
+    })
+    id: string,
+  ): Promise<WarriorWithId> {
     return {
       damage: 10,
       health: 100,

--- a/packages/framework/http/tools/e2e-tests/src/warrior/params/controllers/WarriorsPutParamsNamedController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/params/controllers/WarriorsPutParamsNamedController.ts
@@ -5,7 +5,12 @@ import { WarriorWithId } from '../models/WarriorWithId';
 @Controller('/warriors')
 export class WarriorsPutParamsNamedController {
   @Put('/:id')
-  public async updateWarrior(@Params('id') id: string): Promise<WarriorWithId> {
+  public async updateWarrior(
+    @Params({
+      name: 'id',
+    })
+    id: string,
+  ): Promise<WarriorWithId> {
     return {
       damage: 10,
       health: 100,

--- a/packages/framework/http/tools/e2e-tests/src/warrior/query/controllers/WarriorsDeleteQueryNamedController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/query/controllers/WarriorsDeleteQueryNamedController.ts
@@ -6,7 +6,10 @@ import { WarriorWithQuery } from '../models/WarriorWithQuery';
 export class WarriorsDeleteQueryNamedController {
   @Delete()
   public async deleteWarrior(
-    @Query('filter') filter: string,
+    @Query({
+      name: 'filter',
+    })
+    filter: string,
   ): Promise<WarriorWithQuery> {
     return {
       damage: 10,

--- a/packages/framework/http/tools/e2e-tests/src/warrior/query/controllers/WarriorsGetQueryNamedController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/query/controllers/WarriorsGetQueryNamedController.ts
@@ -6,7 +6,10 @@ import { WarriorWithQuery } from '../models/WarriorWithQuery';
 export class WarriorsGetQueryNamedController {
   @Get()
   public async getWarrior(
-    @Query('filter') filter: string,
+    @Query({
+      name: 'filter',
+    })
+    filter: string,
   ): Promise<WarriorWithQuery> {
     return {
       damage: 10,

--- a/packages/framework/http/tools/e2e-tests/src/warrior/query/controllers/WarriorsOptionsQueryNamedController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/query/controllers/WarriorsOptionsQueryNamedController.ts
@@ -6,7 +6,10 @@ import { WarriorWithQuery } from '../models/WarriorWithQuery';
 export class WarriorsOptionsQueryNamedController {
   @Options()
   public async optionsWarrior(
-    @Query('filter') filter: string,
+    @Query({
+      name: 'filter',
+    })
+    filter: string,
   ): Promise<WarriorWithQuery> {
     return {
       damage: 10,

--- a/packages/framework/http/tools/e2e-tests/src/warrior/query/controllers/WarriorsPatchQueryNamedController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/query/controllers/WarriorsPatchQueryNamedController.ts
@@ -6,7 +6,10 @@ import { WarriorWithQuery } from '../models/WarriorWithQuery';
 export class WarriorsPatchQueryNamedController {
   @Patch()
   public async patchWarrior(
-    @Query('filter') filter: string,
+    @Query({
+      name: 'filter',
+    })
+    filter: string,
   ): Promise<WarriorWithQuery> {
     return {
       damage: 10,

--- a/packages/framework/http/tools/e2e-tests/src/warrior/query/controllers/WarriorsPostQueryNamedController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/query/controllers/WarriorsPostQueryNamedController.ts
@@ -6,7 +6,10 @@ import { WarriorWithQuery } from '../models/WarriorWithQuery';
 export class WarriorsPostQueryNamedController {
   @Post()
   public async postWarrior(
-    @Query('filter') filter: string,
+    @Query({
+      name: 'filter',
+    })
+    filter: string,
   ): Promise<WarriorWithQuery> {
     return {
       damage: 10,

--- a/packages/framework/http/tools/e2e-tests/src/warrior/query/controllers/WarriorsPutQueryNamedController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/query/controllers/WarriorsPutQueryNamedController.ts
@@ -6,7 +6,10 @@ import { WarriorWithQuery } from '../models/WarriorWithQuery';
 export class WarriorsPutQueryNamedController {
   @Put()
   public async putWarrior(
-    @Query('filter') filter: string,
+    @Query({
+      name: 'filter',
+    })
+    filter: string,
   ): Promise<WarriorWithQuery> {
     return {
       damage: 10,


### PR DESCRIPTION
### Changed
- Guards, Middlewares, Interceptors and Pipes can now be injected as service identifiers.
- Updated decorators accordingly.
- Updated framework metadata accordingly.
- Updated adapters accordingly.
- Updated e2e tests with the new named parameter syntax.