### PR TITLE
Update controller metadata to allow setting custom service identifier

### DIFF
--- a/packages/framework/http/libraries/core/src/http/adapter/InversifyHttpAdapter.ts
+++ b/packages/framework/http/libraries/core/src/http/adapter/InversifyHttpAdapter.ts
@@ -233,8 +233,7 @@ export abstract class InversifyHttpAdapter<
           routerExplorerControllerMetadata.preHandlerMiddlewareList,
         ),
         routeParamsList: this.#builRouteParamdHandlerList(
-          routerExplorerControllerMetadata.target,
-          routerExplorerControllerMetadata.controllerMethodMetadataList,
+          routerExplorerControllerMetadata,
         ),
       });
 
@@ -249,14 +248,13 @@ export abstract class InversifyHttpAdapter<
   }
 
   #builRouteParamdHandlerList(
-    target: NewableFunction,
-    routerExplorerControllerMethodMetadata: RouterExplorerControllerMethodMetadata<
+    routerExplorerControllerMetadata: RouterExplorerControllerMetadata<
       TRequest,
       TResponse,
-      unknown
-    >[],
+      TResult
+    >,
   ): RouteParams<TRequest, TResponse, TNextFunction, TResult>[] {
-    return routerExplorerControllerMethodMetadata.map(
+    return routerExplorerControllerMetadata.controllerMethodMetadataList.map(
       (
         routerExplorerControllerMethodMetadata: RouterExplorerControllerMethodMetadata<
           TRequest,
@@ -275,7 +273,8 @@ export abstract class InversifyHttpAdapter<
           ),
         ],
         handler: this.#buildHandler(
-          target,
+          routerExplorerControllerMetadata.serviceIdentifier,
+          routerExplorerControllerMetadata.target,
           routerExplorerControllerMethodMetadata,
         ),
         path: routerExplorerControllerMethodMetadata.path,
@@ -292,6 +291,7 @@ export abstract class InversifyHttpAdapter<
   }
 
   #buildHandler(
+    serviceIdentifier: ServiceIdentifier,
     targetClass: NewableFunction,
     routerExplorerControllerMethodMetadata: RouterExplorerControllerMethodMetadata<
       TRequest,
