### PR TITLE
Fix OpenApi type exports

### DIFF
--- a/.changeset/cute-wombats-nail.md
+++ b/.changeset/cute-wombats-nail.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/json-schema-types": patch
+---
+
+Fixed missing 202012 types

--- a/.changeset/fast-clocks-brake.md
+++ b/.changeset/fast-clocks-brake.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/open-api-types": patch
+---
+
+Fixed missing v3Dot1 types

--- a/packages/json-schema/libraries/json-schema-types/.npmignore
+++ b/packages/json-schema/libraries/json-schema-types/.npmignore
@@ -11,6 +11,8 @@ lib/cjs/**/fixtures/**
 lib/esm/**/*.d.ts.map
 !lib/esm/index.d.ts
 !lib/esm/index.d.ts.map
+!lib/esm/jsonSchema/202012/index.d.ts
+!lib/esm/jsonSchema/202012/index.d.ts.map
 
 .lintstagedrc.json
 eslint.config.mjs

--- a/packages/open-api/libraries/open-api-types/.npmignore
+++ b/packages/open-api/libraries/open-api-types/.npmignore
@@ -11,6 +11,8 @@ lib/cjs/**/fixtures/**
 lib/esm/**/*.d.ts.map
 !lib/esm/index.d.ts
 !lib/esm/index.d.ts.map
+!lib/esm/openApi/v3Dot1/index.d.ts
+!lib/esm/openApi/v3Dot1/index.d.ts.map
 
 .lintstagedrc.json
 eslint.config.mjs


### PR DESCRIPTION
### Changed
- Updated npmignore to no longer ignore missing types.