### PR TITLE
Update changesets to update peer dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,9 +28,10 @@
   "packageRules": [
     {
       "enabled": false,
-      "matchDepTypes": [
-        "peerDependencies"
-      ]
+      "matchDepTypes": ["peerDependencies"],
+      "matchPackageNames": ["express"],
+      "matchUpdateTypes": ["major"],
+      "matchCurrentVersion": ">=4.0.0 <5.0.0"
     },
     {
       "groupName": "auto merge on patch or minor",


### PR DESCRIPTION
### Changed
- Updated changesets to only exclude peer dependency updates for major releases from express@4.