@@ -337,7 +337,7 @@ export abstract class InversifyHttpAdapter<
     );
 
     return buildInterceptedHandler(
-      targetClass,
+      serviceIdentifier,
       routerExplorerControllerMethodMetadata,
       this.#container,
       buildHandlerParams,

--- a/packages/framework/http/libraries/core/src/http/calculations/buildInterceptedHandler.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/calculations/buildInterceptedHandler.spec.ts
@@ -13,7 +13,7 @@ import {
   Interceptor,
   InterceptorTransformObject,
 } from '@inversifyjs/framework-core';
-import { Container, Newable } from 'inversify';
+import { Container, Newable, ServiceIdentifier } from 'inversify';
 
 import { RouterExplorerControllerMethodMetadata } from '../../routerExplorer/model/RouterExplorerControllerMethodMetadata';
 import { ControllerResponse } from '../models/ControllerResponse';
@@ -21,7 +21,7 @@ import { RequestHandler } from '../models/RequestHandler';
 import { buildInterceptedHandler } from './buildInterceptedHandler';
 
 describe(buildInterceptedHandler, () => {
-  let targetClassFixture: NewableFunction;
+  let serviceIdentifierFixture: ServiceIdentifier;
   let containerMock: Mocked<Container>;
   let buildHandlerParamsMock: Mock<
     (
@@ -49,7 +49,7 @@ describe(buildInterceptedHandler, () => {
   let nextFixture: () => void;
 
   beforeAll(() => {
-    targetClassFixture = class TestController {
+    serviceIdentifierFixture = class TestController {
       public testMethod(): ControllerResponse {
         return { body: 'test' };
       }
@@ -113,7 +113,7 @@ describe(buildInterceptedHandler, () => {
 
         const handler: RequestHandler<unknown, unknown, () => void, string> =
           buildInterceptedHandler(
-            targetClassFixture,
+            serviceIdentifierFixture,
             routerExplorerControllerMethodMetadataFixture,
             containerMock,
             buildHandlerParamsMock,
@@ -131,7 +131,9 @@ describe(buildInterceptedHandler, () => {
 
       it('should call container.getAsync()', () => {
         expect(containerMock.getAsync).toHaveBeenCalledTimes(1);
-        expect(containerMock.getAsync).toHaveBeenCalledWith(targetClassFixture);
+        expect(containerMock.getAsync).toHaveBeenCalledWith(
+          serviceIdentifierFixture,
+        );
       });
 
       it('should call buildHandlerParams()', () => {
@@ -188,7 +190,7 @@ describe(buildInterceptedHandler, () => {
 
         const handler: RequestHandler<unknown, unknown, () => void, string> =
           buildInterceptedHandler(
-            targetClassFixture,
+            serviceIdentifierFixture,
             routerExplorerControllerMethodMetadataFixture,
             containerMock,
             buildHandlerParamsMock,
@@ -314,7 +316,7 @@ describe(buildInterceptedHandler, () => {
 
         const handler: RequestHandler<unknown, unknown, () => void, string> =
           buildInterceptedHandler(
-            targetClassFixture,
+            serviceIdentifierFixture,
             routerExplorerControllerMethodMetadataFixture,
             containerMock,
             buildHandlerParamsMock,
@@ -342,7 +344,7 @@ describe(buildInterceptedHandler, () => {
         );
         expect(containerMock.getAsync).toHaveBeenNthCalledWith(
           3,
-          targetClassFixture,
+          serviceIdentifierFixture,
         );
       });
 
@@ -473,7 +475,7 @@ describe(buildInterceptedHandler, () => {
 
         const handler: RequestHandler<unknown, unknown, () => void, string> =
           buildInterceptedHandler(
-            targetClassFixture,
+            serviceIdentifierFixture,
             routerExplorerControllerMethodMetadataFixture,
             containerMock,
             buildHandlerParamsMock,
@@ -501,7 +503,7 @@ describe(buildInterceptedHandler, () => {
         );
         expect(containerMock.getAsync).toHaveBeenNthCalledWith(
           3,
-          targetClassFixture,
+          serviceIdentifierFixture,
         );
       });
 
@@ -589,7 +591,7 @@ describe(buildInterceptedHandler, () => {
 
         const handler: RequestHandler<unknown, unknown, () => void, string> =
           buildInterceptedHandler(
-            targetClassFixture,
+            serviceIdentifierFixture,
             routerExplorerControllerMethodMetadataFixture,
             containerMock,
             buildHandlerParamsMock,
@@ -663,7 +665,7 @@ describe(buildInterceptedHandler, () => {
 
         const handler: RequestHandler<unknown, unknown, () => void, string> =
           buildInterceptedHandler(
-            targetClassFixture,
+            serviceIdentifierFixture,
             routerExplorerControllerMethodMetadataFixture,
             containerMock,
             buildHandlerParamsMock,

--- a/packages/framework/http/libraries/core/src/http/calculations/buildInterceptedHandler.ts
+++ b/packages/framework/http/libraries/core/src/http/calculations/buildInterceptedHandler.ts
@@ -16,7 +16,7 @@ export function buildInterceptedHandler<
   TNextFunction extends (err?: any) => Promise<void> | void,
   TResult,
 >(
-  targetClass: NewableFunction,
+  serviceIdentifier: ServiceIdentifier<Controller>,
   routerExplorerControllerMethodMetadata: RouterExplorerControllerMethodMetadata<
     TRequest,
     TResponse,
@@ -47,7 +47,8 @@ export function buildInterceptedHandler<
       next: TNextFunction,
     ): Promise<TResult> => {
       try {
-        const controller: Controller = await container.getAsync(targetClass);
+        const controller: Controller =
+          await container.getAsync(serviceIdentifier);
 
         const handlerParams: unknown[] = await buildHandlerParams(
           request,
@@ -113,7 +114,8 @@ export function buildInterceptedHandler<
         };
       } else {
         return async (): Promise<InterceptorTransformObject> => {
-          const controller: Controller = await container.getAsync(targetClass);
+          const controller: Controller =
+            await container.getAsync(serviceIdentifier);
 
           const handlerParams: unknown[] = await buildHandlerParams(
             request,

--- a/packages/framework/http/libraries/core/src/http/decorators/Controller.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Controller.ts
@@ -17,6 +17,7 @@ export function Controller(
   return (target: NewableFunction): void => {
     const controllerMetadata: ControllerMetadata = {
       path: '/',
+      serviceIdentifier: target,
       target,
     };
 
@@ -29,6 +30,12 @@ export function Controller(
         controllerMetadata.path = buildNormalizedPath(
           pathOrOptions.path ?? '/',
         );
+
+        if (pathOrOptions.serviceIdentifier !== undefined) {
+          controllerMetadata.serviceIdentifier =
+            pathOrOptions.serviceIdentifier;
+        }
+
         scope = pathOrOptions.scope;
       }
     }

--- a/packages/framework/http/libraries/core/src/http/models/ControllerOptions.ts
+++ b/packages/framework/http/libraries/core/src/http/models/ControllerOptions.ts
@@ -1,6 +1,7 @@
-import { BindingScope } from 'inversify';
+import { BindingScope, ServiceIdentifier } from 'inversify';
 
 export interface ControllerOptions {
   path?: string;
   scope?: BindingScope;
+  serviceIdentifier?: ServiceIdentifier;
 }

--- a/packages/framework/http/libraries/core/src/index.ts
+++ b/packages/framework/http/libraries/core/src/index.ts
@@ -78,8 +78,8 @@ import { ResetContentHttpResponse } from './httpResponse/models/ResetContentHttp
 import { ServiceUnavailableHttpResponse } from './httpResponse/models/ServiceUnavailableHttpResponse';
 import { UnauthorizedHttpResponse } from './httpResponse/models/UnauthorizedHttpResponse';
 import { UnprocessableEntityHttpResponse } from './httpResponse/models/UnprocessableEntityHttpResponse';
+import { getControllerMetadataList } from './routerExplorer/calculations/getControllerMetadataList';
 import { getControllerMethodMetadataList } from './routerExplorer/calculations/getControllerMethodMetadataList';
-import { getControllers } from './routerExplorer/calculations/getControllers';
 import { ControllerMetadata } from './routerExplorer/model/ControllerMetadata';
 import { ControllerMethodMetadata } from './routerExplorer/model/ControllerMethodMetadata';
 
@@ -124,7 +124,7 @@ export {
   ForbiddenHttpResponse,
   GatewayTimeoutHttpResponse,
   Get,
-  getControllers as getControllerMetadataList,
+  getControllerMetadataList,
   getControllerMethodMetadataList as getControllerMethodMetadataList,
   GoneHttpResponse,
   Head,

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMetadata.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMetadata.spec.ts
@@ -33,6 +33,7 @@ describe(buildRouterExplorerControllerMetadata, () => {
     beforeAll(() => {
       controllerMetadataFixture = {
         path: '/test',
+        serviceIdentifier: Symbol(),
         target: class TestController {},
       };
       controllerMethodMetadataListFixture = [];
@@ -92,7 +93,7 @@ describe(buildRouterExplorerControllerMetadata, () => {
       expect(
         buildRouterExplorerControllerMethodMetadataList,
       ).toHaveBeenCalledWith(
-        controllerMetadataFixture.target,
+        controllerMetadataFixture,
         controllerMethodMetadataListFixture,
       );
     });
@@ -106,6 +107,7 @@ describe(buildRouterExplorerControllerMetadata, () => {
           middlewareOptionsFixture.postHandlerMiddlewareList,
         preHandlerMiddlewareList:
           middlewareOptionsFixture.preHandlerMiddlewareList,
+        serviceIdentifier: controllerMetadataFixture.serviceIdentifier,
         target: controllerMetadataFixture.target,
       };
 

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMetadata.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMetadata.ts
@@ -35,12 +35,13 @@ export function buildRouterExplorerControllerMetadata<
   return {
     controllerMethodMetadataList:
       buildRouterExplorerControllerMethodMetadataList(
-        controllerMetadata.target,
+        controllerMetadata,
         controllerMethodMetadataList,
       ),
     path: controllerMetadata.path,
     postHandlerMiddlewareList: middlewareOptions.postHandlerMiddlewareList,
     preHandlerMiddlewareList: middlewareOptions.preHandlerMiddlewareList,
+    serviceIdentifier: controllerMetadata.serviceIdentifier,
     target: controllerMetadata.target,
   };
 }

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMetadataList.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMetadataList.spec.ts
@@ -8,7 +8,7 @@ import {
   vitest,
 } from 'vitest';
 
-vitest.mock('./getControllers');
+vitest.mock('./getControllerMetadataList');
 vitest.mock('./buildRouterExplorerControllerMetadata');
 
 import { Container } from 'inversify';
@@ -19,7 +19,7 @@ import { ControllerMetadata } from '../model/ControllerMetadata';
 import { RouterExplorerControllerMetadata } from '../model/RouterExplorerControllerMetadata';
 import { buildRouterExplorerControllerMetadata } from './buildRouterExplorerControllerMetadata';
 import { buildRouterExplorerControllerMetadataList } from './buildRouterExplorerControllerMetadataList';
-import { getControllers } from './getControllers';
+import { getControllerMetadataList } from './getControllerMetadataList';
 
 describe(buildRouterExplorerControllerMetadataList, () => {
   describe('when called, and exploreControllers returns undefined', () => {
@@ -32,7 +32,7 @@ describe(buildRouterExplorerControllerMetadataList, () => {
       controllerMetadataListFixture = undefined;
 
       vitest
-        .mocked(getControllers)
+        .mocked(getControllerMetadataList)
         .mockReturnValueOnce(controllerMetadataListFixture);
 
       try {
@@ -47,8 +47,8 @@ describe(buildRouterExplorerControllerMetadataList, () => {
     });
 
     it('should call exploreControllers', () => {
-      expect(getControllers).toHaveBeenCalledTimes(1);
-      expect(getControllers).toHaveBeenCalledWith();
+      expect(getControllerMetadataList).toHaveBeenCalledTimes(1);
+      expect(getControllerMetadataList).toHaveBeenCalledWith();
     });
 
     it('should throw an InversifyHttpAdapterError with the correct kind', () => {
@@ -73,6 +73,7 @@ describe(buildRouterExplorerControllerMetadataList, () => {
       > as Mocked<Container>;
       controllerMetadataFixture = {
         path: '',
+        serviceIdentifier: Symbol(),
         target: {} as NewableFunction,
       };
       controllerMetadataListFixture = [controllerMetadataFixture];
@@ -81,11 +82,12 @@ describe(buildRouterExplorerControllerMetadataList, () => {
         path: '',
         postHandlerMiddlewareList: [],
         preHandlerMiddlewareList: [],
+        serviceIdentifier: Symbol(),
         target: {} as NewableFunction,
       };
 
       vitest
-        .mocked(getControllers)
+        .mocked(getControllerMetadataList)
         .mockReturnValueOnce(controllerMetadataListFixture);
 
       containerMock.isBound.mockReturnValueOnce(true);
@@ -101,15 +103,15 @@ describe(buildRouterExplorerControllerMetadataList, () => {
       vitest.clearAllMocks();
     });
 
-    it('should call getControllers()', () => {
-      expect(getControllers).toHaveBeenCalledTimes(1);
-      expect(getControllers).toHaveBeenCalledWith();
+    it('should call getControllerMetadataList()', () => {
+      expect(getControllerMetadataList).toHaveBeenCalledTimes(1);
+      expect(getControllerMetadataList).toHaveBeenCalledWith();
     });
 
     it('should call container.isBound()', () => {
       expect(containerMock.isBound).toHaveBeenCalledTimes(1);
       expect(containerMock.isBound).toHaveBeenCalledWith(
-        controllerMetadataFixture.target,
+        controllerMetadataFixture.serviceIdentifier,
       );
     });
 

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMetadataList.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMetadataList.ts
@@ -5,7 +5,7 @@ import { InversifyHttpAdapterErrorKind } from '../../error/models/InversifyHttpA
 import { ControllerMetadata } from '../model/ControllerMetadata';
 import { RouterExplorerControllerMetadata } from '../model/RouterExplorerControllerMetadata';
 import { buildRouterExplorerControllerMetadata } from './buildRouterExplorerControllerMetadata';
-import { getControllers } from './getControllers';
+import { getControllerMetadataList } from './getControllerMetadataList';
 
 export function buildRouterExplorerControllerMetadataList<
   TRequest,
@@ -15,7 +15,7 @@ export function buildRouterExplorerControllerMetadataList<
   container: Container,
 ): RouterExplorerControllerMetadata<TRequest, TResponse, TResult>[] {
   const controllerMetadataList: ControllerMetadata[] | undefined =
-    getControllers();
+    getControllerMetadataList();
 
   if (controllerMetadataList === undefined) {
     throw new InversifyHttpAdapterError(
@@ -31,7 +31,7 @@ export function buildRouterExplorerControllerMetadataList<
   >[] = [];
 
   for (const controllerMetadata of controllerMetadataList) {
-    if (container.isBound(controllerMetadata.target)) {
+    if (container.isBound(controllerMetadata.serviceIdentifier)) {
       routerExplorerControllerMetadataList.push(
         buildRouterExplorerControllerMetadata(controllerMetadata),
       );

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadata.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadata.spec.ts
@@ -24,6 +24,7 @@ import {
 import { Newable, ServiceIdentifier } from 'inversify';
 
 import { RequestMethodType } from '../../http/models/RequestMethodType';
+import { ControllerMetadata } from '../model/ControllerMetadata';
 import { ControllerMethodMetadata } from '../model/ControllerMethodMetadata';
 import { ControllerMethodParameterMetadata } from '../model/ControllerMethodParameterMetadata';
 import { RouterExplorerControllerMethodMetadata } from '../model/RouterExplorerControllerMethodMetadata';
@@ -36,8 +37,8 @@ import { getControllerMethodUseNativeHandlerMetadata } from './getControllerMeth
 
 describe(buildRouterExplorerControllerMethodMetadata, () => {
   describe('when called', () => {
+    let controllerMetadataFixture: ControllerMetadata;
     let controllerMethodMetadataFixture: ControllerMethodMetadata;
-    let controllerFixture: NewableFunction;
     let controllerMethodParameterMetadataListFixture: (
       | ControllerMethodParameterMetadata
       | undefined
@@ -60,12 +61,16 @@ describe(buildRouterExplorerControllerMethodMetadata, () => {
     let result: unknown;
 
     beforeAll(() => {
+      controllerMetadataFixture = {
+        path: '/',
+        serviceIdentifier: Symbol(),
+        target: class TestController {},
+      };
       controllerMethodMetadataFixture = {
         methodKey: 'testMethod',
         path: '/test',
         requestMethodType: RequestMethodType.Get,
       };
-      controllerFixture = class Test {};
       controllerMethodParameterMetadataListFixture = [];
       controllerMethodStatusCodeMetadataFixture = undefined;
       classGuardListFixture = [Symbol() as unknown as Newable<Guard>];
@@ -138,7 +143,7 @@ describe(buildRouterExplorerControllerMethodMetadata, () => {
         .mockReturnValueOnce(errorTypeToErrorFilterMapFixture);
 
       result = buildRouterExplorerControllerMethodMetadata(
-        controllerFixture,
+        controllerMetadataFixture,
         controllerMethodMetadataFixture,
       );
     });
@@ -150,7 +155,7 @@ describe(buildRouterExplorerControllerMethodMetadata, () => {
     it('should call getControllerMethodParameterMetadataList()', () => {
       expect(getControllerMethodParameterMetadataList).toHaveBeenCalledTimes(1);
       expect(getControllerMethodParameterMetadataList).toHaveBeenCalledWith(
-        controllerFixture,
+        controllerMetadataFixture.target,
         controllerMethodMetadataFixture.methodKey,
       );
     });
@@ -158,33 +163,37 @@ describe(buildRouterExplorerControllerMethodMetadata, () => {
     it('should call getControllerMethodStatusCodeMetadata()', () => {
       expect(getControllerMethodStatusCodeMetadata).toHaveBeenCalledTimes(1);
       expect(getControllerMethodStatusCodeMetadata).toHaveBeenCalledWith(
-        controllerFixture,
+        controllerMetadataFixture.target,
         controllerMethodMetadataFixture.methodKey,
       );
     });
 
     it('should call getClassGuardList()', () => {
       expect(getClassGuardList).toHaveBeenCalledTimes(1);
-      expect(getClassGuardList).toHaveBeenCalledWith(controllerFixture);
+      expect(getClassGuardList).toHaveBeenCalledWith(
+        controllerMetadataFixture.target,
+      );
     });
 
     it('should call getClassMethodGuardList()', () => {
       expect(getClassMethodGuardList).toHaveBeenCalledTimes(1);
       expect(getClassMethodGuardList).toHaveBeenCalledWith(
-        controllerFixture,
+        controllerMetadataFixture.target,
         controllerMethodMetadataFixture.methodKey,
       );
     });
 
     it('should call getClassInterceptorList()', () => {
       expect(getClassInterceptorList).toHaveBeenCalledTimes(1);
-      expect(getClassInterceptorList).toHaveBeenCalledWith(controllerFixture);
+      expect(getClassInterceptorList).toHaveBeenCalledWith(
+        controllerMetadataFixture.target,
+      );
     });
 
     it('should call getClassMethodInterceptorList()', () => {
       expect(getClassMethodInterceptorList).toHaveBeenCalledTimes(1);
       expect(getClassMethodInterceptorList).toHaveBeenCalledWith(
-        controllerFixture,
+        controllerMetadataFixture.target,
         controllerMethodMetadataFixture.methodKey,
       );
     });
@@ -192,7 +201,7 @@ describe(buildRouterExplorerControllerMethodMetadata, () => {
     it('should call getClassMethodMiddlewareList()', () => {
       expect(getClassMethodMiddlewareList).toHaveBeenCalledTimes(1);
       expect(getClassMethodMiddlewareList).toHaveBeenCalledWith(
-        controllerFixture,
+        controllerMetadataFixture.target,
         controllerMethodMetadataFixture.methodKey,
       );
     });
@@ -209,7 +218,7 @@ describe(buildRouterExplorerControllerMethodMetadata, () => {
     it('should call getControllerMethodHeaderMetadataList()', () => {
       expect(getControllerMethodHeaderMetadataList).toHaveBeenCalledTimes(1);
       expect(getControllerMethodHeaderMetadataList).toHaveBeenCalledWith(
-        controllerFixture,
+        controllerMetadataFixture.target,
         controllerMethodMetadataFixture.methodKey,
       );
     });
@@ -219,7 +228,7 @@ describe(buildRouterExplorerControllerMethodMetadata, () => {
         1,
       );
       expect(getControllerMethodUseNativeHandlerMetadata).toHaveBeenCalledWith(
-        controllerFixture,
+        controllerMetadataFixture.target,
         controllerMethodMetadataFixture.methodKey,
       );
     });
@@ -227,7 +236,7 @@ describe(buildRouterExplorerControllerMethodMetadata, () => {
     it('should call buildErrorTypeToErrorFilterMap()', () => {
       expect(buildErrorTypeToErrorFilterMap).toHaveBeenCalledTimes(1);
       expect(buildErrorTypeToErrorFilterMap).toHaveBeenCalledWith(
-        controllerFixture,
+        controllerMetadataFixture.target,
         controllerMethodMetadataFixture.methodKey,
       );
     });

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadata.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadata.ts
@@ -15,6 +15,7 @@ import {
 import { Newable, ServiceIdentifier } from 'inversify';
 
 import { HttpStatusCode } from '../../http/models/HttpStatusCode';
+import { ControllerMetadata } from '../model/ControllerMetadata';
 import { ControllerMethodMetadata } from '../model/ControllerMethodMetadata';
 import { ControllerMethodParameterMetadata } from '../model/ControllerMethodParameterMetadata';
 import { RouterExplorerControllerMethodMetadata } from '../model/RouterExplorerControllerMethodMetadata';
@@ -29,34 +30,37 @@ export function buildRouterExplorerControllerMethodMetadata<
   TResponse,
   TResult,
 >(
-  controller: NewableFunction,
+  controllerMetadata: ControllerMetadata,
   controllerMethodMetadata: ControllerMethodMetadata,
 ): RouterExplorerControllerMethodMetadata<TRequest, TResponse, TResult> {
   const controllerMethodParameterMetadataList: (
     | ControllerMethodParameterMetadata
     | undefined
   )[] = getControllerMethodParameterMetadataList(
-    controller,
+    controllerMetadata.target,
     controllerMethodMetadata.methodKey,
   );
 
   const controllerMethodStatusCode: HttpStatusCode | undefined =
     getControllerMethodStatusCodeMetadata(
-      controller,
+      controllerMetadata.target,
       controllerMethodMetadata.methodKey,
     );
 
   const controllerMethodGuardList: ServiceIdentifier<Guard<TRequest>>[] = [
-    ...getClassGuardList(controller),
-    ...getClassMethodGuardList(controller, controllerMethodMetadata.methodKey),
+    ...getClassGuardList(controllerMetadata.target),
+    ...getClassMethodGuardList(
+      controllerMetadata.target,
+      controllerMethodMetadata.methodKey,
+    ),
   ];
 
   const controllerMethodInterceptorList: ServiceIdentifier<
     Interceptor<TRequest, TResponse>
   >[] = [
-    ...getClassInterceptorList(controller),
+    ...getClassInterceptorList(controllerMetadata.target),
     ...getClassMethodInterceptorList(
-      controller,
+      controllerMetadata.target,
       controllerMethodMetadata.methodKey,
     ),
   ];
@@ -66,7 +70,7 @@ export function buildRouterExplorerControllerMethodMetadata<
     ServiceIdentifier<Middleware<TRequest, TResponse, any, TResult>>
     | ApplyMiddlewareOptions
   )[] = getClassMethodMiddlewareList(
-    controller,
+    controllerMetadata.target,
     controllerMethodMetadata.methodKey,
   );
 
@@ -74,7 +78,7 @@ export function buildRouterExplorerControllerMethodMetadata<
     Newable<Error> | null,
     Newable<ErrorFilter>
   > = buildErrorTypeToErrorFilterMap(
-    controller,
+    controllerMetadata.target,
     controllerMethodMetadata.methodKey,
   );
 
@@ -85,12 +89,12 @@ export function buildRouterExplorerControllerMethodMetadata<
 
   const headerMetadataList: [string, string][] =
     getControllerMethodHeaderMetadataList(
-      controller,
+      controllerMetadata.target,
       controllerMethodMetadata.methodKey,
     );
 
   const useNativeHandler: boolean = getControllerMethodUseNativeHandlerMetadata(
-    controller,
+    controllerMetadata.target,
     controllerMethodMetadata.methodKey,
   );
 

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadataList.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadataList.spec.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
 
 vitest.mock('./buildRouterExplorerControllerMethodMetadata');
 
+import { ControllerMetadata } from '../model/ControllerMetadata';
 import { ControllerMethodMetadata } from '../model/ControllerMethodMetadata';
 import { RouterExplorerControllerMethodMetadata } from '../model/RouterExplorerControllerMethodMetadata';
 import { buildRouterExplorerControllerMethodMetadata } from './buildRouterExplorerControllerMethodMetadata';
@@ -9,14 +10,18 @@ import { buildRouterExplorerControllerMethodMetadataList } from './buildRouterEx
 
 describe(buildRouterExplorerControllerMethodMetadataList, () => {
   describe('when called', () => {
-    let controllerFixture: NewableFunction;
+    let controllerMetadataFixture: ControllerMetadata;
     let controllerMethodMetadataFixture: ControllerMethodMetadata;
     let controllerMethodMetadataListFixture: ControllerMethodMetadata[];
     let routerExplorerControllerMethodMetadataFixture: RouterExplorerControllerMethodMetadata;
     let result: unknown;
 
     beforeAll(() => {
-      controllerFixture = class Test {};
+      controllerMetadataFixture = {
+        path: '/',
+        serviceIdentifier: Symbol(),
+        target: class Test {},
+      };
       controllerMethodMetadataFixture = {} as ControllerMethodMetadata;
       controllerMethodMetadataListFixture = [controllerMethodMetadataFixture];
       routerExplorerControllerMethodMetadataFixture =
@@ -27,7 +32,7 @@ describe(buildRouterExplorerControllerMethodMetadataList, () => {
         .mockReturnValueOnce(routerExplorerControllerMethodMetadataFixture);
 
       result = buildRouterExplorerControllerMethodMetadataList(
-        controllerFixture,
+        controllerMetadataFixture,
         controllerMethodMetadataListFixture,
       );
     });
@@ -42,7 +47,7 @@ describe(buildRouterExplorerControllerMethodMetadataList, () => {
       );
 
       expect(buildRouterExplorerControllerMethodMetadata).toHaveBeenCalledWith(
-        controllerFixture,
+        controllerMetadataFixture,
         controllerMethodMetadataFixture,
       );
     });

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadataList.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadataList.ts
@@ -1,3 +1,4 @@
+import { ControllerMetadata } from '../model/ControllerMetadata';
 import { ControllerMethodMetadata } from '../model/ControllerMethodMetadata';
 import { RouterExplorerControllerMethodMetadata } from '../model/RouterExplorerControllerMethodMetadata';
 import { buildRouterExplorerControllerMethodMetadata } from './buildRouterExplorerControllerMethodMetadata';
@@ -7,13 +8,13 @@ export function buildRouterExplorerControllerMethodMetadataList<
   TResponse,
   TResult,
 >(
-  controller: NewableFunction,
+  controllerMetadata: ControllerMetadata,
   controllerMethodMetadataList: ControllerMethodMetadata[],
 ): RouterExplorerControllerMethodMetadata<TRequest, TResponse, TResult>[] {
   return controllerMethodMetadataList.map(
     (controllerMethodMetadata: ControllerMethodMetadata) =>
       buildRouterExplorerControllerMethodMetadata(
-        controller,
+        controllerMetadata,
         controllerMethodMetadata,
       ),
   );

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/getControllerMetadataList.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/getControllerMetadataList.spec.ts
@@ -5,9 +5,9 @@ vitest.mock('@inversifyjs/reflect-metadata-utils');
 import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
 
 import { controllerMetadataReflectKey } from '../../reflectMetadata/data/controllerMetadataReflectKey';
-import { getControllers } from './getControllers';
+import { getControllerMetadataList } from './getControllerMetadataList';
 
-describe(getControllers, () => {
+describe(getControllerMetadataList, () => {
   describe('when called', () => {
     let controllerMetadataFixture: undefined;
     let result: unknown;
@@ -15,7 +15,7 @@ describe(getControllers, () => {
     beforeAll(() => {
       controllerMetadataFixture = undefined;
 
-      result = getControllers();
+      result = getControllerMetadataList();
     });
 
     afterAll(() => {

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/getControllerMetadataList.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/getControllerMetadataList.ts
@@ -3,6 +3,6 @@ import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
 import { controllerMetadataReflectKey } from '../../reflectMetadata/data/controllerMetadataReflectKey';
 import { ControllerMetadata } from '../model/ControllerMetadata';
 
-export function getControllers(): ControllerMetadata[] | undefined {
+export function getControllerMetadataList(): ControllerMetadata[] | undefined {
   return getOwnReflectMetadata(Reflect, controllerMetadataReflectKey);
 }

--- a/packages/framework/http/libraries/core/src/routerExplorer/model/ControllerMetadata.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/model/ControllerMetadata.ts
@@ -1,4 +1,7 @@
+import { ServiceIdentifier } from 'inversify';
+
 export interface ControllerMetadata {
   path: string;
+  serviceIdentifier: ServiceIdentifier;
   target: NewableFunction;
 }

--- a/packages/framework/http/libraries/core/src/routerExplorer/model/RouterExplorerControllerMetadata.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/model/RouterExplorerControllerMetadata.ts
@@ -22,5 +22,6 @@ export interface RouterExplorerControllerMetadata<
   readonly preHandlerMiddlewareList: ServiceIdentifier<
     Middleware<TRequest, TResponse, any, TResult>
   >[];
+  readonly serviceIdentifier: ServiceIdentifier;
   readonly target: NewableFunction;
 }

--- a/packages/framework/http/libraries/open-api/src/openApi/services/SwaggerUiProvider.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/services/SwaggerUiProvider.spec.ts
@@ -200,6 +200,7 @@ describe(SwaggerUiProvider, () => {
         controllerMetadataListFixture = [
           {
             path: '/test',
+            serviceIdentifier: Symbol(),
             target: Symbol() as unknown as NewableFunction,
           },
         ];
@@ -232,7 +233,8 @@ describe(SwaggerUiProvider, () => {
       it('should call container.isBound()', () => {
         expect(containerMock.isBound).toHaveBeenCalledTimes(1);
         expect(containerMock.isBound).toHaveBeenCalledWith(
-          (controllerMetadataListFixture[0] as ControllerMetadata).target,
+          (controllerMetadataListFixture[0] as ControllerMetadata)
+            .serviceIdentifier,
         );
       });
 
@@ -280,6 +282,7 @@ describe(SwaggerUiProvider, () => {
         controllerMetadataListFixture = [
           {
             path: '/test',
+            serviceIdentifier: Symbol(),
             target: Symbol() as unknown as NewableFunction,
           },
         ];
@@ -310,7 +313,8 @@ describe(SwaggerUiProvider, () => {
       it('should call container.isBound()', () => {
         expect(containerMock.isBound).toHaveBeenCalledTimes(1);
         expect(containerMock.isBound).toHaveBeenCalledWith(
-          (controllerMetadataListFixture[0] as ControllerMetadata).target,
+          (controllerMetadataListFixture[0] as ControllerMetadata)
+            .serviceIdentifier,
         );
       });
 
@@ -376,6 +380,7 @@ describe(SwaggerUiProvider, () => {
         controllerMetadataListFixture = [
           {
             path: '/api',
+            serviceIdentifier: Symbol(),
             target: Symbol() as unknown as NewableFunction,
           },
         ];
@@ -485,6 +490,7 @@ describe(SwaggerUiProvider, () => {
         controllerMetadataListFixture = [
           {
             path: '/api',
+            serviceIdentifier: Symbol(),
             target: Symbol() as unknown as NewableFunction,
           },
         ];
@@ -571,6 +577,7 @@ describe(SwaggerUiProvider, () => {
         controllerMetadataListFixture = [
           {
             path: '/api',
+            serviceIdentifier: Symbol(),
             target: Symbol() as unknown as NewableFunction,
           },
         ];
@@ -673,6 +680,7 @@ describe(SwaggerUiProvider, () => {
         controllerMetadataListFixture = [
           {
             path: '/api',
+            serviceIdentifier: Symbol(),
             target: Symbol() as unknown as NewableFunction,
           },
         ];
@@ -812,6 +820,7 @@ describe(SwaggerUiProvider, () => {
         controllerMetadataListFixture = [
           {
             path: '/api',
+            serviceIdentifier: Symbol(),
             target: Symbol() as unknown as NewableFunction,
           },
         ];
@@ -881,6 +890,7 @@ describe(SwaggerUiProvider, () => {
         controllerMetadataListFixture = [
           {
             path: '/api',
+            serviceIdentifier: Symbol(),
             target: Symbol() as unknown as NewableFunction,
           },
         ];
@@ -954,6 +964,7 @@ describe(SwaggerUiProvider, () => {
         controllerMetadataListFixture = [
           {
             path: '/api',
+            serviceIdentifier: Symbol(),
             target: Symbol() as unknown as NewableFunction,
           },
         ];

--- a/packages/framework/http/libraries/open-api/src/openApi/services/SwaggerUiProvider.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/services/SwaggerUiProvider.ts
@@ -185,7 +185,7 @@ export abstract class SwaggerUiProvider<TResponse, TResult> {
       const filteredControllerMetadata: ControllerMetadata[] =
         controllerMetadataList.filter(
           (controllerMetadata: ControllerMetadata): boolean =>
-            container.isBound(controllerMetadata.target),
+            container.isBound(controllerMetadata.serviceIdentifier),
         );
 
       for (const controllerMetadata of filteredControllerMetadata) {


### PR DESCRIPTION
### Changed
- Updated `Controller` decorator to no longer need to be injected using the controller class as service identifier.