### PR TITLE
Apply linter rule

### DIFF
--- a/packages/container/libraries/binding-decorators/src/metadata/calculations/buildProviderModule.spec.ts
+++ b/packages/container/libraries/binding-decorators/src/metadata/calculations/buildProviderModule.spec.ts
@@ -40,8 +40,7 @@ describe(buildProviderModule, () => {
     });
 
     it('should call getReflectMetadata()', () => {
-      expect(getReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getReflectMetadata).toHaveBeenCalledWith(
+      expect(getReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         Object,
         bindingMetadataMapReflectKey,
       );
@@ -75,16 +74,14 @@ describe(buildProviderModule, () => {
     });
 
     it('should call getReflectMetadata()', () => {
-      expect(getReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getReflectMetadata).toHaveBeenCalledWith(
+      expect(getReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         Object,
         bindingMetadataMapReflectKey,
       );
     });
 
     it('should call bindingMetadata.action()', () => {
-      expect(bindingMetadataMock.action).toHaveBeenCalledTimes(1);
-      expect(bindingMetadataMock.action).toHaveBeenCalledWith(
+      expect(bindingMetadataMock.action).toHaveBeenCalledExactlyOnceWith(
         optionsFixture.bind,
       );
     });

--- a/packages/container/libraries/binding-decorators/src/metadata/decorators/provide.spec.ts
+++ b/packages/container/libraries/binding-decorators/src/metadata/decorators/provide.spec.ts
@@ -68,16 +68,17 @@ describe(provide, () => {
       });
 
       it('should call updateMetadataMap()', () => {
-        expect(updateMetadataMap).toHaveBeenCalledTimes(1);
-        expect(updateMetadataMap).toHaveBeenCalledWith(targetFixture, {
-          action: expect.any(Function),
-          serviceIdentifier: targetFixture,
-        });
+        expect(updateMetadataMap).toHaveBeenCalledExactlyOnceWith(
+          targetFixture,
+          {
+            action: expect.any(Function),
+            serviceIdentifier: targetFixture,
+          },
+        );
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           Object,
           bindingMetadataMapReflectKey,
           buildDefaultBindingMetadataMap,
@@ -136,16 +137,17 @@ describe(provide, () => {
       });
 
       it('should call updateMetadataMap()', () => {
-        expect(updateMetadataMap).toHaveBeenCalledTimes(1);
-        expect(updateMetadataMap).toHaveBeenCalledWith(targetFixture, {
-          action: expect.any(Function),
-          serviceIdentifier: serviceIdentifierFixture,
-        });
+        expect(updateMetadataMap).toHaveBeenCalledExactlyOnceWith(
+          targetFixture,
+          {
+            action: expect.any(Function),
+            serviceIdentifier: serviceIdentifierFixture,
+          },
+        );
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           Object,
           bindingMetadataMapReflectKey,
           buildDefaultBindingMetadataMap,

--- a/packages/container/libraries/common/src/services/models/LazyServiceIdentifier.spec.ts
+++ b/packages/container/libraries/common/src/services/models/LazyServiceIdentifier.spec.ts
@@ -125,8 +125,7 @@ describe(LazyServiceIdentifier, () => {
       });
 
       it('should call buildServiceId()', () => {
-        expect(buildServiceIdMock).toHaveBeenCalledTimes(1);
-        expect(buildServiceIdMock).toHaveBeenCalledWith();
+        expect(buildServiceIdMock).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should return expected result', () => {

--- a/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingConstraints.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingConstraints.spec.ts
@@ -38,8 +38,7 @@ describe(isAnyAncestorBindingConstraints, () => {
     });
 
     it('should call constraints.getAncestor()', () => {
-      expect(constraintsMock.getAncestor).toHaveBeenCalledTimes(1);
-      expect(constraintsMock.getAncestor).toHaveBeenCalledWith();
+      expect(constraintsMock.getAncestor).toHaveBeenCalledExactlyOnceWith();
     });
 
     it('should not call constraint()', () => {
@@ -75,8 +74,7 @@ describe(isAnyAncestorBindingConstraints, () => {
     });
 
     it('should call condition()', () => {
-      expect(conditionMock).toHaveBeenCalledTimes(1);
-      expect(conditionMock).toHaveBeenCalledWith(constraintsMock);
+      expect(conditionMock).toHaveBeenCalledExactlyOnceWith(constraintsMock);
     });
 
     it('should return expected result', () => {
@@ -100,13 +98,11 @@ describe(isAnyAncestorBindingConstraints, () => {
     });
 
     it('should call constraints.getAncestor()', () => {
-      expect(constraintsMock.getAncestor).toHaveBeenCalledTimes(1);
-      expect(constraintsMock.getAncestor).toHaveBeenCalledWith();
+      expect(constraintsMock.getAncestor).toHaveBeenCalledExactlyOnceWith();
     });
 
     it('should call condition()', () => {
-      expect(conditionMock).toHaveBeenCalledTimes(1);
-      expect(conditionMock).toHaveBeenCalledWith(constraintsMock);
+      expect(conditionMock).toHaveBeenCalledExactlyOnceWith(constraintsMock);
     });
 
     it('should return expected result', () => {

--- a/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingConstraintsWithName.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingConstraintsWithName.spec.ts
@@ -54,13 +54,13 @@ describe(isAnyAncestorBindingConstraintsWithName, () => {
     });
 
     it('should call isBindingConstraintsWithName()', () => {
-      expect(isBindingConstraintsWithName).toHaveBeenCalledTimes(1);
-      expect(isBindingConstraintsWithName).toHaveBeenCalledWith(nameFixture);
+      expect(isBindingConstraintsWithName).toHaveBeenCalledExactlyOnceWith(
+        nameFixture,
+      );
     });
 
     it('should call isAnyAncestorBindingConstraints()', () => {
-      expect(isAnyAncestorBindingConstraints).toHaveBeenCalledTimes(1);
-      expect(isAnyAncestorBindingConstraints).toHaveBeenCalledWith(
+      expect(isAnyAncestorBindingConstraints).toHaveBeenCalledExactlyOnceWith(
         isBindingConstraintsWithNameResultMock,
       );
     });

--- a/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingConstraintsWithServiceId.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingConstraintsWithServiceId.spec.ts
@@ -56,15 +56,13 @@ describe(isAnyAncestorBindingConstraintsWithServiceId, () => {
     });
 
     it('should call isBindingConstraintsWithServiceId()', () => {
-      expect(isBindingConstraintsWithServiceId).toHaveBeenCalledTimes(1);
-      expect(isBindingConstraintsWithServiceId).toHaveBeenCalledWith(
+      expect(isBindingConstraintsWithServiceId).toHaveBeenCalledExactlyOnceWith(
         serviceIdFixture,
       );
     });
 
     it('should call isAnyAncestorBindingConstraints()', () => {
-      expect(isAnyAncestorBindingConstraints).toHaveBeenCalledTimes(1);
-      expect(isAnyAncestorBindingConstraints).toHaveBeenCalledWith(
+      expect(isAnyAncestorBindingConstraints).toHaveBeenCalledExactlyOnceWith(
         isBindingConstraintsWithNameResultMock,
       );
     });

--- a/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingConstraintsWithTag.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isAnyAncestorBindingConstraintsWithTag.spec.ts
@@ -59,16 +59,14 @@ describe(isAnyAncestorBindingConstraintsWithTag, () => {
     });
 
     it('should call isBindingConstraintsWithTag()', () => {
-      expect(isBindingConstraintsWithTag).toHaveBeenCalledTimes(1);
-      expect(isBindingConstraintsWithTag).toHaveBeenCalledWith(
+      expect(isBindingConstraintsWithTag).toHaveBeenCalledExactlyOnceWith(
         tagFixture,
         tagValueFixture,
       );
     });
 
     it('should call isAnyAncestorBindingConstraints()', () => {
-      expect(isAnyAncestorBindingConstraints).toHaveBeenCalledTimes(1);
-      expect(isAnyAncestorBindingConstraints).toHaveBeenCalledWith(
+      expect(isAnyAncestorBindingConstraints).toHaveBeenCalledExactlyOnceWith(
         isBindingConstraintsWithNameResultMock,
       );
     });

--- a/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingConstraints.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingConstraints.spec.ts
@@ -46,8 +46,7 @@ describe(isNoAncestorBindingConstraints, () => {
     });
 
     it('should call isAnyAncestorBindingConstraints()', () => {
-      expect(isAnyAncestorBindingConstraints).toHaveBeenCalledTimes(1);
-      expect(isAnyAncestorBindingConstraints).toHaveBeenCalledWith(
+      expect(isAnyAncestorBindingConstraints).toHaveBeenCalledExactlyOnceWith(
         conditionMock,
       );
     });
@@ -55,10 +54,7 @@ describe(isNoAncestorBindingConstraints, () => {
     it('should call isAnyAncestorBindingConstraintsConstraint()', () => {
       expect(
         isAnyAncestorBindingConstraintsConstraintMock,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        isAnyAncestorBindingConstraintsConstraintMock,
-      ).toHaveBeenCalledWith(constraintsFixture);
+      ).toHaveBeenCalledExactlyOnceWith(constraintsFixture);
     });
 
     it('should return false', () => {
@@ -83,8 +79,7 @@ describe(isNoAncestorBindingConstraints, () => {
     });
 
     it('should call isAnyAncestorBindingConstraints()', () => {
-      expect(isAnyAncestorBindingConstraints).toHaveBeenCalledTimes(1);
-      expect(isAnyAncestorBindingConstraints).toHaveBeenCalledWith(
+      expect(isAnyAncestorBindingConstraints).toHaveBeenCalledExactlyOnceWith(
         conditionMock,
       );
     });
@@ -92,10 +87,7 @@ describe(isNoAncestorBindingConstraints, () => {
     it('should call isAnyAncestorBindingConstraintsConstraint()', () => {
       expect(
         isAnyAncestorBindingConstraintsConstraintMock,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        isAnyAncestorBindingConstraintsConstraintMock,
-      ).toHaveBeenCalledWith(constraintsFixture);
+      ).toHaveBeenCalledExactlyOnceWith(constraintsFixture);
     });
 
     it('should return true', () => {

--- a/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingConstraintsWithName.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingConstraintsWithName.spec.ts
@@ -54,13 +54,13 @@ describe(isNoAncestorBindingConstraintsWithName, () => {
     });
 
     it('should call isBindingConstraintsWithName()', () => {
-      expect(isBindingConstraintsWithName).toHaveBeenCalledTimes(1);
-      expect(isBindingConstraintsWithName).toHaveBeenCalledWith(nameFixture);
+      expect(isBindingConstraintsWithName).toHaveBeenCalledExactlyOnceWith(
+        nameFixture,
+      );
     });
 
     it('should call isNoAncestorBindingConstraints()', () => {
-      expect(isNoAncestorBindingConstraints).toHaveBeenCalledTimes(1);
-      expect(isNoAncestorBindingConstraints).toHaveBeenCalledWith(
+      expect(isNoAncestorBindingConstraints).toHaveBeenCalledExactlyOnceWith(
         isBindingConstraintsWithNameResultMock,
       );
     });

--- a/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingConstraintsWithServiceId.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingConstraintsWithServiceId.spec.ts
@@ -56,15 +56,13 @@ describe(isNoAncestorBindingConstraintsWithServiceId, () => {
     });
 
     it('should call isBindingConstraintsWithServiceId()', () => {
-      expect(isBindingConstraintsWithServiceId).toHaveBeenCalledTimes(1);
-      expect(isBindingConstraintsWithServiceId).toHaveBeenCalledWith(
+      expect(isBindingConstraintsWithServiceId).toHaveBeenCalledExactlyOnceWith(
         serviceIdFixture,
       );
     });
 
     it('should call isNoAncestorBindingConstraints()', () => {
-      expect(isNoAncestorBindingConstraints).toHaveBeenCalledTimes(1);
-      expect(isNoAncestorBindingConstraints).toHaveBeenCalledWith(
+      expect(isNoAncestorBindingConstraints).toHaveBeenCalledExactlyOnceWith(
         isBindingConstraintsWithNameResultMock,
       );
     });

--- a/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingConstraintsWithTag.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNoAncestorBindingConstraintsWithTag.spec.ts
@@ -59,16 +59,14 @@ describe(isNoAncestorBindingConstraintsWithTag, () => {
     });
 
     it('should call isBindingConstraintsWithTag()', () => {
-      expect(isBindingConstraintsWithTag).toHaveBeenCalledTimes(1);
-      expect(isBindingConstraintsWithTag).toHaveBeenCalledWith(
+      expect(isBindingConstraintsWithTag).toHaveBeenCalledExactlyOnceWith(
         tagFixture,
         tagValueFixture,
       );
     });
 
     it('should call isNoAncestorBindingConstraints()', () => {
-      expect(isNoAncestorBindingConstraints).toHaveBeenCalledTimes(1);
-      expect(isNoAncestorBindingConstraints).toHaveBeenCalledWith(
+      expect(isNoAncestorBindingConstraints).toHaveBeenCalledExactlyOnceWith(
         isBindingConstraintsWithNameResultMock,
       );
     });

--- a/packages/container/libraries/container/src/binding/calculations/isNotParentBindingConstraints.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNotParentBindingConstraints.spec.ts
@@ -38,8 +38,7 @@ describe(isNotParentBindingConstraints, () => {
     });
 
     it('should call constraints.getAncestor()', () => {
-      expect(constraintsMock.getAncestor).toHaveBeenCalledTimes(1);
-      expect(constraintsMock.getAncestor).toHaveBeenCalledWith();
+      expect(constraintsMock.getAncestor).toHaveBeenCalledExactlyOnceWith();
     });
 
     it('should not call constraint()', () => {
@@ -71,13 +70,11 @@ describe(isNotParentBindingConstraints, () => {
     });
 
     it('should call constraints.getAncestor()', () => {
-      expect(constraintsMock.getAncestor).toHaveBeenCalledTimes(1);
-      expect(constraintsMock.getAncestor).toHaveBeenCalledWith();
+      expect(constraintsMock.getAncestor).toHaveBeenCalledExactlyOnceWith();
     });
 
     it('should call condition()', () => {
-      expect(conditionMock).toHaveBeenCalledTimes(1);
-      expect(conditionMock).toHaveBeenCalledWith(constraintsMock);
+      expect(conditionMock).toHaveBeenCalledExactlyOnceWith(constraintsMock);
     });
 
     it('should return expected result', () => {

--- a/packages/container/libraries/container/src/binding/calculations/isNotParentBindingConstraintsWithName.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNotParentBindingConstraintsWithName.spec.ts
@@ -54,13 +54,13 @@ describe(isNotParentBindingConstraintsWithName, () => {
     });
 
     it('should call isBindingConstraintsWithName()', () => {
-      expect(isBindingConstraintsWithName).toHaveBeenCalledTimes(1);
-      expect(isBindingConstraintsWithName).toHaveBeenCalledWith(nameFixture);
+      expect(isBindingConstraintsWithName).toHaveBeenCalledExactlyOnceWith(
+        nameFixture,
+      );
     });
 
     it('should call isNotParentBindingConstraints()', () => {
-      expect(isNotParentBindingConstraints).toHaveBeenCalledTimes(1);
-      expect(isNotParentBindingConstraints).toHaveBeenCalledWith(
+      expect(isNotParentBindingConstraints).toHaveBeenCalledExactlyOnceWith(
         isBindingConstraintsWithNameResultMock,
       );
     });

--- a/packages/container/libraries/container/src/binding/calculations/isNotParentBindingConstraintsWithServiceId.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNotParentBindingConstraintsWithServiceId.spec.ts
@@ -56,15 +56,13 @@ describe(isNotParentBindingConstraintsWithServiceId, () => {
     });
 
     it('should call isBindingConstraintsWithServiceId()', () => {
-      expect(isBindingConstraintsWithServiceId).toHaveBeenCalledTimes(1);
-      expect(isBindingConstraintsWithServiceId).toHaveBeenCalledWith(
+      expect(isBindingConstraintsWithServiceId).toHaveBeenCalledExactlyOnceWith(
         serviceIdFixture,
       );
     });
 
     it('should call isNotParentBindingConstraints()', () => {
-      expect(isNotParentBindingConstraints).toHaveBeenCalledTimes(1);
-      expect(isNotParentBindingConstraints).toHaveBeenCalledWith(
+      expect(isNotParentBindingConstraints).toHaveBeenCalledExactlyOnceWith(
         isBindingConstraintsWithNameResultMock,
       );
     });

--- a/packages/container/libraries/container/src/binding/calculations/isNotParentBindingConstraintsWithTag.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isNotParentBindingConstraintsWithTag.spec.ts
@@ -59,16 +59,14 @@ describe(isNotParentBindingConstraintsWithTag, () => {
     });
 
     it('should call isBindingConstraintsWithTag()', () => {
-      expect(isBindingConstraintsWithTag).toHaveBeenCalledTimes(1);
-      expect(isBindingConstraintsWithTag).toHaveBeenCalledWith(
+      expect(isBindingConstraintsWithTag).toHaveBeenCalledExactlyOnceWith(
         tagFixture,
         tagValueFixture,
       );
     });
 
     it('should call isNotParentBindingConstraints()', () => {
-      expect(isNotParentBindingConstraints).toHaveBeenCalledTimes(1);
-      expect(isNotParentBindingConstraints).toHaveBeenCalledWith(
+      expect(isNotParentBindingConstraints).toHaveBeenCalledExactlyOnceWith(
         isBindingConstraintsWithNameResultMock,
       );
     });

--- a/packages/container/libraries/container/src/binding/calculations/isParentBindingConstraints.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isParentBindingConstraints.spec.ts
@@ -38,8 +38,7 @@ describe(isParentBindingConstraints, () => {
     });
 
     it('should call constraints.getAncestor()', () => {
-      expect(constraintsMock.getAncestor).toHaveBeenCalledTimes(1);
-      expect(constraintsMock.getAncestor).toHaveBeenCalledWith();
+      expect(constraintsMock.getAncestor).toHaveBeenCalledExactlyOnceWith();
     });
 
     it('should not call constraint()', () => {
@@ -71,13 +70,11 @@ describe(isParentBindingConstraints, () => {
     });
 
     it('should call constraints.getAncestor()', () => {
-      expect(constraintsMock.getAncestor).toHaveBeenCalledTimes(1);
-      expect(constraintsMock.getAncestor).toHaveBeenCalledWith();
+      expect(constraintsMock.getAncestor).toHaveBeenCalledExactlyOnceWith();
     });
 
     it('should call condition()', () => {
-      expect(conditionMock).toHaveBeenCalledTimes(1);
-      expect(conditionMock).toHaveBeenCalledWith(constraintsMock);
+      expect(conditionMock).toHaveBeenCalledExactlyOnceWith(constraintsMock);
     });
 
     it('should return expected result', () => {

--- a/packages/container/libraries/container/src/binding/calculations/isParentBindingConstraintsWithName.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isParentBindingConstraintsWithName.spec.ts
@@ -54,13 +54,13 @@ describe(isParentBindingConstraintsWithName, () => {
     });
 
     it('should call isBindingConstraintsWithName()', () => {
-      expect(isBindingConstraintsWithName).toHaveBeenCalledTimes(1);
-      expect(isBindingConstraintsWithName).toHaveBeenCalledWith(nameFixture);
+      expect(isBindingConstraintsWithName).toHaveBeenCalledExactlyOnceWith(
+        nameFixture,
+      );
     });
 
     it('should call isParentBindingConstraints()', () => {
-      expect(isParentBindingConstraints).toHaveBeenCalledTimes(1);
-      expect(isParentBindingConstraints).toHaveBeenCalledWith(
+      expect(isParentBindingConstraints).toHaveBeenCalledExactlyOnceWith(
         isBindingConstraintsWithNameResultMock,
       );
     });

--- a/packages/container/libraries/container/src/binding/calculations/isParentBindingConstraintsWithServiceId.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isParentBindingConstraintsWithServiceId.spec.ts
@@ -56,15 +56,13 @@ describe(isParentBindingConstraintsWithServiceId, () => {
     });
 
     it('should call isBindingConstraintsWithServiceId()', () => {
-      expect(isBindingConstraintsWithServiceId).toHaveBeenCalledTimes(1);
-      expect(isBindingConstraintsWithServiceId).toHaveBeenCalledWith(
+      expect(isBindingConstraintsWithServiceId).toHaveBeenCalledExactlyOnceWith(
         serviceIdFixture,
       );
     });
 
     it('should call isParentBindingConstraints()', () => {
-      expect(isParentBindingConstraints).toHaveBeenCalledTimes(1);
-      expect(isParentBindingConstraints).toHaveBeenCalledWith(
+      expect(isParentBindingConstraints).toHaveBeenCalledExactlyOnceWith(
         isBindingConstraintsWithNameResultMock,
       );
     });

--- a/packages/container/libraries/container/src/binding/calculations/isParentBindingConstraintsWithTag.spec.ts
+++ b/packages/container/libraries/container/src/binding/calculations/isParentBindingConstraintsWithTag.spec.ts
@@ -55,16 +55,14 @@ describe(isParentBindingConstraintsWithTag, () => {
     });
 
     it('should call isBindingConstraintsWithTag()', () => {
-      expect(isBindingConstraintsWithTag).toHaveBeenCalledTimes(1);
-      expect(isBindingConstraintsWithTag).toHaveBeenCalledWith(
+      expect(isBindingConstraintsWithTag).toHaveBeenCalledExactlyOnceWith(
         tagFixture,
         tagValueFixture,
       );
     });
 
     it('should call isParentBindingConstraints()', () => {
-      expect(isParentBindingConstraints).toHaveBeenCalledTimes(1);
-      expect(isParentBindingConstraints).toHaveBeenCalledWith(
+      expect(isParentBindingConstraints).toHaveBeenCalledExactlyOnceWith(
         isBindingConstraintsWithNameResultMock,
       );
     });

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.spec.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.spec.ts
@@ -185,8 +185,9 @@ describe(BindInFluentSyntaxImplementation, () => {
         });
 
         it('should set binding scope', () => {
-          expect(bindingMockSetScopeMock).toHaveBeenCalledTimes(1);
-          expect(bindingMockSetScopeMock).toHaveBeenCalledWith(expectedScope);
+          expect(bindingMockSetScopeMock).toHaveBeenCalledExactlyOnceWith(
+            expectedScope,
+          );
         });
 
         it('should return BindWhenOnFluentSyntax', () => {
@@ -215,8 +216,9 @@ describe(BindInFluentSyntaxImplementation, () => {
     });
 
     it('should call buildBindingIdentifier', () => {
-      expect(buildBindingIdentifier).toHaveBeenCalledTimes(1);
-      expect(buildBindingIdentifier).toHaveBeenCalledWith(bindingMock);
+      expect(buildBindingIdentifier).toHaveBeenCalledExactlyOnceWith(
+        bindingMock,
+      );
     });
 
     it('should return the mocked identifier', () => {
@@ -406,13 +408,11 @@ describe(BindToFluentSyntaxImplementation, () => {
         });
 
         it('should call getBindingId', () => {
-          expect(getBindingId).toHaveBeenCalledTimes(1);
-          expect(getBindingId).toHaveBeenCalledWith();
+          expect(getBindingId).toHaveBeenCalledExactlyOnceWith();
         });
 
         it('should call callback', () => {
-          expect(callbackMock).toHaveBeenCalledTimes(1);
-          expect(callbackMock).toHaveBeenCalledWith(expectedBinding);
+          expect(callbackMock).toHaveBeenCalledExactlyOnceWith(expectedBinding);
         });
 
         it('should return expected result', () => {
@@ -463,13 +463,11 @@ describe(BindToFluentSyntaxImplementation, () => {
         });
 
         it('should call getBindingId', () => {
-          expect(getBindingId).toHaveBeenCalledTimes(1);
-          expect(getBindingId).toHaveBeenCalledWith();
+          expect(getBindingId).toHaveBeenCalledExactlyOnceWith();
         });
 
         it('should call callback', () => {
-          expect(callbackMock).toHaveBeenCalledTimes(1);
-          expect(callbackMock).toHaveBeenCalledWith(expectedBinding);
+          expect(callbackMock).toHaveBeenCalledExactlyOnceWith(expectedBinding);
         });
 
         it('should return expected result', () => {
@@ -534,20 +532,17 @@ describe(BindToFluentSyntaxImplementation, () => {
         });
 
         it('should call isResolvedValueMetadataInjectOptions()', () => {
-          expect(isResolvedValueMetadataInjectOptions).toHaveBeenCalledTimes(1);
-          expect(isResolvedValueMetadataInjectOptions).toHaveBeenCalledWith(
-            injectOptions,
-          );
+          expect(
+            isResolvedValueMetadataInjectOptions,
+          ).toHaveBeenCalledExactlyOnceWith(injectOptions);
         });
 
         it('should call getBindingId', () => {
-          expect(getBindingId).toHaveBeenCalledTimes(1);
-          expect(getBindingId).toHaveBeenCalledWith();
+          expect(getBindingId).toHaveBeenCalledExactlyOnceWith();
         });
 
         it('should call callback', () => {
-          expect(callbackMock).toHaveBeenCalledTimes(1);
-          expect(callbackMock).toHaveBeenCalledWith(expectedBinding);
+          expect(callbackMock).toHaveBeenCalledExactlyOnceWith(expectedBinding);
         });
 
         it('should return expected result', () => {
@@ -612,20 +607,17 @@ describe(BindToFluentSyntaxImplementation, () => {
         });
 
         it('should call isResolvedValueMetadataInjectOptions()', () => {
-          expect(isResolvedValueMetadataInjectOptions).toHaveBeenCalledTimes(1);
-          expect(isResolvedValueMetadataInjectOptions).toHaveBeenCalledWith(
-            injectOptions,
-          );
+          expect(
+            isResolvedValueMetadataInjectOptions,
+          ).toHaveBeenCalledExactlyOnceWith(injectOptions);
         });
 
         it('should call getBindingId', () => {
-          expect(getBindingId).toHaveBeenCalledTimes(1);
-          expect(getBindingId).toHaveBeenCalledWith();
+          expect(getBindingId).toHaveBeenCalledExactlyOnceWith();
         });
 
         it('should call callback', () => {
-          expect(callbackMock).toHaveBeenCalledTimes(1);
-          expect(callbackMock).toHaveBeenCalledWith(expectedBinding);
+          expect(callbackMock).toHaveBeenCalledExactlyOnceWith(expectedBinding);
         });
 
         it('should return expected result', () => {
@@ -704,20 +696,17 @@ describe(BindToFluentSyntaxImplementation, () => {
         });
 
         it('should call isResolvedValueMetadataInjectOptions()', () => {
-          expect(isResolvedValueMetadataInjectOptions).toHaveBeenCalledTimes(1);
-          expect(isResolvedValueMetadataInjectOptions).toHaveBeenCalledWith(
-            injectOptions,
-          );
+          expect(
+            isResolvedValueMetadataInjectOptions,
+          ).toHaveBeenCalledExactlyOnceWith(injectOptions);
         });
 
         it('should call getBindingId', () => {
-          expect(getBindingId).toHaveBeenCalledTimes(1);
-          expect(getBindingId).toHaveBeenCalledWith();
+          expect(getBindingId).toHaveBeenCalledExactlyOnceWith();
         });
 
         it('should call callback', () => {
-          expect(callbackMock).toHaveBeenCalledTimes(1);
-          expect(callbackMock).toHaveBeenCalledWith(expectedBinding);
+          expect(callbackMock).toHaveBeenCalledExactlyOnceWith(expectedBinding);
         });
 
         it('should return expected result', () => {
@@ -819,8 +808,7 @@ describe(BindToFluentSyntaxImplementation, () => {
         });
 
         it('should call getClassMetadata()', () => {
-          expect(getClassMetadata).toHaveBeenCalledTimes(1);
-          expect(getClassMetadata).toHaveBeenCalledWith(
+          expect(getClassMetadata).toHaveBeenCalledExactlyOnceWith(
             serviceIdentifierFixture,
           );
         });
@@ -844,8 +832,7 @@ describe(BindToFluentSyntaxImplementation, () => {
             type: bindingTypeValues.Instance,
           };
 
-          expect(callbackMock).toHaveBeenCalledTimes(1);
-          expect(callbackMock).toHaveBeenCalledWith(expectedBinding);
+          expect(callbackMock).toHaveBeenCalledExactlyOnceWith(expectedBinding);
         });
 
         it('should return expected result', () => {
@@ -873,8 +860,7 @@ describe(BindToFluentSyntaxImplementation, () => {
         });
 
         it('should call getClassMetadata()', () => {
-          expect(getClassMetadata).toHaveBeenCalledTimes(1);
-          expect(getClassMetadata).toHaveBeenCalledWith(
+          expect(getClassMetadata).toHaveBeenCalledExactlyOnceWith(
             serviceIdentifierFixture,
           );
         });
@@ -898,8 +884,7 @@ describe(BindToFluentSyntaxImplementation, () => {
             type: bindingTypeValues.Instance,
           };
 
-          expect(callbackMock).toHaveBeenCalledTimes(1);
-          expect(callbackMock).toHaveBeenCalledWith(expectedBinding);
+          expect(callbackMock).toHaveBeenCalledExactlyOnceWith(expectedBinding);
         });
 
         it('should return expected result', () => {
@@ -938,8 +923,7 @@ describe(BindToFluentSyntaxImplementation, () => {
           type: bindingTypeValues.ServiceRedirection,
         };
 
-        expect(callbackMock).toHaveBeenCalledTimes(1);
-        expect(callbackMock).toHaveBeenCalledWith(expectedBinding);
+        expect(callbackMock).toHaveBeenCalledExactlyOnceWith(expectedBinding);
       });
 
       it('should return undefined', () => {
@@ -1011,8 +995,7 @@ describe(BindOnFluentSyntaxImplementation, () => {
       });
 
       it('should set binding activation', () => {
-        expect(bindingActivationSetterMock).toHaveBeenCalledTimes(1);
-        expect(bindingActivationSetterMock).toHaveBeenCalledWith(
+        expect(bindingActivationSetterMock).toHaveBeenCalledExactlyOnceWith(
           activationFixture,
         );
       });
@@ -1091,8 +1074,7 @@ describe(BindOnFluentSyntaxImplementation, () => {
         });
 
         it('should call stringifyServiceIdentifier()', () => {
-          expect(stringifyServiceIdentifier).toHaveBeenCalledTimes(1);
-          expect(stringifyServiceIdentifier).toHaveBeenCalledWith(
+          expect(stringifyServiceIdentifier).toHaveBeenCalledExactlyOnceWith(
             bindingFixture.serviceIdentifier,
           );
         });
@@ -1169,8 +1151,7 @@ describe(BindOnFluentSyntaxImplementation, () => {
         });
 
         it('should set binding deactivation', () => {
-          expect(bindingDeactivationSetterMock).toHaveBeenCalledTimes(1);
-          expect(bindingDeactivationSetterMock).toHaveBeenCalledWith(
+          expect(bindingDeactivationSetterMock).toHaveBeenCalledExactlyOnceWith(
             deactivationFixture,
           );
         });
@@ -1201,8 +1182,9 @@ describe(BindOnFluentSyntaxImplementation, () => {
     });
 
     it('should call buildBindingIdentifier', () => {
-      expect(buildBindingIdentifier).toHaveBeenCalledTimes(1);
-      expect(buildBindingIdentifier).toHaveBeenCalledWith(bindingFixture);
+      expect(buildBindingIdentifier).toHaveBeenCalledExactlyOnceWith(
+        bindingFixture,
+      );
     });
 
     it('should return the mocked identifier', () => {
@@ -1265,8 +1247,9 @@ describe(BindWhenFluentSyntaxImplementation, () => {
     });
 
     it('should set constraint', () => {
-      expect(isSatisfiedBySetterMock).toHaveBeenCalledTimes(1);
-      expect(isSatisfiedBySetterMock).toHaveBeenCalledWith(constraintFixture);
+      expect(isSatisfiedBySetterMock).toHaveBeenCalledExactlyOnceWith(
+        constraintFixture,
+      );
     });
 
     it('should return expected result', () => {
@@ -1291,8 +1274,7 @@ describe(BindWhenFluentSyntaxImplementation, () => {
     });
 
     it('should call isAnyAncestorBindingConstraints', () => {
-      expect(isAnyAncestorBindingConstraints).toHaveBeenCalledTimes(1);
-      expect(isAnyAncestorBindingConstraints).toHaveBeenCalledWith(
+      expect(isAnyAncestorBindingConstraints).toHaveBeenCalledExactlyOnceWith(
         constraintFixture,
       );
     });
@@ -1321,10 +1303,7 @@ describe(BindWhenFluentSyntaxImplementation, () => {
     it('should call isAnyAncestorBindingConstraintsWithServiceId', () => {
       expect(
         isAnyAncestorBindingConstraintsWithServiceId,
-      ).toHaveBeenCalledTimes(1);
-      expect(isAnyAncestorBindingConstraintsWithServiceId).toHaveBeenCalledWith(
-        serviceIdFixture,
-      );
+      ).toHaveBeenCalledExactlyOnceWith(serviceIdFixture);
     });
 
     it('should return expected result', () => {
@@ -1349,10 +1328,9 @@ describe(BindWhenFluentSyntaxImplementation, () => {
     });
 
     it('should call isAnyAncestorBindingConstraintsWithName', () => {
-      expect(isAnyAncestorBindingConstraintsWithName).toHaveBeenCalledTimes(1);
-      expect(isAnyAncestorBindingConstraintsWithName).toHaveBeenCalledWith(
-        nameFixture,
-      );
+      expect(
+        isAnyAncestorBindingConstraintsWithName,
+      ).toHaveBeenCalledExactlyOnceWith(nameFixture);
     });
 
     it('should return expected result', () => {
@@ -1381,11 +1359,9 @@ describe(BindWhenFluentSyntaxImplementation, () => {
     });
 
     it('should call isAnyAncestorBindingConstraintsWithTag', () => {
-      expect(isAnyAncestorBindingConstraintsWithTag).toHaveBeenCalledTimes(1);
-      expect(isAnyAncestorBindingConstraintsWithTag).toHaveBeenCalledWith(
-        tagFixture,
-        tagValueFixture,
-      );
+      expect(
+        isAnyAncestorBindingConstraintsWithTag,
+      ).toHaveBeenCalledExactlyOnceWith(tagFixture, tagValueFixture);
     });
 
     it('should return expected result', () => {
@@ -1405,8 +1381,7 @@ describe(BindWhenFluentSyntaxImplementation, () => {
     });
 
     it('should set constraint', () => {
-      expect(isSatisfiedBySetterMock).toHaveBeenCalledTimes(1);
-      expect(isSatisfiedBySetterMock).toHaveBeenCalledWith(
+      expect(isSatisfiedBySetterMock).toHaveBeenCalledExactlyOnceWith(
         isBindingConstraintsWithNoNameNorTags,
       );
     });
@@ -1432,8 +1407,9 @@ describe(BindWhenFluentSyntaxImplementation, () => {
     });
 
     it('should call isBindingConstraintsWithName', () => {
-      expect(isBindingConstraintsWithName).toHaveBeenCalledTimes(1);
-      expect(isBindingConstraintsWithName).toHaveBeenCalledWith(nameFixture);
+      expect(isBindingConstraintsWithName).toHaveBeenCalledExactlyOnceWith(
+        nameFixture,
+      );
     });
 
     it('should return expected result', () => {
@@ -1457,8 +1433,7 @@ describe(BindWhenFluentSyntaxImplementation, () => {
     });
 
     it('should call isParentBindingConstraints', () => {
-      expect(isParentBindingConstraints).toHaveBeenCalledTimes(1);
-      expect(isParentBindingConstraints).toHaveBeenCalledWith(
+      expect(isParentBindingConstraints).toHaveBeenCalledExactlyOnceWith(
         constraintFixture,
       );
     });
@@ -1485,10 +1460,9 @@ describe(BindWhenFluentSyntaxImplementation, () => {
     });
 
     it('should call isParentBindingConstraintsWithServiceId', () => {
-      expect(isParentBindingConstraintsWithServiceId).toHaveBeenCalledTimes(1);
-      expect(isParentBindingConstraintsWithServiceId).toHaveBeenCalledWith(
-        serviceIdFixture,
-      );
+      expect(
+        isParentBindingConstraintsWithServiceId,
+      ).toHaveBeenCalledExactlyOnceWith(serviceIdFixture);
     });
 
     it('should return expected result', () => {
@@ -1512,10 +1486,9 @@ describe(BindWhenFluentSyntaxImplementation, () => {
     });
 
     it('should call isParentBindingConstraintsWithName', () => {
-      expect(isParentBindingConstraintsWithName).toHaveBeenCalledTimes(1);
-      expect(isParentBindingConstraintsWithName).toHaveBeenCalledWith(
-        nameFixture,
-      );
+      expect(
+        isParentBindingConstraintsWithName,
+      ).toHaveBeenCalledExactlyOnceWith(nameFixture);
     });
 
     it('should return expected result', () => {
@@ -1544,8 +1517,7 @@ describe(BindWhenFluentSyntaxImplementation, () => {
     });
 
     it('should call isParentBindingConstraintsWithTag', () => {
-      expect(isParentBindingConstraintsWithTag).toHaveBeenCalledTimes(1);
-      expect(isParentBindingConstraintsWithTag).toHaveBeenCalledWith(
+      expect(isParentBindingConstraintsWithTag).toHaveBeenCalledExactlyOnceWith(
         tagFixture,
         tagValueFixture,
       );
@@ -1577,8 +1549,7 @@ describe(BindWhenFluentSyntaxImplementation, () => {
     });
 
     it('should call isBindingConstraintsWithTag', () => {
-      expect(isBindingConstraintsWithTag).toHaveBeenCalledTimes(1);
-      expect(isBindingConstraintsWithTag).toHaveBeenCalledWith(
+      expect(isBindingConstraintsWithTag).toHaveBeenCalledExactlyOnceWith(
         tagFixture,
         tagValueFixture,
       );
@@ -1606,12 +1577,9 @@ describe(BindWhenFluentSyntaxImplementation, () => {
     });
 
     it('should call isNotParentBindingConstraintsWithServiceId', () => {
-      expect(isNotParentBindingConstraintsWithServiceId).toHaveBeenCalledTimes(
-        1,
-      );
-      expect(isNotParentBindingConstraintsWithServiceId).toHaveBeenCalledWith(
-        serviceIdFixture,
-      );
+      expect(
+        isNotParentBindingConstraintsWithServiceId,
+      ).toHaveBeenCalledExactlyOnceWith(serviceIdFixture);
     });
 
     it('should return expected result', () => {
@@ -1636,10 +1604,9 @@ describe(BindWhenFluentSyntaxImplementation, () => {
     });
 
     it('should call isNotParentBindingConstraintsWithName', () => {
-      expect(isNotParentBindingConstraintsWithName).toHaveBeenCalledTimes(1);
-      expect(isNotParentBindingConstraintsWithName).toHaveBeenCalledWith(
-        nameFixture,
-      );
+      expect(
+        isNotParentBindingConstraintsWithName,
+      ).toHaveBeenCalledExactlyOnceWith(nameFixture);
     });
 
     it('should return expected result', () => {
@@ -1668,11 +1635,9 @@ describe(BindWhenFluentSyntaxImplementation, () => {
     });
 
     it('should call isNotParentBindingConstraintsWithTag', () => {
-      expect(isNotParentBindingConstraintsWithTag).toHaveBeenCalledTimes(1);
-      expect(isNotParentBindingConstraintsWithTag).toHaveBeenCalledWith(
-        tagFixture,
-        tagValueFixture,
-      );
+      expect(
+        isNotParentBindingConstraintsWithTag,
+      ).toHaveBeenCalledExactlyOnceWith(tagFixture, tagValueFixture);
     });
 
     it('should return expected result', () => {
@@ -1697,8 +1662,7 @@ describe(BindWhenFluentSyntaxImplementation, () => {
     });
 
     it('should call isNotParentBindingConstraints', () => {
-      expect(isNotParentBindingConstraints).toHaveBeenCalledTimes(1);
-      expect(isNotParentBindingConstraints).toHaveBeenCalledWith(
+      expect(isNotParentBindingConstraints).toHaveBeenCalledExactlyOnceWith(
         constraintFixture,
       );
     });
@@ -1725,8 +1689,7 @@ describe(BindWhenFluentSyntaxImplementation, () => {
     });
 
     it('should call isNoAncestorBindingConstraints', () => {
-      expect(isNoAncestorBindingConstraints).toHaveBeenCalledTimes(1);
-      expect(isNoAncestorBindingConstraints).toHaveBeenCalledWith(
+      expect(isNoAncestorBindingConstraints).toHaveBeenCalledExactlyOnceWith(
         constraintFixture,
       );
     });
@@ -1753,12 +1716,9 @@ describe(BindWhenFluentSyntaxImplementation, () => {
     });
 
     it('should call isNoAncestorBindingConstraintsWithServiceId', () => {
-      expect(isNoAncestorBindingConstraintsWithServiceId).toHaveBeenCalledTimes(
-        1,
-      );
-      expect(isNoAncestorBindingConstraintsWithServiceId).toHaveBeenCalledWith(
-        serviceIdFixture,
-      );
+      expect(
+        isNoAncestorBindingConstraintsWithServiceId,
+      ).toHaveBeenCalledExactlyOnceWith(serviceIdFixture);
     });
 
     it('should return expected result', () => {
@@ -1783,10 +1743,9 @@ describe(BindWhenFluentSyntaxImplementation, () => {
     });
 
     it('should call isNoAncestorBindingConstraintsWithName', () => {
-      expect(isNoAncestorBindingConstraintsWithName).toHaveBeenCalledTimes(1);
-      expect(isNoAncestorBindingConstraintsWithName).toHaveBeenCalledWith(
-        nameFixture,
-      );
+      expect(
+        isNoAncestorBindingConstraintsWithName,
+      ).toHaveBeenCalledExactlyOnceWith(nameFixture);
     });
 
     it('should return expected result', () => {
@@ -1815,11 +1774,9 @@ describe(BindWhenFluentSyntaxImplementation, () => {
     });
 
     it('should call isNoAncestorBindingConstraintsWithTag', () => {
-      expect(isNoAncestorBindingConstraintsWithTag).toHaveBeenCalledTimes(1);
-      expect(isNoAncestorBindingConstraintsWithTag).toHaveBeenCalledWith(
-        tagFixture,
-        tagValueFixture,
-      );
+      expect(
+        isNoAncestorBindingConstraintsWithTag,
+      ).toHaveBeenCalledExactlyOnceWith(tagFixture, tagValueFixture);
     });
 
     it('should return expected result', () => {
@@ -1846,8 +1803,9 @@ describe(BindWhenFluentSyntaxImplementation, () => {
     });
 
     it('should call buildBindingIdentifier', () => {
-      expect(buildBindingIdentifier).toHaveBeenCalledTimes(1);
-      expect(buildBindingIdentifier).toHaveBeenCalledWith(bindingFixture);
+      expect(buildBindingIdentifier).toHaveBeenCalledExactlyOnceWith(
+        bindingFixture,
+      );
     });
 
     it('should return the mocked identifier', () => {
@@ -1917,8 +1875,7 @@ describe(BindWhenOnFluentSyntaxImplementation, () => {
       });
 
       it('should set binding activation', () => {
-        expect(bindingActivationSetterMock).toHaveBeenCalledTimes(1);
-        expect(bindingActivationSetterMock).toHaveBeenCalledWith(
+        expect(bindingActivationSetterMock).toHaveBeenCalledExactlyOnceWith(
           activationFixture,
         );
       });
@@ -1945,8 +1902,7 @@ describe(BindWhenOnFluentSyntaxImplementation, () => {
       });
 
       it('should set binding deactivation', () => {
-        expect(bindingDeactivationSetterMock).toHaveBeenCalledTimes(1);
-        expect(bindingDeactivationSetterMock).toHaveBeenCalledWith(
+        expect(bindingDeactivationSetterMock).toHaveBeenCalledExactlyOnceWith(
           deactivationFixture,
         );
       });
@@ -1976,8 +1932,9 @@ describe(BindWhenOnFluentSyntaxImplementation, () => {
     });
 
     it('should call buildBindingIdentifier', () => {
-      expect(buildBindingIdentifier).toHaveBeenCalledTimes(1);
-      expect(buildBindingIdentifier).toHaveBeenCalledWith(bindingFixture);
+      expect(buildBindingIdentifier).toHaveBeenCalledExactlyOnceWith(
+        bindingFixture,
+      );
     });
 
     it('should return the mocked identifier', () => {
@@ -2066,8 +2023,9 @@ describe(BindInWhenOnFluentSyntaxImplementation, () => {
         });
 
         it('should set binding scope', () => {
-          expect(bindingMockSetScopeMock).toHaveBeenCalledTimes(1);
-          expect(bindingMockSetScopeMock).toHaveBeenCalledWith(expectedScope);
+          expect(bindingMockSetScopeMock).toHaveBeenCalledExactlyOnceWith(
+            expectedScope,
+          );
         });
 
         it('should return BindWhenOnFluentSyntax', () => {
@@ -2096,8 +2054,9 @@ describe(BindInWhenOnFluentSyntaxImplementation, () => {
     });
 
     it('should call buildBindingIdentifier', () => {
-      expect(buildBindingIdentifier).toHaveBeenCalledTimes(1);
-      expect(buildBindingIdentifier).toHaveBeenCalledWith(bindingMock);
+      expect(buildBindingIdentifier).toHaveBeenCalledExactlyOnceWith(
+        bindingMock,
+      );
     });
 
     it('should return the mocked identifier', () => {

--- a/packages/container/libraries/container/src/common/calculations/getFirstIterableResult.spec.ts
+++ b/packages/container/libraries/container/src/common/calculations/getFirstIterableResult.spec.ts
@@ -35,8 +35,9 @@ describe(getFirstIterableResult, () => {
       });
 
       it('should call getFirstIteratorResult()', () => {
-        expect(getFirstIteratorResult).toHaveBeenCalledTimes(1);
-        expect(getFirstIteratorResult).toHaveBeenCalledWith(undefined);
+        expect(getFirstIteratorResult).toHaveBeenCalledExactlyOnceWith(
+          undefined,
+        );
       });
 
       it('should return expected value', () => {
@@ -78,13 +79,13 @@ describe(getFirstIterableResult, () => {
       });
 
       it('should call iterable[Symbol.iterator]()', () => {
-        expect(iterableMock[Symbol.iterator]).toHaveBeenCalledTimes(1);
-        expect(iterableMock[Symbol.iterator]).toHaveBeenCalledWith();
+        expect(iterableMock[Symbol.iterator]).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should call getFirstIteratorResult()', () => {
-        expect(getFirstIteratorResult).toHaveBeenCalledTimes(1);
-        expect(getFirstIteratorResult).toHaveBeenCalledWith(iteratorFixture);
+        expect(getFirstIteratorResult).toHaveBeenCalledExactlyOnceWith(
+          iteratorFixture,
+        );
       });
 
       it('should return expected result', () => {

--- a/packages/container/libraries/container/src/container/actions/getContainerModuleId.spec.ts
+++ b/packages/container/libraries/container/src/container/actions/getContainerModuleId.spec.ts
@@ -25,16 +25,14 @@ describe(getContainerModuleId, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         Object,
         '@inversifyjs/container/bindingId',
       );
     });
 
     it('should call updateOwnReflectMetadata()', () => {
-      expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         Object,
         '@inversifyjs/container/bindingId',
         expect.any(Function),
@@ -63,16 +61,14 @@ describe(getContainerModuleId, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         Object,
         '@inversifyjs/container/bindingId',
       );
     });
 
     it('should call setReflectMetadata()', () => {
-      expect(setReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(setReflectMetadata).toHaveBeenCalledWith(
+      expect(setReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         Object,
         '@inversifyjs/container/bindingId',
         Number.MIN_SAFE_INTEGER,

--- a/packages/container/libraries/container/src/container/models/ContainerModule.spec.ts
+++ b/packages/container/libraries/container/src/container/models/ContainerModule.spec.ts
@@ -47,8 +47,7 @@ describe(ContainerModule, () => {
       });
 
       it('should call load()', () => {
-        expect(asyncLoadMock).toHaveBeenCalledTimes(1);
-        expect(asyncLoadMock).toHaveBeenCalledWith(optionsFixture);
+        expect(asyncLoadMock).toHaveBeenCalledExactlyOnceWith(optionsFixture);
       });
 
       it('should return expected value', () => {
@@ -67,8 +66,7 @@ describe(ContainerModule, () => {
       });
 
       it('should call load()', () => {
-        expect(syncLoadMock).toHaveBeenCalledTimes(1);
-        expect(syncLoadMock).toHaveBeenCalledWith(optionsFixture);
+        expect(syncLoadMock).toHaveBeenCalledExactlyOnceWith(optionsFixture);
       });
 
       it('should return expected value', () => {

--- a/packages/container/libraries/container/src/container/services/BindingManager.spec.ts
+++ b/packages/container/libraries/container/src/container/services/BindingManager.spec.ts
@@ -152,10 +152,7 @@ describe(BindingManager, () => {
       it('should call bindingService.get()', () => {
         expect(
           serviceReferenceManagerMock.bindingService.get,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.bindingService.get,
-        ).toHaveBeenCalledWith(serviceIdentifierFixture);
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
       });
 
       it('should return false', () => {
@@ -209,10 +206,7 @@ describe(BindingManager, () => {
       it('should call bindingService.get()', () => {
         expect(
           serviceReferenceManagerMock.bindingService.get,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.bindingService.get,
-        ).toHaveBeenCalledWith(serviceIdentifierFixture);
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
       });
 
       it('should call binding.isSatisfiedBy()', () => {
@@ -225,8 +219,7 @@ describe(BindingManager, () => {
           tags: new Map([[tagFixture.key, tagFixture.value]]),
         };
 
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledExactlyOnceWith(
           expectedBindingConstraints,
         );
       });
@@ -282,10 +275,7 @@ describe(BindingManager, () => {
       it('should call bindingService.get()', () => {
         expect(
           serviceReferenceManagerMock.bindingService.get,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.bindingService.get,
-        ).toHaveBeenCalledWith(serviceIdentifierFixture);
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
       });
 
       it('should call binding.isSatisfiedBy()', () => {
@@ -298,8 +288,7 @@ describe(BindingManager, () => {
           tags: new Map([[tagFixture.key, tagFixture.value]]),
         };
 
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledExactlyOnceWith(
           expectedBindingConstraints,
         );
       });
@@ -350,10 +339,7 @@ describe(BindingManager, () => {
       it('should call bindingService.getNonParentBindings()', () => {
         expect(
           serviceReferenceManagerMock.bindingService.getNonParentBindings,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.bindingService.getNonParentBindings,
-        ).toHaveBeenCalledWith(serviceIdentifierFixture);
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
       });
 
       it('should return false', () => {
@@ -407,10 +393,7 @@ describe(BindingManager, () => {
       it('should call bindingService.getNonParentBindings()', () => {
         expect(
           serviceReferenceManagerMock.bindingService.getNonParentBindings,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.bindingService.getNonParentBindings,
-        ).toHaveBeenCalledWith(serviceIdentifierFixture);
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
       });
 
       it('should call binding.isSatisfiedBy()', () => {
@@ -423,8 +406,7 @@ describe(BindingManager, () => {
           tags: new Map([[tagFixture.key, tagFixture.value]]),
         };
 
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledExactlyOnceWith(
           expectedBindingConstraints,
         );
       });
@@ -480,10 +462,7 @@ describe(BindingManager, () => {
       it('should call bindingService.getNonParentBindings()', () => {
         expect(
           serviceReferenceManagerMock.bindingService.getNonParentBindings,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.bindingService.getNonParentBindings,
-        ).toHaveBeenCalledWith(serviceIdentifierFixture);
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
       });
 
       it('should call binding.isSatisfiedBy()', () => {
@@ -496,8 +475,7 @@ describe(BindingManager, () => {
           tags: new Map([[tagFixture.key, tagFixture.value]]),
         };
 
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledExactlyOnceWith(
           expectedBindingConstraints,
         );
       });
@@ -538,15 +516,11 @@ describe(BindingManager, () => {
       it('should call serviceReferenceManager.bindingService.get()', () => {
         expect(
           serviceReferenceManagerMock.bindingService.get,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.bindingService.get,
-        ).toHaveBeenCalledWith(serviceIdentifierFixture);
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
       });
 
       it('should call resolveBindingsDeactivations', () => {
-        expect(resolveBindingsDeactivations).toHaveBeenCalledTimes(1);
-        expect(resolveBindingsDeactivations).toHaveBeenCalledWith(
+        expect(resolveBindingsDeactivations).toHaveBeenCalledExactlyOnceWith(
           deactivationParamsFixture,
           [bindingFixture],
         );
@@ -555,28 +529,19 @@ describe(BindingManager, () => {
       it('should call activationService.removeAllByServiceId()', () => {
         expect(
           serviceReferenceManagerMock.activationService.removeAllByServiceId,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.activationService.removeAllByServiceId,
-        ).toHaveBeenCalledWith(serviceIdentifierFixture);
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
       });
 
       it('should call bindingService.removeAllByServiceId()', () => {
         expect(
           serviceReferenceManagerMock.bindingService.removeAllByServiceId,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.bindingService.removeAllByServiceId,
-        ).toHaveBeenCalledWith(serviceIdentifierFixture);
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
       });
 
       it('should call deactivationService.removeAllByServiceId()', () => {
         expect(
           serviceReferenceManagerMock.deactivationService.removeAllByServiceId,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.deactivationService.removeAllByServiceId,
-        ).toHaveBeenCalledWith(serviceIdentifierFixture);
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
       });
 
       it('should call planResultCacheManager.invalidateService()', () => {
@@ -587,10 +552,7 @@ describe(BindingManager, () => {
 
         expect(
           planResultCacheManagerMock.invalidateService,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          planResultCacheManagerMock.invalidateService,
-        ).toHaveBeenCalledWith(invalidation);
+        ).toHaveBeenCalledExactlyOnceWith(invalidation);
       });
 
       it('should return BindToFluentSyntax', () => {
@@ -639,15 +601,11 @@ describe(BindingManager, () => {
       it('should call serviceReferenceManager.bindingService.get()', () => {
         expect(
           serviceReferenceManagerMock.bindingService.get,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.bindingService.get,
-        ).toHaveBeenCalledWith(serviceIdentifierFixture);
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
       });
 
       it('should call resolveBindingsDeactivations', () => {
-        expect(resolveBindingsDeactivations).toHaveBeenCalledTimes(1);
-        expect(resolveBindingsDeactivations).toHaveBeenCalledWith(
+        expect(resolveBindingsDeactivations).toHaveBeenCalledExactlyOnceWith(
           deactivationParamsFixture,
           [bindingFixture],
         );
@@ -656,28 +614,19 @@ describe(BindingManager, () => {
       it('should call activationService.removeAllByServiceId()', () => {
         expect(
           serviceReferenceManagerMock.activationService.removeAllByServiceId,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.activationService.removeAllByServiceId,
-        ).toHaveBeenCalledWith(serviceIdentifierFixture);
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
       });
 
       it('should call bindingService.removeAllByServiceId()', () => {
         expect(
           serviceReferenceManagerMock.bindingService.removeAllByServiceId,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.bindingService.removeAllByServiceId,
-        ).toHaveBeenCalledWith(serviceIdentifierFixture);
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
       });
 
       it('should call deactivationService.removeAllByServiceId()', () => {
         expect(
           serviceReferenceManagerMock.deactivationService.removeAllByServiceId,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.deactivationService.removeAllByServiceId,
-        ).toHaveBeenCalledWith(serviceIdentifierFixture);
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
       });
 
       it('should call serviceReferenceManager.invalidateService()', () => {
@@ -688,10 +637,7 @@ describe(BindingManager, () => {
 
         expect(
           planResultCacheManagerMock.invalidateService,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          planResultCacheManagerMock.invalidateService,
-        ).toHaveBeenCalledWith(invalidation);
+        ).toHaveBeenCalledExactlyOnceWith(invalidation);
       });
 
       it('should return BindToFluentSyntax', () => {
@@ -744,15 +690,11 @@ describe(BindingManager, () => {
         it('should call serviceReferenceManager.bindingService.get()', () => {
           expect(
             serviceReferenceManagerMock.bindingService.get,
-          ).toHaveBeenCalledTimes(1);
-          expect(
-            serviceReferenceManagerMock.bindingService.get,
-          ).toHaveBeenCalledWith(serviceIdentifierFixture);
+          ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
         });
 
         it('should call resolveBindingsDeactivations', () => {
-          expect(resolveBindingsDeactivations).toHaveBeenCalledTimes(1);
-          expect(resolveBindingsDeactivations).toHaveBeenCalledWith(
+          expect(resolveBindingsDeactivations).toHaveBeenCalledExactlyOnceWith(
             deactivationParamsFixture,
             [bindingFixture],
           );
@@ -761,30 +703,20 @@ describe(BindingManager, () => {
         it('should call activationService.removeAllByServiceId()', () => {
           expect(
             serviceReferenceManagerMock.activationService.removeAllByServiceId,
-          ).toHaveBeenCalledTimes(1);
-          expect(
-            serviceReferenceManagerMock.activationService.removeAllByServiceId,
-          ).toHaveBeenCalledWith(serviceIdentifierFixture);
+          ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
         });
 
         it('should call bindingService.removeAllByServiceId()', () => {
           expect(
             serviceReferenceManagerMock.bindingService.removeAllByServiceId,
-          ).toHaveBeenCalledTimes(1);
-          expect(
-            serviceReferenceManagerMock.bindingService.removeAllByServiceId,
-          ).toHaveBeenCalledWith(serviceIdentifierFixture);
+          ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
         });
 
         it('should call deactivationService.removeAllByServiceId()', () => {
           expect(
             serviceReferenceManagerMock.deactivationService
               .removeAllByServiceId,
-          ).toHaveBeenCalledTimes(1);
-          expect(
-            serviceReferenceManagerMock.deactivationService
-              .removeAllByServiceId,
-          ).toHaveBeenCalledWith(serviceIdentifierFixture);
+          ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
         });
 
         it('should call serviceReferenceManager.invalidateService()', () => {
@@ -795,10 +727,7 @@ describe(BindingManager, () => {
 
           expect(
             planResultCacheManagerMock.invalidateService,
-          ).toHaveBeenCalledTimes(1);
-          expect(
-            planResultCacheManagerMock.invalidateService,
-          ).toHaveBeenCalledWith(invalidation);
+          ).toHaveBeenCalledExactlyOnceWith(invalidation);
         });
 
         it('should return undefined', () => {
@@ -837,15 +766,11 @@ describe(BindingManager, () => {
         it('should call serviceReferenceManager.bindingService.get()', () => {
           expect(
             serviceReferenceManagerMock.bindingService.get,
-          ).toHaveBeenCalledTimes(1);
-          expect(
-            serviceReferenceManagerMock.bindingService.get,
-          ).toHaveBeenCalledWith(serviceIdentifierFixture);
+          ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
         });
 
         it('should call resolveBindingsDeactivations', () => {
-          expect(resolveBindingsDeactivations).toHaveBeenCalledTimes(1);
-          expect(resolveBindingsDeactivations).toHaveBeenCalledWith(
+          expect(resolveBindingsDeactivations).toHaveBeenCalledExactlyOnceWith(
             deactivationParamsFixture,
             [bindingFixture],
           );
@@ -854,30 +779,20 @@ describe(BindingManager, () => {
         it('should call activationService.removeAllByServiceId()', () => {
           expect(
             serviceReferenceManagerMock.activationService.removeAllByServiceId,
-          ).toHaveBeenCalledTimes(1);
-          expect(
-            serviceReferenceManagerMock.activationService.removeAllByServiceId,
-          ).toHaveBeenCalledWith(serviceIdentifierFixture);
+          ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
         });
 
         it('should call bindingService.removeAllByServiceId()', () => {
           expect(
             serviceReferenceManagerMock.bindingService.removeAllByServiceId,
-          ).toHaveBeenCalledTimes(1);
-          expect(
-            serviceReferenceManagerMock.bindingService.removeAllByServiceId,
-          ).toHaveBeenCalledWith(serviceIdentifierFixture);
+          ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
         });
 
         it('should call deactivationService.removeAllByServiceId()', () => {
           expect(
             serviceReferenceManagerMock.deactivationService
               .removeAllByServiceId,
-          ).toHaveBeenCalledTimes(1);
-          expect(
-            serviceReferenceManagerMock.deactivationService
-              .removeAllByServiceId,
-          ).toHaveBeenCalledWith(serviceIdentifierFixture);
+          ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
         });
 
         it('should call serviceReferenceManager.invalidateService()', () => {
@@ -888,10 +803,7 @@ describe(BindingManager, () => {
 
           expect(
             planResultCacheManagerMock.invalidateService,
-          ).toHaveBeenCalledTimes(1);
-          expect(
-            planResultCacheManagerMock.invalidateService,
-          ).toHaveBeenCalledWith(invalidation);
+          ).toHaveBeenCalledExactlyOnceWith(invalidation);
         });
 
         it('should return undefined', () => {
@@ -951,15 +863,11 @@ describe(BindingManager, () => {
         it('should call bindingService.getById()', () => {
           expect(
             serviceReferenceManagerMock.bindingService.getById,
-          ).toHaveBeenCalledTimes(1);
-          expect(
-            serviceReferenceManagerMock.bindingService.getById,
-          ).toHaveBeenCalledWith(bindingIdentifierFixture.id);
+          ).toHaveBeenCalledExactlyOnceWith(bindingIdentifierFixture.id);
         });
 
         it('should call resolveBindingsDeactivations()', () => {
-          expect(resolveBindingsDeactivations).toHaveBeenCalledTimes(1);
-          expect(resolveBindingsDeactivations).toHaveBeenCalledWith(
+          expect(resolveBindingsDeactivations).toHaveBeenCalledExactlyOnceWith(
             deactivationParamsFixture,
             [bindingMock],
           );
@@ -968,10 +876,7 @@ describe(BindingManager, () => {
         it('should call bindingService.removeById()', () => {
           expect(
             serviceReferenceManagerMock.bindingService.removeById,
-          ).toHaveBeenCalledTimes(1);
-          expect(
-            serviceReferenceManagerMock.bindingService.removeById,
-          ).toHaveBeenCalledWith(bindingIdentifierFixture.id);
+          ).toHaveBeenCalledExactlyOnceWith(bindingIdentifierFixture.id);
         });
 
         it('should call serviceReferenceManager.invalidateService()', () => {
@@ -982,10 +887,7 @@ describe(BindingManager, () => {
 
           expect(
             planResultCacheManagerMock.invalidateService,
-          ).toHaveBeenCalledTimes(1);
-          expect(
-            planResultCacheManagerMock.invalidateService,
-          ).toHaveBeenCalledWith(invalidation);
+          ).toHaveBeenCalledExactlyOnceWith(invalidation);
         });
 
         it('should return undefined', () => {
@@ -1037,15 +939,11 @@ describe(BindingManager, () => {
         it('should call bindingService.getById()', () => {
           expect(
             serviceReferenceManagerMock.bindingService.getById,
-          ).toHaveBeenCalledTimes(1);
-          expect(
-            serviceReferenceManagerMock.bindingService.getById,
-          ).toHaveBeenCalledWith(bindingIdentifierFixture.id);
+          ).toHaveBeenCalledExactlyOnceWith(bindingIdentifierFixture.id);
         });
 
         it('should call resolveBindingsDeactivations()', () => {
-          expect(resolveBindingsDeactivations).toHaveBeenCalledTimes(1);
-          expect(resolveBindingsDeactivations).toHaveBeenCalledWith(
+          expect(resolveBindingsDeactivations).toHaveBeenCalledExactlyOnceWith(
             deactivationParamsFixture,
             [bindingMock],
           );
@@ -1054,19 +952,13 @@ describe(BindingManager, () => {
         it('should call bindingService.removeById()', () => {
           expect(
             serviceReferenceManagerMock.bindingService.removeById,
-          ).toHaveBeenCalledTimes(1);
-          expect(
-            serviceReferenceManagerMock.bindingService.removeById,
-          ).toHaveBeenCalledWith(bindingIdentifierFixture.id);
+          ).toHaveBeenCalledExactlyOnceWith(bindingIdentifierFixture.id);
         });
 
         it('should call serviceReferenceManager.bindingService.getById()', () => {
           expect(
             serviceReferenceManagerMock.bindingService.getById,
-          ).toHaveBeenCalledTimes(1);
-          expect(
-            serviceReferenceManagerMock.bindingService.getById,
-          ).toHaveBeenCalledWith(bindingIdentifierFixture.id);
+          ).toHaveBeenCalledExactlyOnceWith(bindingIdentifierFixture.id);
         });
 
         it('should return undefined', () => {
@@ -1105,6 +997,7 @@ describe(BindingManager, () => {
         );
 
         for (const serviceId of serviceIdsFixture) {
+          // eslint-disable-next-line vitest/prefer-called-exactly-once-with
           expect(resolveServiceDeactivations).toHaveBeenCalledWith(
             deactivationParamsFixture,
             serviceId,
@@ -1120,6 +1013,7 @@ describe(BindingManager, () => {
         for (const serviceId of serviceIdsFixture) {
           expect(
             serviceReferenceManagerMock.activationService.removeAllByServiceId,
+            // eslint-disable-next-line vitest/prefer-called-exactly-once-with
           ).toHaveBeenCalledWith(serviceId);
         }
       });
@@ -1132,6 +1026,7 @@ describe(BindingManager, () => {
         for (const serviceId of serviceIdsFixture) {
           expect(
             serviceReferenceManagerMock.bindingService.removeAllByServiceId,
+            // eslint-disable-next-line vitest/prefer-called-exactly-once-with
           ).toHaveBeenCalledWith(serviceId);
         }
       });
@@ -1145,6 +1040,7 @@ describe(BindingManager, () => {
           expect(
             serviceReferenceManagerMock.deactivationService
               .removeAllByServiceId,
+            // eslint-disable-next-line vitest/prefer-called-exactly-once-with
           ).toHaveBeenCalledWith(serviceId);
         }
       });
@@ -1152,10 +1048,7 @@ describe(BindingManager, () => {
       it('should call planResultCacheService.clearCache()', () => {
         expect(
           serviceReferenceManagerMock.planResultCacheService.clearCache,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.planResultCacheService.clearCache,
-        ).toHaveBeenCalledWith();
+        ).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should return undefined', () => {

--- a/packages/container/libraries/container/src/container/services/Container.spec.ts
+++ b/packages/container/libraries/container/src/container/services/Container.spec.ts
@@ -274,10 +274,9 @@ describe(Container, () => {
         });
 
         it('should call planResultCacheService.subscribe()', () => {
-          expect(planResultCacheServiceMock.subscribe).toHaveBeenCalledTimes(1);
-          expect(planResultCacheServiceMock.subscribe).toHaveBeenCalledWith(
-            planResultCacheServiceMock,
-          );
+          expect(
+            planResultCacheServiceMock.subscribe,
+          ).toHaveBeenCalledExactlyOnceWith(planResultCacheServiceMock);
         });
 
         it('should call ServiceReferenceManager()', () => {
@@ -320,8 +319,7 @@ describe(Container, () => {
         });
 
         it('should call new ActivationsService.build()', () => {
-          expect(ActivationsService.build).toHaveBeenCalledTimes(1);
-          expect(ActivationsService.build).toHaveBeenCalledWith(
+          expect(ActivationsService.build).toHaveBeenCalledExactlyOnceWith(
             expect.any(Function),
           );
         });
@@ -331,23 +329,20 @@ describe(Container, () => {
             scope: defaultScopeFixture,
           };
 
-          expect(BindingService.build).toHaveBeenCalledTimes(1);
-          expect(BindingService.build).toHaveBeenCalledWith(
+          expect(BindingService.build).toHaveBeenCalledExactlyOnceWith(
             expect.any(Function),
             expectedAutobindOptions,
           );
         });
 
         it('should call DeactivationsService.build()', () => {
-          expect(DeactivationsService.build).toHaveBeenCalledTimes(1);
-          expect(DeactivationsService.build).toHaveBeenCalledWith(
+          expect(DeactivationsService.build).toHaveBeenCalledExactlyOnceWith(
             expect.any(Function),
           );
         });
 
         it('should call PlanResultCacheService()', () => {
-          expect(PlanResultCacheService).toHaveBeenCalledTimes(1);
-          expect(PlanResultCacheService).toHaveBeenCalledWith();
+          expect(PlanResultCacheService).toHaveBeenCalledExactlyOnceWith();
         });
 
         it('should not call planResultCacheService.subscribe()', () => {
@@ -355,8 +350,7 @@ describe(Container, () => {
         });
 
         it('should call ServiceReferenceManager()', () => {
-          expect(ServiceReferenceManager).toHaveBeenCalledTimes(1);
-          expect(ServiceReferenceManager).toHaveBeenCalledWith(
+          expect(ServiceReferenceManager).toHaveBeenCalledExactlyOnceWith(
             activationServiceMock,
             bindingServiceMock,
             deactivationServiceMock,
@@ -385,8 +379,7 @@ describe(Container, () => {
       });
 
       it('should call bindingManager.bind()', () => {
-        expect(bindingManagerMock.bind).toHaveBeenCalledTimes(1);
-        expect(bindingManagerMock.bind).toHaveBeenCalledWith(
+        expect(bindingManagerMock.bind).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
         );
       });
@@ -436,8 +429,9 @@ describe(Container, () => {
       });
 
       it('should call serviceResolutionManager.get()', () => {
-        expect(serviceResolutionManagerMock.get).toHaveBeenCalledTimes(1);
-        expect(serviceResolutionManagerMock.get).toHaveBeenCalledWith(
+        expect(
+          serviceResolutionManagerMock.get,
+        ).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
           getOptionsFixture,
         );
@@ -488,8 +482,9 @@ describe(Container, () => {
       });
 
       it('should call serviceResolutionManager.getAll()', () => {
-        expect(serviceResolutionManagerMock.getAll).toHaveBeenCalledTimes(1);
-        expect(serviceResolutionManagerMock.getAll).toHaveBeenCalledWith(
+        expect(
+          serviceResolutionManagerMock.getAll,
+        ).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
           getOptionsFixture,
         );
@@ -540,10 +535,9 @@ describe(Container, () => {
       });
 
       it('should call serviceResolutionManager.getAllAsync()', () => {
-        expect(serviceResolutionManagerMock.getAllAsync).toHaveBeenCalledTimes(
-          1,
-        );
-        expect(serviceResolutionManagerMock.getAllAsync).toHaveBeenCalledWith(
+        expect(
+          serviceResolutionManagerMock.getAllAsync,
+        ).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
           getOptionsFixture,
         );
@@ -594,8 +588,9 @@ describe(Container, () => {
       });
 
       it('should call serviceResolutionManager.getAsync()', () => {
-        expect(serviceResolutionManagerMock.getAsync).toHaveBeenCalledTimes(1);
-        expect(serviceResolutionManagerMock.getAsync).toHaveBeenCalledWith(
+        expect(
+          serviceResolutionManagerMock.getAsync,
+        ).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
           getOptionsFixture,
         );
@@ -643,8 +638,7 @@ describe(Container, () => {
       });
 
       it('should call bindingService.isBound()', () => {
-        expect(bindingManagerMock.isBound).toHaveBeenCalledTimes(1);
-        expect(bindingManagerMock.isBound).toHaveBeenCalledWith(
+        expect(bindingManagerMock.isBound).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
           {
             name: nameFixture,
@@ -693,14 +687,12 @@ describe(Container, () => {
       });
 
       it('should call bindingService.isCurrentBound()', () => {
-        expect(bindingManagerMock.isCurrentBound).toHaveBeenCalledTimes(1);
-        expect(bindingManagerMock.isCurrentBound).toHaveBeenCalledWith(
-          serviceIdentifierFixture,
-          {
-            name: nameFixture,
-            tag: tagFixture,
-          },
-        );
+        expect(
+          bindingManagerMock.isCurrentBound,
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture, {
+          name: nameFixture,
+          tag: tagFixture,
+        });
       });
 
       it('should return expected result', () => {
@@ -730,8 +722,7 @@ describe(Container, () => {
       });
 
       it('should call containerModuleManager.load', () => {
-        expect(containerModuleManagerMock.load).toHaveBeenCalledTimes(1);
-        expect(containerModuleManagerMock.load).toHaveBeenCalledWith(
+        expect(containerModuleManagerMock.load).toHaveBeenCalledExactlyOnceWith(
           containerModuleMock,
         );
       });
@@ -763,10 +754,9 @@ describe(Container, () => {
       });
 
       it('should call containerModuleManager.loadSync', () => {
-        expect(containerModuleManagerMock.loadSync).toHaveBeenCalledTimes(1);
-        expect(containerModuleManagerMock.loadSync).toHaveBeenCalledWith(
-          containerModuleMock,
-        );
+        expect(
+          containerModuleManagerMock.loadSync,
+        ).toHaveBeenCalledExactlyOnceWith(containerModuleMock);
       });
 
       it('should return undefined', () => {
@@ -803,8 +793,7 @@ describe(Container, () => {
           serviceId: serviceIdentifierFixture,
         };
 
-        expect(activationServiceMock.add).toHaveBeenCalledTimes(1);
-        expect(activationServiceMock.add).toHaveBeenCalledWith(
+        expect(activationServiceMock.add).toHaveBeenCalledExactlyOnceWith(
           activationMock,
           bindingActivationRelation,
         );
@@ -844,8 +833,7 @@ describe(Container, () => {
           serviceId: serviceIdentifierFixture,
         };
 
-        expect(deactivationServiceMock.add).toHaveBeenCalledTimes(1);
-        expect(deactivationServiceMock.add).toHaveBeenCalledWith(
+        expect(deactivationServiceMock.add).toHaveBeenCalledExactlyOnceWith(
           deactivationMock,
           bindingDeactivationRelation,
         );
@@ -881,8 +869,7 @@ describe(Container, () => {
       });
 
       it('should call bindingManager.rebind()', () => {
-        expect(bindingManagerMock.rebind).toHaveBeenCalledTimes(1);
-        expect(bindingManagerMock.rebind).toHaveBeenCalledWith(
+        expect(bindingManagerMock.rebind).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
         );
       });
@@ -917,8 +904,7 @@ describe(Container, () => {
       });
 
       it('should call bindingManager.rebindSync()', () => {
-        expect(bindingManagerMock.rebindSync).toHaveBeenCalledTimes(1);
-        expect(bindingManagerMock.rebindSync).toHaveBeenCalledWith(
+        expect(bindingManagerMock.rebindSync).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
         );
       });
@@ -956,8 +942,7 @@ describe(Container, () => {
       });
 
       it('should call pluginManager.register()', () => {
-        expect(pluginManagerMock.register).toHaveBeenCalledTimes(1);
-        expect(pluginManagerMock.register).toHaveBeenCalledWith(
+        expect(pluginManagerMock.register).toHaveBeenCalledExactlyOnceWith(
           container,
           pluginConstructorFixture,
         );
@@ -982,8 +967,7 @@ describe(Container, () => {
       });
 
       it('should call snapshotManager.restore()', () => {
-        expect(snapshotManagerMock.restore).toHaveBeenCalledTimes(1);
-        expect(snapshotManagerMock.restore).toHaveBeenCalledWith();
+        expect(snapshotManagerMock.restore).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should return undefined', () => {
@@ -1005,8 +989,7 @@ describe(Container, () => {
       });
 
       it('should call snapshotManager.snapshot()', () => {
-        expect(snapshotManagerMock.snapshot).toHaveBeenCalledTimes(1);
-        expect(snapshotManagerMock.snapshot).toHaveBeenCalledWith();
+        expect(snapshotManagerMock.snapshot).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should return undefined', () => {
@@ -1036,8 +1019,7 @@ describe(Container, () => {
       });
 
       it('should call bindingManager.unbind()', () => {
-        expect(bindingManagerMock.unbind).toHaveBeenCalledTimes(1);
-        expect(bindingManagerMock.unbind).toHaveBeenCalledWith(
+        expect(bindingManagerMock.unbind).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
         );
       });
@@ -1069,8 +1051,7 @@ describe(Container, () => {
       });
 
       it('should call bindingManager.unbindSync()', () => {
-        expect(bindingManagerMock.unbindSync).toHaveBeenCalledTimes(1);
-        expect(bindingManagerMock.unbindSync).toHaveBeenCalledWith(
+        expect(bindingManagerMock.unbindSync).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
         );
       });
@@ -1096,8 +1077,7 @@ describe(Container, () => {
       });
 
       it('should call bindingManager.unbindAll()', () => {
-        expect(bindingManagerMock.unbindAll).toHaveBeenCalledTimes(1);
-        expect(bindingManagerMock.unbindAll).toHaveBeenCalledWith();
+        expect(bindingManagerMock.unbindAll).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should return undefined', () => {
@@ -1127,10 +1107,9 @@ describe(Container, () => {
       });
 
       it('should call containerModuleManager.unload()', () => {
-        expect(containerModuleManagerMock.unload).toHaveBeenCalledTimes(1);
-        expect(containerModuleManagerMock.unload).toHaveBeenCalledWith(
-          containerModuleFixture,
-        );
+        expect(
+          containerModuleManagerMock.unload,
+        ).toHaveBeenCalledExactlyOnceWith(containerModuleFixture);
       });
 
       it('should return undefined', () => {
@@ -1160,10 +1139,9 @@ describe(Container, () => {
       });
 
       it('should call containerModuleManager.unloadSync()', () => {
-        expect(containerModuleManagerMock.unloadSync).toHaveBeenCalledTimes(1);
-        expect(containerModuleManagerMock.unloadSync).toHaveBeenCalledWith(
-          containerModuleFixture,
-        );
+        expect(
+          containerModuleManagerMock.unloadSync,
+        ).toHaveBeenCalledExactlyOnceWith(containerModuleFixture);
       });
 
       it('should return undefined', () => {

--- a/packages/container/libraries/container/src/container/services/ContainerModuleManager.spec.ts
+++ b/packages/container/libraries/container/src/container/services/ContainerModuleManager.spec.ts
@@ -140,8 +140,9 @@ describe(ContainerModuleManager, () => {
           ) => void,
         };
 
-        expect(asyncContainerModuleMock.load).toHaveBeenCalledTimes(1);
-        expect(asyncContainerModuleMock.load).toHaveBeenCalledWith(options);
+        expect(asyncContainerModuleMock.load).toHaveBeenCalledExactlyOnceWith(
+          options,
+        );
       });
 
       it('should return undefined', () => {
@@ -197,8 +198,9 @@ describe(ContainerModuleManager, () => {
           ) => void,
         };
 
-        expect(syncContainerModuleMock.load).toHaveBeenCalledTimes(1);
-        expect(syncContainerModuleMock.load).toHaveBeenCalledWith(options);
+        expect(syncContainerModuleMock.load).toHaveBeenCalledExactlyOnceWith(
+          options,
+        );
       });
 
       it('should return undefined', () => {
@@ -269,8 +271,9 @@ describe(ContainerModuleManager, () => {
           ) => void,
         };
 
-        expect(syncContainerModuleMock.load).toHaveBeenCalledTimes(1);
-        expect(syncContainerModuleMock.load).toHaveBeenCalledWith(options);
+        expect(syncContainerModuleMock.load).toHaveBeenCalledExactlyOnceWith(
+          options,
+        );
       });
 
       it('should return undefined', () => {
@@ -330,8 +333,9 @@ describe(ContainerModuleManager, () => {
           ) => void,
         };
 
-        expect(asyncContainerModuleMock.load).toHaveBeenCalledTimes(1);
-        expect(asyncContainerModuleMock.load).toHaveBeenCalledWith(options);
+        expect(asyncContainerModuleMock.load).toHaveBeenCalledExactlyOnceWith(
+          options,
+        );
       });
 
       it('should throw an InversifyContainerError', () => {

--- a/packages/container/libraries/container/src/container/services/PlanResultCacheManager.spec.ts
+++ b/packages/container/libraries/container/src/container/services/PlanResultCacheManager.spec.ts
@@ -68,7 +68,7 @@ describe(PlanResultCacheManager, () => {
         expect(
           serviceReferenceManagerMock.planResultCacheService
             .invalidateServiceBinding,
-        ).toHaveBeenCalledWith({
+        ).toHaveBeenCalledExactlyOnceWith({
           ...invalidationFixture,
           operations: planParamsOperationsManagerFixture.planParamsOperations,
         });

--- a/packages/container/libraries/container/src/container/services/PluginManager.spec.ts
+++ b/packages/container/libraries/container/src/container/services/PluginManager.spec.ts
@@ -87,8 +87,10 @@ describe(PluginManager, () => {
             planResultCacheService: expect.any(Object) as unknown,
           } as Partial<PluginContext> as PluginContext;
 
-          expect(pluginType).toHaveBeenCalledTimes(1);
-          expect(pluginType).toHaveBeenCalledWith(containerFixture, expected);
+          expect(pluginType).toHaveBeenCalledExactlyOnceWith(
+            containerFixture,
+            expected,
+          );
         });
 
         it('should throw an InversifyContainerError', () => {
@@ -146,8 +148,10 @@ describe(PluginManager, () => {
             planResultCacheService: expect.any(Object) as unknown,
           } as Partial<PluginContext> as PluginContext;
 
-          expect(pluginType).toHaveBeenCalledTimes(1);
-          expect(pluginType).toHaveBeenCalledWith(containerFixture, expected);
+          expect(pluginType).toHaveBeenCalledExactlyOnceWith(
+            containerFixture,
+            expected,
+          );
         });
 
         it('should call load method of the plugin instance', () => {
@@ -156,8 +160,7 @@ describe(PluginManager, () => {
             onPlan: expect.any(Function) as unknown,
           } as Partial<PluginApi> as PluginApi;
 
-          expect(pluginMock.load).toHaveBeenCalledTimes(1);
-          expect(pluginMock.load).toHaveBeenCalledWith(expected);
+          expect(pluginMock.load).toHaveBeenCalledExactlyOnceWith(expected);
         });
 
         it('should return undefined', () => {

--- a/packages/container/libraries/container/src/container/services/ServiceReferenceManager.spec.ts
+++ b/packages/container/libraries/container/src/container/services/ServiceReferenceManager.spec.ts
@@ -172,8 +172,9 @@ describe(ServiceReferenceManager, () => {
       });
 
       it('should call onResetComputedPropertiesListenerMock()', () => {
-        expect(onResetComputedPropertiesListenerMock).toHaveBeenCalledTimes(1);
-        expect(onResetComputedPropertiesListenerMock).toHaveBeenCalledWith();
+        expect(
+          onResetComputedPropertiesListenerMock,
+        ).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should return undefined', () => {

--- a/packages/container/libraries/container/src/container/services/ServiceResolutionManager.spec.ts
+++ b/packages/container/libraries/container/src/container/services/ServiceResolutionManager.spec.ts
@@ -138,10 +138,7 @@ describe(ServiceResolutionManager, () => {
 
           expect(
             serviceReferenceManagerMock.planResultCacheService.get,
-          ).toHaveBeenCalledTimes(1);
-          expect(
-            serviceReferenceManagerMock.planResultCacheService.get,
-          ).toHaveBeenCalledWith(expectedGetPlanOptions);
+          ).toHaveBeenCalledExactlyOnceWith(expectedGetPlanOptions);
         });
 
         it('should call plan()', () => {
@@ -158,8 +155,7 @@ describe(ServiceResolutionManager, () => {
             servicesBranch: [],
           };
 
-          expect(plan).toHaveBeenCalledTimes(1);
-          expect(plan).toHaveBeenCalledWith(expectedPlanParams);
+          expect(plan).toHaveBeenCalledExactlyOnceWith(expectedPlanParams);
         });
 
         it('should call resolve()', () => {
@@ -177,8 +173,9 @@ describe(ServiceResolutionManager, () => {
             requestScopeCache: new Map(),
           };
 
-          expect(resolve).toHaveBeenCalledTimes(1);
-          expect(resolve).toHaveBeenCalledWith(expectedResolveParams);
+          expect(resolve).toHaveBeenCalledExactlyOnceWith(
+            expectedResolveParams,
+          );
         });
 
         it('should return expected value', () => {
@@ -240,10 +237,7 @@ describe(ServiceResolutionManager, () => {
 
           expect(
             serviceReferenceManagerMock.planResultCacheService.get,
-          ).toHaveBeenCalledTimes(1);
-          expect(
-            serviceReferenceManagerMock.planResultCacheService.get,
-          ).toHaveBeenCalledWith(expectedGetPlanOptions);
+          ).toHaveBeenCalledExactlyOnceWith(expectedGetPlanOptions);
         });
 
         it('should call plan()', () => {
@@ -260,8 +254,7 @@ describe(ServiceResolutionManager, () => {
             servicesBranch: [],
           };
 
-          expect(plan).toHaveBeenCalledTimes(1);
-          expect(plan).toHaveBeenCalledWith(expectedPlanParams);
+          expect(plan).toHaveBeenCalledExactlyOnceWith(expectedPlanParams);
         });
 
         it('should call resolve()', () => {
@@ -279,8 +272,9 @@ describe(ServiceResolutionManager, () => {
             requestScopeCache: new Map(),
           };
 
-          expect(resolve).toHaveBeenCalledTimes(1);
-          expect(resolve).toHaveBeenCalledWith(expectedResolveParams);
+          expect(resolve).toHaveBeenCalledExactlyOnceWith(
+            expectedResolveParams,
+          );
         });
 
         it('should throw an InversifyContainerError', () => {
@@ -350,10 +344,7 @@ describe(ServiceResolutionManager, () => {
 
           expect(
             serviceReferenceManagerMock.planResultCacheService.get,
-          ).toHaveBeenCalledTimes(1);
-          expect(
-            serviceReferenceManagerMock.planResultCacheService.get,
-          ).toHaveBeenCalledWith(expectedGetPlanOptions);
+          ).toHaveBeenCalledExactlyOnceWith(expectedGetPlanOptions);
         });
 
         it('should call plan()', () => {
@@ -370,8 +361,7 @@ describe(ServiceResolutionManager, () => {
             servicesBranch: [],
           };
 
-          expect(plan).toHaveBeenCalledTimes(1);
-          expect(plan).toHaveBeenCalledWith(expectedPlanParams);
+          expect(plan).toHaveBeenCalledExactlyOnceWith(expectedPlanParams);
         });
 
         it('should call onPlanHandler()', () => {
@@ -383,8 +373,7 @@ describe(ServiceResolutionManager, () => {
             tag: getOptionsFixture.tag,
           };
 
-          expect(onPlanHandlerMock).toHaveBeenCalledTimes(1);
-          expect(onPlanHandlerMock).toHaveBeenCalledWith(
+          expect(onPlanHandlerMock).toHaveBeenCalledExactlyOnceWith(
             expectedGetPlanOptions,
             planResultFixture,
           );
@@ -405,8 +394,9 @@ describe(ServiceResolutionManager, () => {
             requestScopeCache: new Map(),
           };
 
-          expect(resolve).toHaveBeenCalledTimes(1);
-          expect(resolve).toHaveBeenCalledWith(expectedResolveParams);
+          expect(resolve).toHaveBeenCalledExactlyOnceWith(
+            expectedResolveParams,
+          );
         });
 
         it('should return expected value', () => {
@@ -479,10 +469,7 @@ describe(ServiceResolutionManager, () => {
 
           expect(
             serviceReferenceManagerMock.planResultCacheService.get,
-          ).toHaveBeenCalledTimes(1);
-          expect(
-            serviceReferenceManagerMock.planResultCacheService.get,
-          ).toHaveBeenCalledWith(expectedGetPlanOptions);
+          ).toHaveBeenCalledExactlyOnceWith(expectedGetPlanOptions);
         });
 
         it('should call plan()', () => {
@@ -501,8 +488,7 @@ describe(ServiceResolutionManager, () => {
             servicesBranch: [],
           };
 
-          expect(plan).toHaveBeenCalledTimes(1);
-          expect(plan).toHaveBeenCalledWith(expectedPlanParams);
+          expect(plan).toHaveBeenCalledExactlyOnceWith(expectedPlanParams);
         });
 
         it('should call resolve()', () => {
@@ -520,8 +506,9 @@ describe(ServiceResolutionManager, () => {
             requestScopeCache: new Map(),
           };
 
-          expect(resolve).toHaveBeenCalledTimes(1);
-          expect(resolve).toHaveBeenCalledWith(expectedResolveParams);
+          expect(resolve).toHaveBeenCalledExactlyOnceWith(
+            expectedResolveParams,
+          );
         });
 
         it('should return expected value', () => {
@@ -595,10 +582,7 @@ describe(ServiceResolutionManager, () => {
 
           expect(
             serviceReferenceManagerMock.planResultCacheService.get,
-          ).toHaveBeenCalledTimes(1);
-          expect(
-            serviceReferenceManagerMock.planResultCacheService.get,
-          ).toHaveBeenCalledWith(expectedGetPlanOptions);
+          ).toHaveBeenCalledExactlyOnceWith(expectedGetPlanOptions);
         });
 
         it('should call plan()', () => {
@@ -617,8 +601,7 @@ describe(ServiceResolutionManager, () => {
             servicesBranch: [],
           };
 
-          expect(plan).toHaveBeenCalledTimes(1);
-          expect(plan).toHaveBeenCalledWith(expectedPlanParams);
+          expect(plan).toHaveBeenCalledExactlyOnceWith(expectedPlanParams);
         });
 
         it('should call resolve()', () => {
@@ -636,8 +619,9 @@ describe(ServiceResolutionManager, () => {
             requestScopeCache: new Map(),
           };
 
-          expect(resolve).toHaveBeenCalledTimes(1);
-          expect(resolve).toHaveBeenCalledWith(expectedResolveParams);
+          expect(resolve).toHaveBeenCalledExactlyOnceWith(
+            expectedResolveParams,
+          );
         });
 
         it('should return expected value', () => {
@@ -709,10 +693,7 @@ describe(ServiceResolutionManager, () => {
 
         expect(
           serviceReferenceManagerMock.planResultCacheService.get,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.planResultCacheService.get,
-        ).toHaveBeenCalledWith(expectedGetPlanOptions);
+        ).toHaveBeenCalledExactlyOnceWith(expectedGetPlanOptions);
       });
 
       it('should not call plan()', () => {
@@ -734,8 +715,7 @@ describe(ServiceResolutionManager, () => {
           requestScopeCache: new Map(),
         };
 
-        expect(resolve).toHaveBeenCalledTimes(1);
-        expect(resolve).toHaveBeenCalledWith(expectedResolveParams);
+        expect(resolve).toHaveBeenCalledExactlyOnceWith(expectedResolveParams);
       });
 
       it('should return expected value', () => {
@@ -794,10 +774,7 @@ describe(ServiceResolutionManager, () => {
 
           expect(
             serviceReferenceManagerMock.planResultCacheService.get,
-          ).toHaveBeenCalledTimes(1);
-          expect(
-            serviceReferenceManagerMock.planResultCacheService.get,
-          ).toHaveBeenCalledWith(expectedGetPlanOptions);
+          ).toHaveBeenCalledExactlyOnceWith(expectedGetPlanOptions);
         });
 
         it('should call plan()', () => {
@@ -812,8 +789,7 @@ describe(ServiceResolutionManager, () => {
             servicesBranch: [],
           };
 
-          expect(plan).toHaveBeenCalledTimes(1);
-          expect(plan).toHaveBeenCalledWith(expectedPlanParams);
+          expect(plan).toHaveBeenCalledExactlyOnceWith(expectedPlanParams);
         });
 
         it('should call resolve()', () => {
@@ -831,8 +807,9 @@ describe(ServiceResolutionManager, () => {
             requestScopeCache: new Map(),
           };
 
-          expect(resolve).toHaveBeenCalledTimes(1);
-          expect(resolve).toHaveBeenCalledWith(expectedResolveParams);
+          expect(resolve).toHaveBeenCalledExactlyOnceWith(
+            expectedResolveParams,
+          );
         });
 
         it('should return expected value', () => {
@@ -894,10 +871,7 @@ describe(ServiceResolutionManager, () => {
 
         expect(
           serviceReferenceManagerMock.planResultCacheService.get,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.planResultCacheService.get,
-        ).toHaveBeenCalledWith(expectedGetPlanOptions);
+        ).toHaveBeenCalledExactlyOnceWith(expectedGetPlanOptions);
       });
 
       it('should call plan()', () => {
@@ -915,8 +889,7 @@ describe(ServiceResolutionManager, () => {
           servicesBranch: [],
         };
 
-        expect(plan).toHaveBeenCalledTimes(1);
-        expect(plan).toHaveBeenCalledWith(expectedPlanParams);
+        expect(plan).toHaveBeenCalledExactlyOnceWith(expectedPlanParams);
       });
 
       it('should call resolve()', () => {
@@ -934,8 +907,7 @@ describe(ServiceResolutionManager, () => {
           requestScopeCache: new Map(),
         };
 
-        expect(resolve).toHaveBeenCalledTimes(1);
-        expect(resolve).toHaveBeenCalledWith(expectedResolveParams);
+        expect(resolve).toHaveBeenCalledExactlyOnceWith(expectedResolveParams);
       });
 
       it('should return expected value', () => {
@@ -1000,10 +972,7 @@ describe(ServiceResolutionManager, () => {
 
         expect(
           serviceReferenceManagerMock.planResultCacheService.get,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.planResultCacheService.get,
-        ).toHaveBeenCalledWith(expectedGetPlanOptions);
+        ).toHaveBeenCalledExactlyOnceWith(expectedGetPlanOptions);
       });
 
       it('should call plan()', () => {
@@ -1021,8 +990,7 @@ describe(ServiceResolutionManager, () => {
           servicesBranch: [],
         };
 
-        expect(plan).toHaveBeenCalledTimes(1);
-        expect(plan).toHaveBeenCalledWith(expectedPlanParams);
+        expect(plan).toHaveBeenCalledExactlyOnceWith(expectedPlanParams);
       });
 
       it('should call resolve()', () => {
@@ -1040,8 +1008,7 @@ describe(ServiceResolutionManager, () => {
           requestScopeCache: new Map(),
         };
 
-        expect(resolve).toHaveBeenCalledTimes(1);
-        expect(resolve).toHaveBeenCalledWith(expectedResolveParams);
+        expect(resolve).toHaveBeenCalledExactlyOnceWith(expectedResolveParams);
       });
 
       it('should throw an InversifyContainerError', () => {
@@ -1112,10 +1079,7 @@ describe(ServiceResolutionManager, () => {
 
         expect(
           serviceReferenceManagerMock.planResultCacheService.get,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.planResultCacheService.get,
-        ).toHaveBeenCalledWith(expectedGetPlanOptions);
+        ).toHaveBeenCalledExactlyOnceWith(expectedGetPlanOptions);
       });
 
       it('should call plan()', () => {
@@ -1133,8 +1097,7 @@ describe(ServiceResolutionManager, () => {
           servicesBranch: [],
         };
 
-        expect(plan).toHaveBeenCalledTimes(1);
-        expect(plan).toHaveBeenCalledWith(expectedPlanParams);
+        expect(plan).toHaveBeenCalledExactlyOnceWith(expectedPlanParams);
       });
 
       it('should call resolve()', () => {
@@ -1152,8 +1115,7 @@ describe(ServiceResolutionManager, () => {
           requestScopeCache: new Map(),
         };
 
-        expect(resolve).toHaveBeenCalledTimes(1);
-        expect(resolve).toHaveBeenCalledWith(expectedResolveParams);
+        expect(resolve).toHaveBeenCalledExactlyOnceWith(expectedResolveParams);
       });
 
       it('should return expected value', () => {
@@ -1215,10 +1177,7 @@ describe(ServiceResolutionManager, () => {
 
         expect(
           serviceReferenceManagerMock.planResultCacheService.get,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.planResultCacheService.get,
-        ).toHaveBeenCalledWith(expectedGetPlanOptions);
+        ).toHaveBeenCalledExactlyOnceWith(expectedGetPlanOptions);
       });
 
       it('should call plan()', () => {
@@ -1235,8 +1194,7 @@ describe(ServiceResolutionManager, () => {
           servicesBranch: [],
         };
 
-        expect(plan).toHaveBeenCalledTimes(1);
-        expect(plan).toHaveBeenCalledWith(expectedPlanParams);
+        expect(plan).toHaveBeenCalledExactlyOnceWith(expectedPlanParams);
       });
 
       it('should call resolve()', () => {
@@ -1254,8 +1212,7 @@ describe(ServiceResolutionManager, () => {
           requestScopeCache: new Map(),
         };
 
-        expect(resolve).toHaveBeenCalledTimes(1);
-        expect(resolve).toHaveBeenCalledWith(expectedResolveParams);
+        expect(resolve).toHaveBeenCalledExactlyOnceWith(expectedResolveParams);
       });
 
       it('should return expected value', () => {

--- a/packages/container/libraries/container/src/container/services/SnapshotManager.spec.ts
+++ b/packages/container/libraries/container/src/container/services/SnapshotManager.spec.ts
@@ -124,28 +124,19 @@ describe(SnapshotManager, () => {
       it('should call activationService.clone()', () => {
         expect(
           serviceReferenceManagerMock.activationService.clone,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.activationService.clone,
-        ).toHaveBeenCalledWith();
+        ).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should call bindingService.clone()', () => {
         expect(
           serviceReferenceManagerMock.bindingService.clone,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.bindingService.clone,
-        ).toHaveBeenCalledWith();
+        ).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should call deactivationService.clone()', () => {
         expect(
           serviceReferenceManagerMock.deactivationService.clone,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          serviceReferenceManagerMock.deactivationService.clone,
-        ).toHaveBeenCalledWith();
+        ).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should return undefined', () => {

--- a/packages/container/libraries/core/src/binding/actions/getBindingId.spec.ts
+++ b/packages/container/libraries/core/src/binding/actions/getBindingId.spec.ts
@@ -25,16 +25,14 @@ describe(getBindingId, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         Object,
         '@inversifyjs/container/bindingId',
       );
     });
 
     it('should call updateOwnReflectMetadata()', () => {
-      expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         Object,
         '@inversifyjs/container/bindingId',
         expect.any(Function),
@@ -63,16 +61,14 @@ describe(getBindingId, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         Object,
         '@inversifyjs/container/bindingId',
       );
     });
 
     it('should call setReflectMetadata()', () => {
-      expect(setReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(setReflectMetadata).toHaveBeenCalledWith(
+      expect(setReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         Object,
         '@inversifyjs/container/bindingId',
         Number.MIN_SAFE_INTEGER,

--- a/packages/container/libraries/core/src/binding/calculations/buildInstanceBinding.spec.ts
+++ b/packages/container/libraries/core/src/binding/calculations/buildInstanceBinding.spec.ts
@@ -54,13 +54,13 @@ describe(buildInstanceBinding, () => {
     });
 
     it('should call getClassMetadata()', () => {
-      expect(getClassMetadata).toHaveBeenCalledTimes(1);
-      expect(getClassMetadata).toHaveBeenCalledWith(serviceIdentifierFixture);
+      expect(getClassMetadata).toHaveBeenCalledExactlyOnceWith(
+        serviceIdentifierFixture,
+      );
     });
 
     it('should call getBindingId', () => {
-      expect(getBindingId).toHaveBeenCalledTimes(1);
-      expect(getBindingId).toHaveBeenCalledWith();
+      expect(getBindingId).toHaveBeenCalledExactlyOnceWith();
     });
 
     it('should return expected InstanceBinding', () => {

--- a/packages/container/libraries/core/src/binding/calculations/cloneBinding.spec.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneBinding.spec.ts
@@ -85,8 +85,9 @@ describe(cloneBinding, () => {
       });
 
       it('should call cloneConstantValueBinding', () => {
-        expect(cloneConstantValueBinding).toHaveBeenCalledTimes(1);
-        expect(cloneConstantValueBinding).toHaveBeenCalledWith(bindingFixture);
+        expect(cloneConstantValueBinding).toHaveBeenCalledExactlyOnceWith(
+          bindingFixture,
+        );
       });
 
       it('should return the cloned binding', () => {
@@ -135,8 +136,9 @@ describe(cloneBinding, () => {
       });
 
       it('should call cloneDynamicValueBinding', () => {
-        expect(cloneDynamicValueBinding).toHaveBeenCalledTimes(1);
-        expect(cloneDynamicValueBinding).toHaveBeenCalledWith(bindingFixture);
+        expect(cloneDynamicValueBinding).toHaveBeenCalledExactlyOnceWith(
+          bindingFixture,
+        );
       });
 
       it('should return the cloned binding', () => {
@@ -181,8 +183,9 @@ describe(cloneBinding, () => {
     });
 
     it('should call cloneFactoryBinding', () => {
-      expect(cloneFactoryBinding).toHaveBeenCalledTimes(1);
-      expect(cloneFactoryBinding).toHaveBeenCalledWith(bindingFixture);
+      expect(cloneFactoryBinding).toHaveBeenCalledExactlyOnceWith(
+        bindingFixture,
+      );
     });
 
     it('should return the cloned binding', () => {
@@ -226,8 +229,9 @@ describe(cloneBinding, () => {
     });
 
     it('should call cloneInstanceBinding', () => {
-      expect(cloneInstanceBinding).toHaveBeenCalledTimes(1);
-      expect(cloneInstanceBinding).toHaveBeenCalledWith(bindingFixture);
+      expect(cloneInstanceBinding).toHaveBeenCalledExactlyOnceWith(
+        bindingFixture,
+      );
     });
 
     it('should return the cloned binding', () => {
@@ -271,8 +275,9 @@ describe(cloneBinding, () => {
     });
 
     it('should call cloneProviderBinding', () => {
-      expect(cloneProviderBinding).toHaveBeenCalledTimes(1);
-      expect(cloneProviderBinding).toHaveBeenCalledWith(bindingFixture);
+      expect(cloneProviderBinding).toHaveBeenCalledExactlyOnceWith(
+        bindingFixture,
+      );
     });
 
     it('should return the cloned binding', () => {
@@ -319,8 +324,9 @@ describe(cloneBinding, () => {
     });
 
     it('should call cloneResolvedValueBinding', () => {
-      expect(cloneResolvedValueBinding).toHaveBeenCalledTimes(1);
-      expect(cloneResolvedValueBinding).toHaveBeenCalledWith(bindingFixture);
+      expect(cloneResolvedValueBinding).toHaveBeenCalledExactlyOnceWith(
+        bindingFixture,
+      );
     });
 
     it('should return the cloned binding', () => {
@@ -357,8 +363,7 @@ describe(cloneBinding, () => {
     });
 
     it('should call cloneServiceRedirectionBinding', () => {
-      expect(cloneServiceRedirectionBinding).toHaveBeenCalledTimes(1);
-      expect(cloneServiceRedirectionBinding).toHaveBeenCalledWith(
+      expect(cloneServiceRedirectionBinding).toHaveBeenCalledExactlyOnceWith(
         bindingFixture,
       );
     });

--- a/packages/container/libraries/core/src/binding/calculations/cloneConstantValueBinding.spec.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneConstantValueBinding.spec.ts
@@ -52,8 +52,7 @@ describe(cloneConstantValueBinding, () => {
     });
 
     it('should call cloneBindingCache', () => {
-      expect(cloneBindingCache).toHaveBeenCalledTimes(1);
-      expect(cloneBindingCache).toHaveBeenCalledWith(
+      expect(cloneBindingCache).toHaveBeenCalledExactlyOnceWith(
         constantValueBindingFixture.cache,
       );
     });

--- a/packages/container/libraries/core/src/binding/calculations/cloneDynamicValueBinding.spec.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneDynamicValueBinding.spec.ts
@@ -52,8 +52,7 @@ describe(cloneDynamicValueBinding, () => {
     });
 
     it('should call cloneBindingCache', () => {
-      expect(cloneBindingCache).toHaveBeenCalledTimes(1);
-      expect(cloneBindingCache).toHaveBeenCalledWith(
+      expect(cloneBindingCache).toHaveBeenCalledExactlyOnceWith(
         dynamicValueBindingFixture.cache,
       );
     });

--- a/packages/container/libraries/core/src/binding/calculations/cloneFactoryBinding.spec.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneFactoryBinding.spec.ts
@@ -53,8 +53,7 @@ describe(cloneFactoryBinding, () => {
     });
 
     it('should call cloneBindingCache', () => {
-      expect(cloneBindingCache).toHaveBeenCalledTimes(1);
-      expect(cloneBindingCache).toHaveBeenCalledWith(
+      expect(cloneBindingCache).toHaveBeenCalledExactlyOnceWith(
         factoryBindingFixture.cache,
       );
     });

--- a/packages/container/libraries/core/src/binding/calculations/cloneInstanceBinding.spec.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneInstanceBinding.spec.ts
@@ -52,8 +52,7 @@ describe(cloneInstanceBinding, () => {
     });
 
     it('should call cloneBindingCache', () => {
-      expect(cloneBindingCache).toHaveBeenCalledTimes(1);
-      expect(cloneBindingCache).toHaveBeenCalledWith(
+      expect(cloneBindingCache).toHaveBeenCalledExactlyOnceWith(
         instanceBindingFixture.cache,
       );
     });

--- a/packages/container/libraries/core/src/binding/calculations/cloneProviderBinding.spec.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneProviderBinding.spec.ts
@@ -53,8 +53,7 @@ describe(cloneProviderBinding, () => {
     });
 
     it('should call cloneBindingCache', () => {
-      expect(cloneBindingCache).toHaveBeenCalledTimes(1);
-      expect(cloneBindingCache).toHaveBeenCalledWith(
+      expect(cloneBindingCache).toHaveBeenCalledExactlyOnceWith(
         providerBindingFixture.cache,
       );
     });

--- a/packages/container/libraries/core/src/binding/calculations/cloneResolvedValueBinding.spec.ts
+++ b/packages/container/libraries/core/src/binding/calculations/cloneResolvedValueBinding.spec.ts
@@ -55,8 +55,7 @@ describe(cloneResolvedValueBinding, () => {
     });
 
     it('should call cloneBindingCache', () => {
-      expect(cloneBindingCache).toHaveBeenCalledTimes(1);
-      expect(cloneBindingCache).toHaveBeenCalledWith(
+      expect(cloneBindingCache).toHaveBeenCalledExactlyOnceWith(
         resolvedValueBindingFixture.cache,
       );
     });

--- a/packages/container/libraries/core/src/binding/services/ActivationsService.spec.ts
+++ b/packages/container/libraries/core/src/binding/services/ActivationsService.spec.ts
@@ -76,8 +76,7 @@ describe(ActivationsService, () => {
       });
 
       it('should call activationMaps.add()', () => {
-        expect(activationMapsMock.add).toHaveBeenCalledTimes(1);
-        expect(activationMapsMock.add).toHaveBeenCalledWith(
+        expect(activationMapsMock.add).toHaveBeenCalledExactlyOnceWith(
           activationFixture,
           relationFixture,
         );
@@ -104,8 +103,7 @@ describe(ActivationsService, () => {
       });
 
       it('should call activationMaps.clone', () => {
-        expect(activationMapsMock.clone).toHaveBeenCalledTimes(1);
-        expect(activationMapsMock.clone).toHaveBeenCalledWith();
+        expect(activationMapsMock.clone).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should return a clone()', () => {
@@ -157,8 +155,9 @@ describe(ActivationsService, () => {
       });
 
       it('should call chain()', () => {
-        expect(chain).toHaveBeenCalledTimes(1);
-        expect(chain).toHaveBeenCalledWith([bindingActivationFixture]);
+        expect(chain).toHaveBeenCalledExactlyOnceWith([
+          bindingActivationFixture,
+        ]);
       });
 
       it('should return BindingActivation[]', () => {
@@ -245,11 +244,9 @@ describe(ActivationsService, () => {
       });
 
       it('should call activationMaps.removeByRelation()', () => {
-        expect(activationMapsMock.removeByRelation).toHaveBeenCalledTimes(1);
-        expect(activationMapsMock.removeByRelation).toHaveBeenCalledWith(
-          'moduleId',
-          moduleIdFixture,
-        );
+        expect(
+          activationMapsMock.removeByRelation,
+        ).toHaveBeenCalledExactlyOnceWith('moduleId', moduleIdFixture);
       });
 
       it('should return undefined', () => {
@@ -277,11 +274,9 @@ describe(ActivationsService, () => {
       });
 
       it('should call activationMaps.removeByRelation()', () => {
-        expect(activationMapsMock.removeByRelation).toHaveBeenCalledTimes(1);
-        expect(activationMapsMock.removeByRelation).toHaveBeenCalledWith(
-          'serviceId',
-          serviceIdFixture,
-        );
+        expect(
+          activationMapsMock.removeByRelation,
+        ).toHaveBeenCalledExactlyOnceWith('serviceId', serviceIdFixture);
       });
 
       it('should return undefined', () => {

--- a/packages/container/libraries/core/src/binding/services/BindingService.spec.ts
+++ b/packages/container/libraries/core/src/binding/services/BindingService.spec.ts
@@ -65,8 +65,7 @@ describe(BindingService, () => {
       });
 
       it('should call activationMaps.clone()', () => {
-        expect(bindingMapsMock.clone).toHaveBeenCalledTimes(1);
-        expect(bindingMapsMock.clone).toHaveBeenCalledWith();
+        expect(bindingMapsMock.clone).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should return a clone()', () => {
@@ -139,8 +138,7 @@ describe(BindingService, () => {
         });
 
         it('should call bindingMaps.get()', () => {
-          expect(bindingMapsMock.get).toHaveBeenCalledTimes(1);
-          expect(bindingMapsMock.get).toHaveBeenCalledWith(
+          expect(bindingMapsMock.get).toHaveBeenCalledExactlyOnceWith(
             'serviceId',
             serviceIdFixture,
           );
@@ -202,8 +200,7 @@ describe(BindingService, () => {
             scope: bindingScopeValues.Singleton,
           };
 
-          expect(buildInstanceBinding).toHaveBeenCalledTimes(1);
-          expect(buildInstanceBinding).toHaveBeenCalledWith(
+          expect(buildInstanceBinding).toHaveBeenCalledExactlyOnceWith(
             expectedAutobindingOptions,
             serviceIdFixture,
           );
@@ -244,8 +241,7 @@ describe(BindingService, () => {
       });
 
       it('should call bindingMaps.get()', () => {
-        expect(bindingMapsMock.get).toHaveBeenCalledTimes(1);
-        expect(bindingMapsMock.get).toHaveBeenCalledWith(
+        expect(bindingMapsMock.get).toHaveBeenCalledExactlyOnceWith(
           'serviceId',
           serviceIdFixture,
         );
@@ -399,8 +395,7 @@ describe(BindingService, () => {
       });
 
       it('should call bindingMaps.get()', () => {
-        expect(bindingMapsMock.get).toHaveBeenCalledTimes(1);
-        expect(bindingMapsMock.get).toHaveBeenCalledWith(
+        expect(bindingMapsMock.get).toHaveBeenCalledExactlyOnceWith(
           'serviceId',
           serviceIdFixture,
         );
@@ -467,8 +462,10 @@ describe(BindingService, () => {
       });
 
       it('should call bindingMaps.get()', () => {
-        expect(bindingMapsMock.get).toHaveBeenCalledTimes(1);
-        expect(bindingMapsMock.get).toHaveBeenCalledWith('id', idFixture);
+        expect(bindingMapsMock.get).toHaveBeenCalledExactlyOnceWith(
+          'id',
+          idFixture,
+        );
       });
 
       it('should return BindingActivation[]', () => {
@@ -540,8 +537,7 @@ describe(BindingService, () => {
       });
 
       it('should call bindingMaps.get()', () => {
-        expect(bindingMapsMock.get).toHaveBeenCalledTimes(1);
-        expect(bindingMapsMock.get).toHaveBeenCalledWith(
+        expect(bindingMapsMock.get).toHaveBeenCalledExactlyOnceWith(
           'moduleId',
           moduleIdFixture,
         );
@@ -576,8 +572,9 @@ describe(BindingService, () => {
       });
 
       it('should call bindingMaps.getAllKeys()', () => {
-        expect(bindingMapsMock.getAllKeys).toHaveBeenCalledTimes(1);
-        expect(bindingMapsMock.getAllKeys).toHaveBeenCalledWith('serviceId');
+        expect(bindingMapsMock.getAllKeys).toHaveBeenCalledExactlyOnceWith(
+          'serviceId',
+        );
       });
     });
   });
@@ -646,11 +643,9 @@ describe(BindingService, () => {
       });
 
       it('should call bindingMaps.removeByRelation()', () => {
-        expect(bindingMapsMock.removeByRelation).toHaveBeenCalledTimes(1);
-        expect(bindingMapsMock.removeByRelation).toHaveBeenCalledWith(
-          'moduleId',
-          moduleIdFixture,
-        );
+        expect(
+          bindingMapsMock.removeByRelation,
+        ).toHaveBeenCalledExactlyOnceWith('moduleId', moduleIdFixture);
       });
 
       it('should return undefined', () => {
@@ -678,11 +673,9 @@ describe(BindingService, () => {
       });
 
       it('should call bindingMaps.removeByRelation()', () => {
-        expect(bindingMapsMock.removeByRelation).toHaveBeenCalledTimes(1);
-        expect(bindingMapsMock.removeByRelation).toHaveBeenCalledWith(
-          'serviceId',
-          serviceIdFixture,
-        );
+        expect(
+          bindingMapsMock.removeByRelation,
+        ).toHaveBeenCalledExactlyOnceWith('serviceId', serviceIdFixture);
       });
 
       it('should return undefined', () => {
@@ -716,8 +709,7 @@ describe(BindingService, () => {
             serviceId: bindingFixture.serviceIdentifier,
           };
 
-          expect(bindingMapsMock.add).toHaveBeenCalledTimes(1);
-          expect(bindingMapsMock.add).toHaveBeenCalledWith(
+          expect(bindingMapsMock.add).toHaveBeenCalledExactlyOnceWith(
             bindingFixture,
             expectedRelation,
           );
@@ -754,8 +746,7 @@ describe(BindingService, () => {
             serviceId: bindingFixture.serviceIdentifier,
           };
 
-          expect(bindingMapsMock.add).toHaveBeenCalledTimes(1);
-          expect(bindingMapsMock.add).toHaveBeenCalledWith(
+          expect(bindingMapsMock.add).toHaveBeenCalledExactlyOnceWith(
             bindingFixture,
             expectedRelation,
           );
@@ -787,11 +778,9 @@ describe(BindingService, () => {
       });
 
       it('should call bindingMapsMock.removeByRelation()', () => {
-        expect(bindingMapsMock.removeByRelation).toHaveBeenCalledTimes(1);
-        expect(bindingMapsMock.removeByRelation).toHaveBeenCalledWith(
-          'id',
-          idFixture,
-        );
+        expect(
+          bindingMapsMock.removeByRelation,
+        ).toHaveBeenCalledExactlyOnceWith('id', idFixture);
       });
 
       it('should return undefined', () => {

--- a/packages/container/libraries/core/src/binding/services/DeactivationsService.spec.ts
+++ b/packages/container/libraries/core/src/binding/services/DeactivationsService.spec.ts
@@ -75,8 +75,7 @@ describe(DeactivationsService, () => {
       });
 
       it('should call deactivationMaps.add()', () => {
-        expect(deactivationMapsMock.add).toHaveBeenCalledTimes(1);
-        expect(deactivationMapsMock.add).toHaveBeenCalledWith(
+        expect(deactivationMapsMock.add).toHaveBeenCalledExactlyOnceWith(
           deactivationFixture,
           relationFixture,
         );
@@ -103,8 +102,7 @@ describe(DeactivationsService, () => {
       });
 
       it('should call deactivationMaps.clone', () => {
-        expect(deactivationMapsMock.clone).toHaveBeenCalledTimes(1);
-        expect(deactivationMapsMock.clone).toHaveBeenCalledWith();
+        expect(deactivationMapsMock.clone).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should return a clone()', () => {
@@ -156,8 +154,9 @@ describe(DeactivationsService, () => {
       });
 
       it('should call chain()', () => {
-        expect(chain).toHaveBeenCalledTimes(1);
-        expect(chain).toHaveBeenCalledWith([bindingDeactivationFixture]);
+        expect(chain).toHaveBeenCalledExactlyOnceWith([
+          bindingDeactivationFixture,
+        ]);
       });
 
       it('should return BindingDeactivation[]', () => {
@@ -244,11 +243,9 @@ describe(DeactivationsService, () => {
       });
 
       it('should call deactivationMaps.removeByRelation()', () => {
-        expect(deactivationMapsMock.removeByRelation).toHaveBeenCalledTimes(1);
-        expect(deactivationMapsMock.removeByRelation).toHaveBeenCalledWith(
-          'moduleId',
-          moduleIdFixture,
-        );
+        expect(
+          deactivationMapsMock.removeByRelation,
+        ).toHaveBeenCalledExactlyOnceWith('moduleId', moduleIdFixture);
       });
 
       it('should return undefined', () => {
@@ -276,11 +273,9 @@ describe(DeactivationsService, () => {
       });
 
       it('should call deactivationMaps.removeByRelation()', () => {
-        expect(deactivationMapsMock.removeByRelation).toHaveBeenCalledTimes(1);
-        expect(deactivationMapsMock.removeByRelation).toHaveBeenCalledWith(
-          'serviceId',
-          serviceIdFixture,
-        );
+        expect(
+          deactivationMapsMock.removeByRelation,
+        ).toHaveBeenCalledExactlyOnceWith('serviceId', serviceIdFixture);
       });
 
       it('should return undefined', () => {

--- a/packages/container/libraries/core/src/decorator/actions/decorate.spec.ts
+++ b/packages/container/libraries/core/src/decorator/actions/decorate.spec.ts
@@ -36,8 +36,9 @@ describe(decorate, () => {
       });
 
       it('should call decorator', () => {
-        expect(classDecoratorMock).toHaveBeenCalledTimes(1);
-        expect(classDecoratorMock).toHaveBeenCalledWith(targetFixture);
+        expect(classDecoratorMock).toHaveBeenCalledExactlyOnceWith(
+          targetFixture,
+        );
       });
 
       it('should return undefined', () => {
@@ -69,8 +70,9 @@ describe(decorate, () => {
       });
 
       it('should call decorator', () => {
-        expect(classDecoratorMock).toHaveBeenCalledTimes(1);
-        expect(classDecoratorMock).toHaveBeenCalledWith(targetFixture);
+        expect(classDecoratorMock).toHaveBeenCalledExactlyOnceWith(
+          targetFixture,
+        );
       });
 
       it('should return undefined', () => {
@@ -109,8 +111,7 @@ describe(decorate, () => {
       });
 
       it('should call decorator', () => {
-        expect(parameterDecoratorMock).toHaveBeenCalledTimes(1);
-        expect(parameterDecoratorMock).toHaveBeenCalledWith(
+        expect(parameterDecoratorMock).toHaveBeenCalledExactlyOnceWith(
           targetFixture,
           undefined,
           parameterIndexFixture,
@@ -156,8 +157,7 @@ describe(decorate, () => {
       });
 
       it('should call decorator', () => {
-        expect(parameterDecoratorMock).toHaveBeenCalledTimes(1);
-        expect(parameterDecoratorMock).toHaveBeenCalledWith(
+        expect(parameterDecoratorMock).toHaveBeenCalledExactlyOnceWith(
           targetFixture,
           methodNameFixture,
           parameterIndexFixture,
@@ -199,8 +199,7 @@ describe(decorate, () => {
       });
 
       it('should call decorator', () => {
-        expect(methodDecoratorMock).toHaveBeenCalledTimes(1);
-        expect(methodDecoratorMock).toHaveBeenCalledWith(
+        expect(methodDecoratorMock).toHaveBeenCalledExactlyOnceWith(
           targetFixture.prototype,
           propertyFixture,
           undefined,

--- a/packages/container/libraries/core/src/metadata/actions/decrementPendingClassMetadataCount.spec.ts
+++ b/packages/container/libraries/core/src/metadata/actions/decrementPendingClassMetadataCount.spec.ts
@@ -43,8 +43,7 @@ describe(decrementPendingClassMetadataCount, () => {
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           typeFixture,
           pendingClassMetadataCountReflectKey,
           getDefaultPendingClassMetadataCount,

--- a/packages/container/libraries/core/src/metadata/actions/incrementPendingClassMetadataCount.spec.ts
+++ b/packages/container/libraries/core/src/metadata/actions/incrementPendingClassMetadataCount.spec.ts
@@ -68,8 +68,7 @@ describe(incrementPendingClassMetadataCount, () => {
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           typeFixture,
           pendingClassMetadataCountReflectKey,
           getDefaultPendingClassMetadataCount,

--- a/packages/container/libraries/core/src/metadata/actions/setIsInjectableFlag.spec.ts
+++ b/packages/container/libraries/core/src/metadata/actions/setIsInjectableFlag.spec.ts
@@ -34,16 +34,14 @@ describe(setIsInjectableFlag, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         targetFixture,
         classIsInjectableFlagReflectKey,
       );
     });
 
     it('should call setReflectMetadata', () => {
-      expect(setReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(setReflectMetadata).toHaveBeenCalledWith(
+      expect(setReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         targetFixture,
         classIsInjectableFlagReflectKey,
         true,

--- a/packages/container/libraries/core/src/metadata/actions/updateClassMetadataWithTypescriptParameterTypes.spec.ts
+++ b/packages/container/libraries/core/src/metadata/actions/updateClassMetadataWithTypescriptParameterTypes.spec.ts
@@ -30,8 +30,7 @@ describe(updateClassMetadataWithTypescriptParameterTypes, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         targetFixture,
         typescriptParameterTypesReflectKey,
       );
@@ -66,16 +65,14 @@ describe(updateClassMetadataWithTypescriptParameterTypes, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         targetFixture,
         typescriptParameterTypesReflectKey,
       );
     });
 
     it('should call updateOwnReflectMetadata()', () => {
-      expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         targetFixture,
         classMetadataReflectKey,
         getDefaultClassMetadata,

--- a/packages/container/libraries/core/src/metadata/actions/updateMaybeClassMetadataConstructorArgument.spec.ts
+++ b/packages/container/libraries/core/src/metadata/actions/updateMaybeClassMetadataConstructorArgument.spec.ts
@@ -62,8 +62,7 @@ describe(updateMaybeClassMetadataConstructorArgument, () => {
     });
 
     it('should call updateMetadata()', () => {
-      expect(updateMetadataMock).toHaveBeenCalledTimes(1);
-      expect(updateMetadataMock).toHaveBeenCalledWith(undefined);
+      expect(updateMetadataMock).toHaveBeenCalledExactlyOnceWith(undefined);
     });
 
     it('should return MaybeClassMetadata', () => {

--- a/packages/container/libraries/core/src/metadata/actions/updateMaybeClassMetadataProperty.spec.ts
+++ b/packages/container/libraries/core/src/metadata/actions/updateMaybeClassMetadataProperty.spec.ts
@@ -62,8 +62,7 @@ describe(updateMaybeClassMetadataProperty, () => {
     });
 
     it('should call updateMetadata()', () => {
-      expect(updateMetadataMock).toHaveBeenCalledTimes(1);
-      expect(updateMetadataMock).toHaveBeenCalledWith(undefined);
+      expect(updateMetadataMock).toHaveBeenCalledExactlyOnceWith(undefined);
     });
 
     it('should return MaybeClassMetadata', () => {

--- a/packages/container/libraries/core/src/metadata/calculations/buildClassElementMetadataFromMaybeClassElementMetadata.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildClassElementMetadataFromMaybeClassElementMetadata.spec.ts
@@ -69,8 +69,9 @@ describe(buildClassElementMetadataFromMaybeClassElementMetadata, () => {
       });
 
       it('should call buildDefaultMetadata()', () => {
-        expect(buildDefaultMetadataMock).toHaveBeenCalledTimes(1);
-        expect(buildDefaultMetadataMock).toHaveBeenCalledWith(...paramsFixture);
+        expect(buildDefaultMetadataMock).toHaveBeenCalledExactlyOnceWith(
+          ...paramsFixture,
+        );
       });
 
       it('should return ClassElementMetadata', () => {
@@ -134,13 +135,9 @@ describe(buildClassElementMetadataFromMaybeClassElementMetadata, () => {
       });
 
       it('should call buildMetadataFromMaybeManagedMetadata()', () => {
-        expect(buildMetadataFromMaybeManagedMetadataMock).toHaveBeenCalledTimes(
-          1,
-        );
-        expect(buildMetadataFromMaybeManagedMetadataMock).toHaveBeenCalledWith(
-          metadataFixture,
-          ...paramsFixture,
-        );
+        expect(
+          buildMetadataFromMaybeManagedMetadataMock,
+        ).toHaveBeenCalledExactlyOnceWith(metadataFixture, ...paramsFixture);
       });
 
       it('should return ClassElementMetadata', () => {

--- a/packages/container/libraries/core/src/metadata/calculations/buildManagedMetadataFromMaybeManagedMetadata.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildManagedMetadataFromMaybeManagedMetadata.spec.ts
@@ -46,10 +46,9 @@ describe(buildManagedMetadataFromMaybeManagedMetadata, () => {
       });
 
       it('should call assertMetadataFromTypescriptIfManaged()', () => {
-        expect(assertMetadataFromTypescriptIfManaged).toHaveBeenCalledTimes(1);
-        expect(assertMetadataFromTypescriptIfManaged).toHaveBeenCalledWith(
-          metadataFixture,
-        );
+        expect(
+          assertMetadataFromTypescriptIfManaged,
+        ).toHaveBeenCalledExactlyOnceWith(metadataFixture);
       });
 
       it('should return ManagedClassElementMetadata', () => {
@@ -102,10 +101,9 @@ describe(buildManagedMetadataFromMaybeManagedMetadata, () => {
       });
 
       it('should call assertMetadataFromTypescriptIfManaged()', () => {
-        expect(assertMetadataFromTypescriptIfManaged).toHaveBeenCalledTimes(1);
-        expect(assertMetadataFromTypescriptIfManaged).toHaveBeenCalledWith(
-          metadataFixture,
-        );
+        expect(
+          assertMetadataFromTypescriptIfManaged,
+        ).toHaveBeenCalledExactlyOnceWith(metadataFixture);
       });
 
       it('should return ManagedClassElementMetadata with chained property', () => {

--- a/packages/container/libraries/core/src/metadata/calculations/buildUnmanagedMetadataFromMaybeManagedMetadata.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/buildUnmanagedMetadataFromMaybeManagedMetadata.spec.ts
@@ -66,12 +66,9 @@ describe(buildUnmanagedMetadataFromMaybeManagedMetadata, () => {
         });
 
         it('should call assertMetadataFromTypescriptIfManaged()', () => {
-          expect(assertMetadataFromTypescriptIfManaged).toHaveBeenCalledTimes(
-            1,
-          );
-          expect(assertMetadataFromTypescriptIfManaged).toHaveBeenCalledWith(
-            maybeManagedClassElementMetadata,
-          );
+          expect(
+            assertMetadataFromTypescriptIfManaged,
+          ).toHaveBeenCalledExactlyOnceWith(maybeManagedClassElementMetadata);
         });
 
         it('should throw an InversifyCoreError', () => {
@@ -126,15 +123,13 @@ describe(buildUnmanagedMetadataFromMaybeManagedMetadata, () => {
       });
 
       it('should call assertMetadataFromTypescriptIfManaged()', () => {
-        expect(assertMetadataFromTypescriptIfManaged).toHaveBeenCalledTimes(1);
-        expect(assertMetadataFromTypescriptIfManaged).toHaveBeenCalledWith(
-          maybeManagedClassElementMetadata,
-        );
+        expect(
+          assertMetadataFromTypescriptIfManaged,
+        ).toHaveBeenCalledExactlyOnceWith(maybeManagedClassElementMetadata);
       });
 
       it('should call buildDefaultUnmanagedMetadata()', () => {
-        expect(buildDefaultUnmanagedMetadata).toHaveBeenCalledTimes(1);
-        expect(buildDefaultUnmanagedMetadata).toHaveBeenCalledWith();
+        expect(buildDefaultUnmanagedMetadata).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should return UnmanagedClassElementMetadata', () => {

--- a/packages/container/libraries/core/src/metadata/calculations/getClassMetadata.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/getClassMetadata.spec.ts
@@ -60,8 +60,7 @@ describe(getClassMetadata, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         typeFixture,
         classMetadataReflectKey,
       );
@@ -72,8 +71,7 @@ describe(getClassMetadata, () => {
     });
 
     it('should call throwAtInvalidClassMetadata()', () => {
-      expect(throwAtInvalidClassMetadata).toHaveBeenCalledTimes(1);
-      expect(throwAtInvalidClassMetadata).toHaveBeenCalledWith(
+      expect(throwAtInvalidClassMetadata).toHaveBeenCalledExactlyOnceWith(
         typeFixture,
         metadataFixture,
       );
@@ -114,21 +112,18 @@ describe(getClassMetadata, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         typeFixture,
         classMetadataReflectKey,
       );
     });
 
     it('should call getDefaultClassMetadata()', () => {
-      expect(getDefaultClassMetadata).toHaveBeenCalledTimes(1);
-      expect(getDefaultClassMetadata).toHaveBeenCalledWith();
+      expect(getDefaultClassMetadata).toHaveBeenCalledExactlyOnceWith();
     });
 
     it('should call validateConstructorMetadataArray()', () => {
-      expect(validateConstructorMetadataArray).toHaveBeenCalledTimes(1);
-      expect(validateConstructorMetadataArray).toHaveBeenCalledWith(
+      expect(validateConstructorMetadataArray).toHaveBeenCalledExactlyOnceWith(
         typeFixture,
         metadataFixture.constructorArguments,
       );

--- a/packages/container/libraries/core/src/metadata/calculations/handleInjectionError.spec.ts
+++ b/packages/container/libraries/core/src/metadata/calculations/handleInjectionError.spec.ts
@@ -64,8 +64,7 @@ describe(handleInjectionError, () => {
       });
 
       it('should call getDecoratorInfo()', () => {
-        expect(getDecoratorInfo).toHaveBeenCalledTimes(1);
-        expect(getDecoratorInfo).toHaveBeenCalledWith(
+        expect(getDecoratorInfo).toHaveBeenCalledExactlyOnceWith(
           targetFixture,
           propertyKeyFixture,
           parameterIndexFixture,
@@ -73,8 +72,7 @@ describe(handleInjectionError, () => {
       });
 
       it('should call stringifyDecoratorInfo()', () => {
-        expect(stringifyDecoratorInfo).toHaveBeenCalledTimes(1);
-        expect(stringifyDecoratorInfo).toHaveBeenCalledWith(
+        expect(stringifyDecoratorInfo).toHaveBeenCalledExactlyOnceWith(
           decoratorInfoFixture,
         );
       });

--- a/packages/container/libraries/core/src/metadata/decorators/inject.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/inject.spec.ts
@@ -72,18 +72,14 @@ describe(inject, () => {
     it('should call buildManagedMetadataFromMaybeClassElementMetadata()', () => {
       expect(
         buildManagedMetadataFromMaybeClassElementMetadata,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        buildManagedMetadataFromMaybeClassElementMetadata,
-      ).toHaveBeenCalledWith(
+      ).toHaveBeenCalledExactlyOnceWith(
         ClassElementMetadataKind.singleInjection,
         serviceIdentifierFixture,
       );
     });
 
     it('should call injectBase()', () => {
-      expect(injectBase).toHaveBeenCalledTimes(1);
-      expect(injectBase).toHaveBeenCalledWith(
+      expect(injectBase).toHaveBeenCalledExactlyOnceWith(
         updateMetadataMock,
         decrementPendingClassMetadataCount,
       );

--- a/packages/container/libraries/core/src/metadata/decorators/injectBase.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/injectBase.spec.ts
@@ -97,8 +97,7 @@ describe(injectBase, () => {
     });
 
     it('should call updateOwnReflectMetadata()', () => {
-      expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         targetFixture,
         classMetadataReflectKey,
         getDefaultClassMetadata,
@@ -137,8 +136,7 @@ describe(injectBase, () => {
     });
 
     it('should call updateOwnReflectMetadata()', () => {
-      expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         targetFixture,
         classMetadataReflectKey,
         getDefaultClassMetadata,
@@ -212,8 +210,7 @@ Found @inject decorator at method "doSomethingWithFoo" at class "TargetFixture"`
     });
 
     it('should call updateOwnReflectMetadata()', () => {
-      expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         targetFixture,
         classMetadataReflectKey,
         getDefaultClassMetadata,
@@ -257,8 +254,7 @@ Found @inject decorator at method "foo" at class "TargetFixture"`,
     });
 
     it('should call handleInjectionError()', () => {
-      expect(handleInjectionError).toHaveBeenCalledTimes(1);
-      expect(handleInjectionError).toHaveBeenCalledWith(
+      expect(handleInjectionError).toHaveBeenCalledExactlyOnceWith(
         expect.any(Object),
         'foo',
         expect.any(Object),

--- a/packages/container/libraries/core/src/metadata/decorators/injectFrom.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/injectFrom.spec.ts
@@ -38,13 +38,13 @@ describe(injectFrom, () => {
     });
 
     it('should call getClassMetadata()', () => {
-      expect(getClassMetadata).toHaveBeenCalledTimes(1);
-      expect(getClassMetadata).toHaveBeenCalledWith(optionsFixture.type);
+      expect(getClassMetadata).toHaveBeenCalledExactlyOnceWith(
+        optionsFixture.type,
+      );
     });
 
     it('should call updateOwnReflectMetadata()', () => {
-      expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         typeFixture,
         classMetadataReflectKey,
         getDefaultClassMetadata,

--- a/packages/container/libraries/core/src/metadata/decorators/injectFromBase.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/injectFromBase.spec.ts
@@ -59,8 +59,7 @@ describe(injectFromBase, () => {
     });
 
     it('should call getBaseType()', () => {
-      expect(getBaseType).toHaveBeenCalledTimes(1);
-      expect(getBaseType).toHaveBeenCalledWith(targetFixture);
+      expect(getBaseType).toHaveBeenCalledExactlyOnceWith(targetFixture);
     });
 
     it('should call injectFrom()', () => {
@@ -69,11 +68,11 @@ describe(injectFromBase, () => {
         type: baseTypefixture,
       };
 
-      expect(injectFrom).toHaveBeenCalledTimes(1);
-      expect(injectFrom).toHaveBeenCalledWith(expected);
+      expect(injectFrom).toHaveBeenCalledExactlyOnceWith(expected);
 
-      expect(injectFromResultMock).toHaveBeenCalledTimes(1);
-      expect(injectFromResultMock).toHaveBeenCalledWith(targetFixture);
+      expect(injectFromResultMock).toHaveBeenCalledExactlyOnceWith(
+        targetFixture,
+      );
     });
 
     it('should return undefined', () => {
@@ -114,8 +113,7 @@ describe(injectFromBase, () => {
     });
 
     it('should call getBaseType()', () => {
-      expect(getBaseType).toHaveBeenCalledTimes(1);
-      expect(getBaseType).toHaveBeenCalledWith(targetFixture);
+      expect(getBaseType).toHaveBeenCalledExactlyOnceWith(targetFixture);
     });
 
     it('should call injectFrom() with lifecycle options', () => {
@@ -124,11 +122,11 @@ describe(injectFromBase, () => {
         type: baseTypefixture,
       };
 
-      expect(injectFrom).toHaveBeenCalledTimes(1);
-      expect(injectFrom).toHaveBeenCalledWith(expected);
+      expect(injectFrom).toHaveBeenCalledExactlyOnceWith(expected);
 
-      expect(injectFromResultMock).toHaveBeenCalledTimes(1);
-      expect(injectFromResultMock).toHaveBeenCalledWith(targetFixture);
+      expect(injectFromResultMock).toHaveBeenCalledExactlyOnceWith(
+        targetFixture,
+      );
     });
 
     it('should return undefined', () => {
@@ -161,8 +159,7 @@ describe(injectFromBase, () => {
     });
 
     it('should call getBaseType()', () => {
-      expect(getBaseType).toHaveBeenCalledTimes(1);
-      expect(getBaseType).toHaveBeenCalledWith(targetFixture);
+      expect(getBaseType).toHaveBeenCalledExactlyOnceWith(targetFixture);
     });
 
     it('should return undefined', () => {

--- a/packages/container/libraries/core/src/metadata/decorators/injectFromHierarchy.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/injectFromHierarchy.spec.ts
@@ -224,14 +224,14 @@ describe(injectFromHierarchy, () => {
       expect(getBaseType).toHaveBeenNthCalledWith(1, targetFixture);
       expect(getBaseType).toHaveBeenNthCalledWith(2, base1Fixture);
 
-      expect(injectFrom).toHaveBeenCalledTimes(1);
-      expect(injectFrom).toHaveBeenCalledWith({
+      expect(injectFrom).toHaveBeenCalledExactlyOnceWith({
         ...optionsFixture,
         type: base1Fixture,
       } satisfies InjectFromOptions);
 
-      expect(injectFromResultMock).toHaveBeenCalledTimes(1);
-      expect(injectFromResultMock).toHaveBeenCalledWith(targetFixture);
+      expect(injectFromResultMock).toHaveBeenCalledExactlyOnceWith(
+        targetFixture,
+      );
     });
   });
 });

--- a/packages/container/libraries/core/src/metadata/decorators/injectable.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/injectable.spec.ts
@@ -38,15 +38,13 @@ describe(injectable, () => {
       it('should call updateClassMetadataWithTypescriptParameterTypes()', () => {
         expect(
           updateClassMetadataWithTypescriptParameterTypes,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          updateClassMetadataWithTypescriptParameterTypes,
-        ).toHaveBeenCalledWith(targetFixture);
+        ).toHaveBeenCalledExactlyOnceWith(targetFixture);
       });
 
       it('should call setIsInjectableFlag()', () => {
-        expect(setIsInjectableFlag).toHaveBeenCalledTimes(1);
-        expect(setIsInjectableFlag).toHaveBeenCalledWith(targetFixture);
+        expect(setIsInjectableFlag).toHaveBeenCalledExactlyOnceWith(
+          targetFixture,
+        );
       });
 
       it('should not call updateOwnReflectMetadata()', () => {
@@ -80,22 +78,17 @@ describe(injectable, () => {
       });
 
       it('should call setIsInjectableFlag()', () => {
-        expect(setIsInjectableFlag).toHaveBeenCalledTimes(1);
-        expect(setIsInjectableFlag).toHaveBeenCalledWith(Foo);
+        expect(setIsInjectableFlag).toHaveBeenCalledExactlyOnceWith(Foo);
       });
 
       it('should call updateClassMetadataWithTypescriptParameterTypes()', () => {
         expect(
           updateClassMetadataWithTypescriptParameterTypes,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          updateClassMetadataWithTypescriptParameterTypes,
-        ).toHaveBeenCalledWith(Foo);
+        ).toHaveBeenCalledExactlyOnceWith(Foo);
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           Foo,
           classMetadataReflectKey,
           getDefaultClassMetadata,

--- a/packages/container/libraries/core/src/metadata/decorators/multiInject.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/multiInject.spec.ts
@@ -73,10 +73,7 @@ describe(multiInject, () => {
     it('should call buildManagedMetadataFromMaybeClassElementMetadata()', () => {
       expect(
         buildManagedMetadataFromMaybeClassElementMetadata,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        buildManagedMetadataFromMaybeClassElementMetadata,
-      ).toHaveBeenCalledWith(
+      ).toHaveBeenCalledExactlyOnceWith(
         ClassElementMetadataKind.multipleInjection,
         serviceIdentifierFixture,
         undefined,
@@ -84,8 +81,7 @@ describe(multiInject, () => {
     });
 
     it('should call injectBase()', () => {
-      expect(injectBase).toHaveBeenCalledTimes(1);
-      expect(injectBase).toHaveBeenCalledWith(
+      expect(injectBase).toHaveBeenCalledExactlyOnceWith(
         updateMetadataMock,
         decrementPendingClassMetadataCount,
       );
@@ -144,10 +140,7 @@ describe(multiInject, () => {
     it('should call buildManagedMetadataFromMaybeClassElementMetadata() with options', () => {
       expect(
         buildManagedMetadataFromMaybeClassElementMetadata,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        buildManagedMetadataFromMaybeClassElementMetadata,
-      ).toHaveBeenCalledWith(
+      ).toHaveBeenCalledExactlyOnceWith(
         ClassElementMetadataKind.multipleInjection,
         serviceIdentifierFixture,
         optionsFixture,
@@ -155,8 +148,7 @@ describe(multiInject, () => {
     });
 
     it('should call injectBase()', () => {
-      expect(injectBase).toHaveBeenCalledTimes(1);
-      expect(injectBase).toHaveBeenCalledWith(
+      expect(injectBase).toHaveBeenCalledExactlyOnceWith(
         updateMetadataMock,
         decrementPendingClassMetadataCount,
       );

--- a/packages/container/libraries/core/src/metadata/decorators/named.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/named.spec.ts
@@ -70,15 +70,11 @@ describe(named, () => {
     it('should call buildMaybeClassElementMetadataFromMaybeClassElementMetadata()', () => {
       expect(
         buildMaybeClassElementMetadataFromMaybeClassElementMetadata,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        buildMaybeClassElementMetadataFromMaybeClassElementMetadata,
-      ).toHaveBeenCalledWith(expect.any(Function));
+      ).toHaveBeenCalledExactlyOnceWith(expect.any(Function));
     });
 
     it('should call injectBase()', () => {
-      expect(injectBase).toHaveBeenCalledTimes(1);
-      expect(injectBase).toHaveBeenCalledWith(
+      expect(injectBase).toHaveBeenCalledExactlyOnceWith(
         updateMetadataMock,
         incrementPendingClassMetadataCount,
       );

--- a/packages/container/libraries/core/src/metadata/decorators/optional.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/optional.spec.ts
@@ -64,15 +64,11 @@ describe(optional, () => {
     it('should call buildMaybeClassElementMetadataFromMaybeClassElementMetadata()', () => {
       expect(
         buildMaybeClassElementMetadataFromMaybeClassElementMetadata,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        buildMaybeClassElementMetadataFromMaybeClassElementMetadata,
-      ).toHaveBeenCalledWith(expect.any(Function));
+      ).toHaveBeenCalledExactlyOnceWith(expect.any(Function));
     });
 
     it('should call injectBase()', () => {
-      expect(injectBase).toHaveBeenCalledTimes(1);
-      expect(injectBase).toHaveBeenCalledWith(
+      expect(injectBase).toHaveBeenCalledExactlyOnceWith(
         updateMetadataMock,
         incrementPendingClassMetadataCount,
       );

--- a/packages/container/libraries/core/src/metadata/decorators/postConstruct.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/postConstruct.spec.ts
@@ -59,15 +59,13 @@ describe(postConstruct, () => {
     });
 
     it('should call updateMaybeClassMetadataPostConstructor()', () => {
-      expect(updateMaybeClassMetadataPostConstructor).toHaveBeenCalledTimes(1);
-      expect(updateMaybeClassMetadataPostConstructor).toHaveBeenCalledWith(
-        propertyKeyFixture,
-      );
+      expect(
+        updateMaybeClassMetadataPostConstructor,
+      ).toHaveBeenCalledExactlyOnceWith(propertyKeyFixture);
     });
 
     it('should call updateOwnReflectMetadata()', () => {
-      expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         targetFixture.constructor,
         classMetadataReflectKey,
         getDefaultClassMetadata,
@@ -114,15 +112,13 @@ describe(postConstruct, () => {
     });
 
     it('should call updateMaybeClassMetadataPostConstructor()', () => {
-      expect(updateMaybeClassMetadataPostConstructor).toHaveBeenCalledTimes(1);
-      expect(updateMaybeClassMetadataPostConstructor).toHaveBeenCalledWith(
-        propertyKeyFixture,
-      );
+      expect(
+        updateMaybeClassMetadataPostConstructor,
+      ).toHaveBeenCalledExactlyOnceWith(propertyKeyFixture);
     });
 
     it('should call updateOwnReflectMetadata()', () => {
-      expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         targetFixture.constructor,
         classMetadataReflectKey,
         getDefaultClassMetadata,
@@ -131,8 +127,7 @@ describe(postConstruct, () => {
     });
 
     it('should call handleInjectionError', () => {
-      expect(handleInjectionError).toHaveBeenCalledTimes(1);
-      expect(handleInjectionError).toHaveBeenCalledWith(
+      expect(handleInjectionError).toHaveBeenCalledExactlyOnceWith(
         targetFixture,
         propertyKeyFixture,
         undefined,

--- a/packages/container/libraries/core/src/metadata/decorators/preDestroy.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/preDestroy.spec.ts
@@ -59,15 +59,13 @@ describe(preDestroy, () => {
     });
 
     it('should call updateMaybeClassMetadataPreDestroy()', () => {
-      expect(updateMaybeClassMetadataPreDestroy).toHaveBeenCalledTimes(1);
-      expect(updateMaybeClassMetadataPreDestroy).toHaveBeenCalledWith(
-        propertyKeyFixture,
-      );
+      expect(
+        updateMaybeClassMetadataPreDestroy,
+      ).toHaveBeenCalledExactlyOnceWith(propertyKeyFixture);
     });
 
     it('should call updateOwnReflectMetadata()', () => {
-      expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         targetFixture.constructor,
         classMetadataReflectKey,
         getDefaultClassMetadata,
@@ -114,15 +112,13 @@ describe(preDestroy, () => {
     });
 
     it('should call updateMaybeClassMetadataPreDestroy()', () => {
-      expect(updateMaybeClassMetadataPreDestroy).toHaveBeenCalledTimes(1);
-      expect(updateMaybeClassMetadataPreDestroy).toHaveBeenCalledWith(
-        propertyKeyFixture,
-      );
+      expect(
+        updateMaybeClassMetadataPreDestroy,
+      ).toHaveBeenCalledExactlyOnceWith(propertyKeyFixture);
     });
 
     it('should call updateOwnReflectMetadata()', () => {
-      expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         targetFixture.constructor,
         classMetadataReflectKey,
         getDefaultClassMetadata,
@@ -131,8 +127,7 @@ describe(preDestroy, () => {
     });
 
     it('should call handleInjectionError', () => {
-      expect(handleInjectionError).toHaveBeenCalledTimes(1);
-      expect(handleInjectionError).toHaveBeenCalledWith(
+      expect(handleInjectionError).toHaveBeenCalledExactlyOnceWith(
         targetFixture,
         propertyKeyFixture,
         undefined,

--- a/packages/container/libraries/core/src/metadata/decorators/tagged.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/tagged.spec.ts
@@ -72,15 +72,11 @@ describe(tagged, () => {
     it('should call buildMaybeClassElementMetadataFromMaybeClassElementMetadata()', () => {
       expect(
         buildMaybeClassElementMetadataFromMaybeClassElementMetadata,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        buildMaybeClassElementMetadataFromMaybeClassElementMetadata,
-      ).toHaveBeenCalledWith(expect.any(Function));
+      ).toHaveBeenCalledExactlyOnceWith(expect.any(Function));
     });
 
     it('should call injectBase()', () => {
-      expect(injectBase).toHaveBeenCalledTimes(1);
-      expect(injectBase).toHaveBeenCalledWith(
+      expect(injectBase).toHaveBeenCalledExactlyOnceWith(
         updateMetadataMock,
         incrementPendingClassMetadataCount,
       );

--- a/packages/container/libraries/core/src/metadata/decorators/unmanaged.spec.ts
+++ b/packages/container/libraries/core/src/metadata/decorators/unmanaged.spec.ts
@@ -63,15 +63,11 @@ describe(unmanaged, () => {
     it('should call buildUnmanagedMetadataFromMaybeClassElementMetadata()', () => {
       expect(
         buildUnmanagedMetadataFromMaybeClassElementMetadata,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        buildUnmanagedMetadataFromMaybeClassElementMetadata,
-      ).toHaveBeenCalledWith();
+      ).toHaveBeenCalledExactlyOnceWith();
     });
 
     it('should call injectBase()', () => {
-      expect(injectBase).toHaveBeenCalledTimes(1);
-      expect(injectBase).toHaveBeenCalledWith(
+      expect(injectBase).toHaveBeenCalledExactlyOnceWith(
         updateMetadataMock,
         decrementPendingClassMetadataCount,
       );

--- a/packages/container/libraries/core/src/planning/actions/addRootServiceNodeBindingIfContextFree.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/addRootServiceNodeBindingIfContextFree.spec.ts
@@ -167,8 +167,9 @@ describe(addRootServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call addServiceNodeBindingIfContextFree()', () => {
-        expect(addServiceNodeBindingIfContextFree).toHaveBeenCalledTimes(1);
-        expect(addServiceNodeBindingIfContextFree).toHaveBeenCalledWith(
+        expect(
+          addServiceNodeBindingIfContextFree,
+        ).toHaveBeenCalledExactlyOnceWith(
           paramsFixture,
           lazyPlanServiceNodeFixture,
           bindingMock,

--- a/packages/container/libraries/core/src/planning/actions/addServiceNodeBindingIfContextFree.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/addServiceNodeBindingIfContextFree.spec.ts
@@ -170,8 +170,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call binding.isSatisfiedBy()', () => {
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledExactlyOnceWith(
           new BindingConstraintsImplementation(
             bindingConstraintsListFixture.last,
           ),
@@ -179,8 +178,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call buildServiceNodeBindings()', () => {
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledTimes(1);
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledWith(
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledExactlyOnceWith(
           paramsFixture,
           bindingConstraintsListFixture,
           [bindingMock],
@@ -190,10 +188,9 @@ describe(addServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call isStackOverflowError()', () => {
-        expect(vitest.mocked(isStackOverflowError)).toHaveBeenCalledTimes(1);
-        expect(vitest.mocked(isStackOverflowError)).toHaveBeenCalledWith(
-          expect.any(Error),
-        );
+        expect(
+          vitest.mocked(isStackOverflowError),
+        ).toHaveBeenCalledExactlyOnceWith(expect.any(Error));
       });
 
       it('should return expected value', () => {
@@ -250,8 +247,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call binding.isSatisfiedBy()', () => {
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledExactlyOnceWith(
           new BindingConstraintsImplementation(
             bindingConstraintsListFixture.last,
           ),
@@ -259,8 +255,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call buildServiceNodeBindings()', () => {
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledTimes(1);
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledWith(
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledExactlyOnceWith(
           paramsFixture,
           bindingConstraintsListFixture,
           [bindingMock],
@@ -270,8 +265,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call isStackOverflowError()', () => {
-        expect(vitest.mocked(isStackOverflowError)).toHaveBeenCalledTimes(1);
-        expect(vitest.mocked(isStackOverflowError)).toHaveBeenCalledWith(
+        expect(isStackOverflowError).toHaveBeenCalledExactlyOnceWith(
           expect.any(Error),
         );
       });
@@ -393,8 +387,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call binding.isSatisfiedBy()', () => {
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledExactlyOnceWith(
           new BindingConstraintsImplementation(
             bindingConstraintsListFixture.last,
           ),
@@ -440,8 +433,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call binding.isSatisfiedBy()', () => {
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledExactlyOnceWith(
           new BindingConstraintsImplementation(
             bindingConstraintsListFixture.last,
           ),
@@ -449,8 +441,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call buildServiceNodeBindings()', () => {
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledTimes(1);
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledWith(
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledExactlyOnceWith(
           paramsFixture,
           bindingConstraintsListFixture,
           [bindingMock],
@@ -543,8 +534,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call binding.isSatisfiedBy()', () => {
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledExactlyOnceWith(
           new BindingConstraintsImplementation(
             bindingConstraintsListFixture.last,
           ),
@@ -643,8 +633,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call binding.isSatisfiedBy()', () => {
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledExactlyOnceWith(
           new BindingConstraintsImplementation(
             bindingConstraintsListFixture.last,
           ),
@@ -652,8 +641,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call buildServiceNodeBindings()', () => {
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledTimes(1);
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledWith(
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledExactlyOnceWith(
           paramsFixture,
           bindingConstraintsListFixture,
           [bindingMock],
@@ -754,8 +742,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call binding.isSatisfiedBy()', () => {
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledExactlyOnceWith(
           new BindingConstraintsImplementation(
             bindingConstraintsListFixture.last,
           ),
@@ -763,8 +750,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call buildServiceNodeBindings()', () => {
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledTimes(1);
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledWith(
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledExactlyOnceWith(
           paramsFixture,
           bindingConstraintsListFixture,
           [bindingMock],
@@ -865,8 +851,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call binding.isSatisfiedBy()', () => {
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledExactlyOnceWith(
           new BindingConstraintsImplementation(
             bindingConstraintsListFixture.last,
           ),
@@ -874,8 +859,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call buildServiceNodeBindings()', () => {
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledTimes(1);
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledWith(
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledExactlyOnceWith(
           paramsFixture,
           bindingConstraintsListFixture,
           [bindingMock],

--- a/packages/container/libraries/core/src/planning/actions/cacheNonRootPlanServiceNode.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/cacheNonRootPlanServiceNode.spec.ts
@@ -73,8 +73,9 @@ describe(cacheNonRootPlanServiceNode, () => {
       });
 
       it('should call operations.setNonCachedServiceNode()', () => {
-        expect(operationsMock.setNonCachedServiceNode).toHaveBeenCalledTimes(1);
-        expect(operationsMock.setNonCachedServiceNode).toHaveBeenCalledWith(
+        expect(
+          operationsMock.setNonCachedServiceNode,
+        ).toHaveBeenCalledExactlyOnceWith(
           planServiceNodeFixture,
           contextFixture,
         );
@@ -118,8 +119,9 @@ describe(cacheNonRootPlanServiceNode, () => {
       });
 
       it('should call operations.setNonCachedServiceNode()', () => {
-        expect(operationsMock.setNonCachedServiceNode).toHaveBeenCalledTimes(1);
-        expect(operationsMock.setNonCachedServiceNode).toHaveBeenCalledWith(
+        expect(
+          operationsMock.setNonCachedServiceNode,
+        ).toHaveBeenCalledExactlyOnceWith(
           planServiceNodeFixture,
           contextFixture,
         );
@@ -163,8 +165,7 @@ describe(cacheNonRootPlanServiceNode, () => {
       });
 
       it('should call operations.setPlan()', () => {
-        expect(operationsMock.setPlan).toHaveBeenCalledTimes(1);
-        expect(operationsMock.setPlan).toHaveBeenCalledWith(
+        expect(operationsMock.setPlan).toHaveBeenCalledExactlyOnceWith(
           getPlanOptionsFixture,
           {
             tree: {
@@ -212,8 +213,7 @@ describe(cacheNonRootPlanServiceNode, () => {
       });
 
       it('should call operations.setPlan()', () => {
-        expect(operationsMock.setPlan).toHaveBeenCalledTimes(1);
-        expect(operationsMock.setPlan).toHaveBeenCalledWith(
+        expect(operationsMock.setPlan).toHaveBeenCalledExactlyOnceWith(
           getPlanOptionsFixture,
           {
             tree: {

--- a/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNode.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNode.spec.ts
@@ -99,15 +99,13 @@ describe(curryBuildPlanServiceNode, () => {
       });
 
       it('should call buildPlanBindingConstraintsList()', () => {
-        expect(buildPlanBindingConstraintsList).toHaveBeenCalledTimes(1);
-        expect(buildPlanBindingConstraintsList).toHaveBeenCalledWith(
+        expect(buildPlanBindingConstraintsList).toHaveBeenCalledExactlyOnceWith(
           planParamsFixture,
         );
       });
 
       it('should call buildFilteredServiceBindings()', () => {
-        expect(buildFilteredServiceBindings).toHaveBeenCalledTimes(1);
-        expect(buildFilteredServiceBindings).toHaveBeenCalledWith(
+        expect(buildFilteredServiceBindings).toHaveBeenCalledExactlyOnceWith(
           planParamsFixture,
           new BindingConstraintsImplementation(
             bindingConstraintsListFixture.last,
@@ -124,8 +122,7 @@ describe(curryBuildPlanServiceNode, () => {
             planParamsFixture.rootConstraints.serviceIdentifier,
         };
 
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledTimes(1);
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledWith(
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledExactlyOnceWith(
           planParamsFixture,
           bindingConstraintsListFixture,
           bindingsFixture,
@@ -201,15 +198,13 @@ describe(curryBuildPlanServiceNode, () => {
       });
 
       it('should call buildPlanBindingConstraintsList()', () => {
-        expect(buildPlanBindingConstraintsList).toHaveBeenCalledTimes(1);
-        expect(buildPlanBindingConstraintsList).toHaveBeenCalledWith(
+        expect(buildPlanBindingConstraintsList).toHaveBeenCalledExactlyOnceWith(
           planParamsFixture,
         );
       });
 
       it('should call buildFilteredServiceBindings()', () => {
-        expect(buildFilteredServiceBindings).toHaveBeenCalledTimes(1);
-        expect(buildFilteredServiceBindings).toHaveBeenCalledWith(
+        expect(buildFilteredServiceBindings).toHaveBeenCalledExactlyOnceWith(
           planParamsFixture,
           new BindingConstraintsImplementation(
             bindingConstraintsListFixture.last,
@@ -226,8 +221,7 @@ describe(curryBuildPlanServiceNode, () => {
             planParamsFixture.rootConstraints.serviceIdentifier,
         };
 
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledTimes(1);
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledWith(
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledExactlyOnceWith(
           planParamsFixture,
           bindingConstraintsListFixture,
           bindingsFixture,
@@ -244,10 +238,9 @@ describe(curryBuildPlanServiceNode, () => {
             planParamsFixture.rootConstraints.serviceIdentifier,
         };
 
-        expect(checkServiceNodeSingleInjectionBindings).toHaveBeenCalledTimes(
-          1,
-        );
-        expect(checkServiceNodeSingleInjectionBindings).toHaveBeenCalledWith(
+        expect(
+          checkServiceNodeSingleInjectionBindings,
+        ).toHaveBeenCalledExactlyOnceWith(
           expectedServiceNode,
           false,
           bindingConstraintsListFixture.last,

--- a/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNodeFromClassElementMetadata.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNodeFromClassElementMetadata.spec.ts
@@ -93,8 +93,7 @@ describe(curryBuildPlanServiceNodeFromClassElementMetadata, () => {
       });
 
       it('should call buildFilteredServiceBindings()', () => {
-        expect(buildFilteredServiceBindings).toHaveBeenCalledTimes(1);
-        expect(buildFilteredServiceBindings).toHaveBeenCalledWith(
+        expect(buildFilteredServiceBindings).toHaveBeenCalledExactlyOnceWith(
           paramsFixture,
           expect.any(BindingConstraintsImplementation),
           { chained: elementMetadataFixture.chained },
@@ -108,8 +107,7 @@ describe(curryBuildPlanServiceNodeFromClassElementMetadata, () => {
           serviceIdentifier: elementMetadataFixture.value as ServiceIdentifier,
         };
 
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledTimes(1);
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledWith(
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledExactlyOnceWith(
           paramsFixture,
           new SingleImmutableLinkedList({
             elem: {
@@ -181,8 +179,7 @@ describe(curryBuildPlanServiceNodeFromClassElementMetadata, () => {
       });
 
       it('should call buildFilteredServiceBindings()', () => {
-        expect(buildFilteredServiceBindings).toHaveBeenCalledTimes(1);
-        expect(buildFilteredServiceBindings).toHaveBeenCalledWith(
+        expect(buildFilteredServiceBindings).toHaveBeenCalledExactlyOnceWith(
           paramsFixture,
           expect.any(BindingConstraintsImplementation),
           { chained: false },
@@ -196,8 +193,7 @@ describe(curryBuildPlanServiceNodeFromClassElementMetadata, () => {
           serviceIdentifier: elementMetadataFixture.value as ServiceIdentifier,
         };
 
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledTimes(1);
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledWith(
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledExactlyOnceWith(
           paramsFixture,
           new SingleImmutableLinkedList({
             elem: {
@@ -232,10 +228,9 @@ describe(curryBuildPlanServiceNodeFromClassElementMetadata, () => {
             previous: bindingConstraintsListFixture.last,
           };
 
-        expect(checkServiceNodeSingleInjectionBindings).toHaveBeenCalledTimes(
-          1,
-        );
-        expect(checkServiceNodeSingleInjectionBindings).toHaveBeenCalledWith(
+        expect(
+          checkServiceNodeSingleInjectionBindings,
+        ).toHaveBeenCalledExactlyOnceWith(
           expectedServiceNode,
           elementMetadataFixture.optional,
           expectedBindingConstraintsListNode,

--- a/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNodeFromResolvedValueElementMetadata.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNodeFromResolvedValueElementMetadata.spec.ts
@@ -93,8 +93,7 @@ describe(curryBuildPlanServiceNodeFromResolvedValueElementMetadata, () => {
       });
 
       it('should call buildFilteredServiceBindings()', () => {
-        expect(buildFilteredServiceBindings).toHaveBeenCalledTimes(1);
-        expect(buildFilteredServiceBindings).toHaveBeenCalledWith(
+        expect(buildFilteredServiceBindings).toHaveBeenCalledExactlyOnceWith(
           paramsFixture,
           expect.any(BindingConstraintsImplementation),
           { chained: elementMetadataFixture.chained },
@@ -108,8 +107,7 @@ describe(curryBuildPlanServiceNodeFromResolvedValueElementMetadata, () => {
           serviceIdentifier: elementMetadataFixture.value as ServiceIdentifier,
         };
 
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledTimes(1);
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledWith(
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledExactlyOnceWith(
           paramsFixture,
           new SingleImmutableLinkedList({
             elem: {
@@ -181,8 +179,7 @@ describe(curryBuildPlanServiceNodeFromResolvedValueElementMetadata, () => {
       });
 
       it('should call buildFilteredServiceBindings()', () => {
-        expect(buildFilteredServiceBindings).toHaveBeenCalledTimes(1);
-        expect(buildFilteredServiceBindings).toHaveBeenCalledWith(
+        expect(buildFilteredServiceBindings).toHaveBeenCalledExactlyOnceWith(
           paramsFixture,
           expect.any(BindingConstraintsImplementation),
           { chained: false },
@@ -196,8 +193,7 @@ describe(curryBuildPlanServiceNodeFromResolvedValueElementMetadata, () => {
           serviceIdentifier: elementMetadataFixture.value as ServiceIdentifier,
         };
 
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledTimes(1);
-        expect(buildServiceNodeBindingsMock).toHaveBeenCalledWith(
+        expect(buildServiceNodeBindingsMock).toHaveBeenCalledExactlyOnceWith(
           paramsFixture,
           new SingleImmutableLinkedList({
             elem: {
@@ -232,10 +228,9 @@ describe(curryBuildPlanServiceNodeFromResolvedValueElementMetadata, () => {
             previous: bindingConstraintsListFixture.last,
           };
 
-        expect(checkServiceNodeSingleInjectionBindings).toHaveBeenCalledTimes(
-          1,
-        );
-        expect(checkServiceNodeSingleInjectionBindings).toHaveBeenCalledWith(
+        expect(
+          checkServiceNodeSingleInjectionBindings,
+        ).toHaveBeenCalledExactlyOnceWith(
           expectedServiceNode,
           elementMetadataFixture.optional,
           expectedBindingConstraintsListNode,

--- a/packages/container/libraries/core/src/planning/actions/curryBuildServiceNodeBindings.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildServiceNodeBindings.spec.ts
@@ -110,10 +110,9 @@ describe(curryBuildServiceNodeBindings, () => {
       it('should call getClassMetadata()', () => {
         expect(
           basePlanParamsMock.operations.getClassMetadata,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          basePlanParamsMock.operations.getClassMetadata,
-        ).toHaveBeenCalledWith(instanceBindingFixture.implementationType);
+        ).toHaveBeenCalledExactlyOnceWith(
+          instanceBindingFixture.implementationType,
+        );
       });
 
       it('should call subplan with correct params', () => {
@@ -129,8 +128,7 @@ describe(curryBuildServiceNodeBindings, () => {
           servicesBranch: basePlanParamsMock.servicesBranch,
         };
 
-        expect(subplanMock).toHaveBeenCalledTimes(1);
-        expect(subplanMock).toHaveBeenCalledWith(
+        expect(subplanMock).toHaveBeenCalledExactlyOnceWith(
           expectedSubplanParams,
           bindingConstraintsListFixture,
         );
@@ -208,8 +206,7 @@ describe(curryBuildServiceNodeBindings, () => {
           servicesBranch: basePlanParamsMock.servicesBranch,
         };
 
-        expect(subplanMock).toHaveBeenCalledTimes(1);
-        expect(subplanMock).toHaveBeenCalledWith(
+        expect(subplanMock).toHaveBeenCalledExactlyOnceWith(
           expectedSubplanParams,
           bindingConstraintsListFixture,
         );
@@ -284,8 +281,7 @@ describe(curryBuildServiceNodeBindings, () => {
             bindingConstraintsListFixture.last,
           );
 
-        expect(buildFilteredServiceBindings).toHaveBeenCalledTimes(1);
-        expect(buildFilteredServiceBindings).toHaveBeenCalledWith(
+        expect(buildFilteredServiceBindings).toHaveBeenCalledExactlyOnceWith(
           basePlanParamsMock,
           expectedBindingConstraints,
           {

--- a/packages/container/libraries/core/src/planning/actions/curryLazyBuildPlanServiceNodeFromClassElementMetadata.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryLazyBuildPlanServiceNodeFromClassElementMetadata.spec.ts
@@ -85,10 +85,7 @@ describe(curryLazyBuildPlanServiceNodeFromClassElementMetadata, () => {
     it('should call curryBuildPlanServiceNodeFromClassElementMetadata()', () => {
       expect(
         curryBuildPlanServiceNodeFromClassElementMetadata,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        curryBuildPlanServiceNodeFromClassElementMetadata,
-      ).toHaveBeenCalledWith(buildServiceNodeBindingsFixture);
+      ).toHaveBeenCalledExactlyOnceWith(buildServiceNodeBindingsFixture);
     });
 
     it('should return a PlanServiceNode', () => {
@@ -138,10 +135,7 @@ describe(curryLazyBuildPlanServiceNodeFromClassElementMetadata, () => {
     it('should call curryBuildPlanServiceNodeFromClassElementMetadata()', () => {
       expect(
         curryBuildPlanServiceNodeFromClassElementMetadata,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        curryBuildPlanServiceNodeFromClassElementMetadata,
-      ).toHaveBeenCalledWith(buildServiceNodeBindingsFixture);
+      ).toHaveBeenCalledExactlyOnceWith(buildServiceNodeBindingsFixture);
     });
 
     it('should throw an Error', () => {
@@ -190,10 +184,7 @@ describe(curryLazyBuildPlanServiceNodeFromClassElementMetadata, () => {
     it('should call curryBuildPlanServiceNodeFromClassElementMetadata()', () => {
       expect(
         curryBuildPlanServiceNodeFromClassElementMetadata,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        curryBuildPlanServiceNodeFromClassElementMetadata,
-      ).toHaveBeenCalledWith(buildServiceNodeBindingsFixture);
+      ).toHaveBeenCalledExactlyOnceWith(buildServiceNodeBindingsFixture);
     });
 
     it('should return undefined', () => {

--- a/packages/container/libraries/core/src/planning/actions/curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata.spec.ts
@@ -87,10 +87,7 @@ describe(curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata, () => {
     it('should call curryBuildPlanServiceNodeFromResolvedValueElementMetadata()', () => {
       expect(
         curryBuildPlanServiceNodeFromResolvedValueElementMetadata,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        curryBuildPlanServiceNodeFromResolvedValueElementMetadata,
-      ).toHaveBeenCalledWith(buildServiceNodeBindingsFixture);
+      ).toHaveBeenCalledExactlyOnceWith(buildServiceNodeBindingsFixture);
     });
 
     it('should return a PlanServiceNode', () => {
@@ -142,10 +139,7 @@ describe(curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata, () => {
     it('should call curryBuildPlanServiceNodeFromResolvedValueElementMetadata()', () => {
       expect(
         curryBuildPlanServiceNodeFromResolvedValueElementMetadata,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        curryBuildPlanServiceNodeFromResolvedValueElementMetadata,
-      ).toHaveBeenCalledWith(buildServiceNodeBindingsFixture);
+      ).toHaveBeenCalledExactlyOnceWith(buildServiceNodeBindingsFixture);
     });
 
     it('should throw an Error', () => {
@@ -196,10 +190,7 @@ describe(curryLazyBuildPlanServiceNodeFromResolvedValueElementMetadata, () => {
     it('should call curryBuildPlanServiceNodeFromResolvedValueElementMetadata()', () => {
       expect(
         curryBuildPlanServiceNodeFromResolvedValueElementMetadata,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        curryBuildPlanServiceNodeFromResolvedValueElementMetadata,
-      ).toHaveBeenCalledWith(buildServiceNodeBindingsFixture);
+      ).toHaveBeenCalledExactlyOnceWith(buildServiceNodeBindingsFixture);
     });
 
     it('should return undefined', () => {

--- a/packages/container/libraries/core/src/planning/actions/currySubplan.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/currySubplan.spec.ts
@@ -182,10 +182,7 @@ describe(currySubplan, () => {
       it('should call tryBuildGetPlanOptionsFromManagedClassElementMetadata()', () => {
         expect(
           tryBuildGetPlanOptionsFromManagedClassElementMetadata,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           instanceBindingNodeFixture.classMetadata.constructorArguments[0],
         );
       });
@@ -193,10 +190,7 @@ describe(currySubplan, () => {
       it('should call buildPlanServiceNodeFromClassElementMetadata()', () => {
         expect(
           buildPlanServiceNodeFromClassElementMetadataMock,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          buildPlanServiceNodeFromClassElementMetadataMock,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           subplanParamsMock,
           bindingConstraintsListFixture,
           instanceBindingNodeFixture.classMetadata.constructorArguments[0],
@@ -204,8 +198,7 @@ describe(currySubplan, () => {
       });
 
       it('should call cacheNonRootPlanServiceNode()', () => {
-        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledTimes(1);
-        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledWith(
+        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledExactlyOnceWith(
           undefined,
           subplanParamsMock.operations,
           expect.any(LazyPlanServiceNode),
@@ -256,28 +249,21 @@ describe(currySubplan, () => {
       it('should call tryBuildGetPlanOptionsFromManagedClassElementMetadata()', () => {
         expect(
           tryBuildGetPlanOptionsFromManagedClassElementMetadata,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           instanceBindingNodeFixture.classMetadata.constructorArguments[0],
         );
       });
 
       it('should call operations.getPlan()', () => {
-        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledTimes(1);
-        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledWith(
-          getPlanOptionsFixture,
-        );
+        expect(
+          subplanParamsMock.operations.getPlan,
+        ).toHaveBeenCalledExactlyOnceWith(getPlanOptionsFixture);
       });
 
       it('should call buildPlanServiceNodeFromClassElementMetadata()', () => {
         expect(
           buildPlanServiceNodeFromClassElementMetadataMock,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          buildPlanServiceNodeFromClassElementMetadataMock,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           subplanParamsMock,
           bindingConstraintsListFixture,
           instanceBindingNodeFixture.classMetadata.constructorArguments[0],
@@ -285,8 +271,7 @@ describe(currySubplan, () => {
       });
 
       it('should call cacheNonRootPlanServiceNode()', () => {
-        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledTimes(1);
-        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledWith(
+        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledExactlyOnceWith(
           getPlanOptionsFixture,
           subplanParamsMock.operations,
           expect.any(LazyPlanServiceNode),
@@ -352,19 +337,15 @@ describe(currySubplan, () => {
       it('should call tryBuildGetPlanOptionsFromManagedClassElementMetadata()', () => {
         expect(
           tryBuildGetPlanOptionsFromManagedClassElementMetadata,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           instanceBindingNodeFixture.classMetadata.constructorArguments[0],
         );
       });
 
       it('should call operations.getPlan()', () => {
-        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledTimes(1);
-        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledWith(
-          getPlanOptionsFixture,
-        );
+        expect(
+          subplanParamsMock.operations.getPlan,
+        ).toHaveBeenCalledExactlyOnceWith(getPlanOptionsFixture);
       });
 
       it('should not call buildPlanServiceNodeFromClassElementMetadata()', () => {
@@ -431,28 +412,21 @@ describe(currySubplan, () => {
       it('should call tryBuildGetPlanOptionsFromManagedClassElementMetadata()', () => {
         expect(
           tryBuildGetPlanOptionsFromManagedClassElementMetadata,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           instanceBindingNodeFixture.classMetadata.constructorArguments[0],
         );
       });
 
       it('should call operations.getPlan()', () => {
-        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledTimes(1);
-        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledWith(
-          getPlanOptionsFixture,
-        );
+        expect(
+          subplanParamsMock.operations.getPlan,
+        ).toHaveBeenCalledExactlyOnceWith(getPlanOptionsFixture);
       });
 
       it('should call buildPlanServiceNodeFromClassElementMetadata()', () => {
         expect(
           buildPlanServiceNodeFromClassElementMetadataMock,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          buildPlanServiceNodeFromClassElementMetadataMock,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           subplanParamsMock,
           bindingConstraintsListFixture,
           instanceBindingNodeFixture.classMetadata.constructorArguments[0],
@@ -460,8 +434,7 @@ describe(currySubplan, () => {
       });
 
       it('should call cacheNonRootPlanServiceNode()', () => {
-        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledTimes(1);
-        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledWith(
+        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledExactlyOnceWith(
           getPlanOptionsFixture,
           subplanParamsMock.operations,
           expect.any(LazyPlanServiceNode),
@@ -537,10 +510,7 @@ describe(currySubplan, () => {
 
         expect(
           tryBuildGetPlanOptionsFromManagedClassElementMetadata,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           instanceBindingNodeFixture.classMetadata.properties.get(property),
         );
       });
@@ -552,10 +522,7 @@ describe(currySubplan, () => {
 
         expect(
           buildPlanServiceNodeFromClassElementMetadataMock,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          buildPlanServiceNodeFromClassElementMetadataMock,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           subplanParamsMock,
           bindingConstraintsListFixture,
           instanceBindingNodeFixture.classMetadata.properties.get(property),
@@ -563,8 +530,7 @@ describe(currySubplan, () => {
       });
 
       it('should call cacheNonRootPlanServiceNode()', () => {
-        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledTimes(1);
-        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledWith(
+        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledExactlyOnceWith(
           undefined,
           subplanParamsMock.operations,
           expect.any(LazyPlanServiceNode),
@@ -619,19 +585,15 @@ describe(currySubplan, () => {
 
         expect(
           tryBuildGetPlanOptionsFromManagedClassElementMetadata,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           instanceBindingNodeFixture.classMetadata.properties.get(property),
         );
       });
 
       it('should call operations.getPlan()', () => {
-        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledTimes(1);
-        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledWith(
-          getPlanOptionsFixture,
-        );
+        expect(
+          subplanParamsMock.operations.getPlan,
+        ).toHaveBeenCalledExactlyOnceWith(getPlanOptionsFixture);
       });
 
       it('should call buildPlanServiceNodeFromClassElementMetadata()', () => {
@@ -641,10 +603,7 @@ describe(currySubplan, () => {
 
         expect(
           buildPlanServiceNodeFromClassElementMetadataMock,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          buildPlanServiceNodeFromClassElementMetadataMock,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           subplanParamsMock,
           bindingConstraintsListFixture,
           instanceBindingNodeFixture.classMetadata.properties.get(property),
@@ -652,8 +611,7 @@ describe(currySubplan, () => {
       });
 
       it('should call cacheNonRootPlanServiceNode()', () => {
-        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledTimes(1);
-        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledWith(
+        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledExactlyOnceWith(
           getPlanOptionsFixture,
           subplanParamsMock.operations,
           expect.any(LazyPlanServiceNode),
@@ -723,19 +681,15 @@ describe(currySubplan, () => {
 
         expect(
           tryBuildGetPlanOptionsFromManagedClassElementMetadata,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           instanceBindingNodeFixture.classMetadata.properties.get(property),
         );
       });
 
       it('should call operations.getPlan()', () => {
-        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledTimes(1);
-        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledWith(
-          getPlanOptionsFixture,
-        );
+        expect(
+          subplanParamsMock.operations.getPlan,
+        ).toHaveBeenCalledExactlyOnceWith(getPlanOptionsFixture);
       });
 
       it('should not call buildPlanServiceNodeFromClassElementMetadata()', () => {
@@ -806,19 +760,15 @@ describe(currySubplan, () => {
 
         expect(
           tryBuildGetPlanOptionsFromManagedClassElementMetadata,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          tryBuildGetPlanOptionsFromManagedClassElementMetadata,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           instanceBindingNodeFixture.classMetadata.properties.get(property),
         );
       });
 
       it('should call operations.getPlan()', () => {
-        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledTimes(1);
-        expect(subplanParamsMock.operations.getPlan).toHaveBeenCalledWith(
-          getPlanOptionsFixture,
-        );
+        expect(
+          subplanParamsMock.operations.getPlan,
+        ).toHaveBeenCalledExactlyOnceWith(getPlanOptionsFixture);
       });
 
       it('should call buildPlanServiceNodeFromClassElementMetadata()', () => {
@@ -828,10 +778,7 @@ describe(currySubplan, () => {
 
         expect(
           buildPlanServiceNodeFromClassElementMetadataMock,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          buildPlanServiceNodeFromClassElementMetadataMock,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           subplanParamsMock,
           bindingConstraintsListFixture,
           instanceBindingNodeFixture.classMetadata.properties.get(property),
@@ -839,8 +786,7 @@ describe(currySubplan, () => {
       });
 
       it('should call cacheNonRootPlanServiceNode()', () => {
-        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledTimes(1);
-        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledWith(
+        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledExactlyOnceWith(
           getPlanOptionsFixture,
           subplanParamsMock.operations,
           expect.any(LazyPlanServiceNode),
@@ -910,10 +856,7 @@ describe(currySubplan, () => {
       it('should call tryBuildGetPlanOptionsFromResolvedValueElementMetadata()', () => {
         expect(
           tryBuildGetPlanOptionsFromResolvedValueElementMetadata,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          tryBuildGetPlanOptionsFromResolvedValueElementMetadata,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           resolvedValueBindingNodeFixture.binding.metadata.arguments[0],
         );
       });
@@ -921,10 +864,7 @@ describe(currySubplan, () => {
       it('should call buildPlanServiceNodeFromResolvedValueElementMetadata()', () => {
         expect(
           buildPlanServiceNodeFromResolvedValueElementMetadataMock,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          buildPlanServiceNodeFromResolvedValueElementMetadataMock,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           subplanParamsMock,
           bindingConstraintsListFixture,
           resolvedValueBindingNodeFixture.binding.metadata.arguments[0],
@@ -932,8 +872,7 @@ describe(currySubplan, () => {
       });
 
       it('should call cacheNonRootPlanServiceNode()', () => {
-        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledTimes(1);
-        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledWith(
+        expect(cacheNonRootPlanServiceNode).toHaveBeenCalledExactlyOnceWith(
           undefined,
           subplanParamsMock.operations,
           expect.any(LazyPlanServiceNode),

--- a/packages/container/libraries/core/src/planning/actions/plan.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/plan.spec.ts
@@ -92,15 +92,13 @@ describe(plan, () => {
     });
 
     it('should call buildGetPlanOptionsFromPlanParams()', () => {
-      expect(buildGetPlanOptionsFromPlanParams).toHaveBeenCalledTimes(1);
-      expect(buildGetPlanOptionsFromPlanParams).toHaveBeenCalledWith(
+      expect(buildGetPlanOptionsFromPlanParams).toHaveBeenCalledExactlyOnceWith(
         paramsFixture,
       );
     });
 
     it('should call params.operations.getPlan()', () => {
-      expect(paramsFixture.operations.getPlan).toHaveBeenCalledTimes(1);
-      expect(paramsFixture.operations.getPlan).toHaveBeenCalledWith(
+      expect(paramsFixture.operations.getPlan).toHaveBeenCalledExactlyOnceWith(
         getPlanOptionsFixture,
       );
     });
@@ -141,22 +139,21 @@ describe(plan, () => {
     });
 
     it('should call buildGetPlanOptionsFromPlanParams()', () => {
-      expect(buildGetPlanOptionsFromPlanParams).toHaveBeenCalledTimes(1);
-      expect(buildGetPlanOptionsFromPlanParams).toHaveBeenCalledWith(
+      expect(buildGetPlanOptionsFromPlanParams).toHaveBeenCalledExactlyOnceWith(
         paramsFixture,
       );
     });
 
     it('should call params.operations.getPlan()', () => {
-      expect(paramsFixture.operations.getPlan).toHaveBeenCalledTimes(1);
-      expect(paramsFixture.operations.getPlan).toHaveBeenCalledWith(
+      expect(paramsFixture.operations.getPlan).toHaveBeenCalledExactlyOnceWith(
         getPlanOptionsFixture,
       );
     });
 
     it('should call buildPlanServiceNode()', () => {
-      expect(buildPlanServiceNodeMock).toHaveBeenCalledTimes(1);
-      expect(buildPlanServiceNodeMock).toHaveBeenCalledWith(paramsFixture);
+      expect(buildPlanServiceNodeMock).toHaveBeenCalledExactlyOnceWith(
+        paramsFixture,
+      );
     });
 
     it('should return expected value', () => {

--- a/packages/container/libraries/core/src/planning/actions/removeRootServiceNodeBindingIfContextFree.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/removeRootServiceNodeBindingIfContextFree.spec.ts
@@ -167,8 +167,9 @@ describe(removeRootServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call removeServiceNodeBindingIfContextFree()', () => {
-        expect(removeServiceNodeBindingIfContextFree).toHaveBeenCalledTimes(1);
-        expect(removeServiceNodeBindingIfContextFree).toHaveBeenCalledWith(
+        expect(
+          removeServiceNodeBindingIfContextFree,
+        ).toHaveBeenCalledExactlyOnceWith(
           lazyPlanServiceNodeFixture,
           bindingMock,
           buildPlanBindingConstraintsListFixture,

--- a/packages/container/libraries/core/src/planning/actions/removeServiceNodeBindingIfContextFree.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/removeServiceNodeBindingIfContextFree.spec.ts
@@ -159,8 +159,7 @@ describe(removeServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call binding.isSatisfiedBy()', () => {
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledExactlyOnceWith(
           new BindingConstraintsImplementation(
             bindingConstraintsListFixture.last,
           ),
@@ -215,8 +214,7 @@ describe(removeServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call binding.isSatisfiedBy()', () => {
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledExactlyOnceWith(
           new BindingConstraintsImplementation(
             bindingConstraintsListFixture.last,
           ),
@@ -307,8 +305,7 @@ describe(removeServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call binding.isSatisfiedBy()', () => {
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledExactlyOnceWith(
           new BindingConstraintsImplementation(
             bindingConstraintsListFixture.last,
           ),
@@ -402,8 +399,7 @@ describe(removeServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call binding.isSatisfiedBy()', () => {
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledExactlyOnceWith(
           new BindingConstraintsImplementation(
             bindingConstraintsListFixture.last,
           ),
@@ -501,8 +497,7 @@ describe(removeServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call binding.isSatisfiedBy()', () => {
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledExactlyOnceWith(
           new BindingConstraintsImplementation(
             bindingConstraintsListFixture.last,
           ),
@@ -598,8 +593,7 @@ describe(removeServiceNodeBindingIfContextFree, () => {
       });
 
       it('should call binding.isSatisfiedBy()', () => {
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledTimes(1);
-        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledWith(
+        expect(bindingMock.isSatisfiedBy).toHaveBeenCalledExactlyOnceWith(
           new BindingConstraintsImplementation(
             bindingConstraintsListFixture.last,
           ),

--- a/packages/container/libraries/core/src/planning/calculations/buildFilteredServiceBindings.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildFilteredServiceBindings.spec.ts
@@ -65,8 +65,9 @@ describe(buildFilteredServiceBindings, () => {
       });
 
       it('should call params.getBinding()', () => {
-        expect(paramsMock.operations.getBindings).toHaveBeenCalledTimes(1);
-        expect(paramsMock.operations.getBindings).toHaveBeenCalledWith(
+        expect(
+          paramsMock.operations.getBindings,
+        ).toHaveBeenCalledExactlyOnceWith(
           bindingConstraintsFixture.serviceIdentifier,
         );
       });
@@ -113,8 +114,9 @@ describe(buildFilteredServiceBindings, () => {
       });
 
       it('should call params.getBinding()', () => {
-        expect(paramsMock.operations.getBindings).toHaveBeenCalledTimes(1);
-        expect(paramsMock.operations.getBindings).toHaveBeenCalledWith(
+        expect(
+          paramsMock.operations.getBindings,
+        ).toHaveBeenCalledExactlyOnceWith(
           bindingConstraintsFixture.serviceIdentifier,
         );
       });
@@ -188,22 +190,21 @@ describe(buildFilteredServiceBindings, () => {
       });
 
       it('should call params.getBinding()', () => {
-        expect(paramsMock.operations.getBindings).toHaveBeenCalledTimes(1);
-        expect(paramsMock.operations.getBindings).toHaveBeenCalledWith(
+        expect(
+          paramsMock.operations.getBindings,
+        ).toHaveBeenCalledExactlyOnceWith(
           bindingConstraintsFixture.serviceIdentifier,
         );
       });
 
       it('should call getClassMetadata()', () => {
-        expect(getClassMetadata).toHaveBeenCalledTimes(1);
-        expect(getClassMetadata).toHaveBeenCalledWith(
+        expect(getClassMetadata).toHaveBeenCalledExactlyOnceWith(
           bindingConstraintsFixture.serviceIdentifier,
         );
       });
 
       it('should call getBindingId()', () => {
-        expect(getBindingId).toHaveBeenCalledTimes(1);
-        expect(getBindingId).toHaveBeenCalledWith();
+        expect(getBindingId).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should call params.setBinding()', () => {
@@ -224,8 +225,9 @@ describe(buildFilteredServiceBindings, () => {
           type: bindingTypeValues.Instance,
         };
 
-        expect(paramsMock.operations.setBinding).toHaveBeenCalledTimes(1);
-        expect(paramsMock.operations.setBinding).toHaveBeenCalledWith(expected);
+        expect(
+          paramsMock.operations.setBinding,
+        ).toHaveBeenCalledExactlyOnceWith(expected);
       });
 
       it('should return an array with a binding', () => {
@@ -289,22 +291,21 @@ describe(buildFilteredServiceBindings, () => {
       });
 
       it('should call params.getBinding()', () => {
-        expect(paramsMock.operations.getBindings).toHaveBeenCalledTimes(1);
-        expect(paramsMock.operations.getBindings).toHaveBeenCalledWith(
+        expect(
+          paramsMock.operations.getBindings,
+        ).toHaveBeenCalledExactlyOnceWith(
           bindingConstraintsFixture.serviceIdentifier,
         );
       });
 
       it('should call getClassMetadata()', () => {
-        expect(getClassMetadata).toHaveBeenCalledTimes(1);
-        expect(getClassMetadata).toHaveBeenCalledWith(
+        expect(getClassMetadata).toHaveBeenCalledExactlyOnceWith(
           bindingConstraintsFixture.serviceIdentifier,
         );
       });
 
       it('should call getBindingId()', () => {
-        expect(getBindingId).toHaveBeenCalledTimes(1);
-        expect(getBindingId).toHaveBeenCalledWith();
+        expect(getBindingId).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should call params.setBinding()', () => {
@@ -325,8 +326,9 @@ describe(buildFilteredServiceBindings, () => {
           type: bindingTypeValues.Instance,
         };
 
-        expect(paramsMock.operations.setBinding).toHaveBeenCalledTimes(1);
-        expect(paramsMock.operations.setBinding).toHaveBeenCalledWith(expected);
+        expect(
+          paramsMock.operations.setBinding,
+        ).toHaveBeenCalledExactlyOnceWith(expected);
       });
 
       it('should return an array with a binding', () => {
@@ -390,8 +392,9 @@ describe(buildFilteredServiceBindings, () => {
       });
 
       it('should call params.getBinding()', () => {
-        expect(paramsMock.operations.getBindings).toHaveBeenCalledTimes(1);
-        expect(paramsMock.operations.getBindings).toHaveBeenCalledWith(
+        expect(
+          paramsMock.operations.getBindings,
+        ).toHaveBeenCalledExactlyOnceWith(
           optionsFixture.customServiceIdentifier,
         );
       });
@@ -444,10 +447,9 @@ describe(buildFilteredServiceBindings, () => {
       });
 
       it('should call params.operations.getBindingsChained()', () => {
-        expect(paramsMock.operations.getBindingsChained).toHaveBeenCalledTimes(
-          1,
-        );
-        expect(paramsMock.operations.getBindingsChained).toHaveBeenCalledWith(
+        expect(
+          paramsMock.operations.getBindingsChained,
+        ).toHaveBeenCalledExactlyOnceWith(
           bindingConstraintsFixture.serviceIdentifier,
         );
       });

--- a/packages/container/libraries/core/src/planning/calculations/checkPlanServiceRedirectionBindingNodeSingleInjectionBindings.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/checkPlanServiceRedirectionBindingNodeSingleInjectionBindings.spec.ts
@@ -60,10 +60,7 @@ describe(checkPlanServiceRedirectionBindingNodeSingleInjectionBindings, () => {
       it('should call throwErrorWhenUnexpectedBindingsAmountFound()', () => {
         expect(
           throwErrorWhenUnexpectedBindingsAmountFound,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          throwErrorWhenUnexpectedBindingsAmountFound,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           planServiceRedirectionBindingNodeFixture.redirections,
           isOptionalFixture,
           internalBindingConstraintsNodeFixture,
@@ -214,10 +211,7 @@ describe(checkPlanServiceRedirectionBindingNodeSingleInjectionBindings, () => {
       it('should call throwErrorWhenUnexpectedBindingsAmountFound()', () => {
         expect(
           throwErrorWhenUnexpectedBindingsAmountFound,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          throwErrorWhenUnexpectedBindingsAmountFound,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           planServiceRedirectionBindingNodeRedirectionFixture.redirections,
           isOptionalFixture,
           internalBindingConstraintsNodeFixture,

--- a/packages/container/libraries/core/src/planning/calculations/checkServiceNodeSingleInjectionBindings.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/checkServiceNodeSingleInjectionBindings.spec.ts
@@ -61,10 +61,7 @@ describe(checkServiceNodeSingleInjectionBindings, () => {
       it('should call throwErrorWhenUnexpectedBindingsAmountFound()', () => {
         expect(
           throwErrorWhenUnexpectedBindingsAmountFound,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          throwErrorWhenUnexpectedBindingsAmountFound,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           nodeFixture.bindings,
           isOptionalFixture,
           internalBindingConstraintsNodeFixture,
@@ -168,10 +165,7 @@ describe(checkServiceNodeSingleInjectionBindings, () => {
       it('should call checkPlanServiceRedirectionBindingNodeSingleInjectionBindings()', () => {
         expect(
           checkPlanServiceRedirectionBindingNodeSingleInjectionBindings,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          checkPlanServiceRedirectionBindingNodeSingleInjectionBindings,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           nodeFixtureBinding,
           isOptionalFixture,
           internalBindingConstraintsNodeFixture,

--- a/packages/container/libraries/core/src/planning/models/LazyPlanServiceNode.spec.ts
+++ b/packages/container/libraries/core/src/planning/models/LazyPlanServiceNode.spec.ts
@@ -74,8 +74,7 @@ describe(LazyPlanServiceNode, () => {
         });
 
         it('should call buildPlanServiceNode()', () => {
-          expect(buildPlanServiceNodeMock).toHaveBeenCalledTimes(1);
-          expect(buildPlanServiceNodeMock).toHaveBeenCalledWith();
+          expect(buildPlanServiceNodeMock).toHaveBeenCalledExactlyOnceWith();
         });
 
         it('should return expected value', () => {
@@ -157,8 +156,7 @@ describe(LazyPlanServiceNode, () => {
         });
 
         it('should call buildPlanServiceNode()', () => {
-          expect(buildPlanServiceNodeMock).toHaveBeenCalledTimes(1);
-          expect(buildPlanServiceNodeMock).toHaveBeenCalledWith();
+          expect(buildPlanServiceNodeMock).toHaveBeenCalledExactlyOnceWith();
         });
 
         it('should return expected value', () => {

--- a/packages/container/libraries/core/src/planning/services/PlanResultCacheService.spec.ts
+++ b/packages/container/libraries/core/src/planning/services/PlanResultCacheService.spec.ts
@@ -536,10 +536,7 @@ describe(PlanResultCacheService, () => {
             it('should call addRootServiceNodeBindingIfContextFree()', () => {
               expect(
                 addRootServiceNodeBindingIfContextFree,
-              ).toHaveBeenCalledTimes(1);
-              expect(
-                addRootServiceNodeBindingIfContextFree,
-              ).toHaveBeenCalledWith(
+              ).toHaveBeenCalledExactlyOnceWith(
                 expectedPlanParamsFixture,
                 planResultFixture.tree.root,
                 planResultCacheServiceInvalidationFixture.binding,
@@ -685,10 +682,7 @@ describe(PlanResultCacheService, () => {
             it('should call addRootServiceNodeBindingIfContextFree()', () => {
               expect(
                 addRootServiceNodeBindingIfContextFree,
-              ).toHaveBeenCalledTimes(1);
-              expect(
-                addRootServiceNodeBindingIfContextFree,
-              ).toHaveBeenCalledWith(
+              ).toHaveBeenCalledExactlyOnceWith(
                 expectedPlanParamsFixture,
                 planResultFixture.tree.root,
                 planResultCacheServiceInvalidationFixture.binding,
@@ -896,10 +890,7 @@ describe(PlanResultCacheService, () => {
             it('should call addRootServiceNodeBindingIfContextFree()', () => {
               expect(
                 addRootServiceNodeBindingIfContextFree,
-              ).toHaveBeenCalledTimes(1);
-              expect(
-                addRootServiceNodeBindingIfContextFree,
-              ).toHaveBeenCalledWith(
+              ).toHaveBeenCalledExactlyOnceWith(
                 expectedPlanParamsFixture,
                 planResultFixture.tree.root,
                 planResultCacheServiceInvalidationFixture.binding,
@@ -1117,10 +1108,7 @@ describe(PlanResultCacheService, () => {
             it('should call addRootServiceNodeBindingIfContextFree()', () => {
               expect(
                 addRootServiceNodeBindingIfContextFree,
-              ).toHaveBeenCalledTimes(1);
-              expect(
-                addRootServiceNodeBindingIfContextFree,
-              ).toHaveBeenCalledWith(
+              ).toHaveBeenCalledExactlyOnceWith(
                 expectedPlanParamsFixture,
                 planResultFixture.tree.root,
                 planResultCacheServiceInvalidationFixture.binding,
@@ -1350,10 +1338,7 @@ describe(PlanResultCacheService, () => {
             it('should call addRootServiceNodeBindingIfContextFree()', () => {
               expect(
                 addRootServiceNodeBindingIfContextFree,
-              ).toHaveBeenCalledTimes(1);
-              expect(
-                addRootServiceNodeBindingIfContextFree,
-              ).toHaveBeenCalledWith(
+              ).toHaveBeenCalledExactlyOnceWith(
                 expectedPlanParamsFixture,
                 planResultFixture.tree.root,
                 planResultCacheServiceInvalidationFixture.binding,
@@ -1571,10 +1556,7 @@ describe(PlanResultCacheService, () => {
             it('should call addRootServiceNodeBindingIfContextFree()', () => {
               expect(
                 addRootServiceNodeBindingIfContextFree,
-              ).toHaveBeenCalledTimes(1);
-              expect(
-                addRootServiceNodeBindingIfContextFree,
-              ).toHaveBeenCalledWith(
+              ).toHaveBeenCalledExactlyOnceWith(
                 expectedPlanParamsFixture,
                 planResultFixture.tree.root,
                 planResultCacheServiceInvalidationFixture.binding,
@@ -1798,10 +1780,7 @@ describe(PlanResultCacheService, () => {
             it('should call addRootServiceNodeBindingIfContextFree()', () => {
               expect(
                 addRootServiceNodeBindingIfContextFree,
-              ).toHaveBeenCalledTimes(1);
-              expect(
-                addRootServiceNodeBindingIfContextFree,
-              ).toHaveBeenCalledWith(
+              ).toHaveBeenCalledExactlyOnceWith(
                 expectedPlanParamsFixture,
                 planResultFixture.tree.root,
                 planResultCacheServiceInvalidationFixture.binding,
@@ -2029,10 +2008,7 @@ describe(PlanResultCacheService, () => {
             it('should call addRootServiceNodeBindingIfContextFree()', () => {
               expect(
                 addRootServiceNodeBindingIfContextFree,
-              ).toHaveBeenCalledTimes(1);
-              expect(
-                addRootServiceNodeBindingIfContextFree,
-              ).toHaveBeenCalledWith(
+              ).toHaveBeenCalledExactlyOnceWith(
                 expectedPlanParamsFixture,
                 planResultFixture.tree.root,
                 planResultCacheServiceInvalidationFixture.binding,
@@ -2127,8 +2103,9 @@ describe(PlanResultCacheService, () => {
             servicesBranch: [],
           };
 
-          expect(addServiceNodeBindingIfContextFree).toHaveBeenCalledTimes(1);
-          expect(addServiceNodeBindingIfContextFree).toHaveBeenCalledWith(
+          expect(
+            addServiceNodeBindingIfContextFree,
+          ).toHaveBeenCalledExactlyOnceWith(
             expectedBasePlanParams,
             lazyPlanServiceNodeFixture,
             planResultCacheServiceInvalidationFixture.binding,
@@ -2219,8 +2196,9 @@ describe(PlanResultCacheService, () => {
             servicesBranch: [],
           };
 
-          expect(addServiceNodeBindingIfContextFree).toHaveBeenCalledTimes(1);
-          expect(addServiceNodeBindingIfContextFree).toHaveBeenCalledWith(
+          expect(
+            addServiceNodeBindingIfContextFree,
+          ).toHaveBeenCalledExactlyOnceWith(
             expectedBasePlanParams,
             lazyPlanServiceNodeFixture,
             planResultCacheServiceInvalidationFixture.binding,
@@ -2318,8 +2296,7 @@ describe(PlanResultCacheService, () => {
       });
 
       it('should call subscriber.clearCache()', () => {
-        expect(subscriberMock.clearCache).toHaveBeenCalledTimes(1);
-        expect(subscriberMock.clearCache).toHaveBeenCalledWith();
+        expect(subscriberMock.clearCache).toHaveBeenCalledExactlyOnceWith();
       });
     });
   });

--- a/packages/container/libraries/core/src/resolution/actions/resolve.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolve.spec.ts
@@ -241,8 +241,7 @@ describe(resolve, () => {
       });
 
       it('should call resolveConstantValueBinding()', () => {
-        expect(resolveConstantValueBinding).toHaveBeenCalledTimes(1);
-        expect(resolveConstantValueBinding).toHaveBeenCalledWith(
+        expect(resolveConstantValueBinding).toHaveBeenCalledExactlyOnceWith(
           resolutionParamsFixture,
           bindingFixture,
         );
@@ -316,8 +315,7 @@ describe(resolve, () => {
       });
 
       it('should call resolveConstantValueBinding()', () => {
-        expect(resolveConstantValueBinding).toHaveBeenCalledTimes(1);
-        expect(resolveConstantValueBinding).toHaveBeenCalledWith(
+        expect(resolveConstantValueBinding).toHaveBeenCalledExactlyOnceWith(
           resolutionParamsFixture,
           bindingFixture,
         );
@@ -348,8 +346,7 @@ describe(resolve, () => {
       });
 
       it('should call resolveConstantValueBinding()', () => {
-        expect(resolveConstantValueBinding).toHaveBeenCalledTimes(1);
-        expect(resolveConstantValueBinding).toHaveBeenCalledWith(
+        expect(resolveConstantValueBinding).toHaveBeenCalledExactlyOnceWith(
           resolutionParamsFixture,
           bindingFixture,
         );
@@ -423,8 +420,7 @@ describe(resolve, () => {
       });
 
       it('should call resolveDynamicValueBinding()', () => {
-        expect(resolveDynamicValueBinding).toHaveBeenCalledTimes(1);
-        expect(resolveDynamicValueBinding).toHaveBeenCalledWith(
+        expect(resolveDynamicValueBinding).toHaveBeenCalledExactlyOnceWith(
           resolutionParamsFixture,
           bindingFixture,
         );
@@ -496,8 +492,7 @@ describe(resolve, () => {
       });
 
       it('should call resolveFactoryBinding()', () => {
-        expect(resolveFactoryBinding).toHaveBeenCalledTimes(1);
-        expect(resolveFactoryBinding).toHaveBeenCalledWith(
+        expect(resolveFactoryBinding).toHaveBeenCalledExactlyOnceWith(
           resolutionParamsFixture,
           bindingFixture,
         );
@@ -574,8 +569,9 @@ describe(resolve, () => {
       });
 
       it('should call resolveInstanceBindingNode()', () => {
-        expect(resolveScopedInstanceBindingNodeMock).toHaveBeenCalledTimes(1);
-        expect(resolveScopedInstanceBindingNodeMock).toHaveBeenCalledWith(
+        expect(
+          resolveScopedInstanceBindingNodeMock,
+        ).toHaveBeenCalledExactlyOnceWith(
           resolutionParamsFixture,
           bindingNodeFixture,
         );
@@ -651,10 +647,9 @@ describe(resolve, () => {
       });
 
       it('should call resolveResolvedValueBindingNode()', () => {
-        expect(resolveScopedResolvedValueBindingNodeMock).toHaveBeenCalledTimes(
-          1,
-        );
-        expect(resolveScopedResolvedValueBindingNodeMock).toHaveBeenCalledWith(
+        expect(
+          resolveScopedResolvedValueBindingNodeMock,
+        ).toHaveBeenCalledExactlyOnceWith(
           resolutionParamsFixture,
           bindingNodeFixture,
         );
@@ -726,8 +721,7 @@ describe(resolve, () => {
       });
 
       it('should call resolveProviderBinding()', () => {
-        expect(resolveProviderBinding).toHaveBeenCalledTimes(1);
-        expect(resolveProviderBinding).toHaveBeenCalledWith(
+        expect(resolveProviderBinding).toHaveBeenCalledExactlyOnceWith(
           resolutionParamsFixture,
           bindingFixture,
         );
@@ -796,10 +790,9 @@ describe(resolve, () => {
       });
 
       it('should call resolveServiceRedirectionBindingNode()', () => {
-        expect(resolveServiceRedirectionBindingNodeMock).toHaveBeenCalledTimes(
-          1,
-        );
-        expect(resolveServiceRedirectionBindingNodeMock).toHaveBeenCalledWith(
+        expect(
+          resolveServiceRedirectionBindingNodeMock,
+        ).toHaveBeenCalledExactlyOnceWith(
           resolutionParamsFixture,
           serviceRedirectionBindingNodeFixture,
         );
@@ -828,10 +821,9 @@ describe(resolve, () => {
       });
 
       it('should call resolveServiceRedirectionBindingNode()', () => {
-        expect(resolveServiceRedirectionBindingNodeMock).toHaveBeenCalledTimes(
-          1,
-        );
-        expect(resolveServiceRedirectionBindingNodeMock).toHaveBeenCalledWith(
+        expect(
+          resolveServiceRedirectionBindingNodeMock,
+        ).toHaveBeenCalledExactlyOnceWith(
           resolutionParamsFixture,
           serviceRedirectionBindingNodeFixture,
         );
@@ -909,10 +901,9 @@ describe(resolve, () => {
       });
 
       it('should call resolveServiceRedirectionBindingNode()', () => {
-        expect(resolveServiceRedirectionBindingNodeMock).toHaveBeenCalledTimes(
-          1,
-        );
-        expect(resolveServiceRedirectionBindingNodeMock).toHaveBeenCalledWith(
+        expect(
+          resolveServiceRedirectionBindingNodeMock,
+        ).toHaveBeenCalledExactlyOnceWith(
           resolutionParamsFixture,
           serviceRedirectionBindingNodeFixture,
         );

--- a/packages/container/libraries/core/src/resolution/actions/resolveBindingActivations.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveBindingActivations.spec.ts
@@ -56,8 +56,9 @@ describe(resolveBindingActivations, () => {
       });
 
       it('should call resolveBindingServiceActivations()', () => {
-        expect(resolveBindingServiceActivations).toHaveBeenCalledTimes(1);
-        expect(resolveBindingServiceActivations).toHaveBeenCalledWith(
+        expect(
+          resolveBindingServiceActivations,
+        ).toHaveBeenCalledExactlyOnceWith(
           paramsMock,
           bindingFixture.serviceIdentifier,
           resolvedValueFixture,
@@ -117,16 +118,16 @@ describe(resolveBindingActivations, () => {
       });
 
       it('should call binding.onActivation()', () => {
-        expect(onActivationMock).toHaveBeenCalledTimes(1);
-        expect(onActivationMock).toHaveBeenCalledWith(
+        expect(onActivationMock).toHaveBeenCalledExactlyOnceWith(
           paramsMock.context,
           resolvedValue,
         );
       });
 
       it('should call resolveBindingServiceActivations()', () => {
-        expect(resolveBindingServiceActivations).toHaveBeenCalledTimes(1);
-        expect(resolveBindingServiceActivations).toHaveBeenCalledWith(
+        expect(
+          resolveBindingServiceActivations,
+        ).toHaveBeenCalledExactlyOnceWith(
           paramsMock,
           bindingFixture.serviceIdentifier,
           onActivationResultFixture,

--- a/packages/container/libraries/core/src/resolution/actions/resolveBindingDeactivations.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveBindingDeactivations.spec.ts
@@ -61,8 +61,7 @@ describe(resolveBindingDeactivations, () => {
       });
 
       it('should call resolveBindingPreDestroy()', () => {
-        expect(resolveBindingPreDestroy).toHaveBeenCalledTimes(1);
-        expect(resolveBindingPreDestroy).toHaveBeenCalledWith(
+        expect(resolveBindingPreDestroy).toHaveBeenCalledExactlyOnceWith(
           paramsMock,
           bindingFixture,
         );
@@ -71,8 +70,9 @@ describe(resolveBindingDeactivations, () => {
       it('should call resolveBindingServiceDeactivations()', () => {
         const bindingCache: Right<Resolved<unknown>> = bindingFixture.cache;
 
-        expect(resolveBindingServiceDeactivations).toHaveBeenCalledTimes(1);
-        expect(resolveBindingServiceDeactivations).toHaveBeenCalledWith(
+        expect(
+          resolveBindingServiceDeactivations,
+        ).toHaveBeenCalledExactlyOnceWith(
           paramsMock,
           bindingFixture.serviceIdentifier,
           bindingCache.value,
@@ -100,8 +100,7 @@ describe(resolveBindingDeactivations, () => {
       });
 
       it('should call resolveBindingPreDestroy()', () => {
-        expect(resolveBindingPreDestroy).toHaveBeenCalledTimes(1);
-        expect(resolveBindingPreDestroy).toHaveBeenCalledWith(
+        expect(resolveBindingPreDestroy).toHaveBeenCalledExactlyOnceWith(
           paramsMock,
           bindingFixture,
         );
@@ -110,8 +109,9 @@ describe(resolveBindingDeactivations, () => {
       it('should call resolveBindingServiceDeactivations()', () => {
         const bindingCache: Right<Resolved<unknown>> = bindingFixture.cache;
 
-        expect(resolveBindingServiceDeactivations).toHaveBeenCalledTimes(1);
-        expect(resolveBindingServiceDeactivations).toHaveBeenCalledWith(
+        expect(
+          resolveBindingServiceDeactivations,
+        ).toHaveBeenCalledExactlyOnceWith(
           paramsMock,
           bindingFixture.serviceIdentifier,
           bindingCache.value,
@@ -149,8 +149,7 @@ describe(resolveBindingDeactivations, () => {
       });
 
       it('should call resolveBindingPreDestroy()', () => {
-        expect(resolveBindingPreDestroy).toHaveBeenCalledTimes(1);
-        expect(resolveBindingPreDestroy).toHaveBeenCalledWith(
+        expect(resolveBindingPreDestroy).toHaveBeenCalledExactlyOnceWith(
           paramsMock,
           bindingFixture,
         );
@@ -159,8 +158,9 @@ describe(resolveBindingDeactivations, () => {
       it('should call resolveBindingServiceDeactivations()', () => {
         const bindingCache: Right<Resolved<unknown>> = bindingFixture.cache;
 
-        expect(resolveBindingServiceDeactivations).toHaveBeenCalledTimes(1);
-        expect(resolveBindingServiceDeactivations).toHaveBeenCalledWith(
+        expect(
+          resolveBindingServiceDeactivations,
+        ).toHaveBeenCalledExactlyOnceWith(
           paramsMock,
           bindingFixture.serviceIdentifier,
           bindingCache.value,
@@ -198,8 +198,7 @@ describe(resolveBindingDeactivations, () => {
       });
 
       it('should call resolveBindingPreDestroy()', () => {
-        expect(resolveBindingPreDestroy).toHaveBeenCalledTimes(1);
-        expect(resolveBindingPreDestroy).toHaveBeenCalledWith(
+        expect(resolveBindingPreDestroy).toHaveBeenCalledExactlyOnceWith(
           paramsMock,
           bindingFixture,
         );
@@ -208,8 +207,9 @@ describe(resolveBindingDeactivations, () => {
       it('should call resolveBindingServiceDeactivations()', async () => {
         const bindingCache: Right<Resolved<unknown>> = bindingFixture.cache;
 
-        expect(resolveBindingServiceDeactivations).toHaveBeenCalledTimes(1);
-        expect(resolveBindingServiceDeactivations).toHaveBeenCalledWith(
+        expect(
+          resolveBindingServiceDeactivations,
+        ).toHaveBeenCalledExactlyOnceWith(
           paramsMock,
           bindingFixture.serviceIdentifier,
           await bindingCache.value,
@@ -249,8 +249,9 @@ describe(resolveBindingDeactivations, () => {
       it('should call resolveBindingServiceDeactivations()', () => {
         const bindingCache: Right<Resolved<unknown>> = bindingFixture.cache;
 
-        expect(resolveBindingServiceDeactivations).toHaveBeenCalledTimes(1);
-        expect(resolveBindingServiceDeactivations).toHaveBeenCalledWith(
+        expect(
+          resolveBindingServiceDeactivations,
+        ).toHaveBeenCalledExactlyOnceWith(
           paramsMock,
           bindingFixture.serviceIdentifier,
           bindingCache.value,

--- a/packages/container/libraries/core/src/resolution/actions/resolveBindingPreDestroy.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveBindingPreDestroy.spec.ts
@@ -97,8 +97,7 @@ describe(resolveBindingPreDestroy, () => {
       });
 
       it('should call params.getClassMetadata()', () => {
-        expect(paramsMock.getClassMetadata).toHaveBeenCalledTimes(1);
-        expect(paramsMock.getClassMetadata).toHaveBeenCalledWith(
+        expect(paramsMock.getClassMetadata).toHaveBeenCalledExactlyOnceWith(
           bindingFixture.implementationType,
         );
       });
@@ -126,8 +125,7 @@ describe(resolveBindingPreDestroy, () => {
       });
 
       it('should call params.getClassMetadata()', () => {
-        expect(paramsMock.getClassMetadata).toHaveBeenCalledTimes(1);
-        expect(paramsMock.getClassMetadata).toHaveBeenCalledWith(
+        expect(paramsMock.getClassMetadata).toHaveBeenCalledExactlyOnceWith(
           bindingFixture.implementationType,
         );
       });
@@ -170,8 +168,7 @@ describe(resolveBindingPreDestroy, () => {
       });
 
       it('should call params.getClassMetadata()', () => {
-        expect(paramsMock.getClassMetadata).toHaveBeenCalledTimes(1);
-        expect(paramsMock.getClassMetadata).toHaveBeenCalledWith(
+        expect(paramsMock.getClassMetadata).toHaveBeenCalledExactlyOnceWith(
           bindingFixture.implementationType,
         );
       });
@@ -238,15 +235,13 @@ describe(resolveBindingPreDestroy, () => {
       });
 
       it('should call params.getClassMetadata()', () => {
-        expect(paramsMock.getClassMetadata).toHaveBeenCalledTimes(1);
-        expect(paramsMock.getClassMetadata).toHaveBeenCalledWith(
+        expect(paramsMock.getClassMetadata).toHaveBeenCalledExactlyOnceWith(
           bindingFixture.implementationType,
         );
       });
 
       it('should call preDestroy() method', () => {
-        expect(preDestroyMock).toHaveBeenCalledTimes(1);
-        expect(preDestroyMock).toHaveBeenCalledWith();
+        expect(preDestroyMock).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should return undefined', () => {

--- a/packages/container/libraries/core/src/resolution/actions/resolveBindingServiceActivations.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveBindingServiceActivations.spec.ts
@@ -47,8 +47,7 @@ describe(resolveBindingServiceActivations, () => {
       });
 
       it('should call params.getActivations', () => {
-        expect(paramsMock.getActivations).toHaveBeenCalledTimes(1);
-        expect(paramsMock.getActivations).toHaveBeenCalledWith(
+        expect(paramsMock.getActivations).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
         );
       });
@@ -83,15 +82,13 @@ describe(resolveBindingServiceActivations, () => {
       });
 
       it('should call params.getActivations', () => {
-        expect(paramsMock.getActivations).toHaveBeenCalledTimes(1);
-        expect(paramsMock.getActivations).toHaveBeenCalledWith(
+        expect(paramsMock.getActivations).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
         );
       });
 
       it('should call activation', () => {
-        expect(activationMock).toHaveBeenCalledTimes(1);
-        expect(activationMock).toHaveBeenCalledWith(
+        expect(activationMock).toHaveBeenCalledExactlyOnceWith(
           paramsMock.context,
           valueFixture,
         );
@@ -127,15 +124,13 @@ describe(resolveBindingServiceActivations, () => {
       });
 
       it('should call params.getActivations', () => {
-        expect(paramsMock.getActivations).toHaveBeenCalledTimes(1);
-        expect(paramsMock.getActivations).toHaveBeenCalledWith(
+        expect(paramsMock.getActivations).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
         );
       });
 
       it('should call activation', () => {
-        expect(activationMock).toHaveBeenCalledTimes(1);
-        expect(activationMock).toHaveBeenCalledWith(
+        expect(activationMock).toHaveBeenCalledExactlyOnceWith(
           paramsMock.context,
           valueFixture,
         );
@@ -176,8 +171,7 @@ describe(resolveBindingServiceActivations, () => {
       });
 
       it('should call params.getActivations', () => {
-        expect(paramsMock.getActivations).toHaveBeenCalledTimes(1);
-        expect(paramsMock.getActivations).toHaveBeenCalledWith(
+        expect(paramsMock.getActivations).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
         );
       });
@@ -212,15 +206,13 @@ describe(resolveBindingServiceActivations, () => {
       });
 
       it('should call params.getActivations', () => {
-        expect(paramsMock.getActivations).toHaveBeenCalledTimes(1);
-        expect(paramsMock.getActivations).toHaveBeenCalledWith(
+        expect(paramsMock.getActivations).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
         );
       });
 
       it('should call activation', () => {
-        expect(activationMock).toHaveBeenCalledTimes(1);
-        expect(activationMock).toHaveBeenCalledWith(
+        expect(activationMock).toHaveBeenCalledExactlyOnceWith(
           paramsMock.context,
           valueFixture,
         );
@@ -256,15 +248,13 @@ describe(resolveBindingServiceActivations, () => {
       });
 
       it('should call params.getActivations', () => {
-        expect(paramsMock.getActivations).toHaveBeenCalledTimes(1);
-        expect(paramsMock.getActivations).toHaveBeenCalledWith(
+        expect(paramsMock.getActivations).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
         );
       });
 
       it('should call activation', () => {
-        expect(activationMock).toHaveBeenCalledTimes(1);
-        expect(activationMock).toHaveBeenCalledWith(
+        expect(activationMock).toHaveBeenCalledExactlyOnceWith(
           paramsMock.context,
           valueFixture,
         );

--- a/packages/container/libraries/core/src/resolution/actions/resolveBindingServiceDeactivations.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveBindingServiceDeactivations.spec.ts
@@ -46,8 +46,7 @@ describe(resolveBindingServiceDeactivations, () => {
       });
 
       it('should call params.getActivations', () => {
-        expect(paramsMock.getDeactivations).toHaveBeenCalledTimes(1);
-        expect(paramsMock.getDeactivations).toHaveBeenCalledWith(
+        expect(paramsMock.getDeactivations).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
         );
       });
@@ -80,15 +79,13 @@ describe(resolveBindingServiceDeactivations, () => {
       });
 
       it('should call params.getActivations', () => {
-        expect(paramsMock.getDeactivations).toHaveBeenCalledTimes(1);
-        expect(paramsMock.getDeactivations).toHaveBeenCalledWith(
+        expect(paramsMock.getDeactivations).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
         );
       });
 
       it('should call activation', () => {
-        expect(deactivationMock).toHaveBeenCalledTimes(1);
-        expect(deactivationMock).toHaveBeenCalledWith(valueFixture);
+        expect(deactivationMock).toHaveBeenCalledExactlyOnceWith(valueFixture);
       });
 
       it('should return undefined', () => {
@@ -119,15 +116,13 @@ describe(resolveBindingServiceDeactivations, () => {
       });
 
       it('should call params.getActivations', () => {
-        expect(paramsMock.getDeactivations).toHaveBeenCalledTimes(1);
-        expect(paramsMock.getDeactivations).toHaveBeenCalledWith(
+        expect(paramsMock.getDeactivations).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
         );
       });
 
       it('should call activation', () => {
-        expect(deactivationMock).toHaveBeenCalledTimes(1);
-        expect(deactivationMock).toHaveBeenCalledWith(valueFixture);
+        expect(deactivationMock).toHaveBeenCalledExactlyOnceWith(valueFixture);
       });
 
       it('should return undefined', () => {
@@ -166,8 +161,7 @@ describe(resolveBindingServiceDeactivations, () => {
       });
 
       it('should call params.getActivations', () => {
-        expect(paramsMock.getDeactivations).toHaveBeenCalledTimes(1);
-        expect(paramsMock.getDeactivations).toHaveBeenCalledWith(
+        expect(paramsMock.getDeactivations).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
         );
       });
@@ -200,15 +194,13 @@ describe(resolveBindingServiceDeactivations, () => {
       });
 
       it('should call params.getActivations', () => {
-        expect(paramsMock.getDeactivations).toHaveBeenCalledTimes(1);
-        expect(paramsMock.getDeactivations).toHaveBeenCalledWith(
+        expect(paramsMock.getDeactivations).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
         );
       });
 
       it('should call activation', () => {
-        expect(deactivationMock).toHaveBeenCalledTimes(1);
-        expect(deactivationMock).toHaveBeenCalledWith(valueFixture);
+        expect(deactivationMock).toHaveBeenCalledExactlyOnceWith(valueFixture);
       });
 
       it('should return undefined', () => {
@@ -239,15 +231,13 @@ describe(resolveBindingServiceDeactivations, () => {
       });
 
       it('should call params.getActivations', () => {
-        expect(paramsMock.getDeactivations).toHaveBeenCalledTimes(1);
-        expect(paramsMock.getDeactivations).toHaveBeenCalledWith(
+        expect(paramsMock.getDeactivations).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
         );
       });
 
       it('should call activation', () => {
-        expect(deactivationMock).toHaveBeenCalledTimes(1);
-        expect(deactivationMock).toHaveBeenCalledWith(valueFixture);
+        expect(deactivationMock).toHaveBeenCalledExactlyOnceWith(valueFixture);
       });
 
       it('should return undefined', () => {

--- a/packages/container/libraries/core/src/resolution/actions/resolveBindingsDeactivations.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveBindingsDeactivations.spec.ts
@@ -92,8 +92,7 @@ describe(resolveBindingsDeactivations, () => {
       });
 
       it('should call resolveBindingDeactivations()', () => {
-        expect(resolveBindingDeactivations).toHaveBeenCalledTimes(1);
-        expect(resolveBindingDeactivations).toHaveBeenCalledWith(
+        expect(resolveBindingDeactivations).toHaveBeenCalledExactlyOnceWith(
           paramsMock,
           bindingFixture,
         );
@@ -120,8 +119,7 @@ describe(resolveBindingsDeactivations, () => {
       });
 
       it('should call resolveBindingDeactivations()', () => {
-        expect(resolveBindingDeactivations).toHaveBeenCalledTimes(1);
-        expect(resolveBindingDeactivations).toHaveBeenCalledWith(
+        expect(resolveBindingDeactivations).toHaveBeenCalledExactlyOnceWith(
           paramsMock,
           bindingFixture,
         );

--- a/packages/container/libraries/core/src/resolution/actions/resolveInstanceBindingConstructorParams.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveInstanceBindingConstructorParams.spec.ts
@@ -92,8 +92,7 @@ describe(resolveInstanceBindingConstructorParams, () => {
       });
 
       it('should call resolveServiceNode()', () => {
-        expect(resolveServiceNodeMock).toHaveBeenCalledTimes(1);
-        expect(resolveServiceNodeMock).toHaveBeenCalledWith(
+        expect(resolveServiceNodeMock).toHaveBeenCalledExactlyOnceWith(
           paramsFixture,
           constructorParamFixture,
         );
@@ -124,8 +123,7 @@ describe(resolveInstanceBindingConstructorParams, () => {
       });
 
       it('should call resolveServiceNode()', () => {
-        expect(resolveServiceNodeMock).toHaveBeenCalledTimes(1);
-        expect(resolveServiceNodeMock).toHaveBeenCalledWith(
+        expect(resolveServiceNodeMock).toHaveBeenCalledExactlyOnceWith(
           paramsFixture,
           constructorParamFixture,
         );

--- a/packages/container/libraries/core/src/resolution/actions/resolveInstanceBindingNode.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveInstanceBindingNode.spec.ts
@@ -76,22 +76,15 @@ describe(resolveInstanceBindingNode, () => {
     });
 
     it('should call resolveInstanceBindingConstructorParams()', () => {
-      expect(resolveInstanceBindingConstructorParamsMock).toHaveBeenCalledTimes(
-        1,
-      );
-      expect(resolveInstanceBindingConstructorParamsMock).toHaveBeenCalledWith(
-        paramsFixture,
-        nodeFixture,
-      );
+      expect(
+        resolveInstanceBindingConstructorParamsMock,
+      ).toHaveBeenCalledExactlyOnceWith(paramsFixture, nodeFixture);
     });
 
     it('should call resolveInstanceBindingNodeFromConstructorParams()', () => {
       expect(
         resolveInstanceBindingNodeFromConstructorParamsMock,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        resolveInstanceBindingNodeFromConstructorParamsMock,
-      ).toHaveBeenCalledWith(
+      ).toHaveBeenCalledExactlyOnceWith(
         constructorResolvedValues,
         paramsFixture,
         nodeFixture,
@@ -133,22 +126,15 @@ describe(resolveInstanceBindingNode, () => {
     });
 
     it('should call resolveInstanceBindingConstructorParams()', () => {
-      expect(resolveInstanceBindingConstructorParamsMock).toHaveBeenCalledTimes(
-        1,
-      );
-      expect(resolveInstanceBindingConstructorParamsMock).toHaveBeenCalledWith(
-        paramsFixture,
-        nodeFixture,
-      );
+      expect(
+        resolveInstanceBindingConstructorParamsMock,
+      ).toHaveBeenCalledExactlyOnceWith(paramsFixture, nodeFixture);
     });
 
     it('should call resolveInstanceBindingNodeAsyncFromConstructorParams()', () => {
       expect(
         resolveInstanceBindingNodeAsyncFromConstructorParamsMock,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        resolveInstanceBindingNodeAsyncFromConstructorParamsMock,
-      ).toHaveBeenCalledWith(
+      ).toHaveBeenCalledExactlyOnceWith(
         Promise.resolve(constructorResolvedValues),
         paramsFixture,
         nodeFixture,

--- a/packages/container/libraries/core/src/resolution/actions/resolveInstanceBindingNodeAsyncFromConstructorParams.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveInstanceBindingNodeAsyncFromConstructorParams.spec.ts
@@ -64,10 +64,7 @@ describe(resolveInstanceBindingNodeAsyncFromConstructorParams, () => {
     it('should call resolveInstanceBindingNodeFromConstructorParams()', () => {
       expect(
         resolveInstanceBindingNodeFromConstructorParamsMock,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        resolveInstanceBindingNodeFromConstructorParamsMock,
-      ).toHaveBeenCalledWith(
+      ).toHaveBeenCalledExactlyOnceWith(
         constructorResolvedValuesFixture,
         paramsFixture,
         nodeFixture,

--- a/packages/container/libraries/core/src/resolution/actions/resolveInstanceBindingNodeFromConstructorParams.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveInstanceBindingNodeFromConstructorParams.spec.ts
@@ -108,15 +108,13 @@ describe(resolveInstanceBindingNodeFromConstructorParams, () => {
     });
 
     it('should call new node.binding.implementationType()', () => {
-      expect(nodeMock.binding.implementationType).toHaveBeenCalledTimes(1);
-      expect(nodeMock.binding.implementationType).toHaveBeenCalledWith(
-        ...constructorValuesFixture,
-      );
+      expect(
+        nodeMock.binding.implementationType,
+      ).toHaveBeenCalledExactlyOnceWith(...constructorValuesFixture);
     });
 
     it('should call setInstanceProperties()', () => {
-      expect(setInstancePropertiesMock).toHaveBeenCalledTimes(1);
-      expect(setInstancePropertiesMock).toHaveBeenCalledWith(
+      expect(setInstancePropertiesMock).toHaveBeenCalledExactlyOnceWith(
         paramsFixture,
         expect.any(Object),
         nodeMock,
@@ -124,8 +122,7 @@ describe(resolveInstanceBindingNodeFromConstructorParams, () => {
     });
 
     it('should call resolvePostConstructor()', () => {
-      expect(resolvePostConstruct).toHaveBeenCalledTimes(1);
-      expect(resolvePostConstruct).toHaveBeenCalledWith(
+      expect(resolvePostConstruct).toHaveBeenCalledExactlyOnceWith(
         expect.any(Object),
         nodeMock.binding,
         'post-construct-method-name',
@@ -173,15 +170,13 @@ describe(resolveInstanceBindingNodeFromConstructorParams, () => {
     });
 
     it('should call new node.binding.implementationType()', () => {
-      expect(nodeMock.binding.implementationType).toHaveBeenCalledTimes(1);
-      expect(nodeMock.binding.implementationType).toHaveBeenCalledWith(
-        ...constructorValuesFixture,
-      );
+      expect(
+        nodeMock.binding.implementationType,
+      ).toHaveBeenCalledExactlyOnceWith(...constructorValuesFixture);
     });
 
     it('should call setInstanceProperties()', () => {
-      expect(setInstancePropertiesMock).toHaveBeenCalledTimes(1);
-      expect(setInstancePropertiesMock).toHaveBeenCalledWith(
+      expect(setInstancePropertiesMock).toHaveBeenCalledExactlyOnceWith(
         paramsFixture,
         expect.any(Object),
         nodeMock,
@@ -189,8 +184,7 @@ describe(resolveInstanceBindingNodeFromConstructorParams, () => {
     });
 
     it('should call resolvePostConstructor()', () => {
-      expect(resolvePostConstruct).toHaveBeenCalledTimes(1);
-      expect(resolvePostConstruct).toHaveBeenCalledWith(
+      expect(resolvePostConstruct).toHaveBeenCalledExactlyOnceWith(
         expect.any(Object),
         nodeMock.binding,
         'post-construct-method-name',

--- a/packages/container/libraries/core/src/resolution/actions/resolveModuleDeactivations.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveModuleDeactivations.spec.ts
@@ -37,15 +37,13 @@ describe(resolveModuleDeactivations, () => {
     });
 
     it('should call params.getBindingsFromModule()', () => {
-      expect(paramsMock.getBindingsFromModule).toHaveBeenCalledTimes(1);
-      expect(paramsMock.getBindingsFromModule).toHaveBeenCalledWith(
+      expect(paramsMock.getBindingsFromModule).toHaveBeenCalledExactlyOnceWith(
         moduleIdFixture,
       );
     });
 
     it('should call resolveBindingsDeactivations()', () => {
-      expect(resolveBindingsDeactivations).toHaveBeenCalledTimes(1);
-      expect(resolveBindingsDeactivations).toHaveBeenCalledWith(
+      expect(resolveBindingsDeactivations).toHaveBeenCalledExactlyOnceWith(
         paramsMock,
         undefined,
       );

--- a/packages/container/libraries/core/src/resolution/actions/resolvePostConstruct.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolvePostConstruct.spec.ts
@@ -183,8 +183,7 @@ describe(resolvePostConstruct, () => {
       });
 
       it('should call post construct method', () => {
-        expect(postConstructMethodMock).toHaveBeenCalledTimes(1);
-        expect(postConstructMethodMock).toHaveBeenCalledWith();
+        expect(postConstructMethodMock).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should return instance', () => {
@@ -220,8 +219,7 @@ describe(resolvePostConstruct, () => {
       });
 
       it('should call post construct method', () => {
-        expect(postConstructMethodMock).toHaveBeenCalledTimes(1);
-        expect(postConstructMethodMock).toHaveBeenCalledWith();
+        expect(postConstructMethodMock).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should throw an InversifyCoreError', () => {
@@ -255,8 +253,7 @@ describe(resolvePostConstruct, () => {
       });
 
       it('should call post construct method', () => {
-        expect(postConstructMethodMock).toHaveBeenCalledTimes(1);
-        expect(postConstructMethodMock).toHaveBeenCalledWith();
+        expect(postConstructMethodMock).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should return instance', () => {
@@ -294,8 +291,7 @@ describe(resolvePostConstruct, () => {
       });
 
       it('should call post construct method', () => {
-        expect(postConstructMethodMock).toHaveBeenCalledTimes(1);
-        expect(postConstructMethodMock).toHaveBeenCalledWith();
+        expect(postConstructMethodMock).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should throw an InversifyCoreError', () => {

--- a/packages/container/libraries/core/src/resolution/actions/resolveResolvedValueBindingNode.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveResolvedValueBindingNode.spec.ts
@@ -68,16 +68,13 @@ describe(resolveResolvedValueBindingNode, () => {
     });
 
     it('should call resolveResolvedValueBindingParams()', () => {
-      expect(resolveResolvedValueBindingParamsMock).toHaveBeenCalledTimes(1);
-      expect(resolveResolvedValueBindingParamsMock).toHaveBeenCalledWith(
-        paramsFixture,
-        nodeMock,
-      );
+      expect(
+        resolveResolvedValueBindingParamsMock,
+      ).toHaveBeenCalledExactlyOnceWith(paramsFixture, nodeMock);
     });
 
     it('should call node.binding.factory()', () => {
-      expect(nodeMock.binding.factory).toHaveBeenCalledTimes(1);
-      expect(nodeMock.binding.factory).toHaveBeenCalledWith(
+      expect(nodeMock.binding.factory).toHaveBeenCalledExactlyOnceWith(
         ...constructorResolvedValues,
       );
     });
@@ -115,16 +112,13 @@ describe(resolveResolvedValueBindingNode, () => {
     });
 
     it('should call resolveResolvedValueBindingParams()', () => {
-      expect(resolveResolvedValueBindingParamsMock).toHaveBeenCalledTimes(1);
-      expect(resolveResolvedValueBindingParamsMock).toHaveBeenCalledWith(
-        paramsFixture,
-        nodeMock,
-      );
+      expect(
+        resolveResolvedValueBindingParamsMock,
+      ).toHaveBeenCalledExactlyOnceWith(paramsFixture, nodeMock);
     });
 
     it('should call node.binding.factory()', () => {
-      expect(nodeMock.binding.factory).toHaveBeenCalledTimes(1);
-      expect(nodeMock.binding.factory).toHaveBeenCalledWith(
+      expect(nodeMock.binding.factory).toHaveBeenCalledExactlyOnceWith(
         ...constructorResolvedValues,
       );
     });

--- a/packages/container/libraries/core/src/resolution/actions/resolveResolvedValueBindingParams.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveResolvedValueBindingParams.spec.ts
@@ -60,8 +60,7 @@ describe(resolveResolvedValueBindingParams, () => {
       });
 
       it('should call resolveServiceNode()', () => {
-        expect(resolveServiceNodeMock).toHaveBeenCalledTimes(1);
-        expect(resolveServiceNodeMock).toHaveBeenCalledWith(
+        expect(resolveServiceNodeMock).toHaveBeenCalledExactlyOnceWith(
           paramsFixture,
           paramNodeFixture,
         );
@@ -93,8 +92,7 @@ describe(resolveResolvedValueBindingParams, () => {
       });
 
       it('should call resolveServiceNode()', () => {
-        expect(resolveServiceNodeMock).toHaveBeenCalledTimes(1);
-        expect(resolveServiceNodeMock).toHaveBeenCalledWith(
+        expect(resolveServiceNodeMock).toHaveBeenCalledExactlyOnceWith(
           paramsFixture,
           paramNodeFixture,
         );

--- a/packages/container/libraries/core/src/resolution/actions/resolveScoped.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveScoped.spec.ts
@@ -93,8 +93,7 @@ describe(resolveScoped, () => {
     });
 
     it('should call getBinding()', () => {
-      expect(getBindingMock).toHaveBeenCalledTimes(1);
-      expect(getBindingMock).toHaveBeenCalledWith(argFixture);
+      expect(getBindingMock).toHaveBeenCalledExactlyOnceWith(argFixture);
     });
 
     it('should return expected result', () => {
@@ -155,18 +154,18 @@ describe(resolveScoped, () => {
     });
 
     it('should call getBinding()', () => {
-      expect(getBindingMock).toHaveBeenCalledTimes(1);
-      expect(getBindingMock).toHaveBeenCalledWith(argFixture);
+      expect(getBindingMock).toHaveBeenCalledExactlyOnceWith(argFixture);
     });
 
     it('should call resolve()', () => {
-      expect(resolveMock).toHaveBeenCalledTimes(1);
-      expect(resolveMock).toHaveBeenCalledWith(paramsMock, argFixture);
+      expect(resolveMock).toHaveBeenCalledExactlyOnceWith(
+        paramsMock,
+        argFixture,
+      );
     });
 
     it('should call resolveBindingActivations()', () => {
-      expect(resolveBindingActivations).toHaveBeenCalledTimes(1);
-      expect(resolveBindingActivations).toHaveBeenCalledWith(
+      expect(resolveBindingActivations).toHaveBeenCalledExactlyOnceWith(
         paramsMock,
         bindingFixture,
         resolveResult,
@@ -174,8 +173,7 @@ describe(resolveScoped, () => {
     });
 
     it('should call cacheResolvedValue()', () => {
-      expect(cacheResolvedValue).toHaveBeenCalledTimes(1);
-      expect(cacheResolvedValue).toHaveBeenCalledWith(
+      expect(cacheResolvedValue).toHaveBeenCalledExactlyOnceWith(
         bindingFixture,
         activatedResolveResult,
       );
@@ -233,20 +231,17 @@ describe(resolveScoped, () => {
     });
 
     it('should call getBinding()', () => {
-      expect(getBindingMock).toHaveBeenCalledTimes(1);
-      expect(getBindingMock).toHaveBeenCalledWith(argFixture);
+      expect(getBindingMock).toHaveBeenCalledExactlyOnceWith(argFixture);
     });
 
     it('should call params.requestScopeCache.has()', () => {
-      expect(paramsMock.requestScopeCache.has).toHaveBeenCalledTimes(1);
-      expect(paramsMock.requestScopeCache.has).toHaveBeenCalledWith(
+      expect(paramsMock.requestScopeCache.has).toHaveBeenCalledExactlyOnceWith(
         bindingFixture.id,
       );
     });
 
     it('should call params.requestScopeCache.get()', () => {
-      expect(paramsMock.requestScopeCache.get).toHaveBeenCalledTimes(1);
-      expect(paramsMock.requestScopeCache.get).toHaveBeenCalledWith(
+      expect(paramsMock.requestScopeCache.get).toHaveBeenCalledExactlyOnceWith(
         bindingFixture.id,
       );
     });
@@ -309,25 +304,24 @@ describe(resolveScoped, () => {
     });
 
     it('should call getBinding()', () => {
-      expect(getBindingMock).toHaveBeenCalledTimes(1);
-      expect(getBindingMock).toHaveBeenCalledWith(argFixture);
+      expect(getBindingMock).toHaveBeenCalledExactlyOnceWith(argFixture);
     });
 
     it('should call params.requestScopeCache.has()', () => {
-      expect(paramsMock.requestScopeCache.has).toHaveBeenCalledTimes(1);
-      expect(paramsMock.requestScopeCache.has).toHaveBeenCalledWith(
+      expect(paramsMock.requestScopeCache.has).toHaveBeenCalledExactlyOnceWith(
         bindingFixture.id,
       );
     });
 
     it('should call resolve()', () => {
-      expect(resolveMock).toHaveBeenCalledTimes(1);
-      expect(resolveMock).toHaveBeenCalledWith(paramsMock, argFixture);
+      expect(resolveMock).toHaveBeenCalledExactlyOnceWith(
+        paramsMock,
+        argFixture,
+      );
     });
 
     it('should call resolveBindingActivations()', () => {
-      expect(resolveBindingActivations).toHaveBeenCalledTimes(1);
-      expect(resolveBindingActivations).toHaveBeenCalledWith(
+      expect(resolveBindingActivations).toHaveBeenCalledExactlyOnceWith(
         paramsMock,
         bindingFixture,
         resolveResult,
@@ -335,8 +329,7 @@ describe(resolveScoped, () => {
     });
 
     it('should call params.requestScopeCache.set()', () => {
-      expect(paramsMock.requestScopeCache.set).toHaveBeenCalledTimes(1);
-      expect(paramsMock.requestScopeCache.set).toHaveBeenCalledWith(
+      expect(paramsMock.requestScopeCache.set).toHaveBeenCalledExactlyOnceWith(
         bindingFixture.id,
         activatedResolveResult,
       );
@@ -396,18 +389,18 @@ describe(resolveScoped, () => {
     });
 
     it('should call getBinding()', () => {
-      expect(getBindingMock).toHaveBeenCalledTimes(1);
-      expect(getBindingMock).toHaveBeenCalledWith(argFixture);
+      expect(getBindingMock).toHaveBeenCalledExactlyOnceWith(argFixture);
     });
 
     it('should call resolve()', () => {
-      expect(resolveMock).toHaveBeenCalledTimes(1);
-      expect(resolveMock).toHaveBeenCalledWith(paramsMock, argFixture);
+      expect(resolveMock).toHaveBeenCalledExactlyOnceWith(
+        paramsMock,
+        argFixture,
+      );
     });
 
     it('should call resolveBindingActivations()', () => {
-      expect(resolveBindingActivations).toHaveBeenCalledTimes(1);
-      expect(resolveBindingActivations).toHaveBeenCalledWith(
+      expect(resolveBindingActivations).toHaveBeenCalledExactlyOnceWith(
         paramsMock,
         bindingFixture,
         resolveResult,

--- a/packages/container/libraries/core/src/resolution/actions/resolveServiceDeactivations.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveServiceDeactivations.spec.ts
@@ -42,15 +42,13 @@ describe(resolveServiceDeactivations, () => {
     });
 
     it('should call params.getBindings()', () => {
-      expect(paramsMock.getBindings).toHaveBeenCalledTimes(1);
-      expect(paramsMock.getBindings).toHaveBeenCalledWith(
+      expect(paramsMock.getBindings).toHaveBeenCalledExactlyOnceWith(
         serviceIdentifierFixture,
       );
     });
 
     it('should call resolveBindingsDeactivations()', () => {
-      expect(resolveBindingsDeactivations).toHaveBeenCalledTimes(1);
-      expect(resolveBindingsDeactivations).toHaveBeenCalledWith(
+      expect(resolveBindingsDeactivations).toHaveBeenCalledExactlyOnceWith(
         paramsMock,
         undefined,
       );

--- a/packages/container/libraries/core/src/resolution/actions/resolveServiceRedirectionBindingNode.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveServiceRedirectionBindingNode.spec.ts
@@ -87,8 +87,7 @@ describe(resolveServiceRedirectionBindingNode, () => {
       });
 
       it('should call resolveBindingNode()', () => {
-        expect(resolveBindingNodeMock).toHaveBeenCalledTimes(1);
-        expect(resolveBindingNodeMock).toHaveBeenCalledWith(
+        expect(resolveBindingNodeMock).toHaveBeenCalledExactlyOnceWith(
           paramsFixture,
           bindingNodeFixture,
         );

--- a/packages/container/libraries/core/src/resolution/actions/resolveSingletonScopedBinding.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveSingletonScopedBinding.spec.ts
@@ -153,16 +153,14 @@ describe(resolveSingletonScopedBinding, () => {
       });
 
       it('should call resolve()', () => {
-        expect(resolveMock).toHaveBeenCalledTimes(1);
-        expect(resolveMock).toHaveBeenCalledWith(
+        expect(resolveMock).toHaveBeenCalledExactlyOnceWith(
           resolutionParamsFixture,
           bindingFixture,
         );
       });
 
       it('should call resolveBindingActivations()', () => {
-        expect(resolveBindingActivations).toHaveBeenCalledTimes(1);
-        expect(resolveBindingActivations).toHaveBeenCalledWith(
+        expect(resolveBindingActivations).toHaveBeenCalledExactlyOnceWith(
           resolutionParamsFixture,
           bindingFixture,
           resolveResult,
@@ -170,8 +168,7 @@ describe(resolveSingletonScopedBinding, () => {
       });
 
       it('should call cacheResolvedValue()', () => {
-        expect(cacheResolvedValue).toHaveBeenCalledTimes(1);
-        expect(cacheResolvedValue).toHaveBeenCalledWith(
+        expect(cacheResolvedValue).toHaveBeenCalledExactlyOnceWith(
           bindingFixture,
           activatedResolveResult,
         );

--- a/packages/container/libraries/core/src/resolution/calculations/resolveDynamicValueBindingCallback.spec.ts
+++ b/packages/container/libraries/core/src/resolution/calculations/resolveDynamicValueBindingCallback.spec.ts
@@ -50,8 +50,7 @@ describe(resolveDynamicValueBindingCallback, () => {
     });
 
     it('should call dynamicValueBinding.value()', () => {
-      expect(dynamicValueBindingMock.value).toHaveBeenCalledTimes(1);
-      expect(dynamicValueBindingMock.value).toHaveBeenCalledWith(
+      expect(dynamicValueBindingMock.value).toHaveBeenCalledExactlyOnceWith(
         resolutionParamsFixture.context,
       );
     });

--- a/packages/container/libraries/core/src/resolution/calculations/resolveFactoryBindingCallback.spec.ts
+++ b/packages/container/libraries/core/src/resolution/calculations/resolveFactoryBindingCallback.spec.ts
@@ -51,8 +51,7 @@ describe(resolveFactoryBindingCallback, () => {
     });
 
     it('should call factoryValueBinding.factory()', () => {
-      expect(factoryValueBindingMock.factory).toHaveBeenCalledTimes(1);
-      expect(factoryValueBindingMock.factory).toHaveBeenCalledWith(
+      expect(factoryValueBindingMock.factory).toHaveBeenCalledExactlyOnceWith(
         resolutionParamsFixture.context,
       );
     });

--- a/packages/container/libraries/core/src/resolution/calculations/resolveProviderBindingCallback.spec.ts
+++ b/packages/container/libraries/core/src/resolution/calculations/resolveProviderBindingCallback.spec.ts
@@ -51,8 +51,7 @@ describe(resolveProviderBindingCallback, () => {
     });
 
     it('should call binding.provider()', () => {
-      expect(providerBindingMock.provider).toHaveBeenCalledTimes(1);
-      expect(providerBindingMock.provider).toHaveBeenCalledWith(
+      expect(providerBindingMock.provider).toHaveBeenCalledExactlyOnceWith(
         resolutionParamsFixture.context,
       );
     });

--- a/packages/container/libraries/plugin-dispose/src/actions/getPluginDisposeBinding.spec.ts
+++ b/packages/container/libraries/plugin-dispose/src/actions/getPluginDisposeBinding.spec.ts
@@ -65,13 +65,11 @@ describe(getPluginDisposeBinding, () => {
     });
 
     it('should call getPluginDisposeBindingMap', () => {
-      expect(getPluginDisposeBindingMap).toHaveBeenCalledTimes(1);
-      expect(getPluginDisposeBindingMap).toHaveBeenCalledWith();
+      expect(getPluginDisposeBindingMap).toHaveBeenCalledExactlyOnceWith();
     });
 
     it('should call map.get with the binding', () => {
-      expect(mapMock.get).toHaveBeenCalledTimes(1);
-      expect(mapMock.get).toHaveBeenCalledWith(bindingFixture);
+      expect(mapMock.get).toHaveBeenCalledExactlyOnceWith(bindingFixture);
     });
 
     it('should return BindingDisposeMetadata', () => {

--- a/packages/container/libraries/plugin-dispose/src/actions/registerSingletonScopedBindings.spec.ts
+++ b/packages/container/libraries/plugin-dispose/src/actions/registerSingletonScopedBindings.spec.ts
@@ -127,15 +127,13 @@ describe(registerSingletonScopedBindings, () => {
       });
 
       it('should call getPluginDisposeBinding()', () => {
-        expect(getPluginDisposeBinding).toHaveBeenCalledTimes(1);
-        expect(getPluginDisposeBinding).toHaveBeenCalledWith(
+        expect(getPluginDisposeBinding).toHaveBeenCalledExactlyOnceWith(
           leafBindingNode.binding,
         );
       });
 
       it('should call setPluginDisposeBinding()', () => {
-        expect(setPluginDisposeBinding).toHaveBeenCalledTimes(1);
-        expect(setPluginDisposeBinding).toHaveBeenCalledWith(
+        expect(setPluginDisposeBinding).toHaveBeenCalledExactlyOnceWith(
           leafBindingNode.binding,
           {
             dependendentBindings: new Set(),
@@ -172,8 +170,7 @@ describe(registerSingletonScopedBindings, () => {
       });
 
       it('should call getPluginDisposeBinding()', () => {
-        expect(getPluginDisposeBinding).toHaveBeenCalledTimes(1);
-        expect(getPluginDisposeBinding).toHaveBeenCalledWith(
+        expect(getPluginDisposeBinding).toHaveBeenCalledExactlyOnceWith(
           leafBindingNode.binding,
         );
       });
@@ -250,15 +247,13 @@ describe(registerSingletonScopedBindings, () => {
       });
 
       it('should call getPluginDisposeBinding()', () => {
-        expect(getPluginDisposeBinding).toHaveBeenCalledTimes(1);
-        expect(getPluginDisposeBinding).toHaveBeenCalledWith(
+        expect(getPluginDisposeBinding).toHaveBeenCalledExactlyOnceWith(
           leafBindingNode.binding,
         );
       });
 
       it('should call setPluginDisposeBinding()', () => {
-        expect(setPluginDisposeBinding).toHaveBeenCalledTimes(1);
-        expect(setPluginDisposeBinding).toHaveBeenCalledWith(
+        expect(setPluginDisposeBinding).toHaveBeenCalledExactlyOnceWith(
           leafBindingNode.binding,
           {
             dependendentBindings: new Set(),
@@ -442,8 +437,7 @@ describe(registerSingletonScopedBindings, () => {
       });
 
       it('should call getPluginDisposeBinding()', () => {
-        expect(getPluginDisposeBinding).toHaveBeenCalledTimes(1);
-        expect(getPluginDisposeBinding).toHaveBeenCalledWith(
+        expect(getPluginDisposeBinding).toHaveBeenCalledExactlyOnceWith(
           instanceBindingNode.binding,
         );
       });
@@ -617,8 +611,7 @@ describe(registerSingletonScopedBindings, () => {
       });
 
       it('should call getPluginDisposeBinding()', () => {
-        expect(getPluginDisposeBinding).toHaveBeenCalledTimes(1);
-        expect(getPluginDisposeBinding).toHaveBeenCalledWith(
+        expect(getPluginDisposeBinding).toHaveBeenCalledExactlyOnceWith(
           resolvedValueBindingNode.binding,
         );
       });
@@ -711,15 +704,13 @@ describe(registerSingletonScopedBindings, () => {
       });
 
       it('should call getPluginDisposeBinding()', () => {
-        expect(getPluginDisposeBinding).toHaveBeenCalledTimes(1);
-        expect(getPluginDisposeBinding).toHaveBeenCalledWith(
+        expect(getPluginDisposeBinding).toHaveBeenCalledExactlyOnceWith(
           leafBindingNode.binding,
         );
       });
 
       it('should call setPluginDisposeBinding()', () => {
-        expect(setPluginDisposeBinding).toHaveBeenCalledTimes(1);
-        expect(setPluginDisposeBinding).toHaveBeenCalledWith(
+        expect(setPluginDisposeBinding).toHaveBeenCalledExactlyOnceWith(
           leafBindingNode.binding,
           {
             dependendentBindings: new Set(),

--- a/packages/container/libraries/plugin-dispose/src/actions/setPluginDisposeBinding.spec.ts
+++ b/packages/container/libraries/plugin-dispose/src/actions/setPluginDisposeBinding.spec.ts
@@ -67,13 +67,11 @@ describe(setPluginDisposeBinding, () => {
     });
 
     it('should call getPluginDisposeBindingMap()', () => {
-      expect(getPluginDisposeBindingMap).toHaveBeenCalledTimes(1);
-      expect(getPluginDisposeBindingMap).toHaveBeenCalledWith();
+      expect(getPluginDisposeBindingMap).toHaveBeenCalledExactlyOnceWith();
     });
 
     it('should call map.set()', () => {
-      expect(mapMock.set).toHaveBeenCalledTimes(1);
-      expect(mapMock.set).toHaveBeenCalledWith(
+      expect(mapMock.set).toHaveBeenCalledExactlyOnceWith(
         bindingFixture,
         bindingDisposeMetadataFixture,
       );

--- a/packages/container/libraries/plugin-dispose/src/plugins/PluginDispose.int.spec.ts
+++ b/packages/container/libraries/plugin-dispose/src/plugins/PluginDispose.int.spec.ts
@@ -45,8 +45,7 @@ describe(PluginDispose, () => {
     });
 
     it('should call the deactivation function', () => {
-      expect(bindingDeactivationMock).toHaveBeenCalledTimes(1);
-      expect(bindingDeactivationMock).toHaveBeenCalledWith(
+      expect(bindingDeactivationMock).toHaveBeenCalledExactlyOnceWith(
         bindingResolvedValue,
       );
     });
@@ -83,8 +82,7 @@ describe(PluginDispose, () => {
     });
 
     it('should call the deactivation function', () => {
-      expect(bindingDeactivationMock).toHaveBeenCalledTimes(1);
-      expect(bindingDeactivationMock).toHaveBeenCalledWith(
+      expect(bindingDeactivationMock).toHaveBeenCalledExactlyOnceWith(
         bindingResolvedValue,
       );
     });
@@ -141,15 +139,13 @@ describe(PluginDispose, () => {
     });
 
     it('should call the first deactivation function', () => {
-      expect(firstBindingDeactivationMock).toHaveBeenCalledTimes(1);
-      expect(firstBindingDeactivationMock).toHaveBeenCalledWith(
+      expect(firstBindingDeactivationMock).toHaveBeenCalledExactlyOnceWith(
         firstBindingResolvedValue,
       );
     });
 
     it('should call the second deactivation function', () => {
-      expect(secondBindingDeactivationMock).toHaveBeenCalledTimes(1);
-      expect(secondBindingDeactivationMock).toHaveBeenCalledWith(
+      expect(secondBindingDeactivationMock).toHaveBeenCalledExactlyOnceWith(
         secondBindingResolvedValue,
       );
     });

--- a/packages/container/libraries/plugin-dispose/src/plugins/PluginDispose.spec.ts
+++ b/packages/container/libraries/plugin-dispose/src/plugins/PluginDispose.spec.ts
@@ -60,8 +60,9 @@ describe(PluginDispose, () => {
       });
 
       it('should register the singleton scoped bindings', () => {
-        expect(pluginApiMock.onPlan).toHaveBeenCalledTimes(1);
-        expect(pluginApiMock.onPlan).toHaveBeenCalledWith(expect.any(Function));
+        expect(pluginApiMock.onPlan).toHaveBeenCalledExactlyOnceWith(
+          expect.any(Function),
+        );
       });
 
       it('should return undefined', () => {

--- a/packages/docs/tools/inversify-code-examples/src/examples/containerApiOnDeactivation.int.spec.ts
+++ b/packages/docs/tools/inversify-code-examples/src/examples/containerApiOnDeactivation.int.spec.ts
@@ -4,7 +4,6 @@ import { katanaDamageSpy } from './containerApiOnDeactivation';
 
 describe('Container API (onDeactivation)', () => {
   it('should provide activated service', () => {
-    expect(katanaDamageSpy).toHaveBeenCalledTimes(1);
-    expect(katanaDamageSpy).toHaveBeenCalledWith();
+    expect(katanaDamageSpy).toHaveBeenCalledExactlyOnceWith();
   });
 });

--- a/packages/docs/tools/inversify-code-examples/src/examples/decoratorApiPreDestroy.int.spec.ts
+++ b/packages/docs/tools/inversify-code-examples/src/examples/decoratorApiPreDestroy.int.spec.ts
@@ -4,7 +4,6 @@ import { katanaDamageSpy } from './decoratorApiPreDestroy';
 
 describe('Decorator API (preDestroy)', () => {
   it('should provide activated service', () => {
-    expect(katanaDamageSpy).toHaveBeenCalledTimes(1);
-    expect(katanaDamageSpy).toHaveBeenCalledWith();
+    expect(katanaDamageSpy).toHaveBeenCalledExactlyOnceWith();
   });
 });

--- a/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/updateOwnReflectMetadata.spec.ts
+++ b/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/updateOwnReflectMetadata.spec.ts
@@ -61,8 +61,7 @@ describe(updateOwnReflectMetadata, () => {
       });
 
       it('should call getOwnReflectMetadata()', () => {
-        expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture,
           metadataKeyFixture,
           undefined,
@@ -70,13 +69,13 @@ describe(updateOwnReflectMetadata, () => {
       });
 
       it('should call buildDefaultValue', () => {
-        expect(buildDefaultValueMock).toHaveBeenCalledTimes(1);
-        expect(buildDefaultValueMock).toHaveBeenCalledWith();
+        expect(buildDefaultValueMock).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should call callback()', () => {
-        expect(callbackMock).toHaveBeenCalledTimes(1);
-        expect(callbackMock).toHaveBeenCalledWith(defaultValueFixture);
+        expect(callbackMock).toHaveBeenCalledExactlyOnceWith(
+          defaultValueFixture,
+        );
       });
 
       it('should define metadata', () => {
@@ -116,8 +115,7 @@ describe(updateOwnReflectMetadata, () => {
       });
 
       it('should call getOwnReflectMetadata()', () => {
-        expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture,
           metadataKeyFixture,
           undefined,
@@ -129,8 +127,7 @@ describe(updateOwnReflectMetadata, () => {
       });
 
       it('should call callback()', () => {
-        expect(callbackMock).toHaveBeenCalledTimes(1);
-        expect(callbackMock).toHaveBeenCalledWith(metadataFixture);
+        expect(callbackMock).toHaveBeenCalledExactlyOnceWith(metadataFixture);
       });
 
       it('should define metadata', () => {
@@ -192,8 +189,7 @@ describe(updateOwnReflectMetadata, () => {
       });
 
       it('should call getOwnReflectMetadata()', () => {
-        expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture,
           metadataKeyFixture,
           propertyKeyFixture,
@@ -201,13 +197,13 @@ describe(updateOwnReflectMetadata, () => {
       });
 
       it('should call buildDefaultValue', () => {
-        expect(buildDefaultValueMock).toHaveBeenCalledTimes(1);
-        expect(buildDefaultValueMock).toHaveBeenCalledWith();
+        expect(buildDefaultValueMock).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should call callback()', () => {
-        expect(callbackMock).toHaveBeenCalledTimes(1);
-        expect(callbackMock).toHaveBeenCalledWith(defaultValueFixture);
+        expect(callbackMock).toHaveBeenCalledExactlyOnceWith(
+          defaultValueFixture,
+        );
       });
 
       it('should define metadata', () => {
@@ -254,8 +250,7 @@ describe(updateOwnReflectMetadata, () => {
       });
 
       it('should call getOwnReflectMetadata()', () => {
-        expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture,
           metadataKeyFixture,
           propertyKeyFixture,
@@ -267,8 +262,7 @@ describe(updateOwnReflectMetadata, () => {
       });
 
       it('should call callback()', () => {
-        expect(callbackMock).toHaveBeenCalledTimes(1);
-        expect(callbackMock).toHaveBeenCalledWith(metadataFixture);
+        expect(callbackMock).toHaveBeenCalledExactlyOnceWith(metadataFixture);
       });
 
       it('should define metadata', () => {

--- a/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/updateReflectMetadata.spec.ts
+++ b/packages/foundation/libraries/reflect-metadata-utils/src/reflectMetadata/utils/updateReflectMetadata.spec.ts
@@ -59,8 +59,7 @@ describe(updateReflectMetadata, () => {
       });
 
       it('should call getReflectMetadata()', () => {
-        expect(getReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(getReflectMetadata).toHaveBeenCalledWith(
+        expect(getReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture,
           metadataKeyFixture,
           undefined,
@@ -68,13 +67,13 @@ describe(updateReflectMetadata, () => {
       });
 
       it('should call buildDefaultValue', () => {
-        expect(buildDefaultValueMock).toHaveBeenCalledTimes(1);
-        expect(buildDefaultValueMock).toHaveBeenCalledWith();
+        expect(buildDefaultValueMock).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should call callback()', () => {
-        expect(callbackMock).toHaveBeenCalledTimes(1);
-        expect(callbackMock).toHaveBeenCalledWith(defaultValueFixture);
+        expect(callbackMock).toHaveBeenCalledExactlyOnceWith(
+          defaultValueFixture,
+        );
       });
 
       it('should define metadata', () => {
@@ -113,8 +112,7 @@ describe(updateReflectMetadata, () => {
       });
 
       it('should call getReflectMetadata()', () => {
-        expect(getReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(getReflectMetadata).toHaveBeenCalledWith(
+        expect(getReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture,
           metadataKeyFixture,
           undefined,
@@ -126,8 +124,7 @@ describe(updateReflectMetadata, () => {
       });
 
       it('should call callback()', () => {
-        expect(callbackMock).toHaveBeenCalledTimes(1);
-        expect(callbackMock).toHaveBeenCalledWith(metadataFixture);
+        expect(callbackMock).toHaveBeenCalledExactlyOnceWith(metadataFixture);
       });
 
       it('should define metadata', () => {
@@ -183,8 +180,7 @@ describe(updateReflectMetadata, () => {
       });
 
       it('should call getReflectMetadata()', () => {
-        expect(getReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(getReflectMetadata).toHaveBeenCalledWith(
+        expect(getReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture,
           metadataKeyFixture,
           propertyKeyFixture,
@@ -192,13 +188,13 @@ describe(updateReflectMetadata, () => {
       });
 
       it('should call buildDefaultValue', () => {
-        expect(buildDefaultValueMock).toHaveBeenCalledTimes(1);
-        expect(buildDefaultValueMock).toHaveBeenCalledWith();
+        expect(buildDefaultValueMock).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should call callback()', () => {
-        expect(callbackMock).toHaveBeenCalledTimes(1);
-        expect(callbackMock).toHaveBeenCalledWith(defaultValueFixture);
+        expect(callbackMock).toHaveBeenCalledExactlyOnceWith(
+          defaultValueFixture,
+        );
       });
 
       it('should define metadata', () => {
@@ -243,8 +239,7 @@ describe(updateReflectMetadata, () => {
       });
 
       it('should call getReflectMetadata()', () => {
-        expect(getReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(getReflectMetadata).toHaveBeenCalledWith(
+        expect(getReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture,
           metadataKeyFixture,
           propertyKeyFixture,
@@ -256,8 +251,7 @@ describe(updateReflectMetadata, () => {
       });
 
       it('should call callback()', () => {
-        expect(callbackMock).toHaveBeenCalledTimes(1);
-        expect(callbackMock).toHaveBeenCalledWith(metadataFixture);
+        expect(callbackMock).toHaveBeenCalledExactlyOnceWith(metadataFixture);
       });
 
       it('should define metadata', () => {

--- a/packages/framework/core/src/error-filter/calculations/getCatchErrorMetadata.spec.ts
+++ b/packages/framework/core/src/error-filter/calculations/getCatchErrorMetadata.spec.ts
@@ -28,8 +28,7 @@ describe(getCatchErrorMetadata, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         targetFixture,
         catchErrorMetadataReflectKey,
       );
@@ -59,8 +58,7 @@ describe(getCatchErrorMetadata, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         targetFixture,
         catchErrorMetadataReflectKey,
       );

--- a/packages/framework/core/src/error-filter/calculations/getClassErrorFilterMetadata.spec.ts
+++ b/packages/framework/core/src/error-filter/calculations/getClassErrorFilterMetadata.spec.ts
@@ -25,8 +25,7 @@ describe(getClassErrorFilterMetadata, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         classFixture,
         classErrorFilterMetadataReflectKey,
       );
@@ -60,8 +59,7 @@ describe(getClassErrorFilterMetadata, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         classFixture,
         classErrorFilterMetadataReflectKey,
       );

--- a/packages/framework/core/src/error-filter/calculations/getClassMethodErrorFilterMetadata.spec.ts
+++ b/packages/framework/core/src/error-filter/calculations/getClassMethodErrorFilterMetadata.spec.ts
@@ -30,8 +30,7 @@ describe(getClassMethodErrorFilterMetadata, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         classFixture,
         classMethodErrorFilterMetadataReflectKey,
         classMethodKeyFixture,
@@ -71,8 +70,7 @@ describe(getClassMethodErrorFilterMetadata, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         classFixture,
         classMethodErrorFilterMetadataReflectKey,
         classMethodKeyFixture,

--- a/packages/framework/core/src/error-filter/decorators/CatchError.spec.ts
+++ b/packages/framework/core/src/error-filter/decorators/CatchError.spec.ts
@@ -60,20 +60,23 @@ describe(CatchError, () => {
       });
 
       it('should call injectable', () => {
-        expect(injectable).toHaveBeenCalledWith(undefined);
+        expect(injectable).toHaveBeenCalledExactlyOnceWith(undefined);
       });
 
       it('should call ClassDecorator', () => {
-        expect(classDecoratorMock).toHaveBeenCalledWith(targetFixture);
+        expect(classDecoratorMock).toHaveBeenCalledExactlyOnceWith(
+          targetFixture,
+        );
       });
 
       it('should call buildCatchErrorMetadata', () => {
-        expect(buildCatchErrorMetadata).toHaveBeenCalledTimes(1);
-        expect(buildCatchErrorMetadata).toHaveBeenCalledWith(errorFixture);
+        expect(buildCatchErrorMetadata).toHaveBeenCalledExactlyOnceWith(
+          errorFixture,
+        );
       });
 
       it('should set metadata with error filter', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture,
           catchErrorMetadataReflectKey,
           buildEmptySetMetadata,
@@ -119,14 +122,13 @@ describe(CatchError, () => {
       });
 
       it('should call buildCatchErrorMetadata', () => {
-        expect(buildCatchErrorMetadata).toHaveBeenCalledTimes(1);
-        expect(buildCatchErrorMetadata).toHaveBeenCalledWith(
+        expect(buildCatchErrorMetadata).toHaveBeenCalledExactlyOnceWith(
           optionsFixture.error,
         );
       });
 
       it('should set metadata with controller options', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture,
           catchErrorMetadataReflectKey,
           buildEmptySetMetadata,
@@ -171,22 +173,25 @@ describe(CatchError, () => {
       });
 
       it('should call injectable', () => {
-        expect(injectable).toHaveBeenCalledWith(optionsFixture.scope);
+        expect(injectable).toHaveBeenCalledExactlyOnceWith(
+          optionsFixture.scope,
+        );
       });
 
       it('should call ClassDecorator', () => {
-        expect(classDecoratorMock).toHaveBeenCalledWith(targetFixture);
+        expect(classDecoratorMock).toHaveBeenCalledExactlyOnceWith(
+          targetFixture,
+        );
       });
 
       it('should call buildCatchErrorMetadata', () => {
-        expect(buildCatchErrorMetadata).toHaveBeenCalledTimes(1);
-        expect(buildCatchErrorMetadata).toHaveBeenCalledWith(
+        expect(buildCatchErrorMetadata).toHaveBeenCalledExactlyOnceWith(
           optionsFixture.error,
         );
       });
 
       it('should set metadata with controller options', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture,
           catchErrorMetadataReflectKey,
           buildEmptySetMetadata,
@@ -228,20 +233,21 @@ describe(CatchError, () => {
       });
 
       it('should call injectable', () => {
-        expect(injectable).toHaveBeenCalledWith(undefined);
+        expect(injectable).toHaveBeenCalledExactlyOnceWith(undefined);
       });
 
       it('should call ClassDecorator', () => {
-        expect(classDecoratorMock).toHaveBeenCalledWith(targetFixture);
+        expect(classDecoratorMock).toHaveBeenCalledExactlyOnceWith(
+          targetFixture,
+        );
       });
 
       it('should call buildCatchErrorMetadata', () => {
-        expect(buildCatchErrorMetadata).toHaveBeenCalledTimes(1);
-        expect(buildCatchErrorMetadata).toHaveBeenCalledWith(null);
+        expect(buildCatchErrorMetadata).toHaveBeenCalledExactlyOnceWith(null);
       });
 
       it('should set metadata with error filter', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture,
           catchErrorMetadataReflectKey,
           buildEmptySetMetadata,

--- a/packages/framework/core/src/error-filter/decorators/UseErrorFilter.spec.ts
+++ b/packages/framework/core/src/error-filter/decorators/UseErrorFilter.spec.ts
@@ -54,15 +54,13 @@ describe(UseErrorFilter, () => {
       });
 
       it('should call updateSetMetadataWithList()', () => {
-        expect(updateSetMetadataWithList).toHaveBeenCalledTimes(1);
-        expect(updateSetMetadataWithList).toHaveBeenCalledWith([
+        expect(updateSetMetadataWithList).toHaveBeenCalledExactlyOnceWith([
           errorFilterFixture,
         ]);
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture,
           classErrorFilterMetadataReflectKey,
           buildEmptySetMetadata,
@@ -115,15 +113,13 @@ describe(UseErrorFilter, () => {
       });
 
       it('should call updateSetMetadataWithList()', () => {
-        expect(updateSetMetadataWithList).toHaveBeenCalledTimes(1);
-        expect(updateSetMetadataWithList).toHaveBeenCalledWith([
+        expect(updateSetMetadataWithList).toHaveBeenCalledExactlyOnceWith([
           errorFilterFixture,
         ]);
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture,
           classMethodErrorFilterMetadataReflectKey,
           buildEmptySetMetadata,

--- a/packages/framework/core/src/guard/calculations/getClassGuardList.spec.ts
+++ b/packages/framework/core/src/guard/calculations/getClassGuardList.spec.ts
@@ -25,8 +25,7 @@ describe(getClassGuardList, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         classFixture,
         classGuardMetadataReflectKey,
       );
@@ -58,8 +57,7 @@ describe(getClassGuardList, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         classFixture,
         classGuardMetadataReflectKey,
       );

--- a/packages/framework/core/src/guard/calculations/getClassMethodGuardList.spec.ts
+++ b/packages/framework/core/src/guard/calculations/getClassMethodGuardList.spec.ts
@@ -27,8 +27,7 @@ describe(getClassMethodGuardList, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         classFixture,
         classMethodGuardMetadataReflectKey,
         classMethodKeyFixture,
@@ -63,8 +62,7 @@ describe(getClassMethodGuardList, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         classFixture,
         classMethodGuardMetadataReflectKey,
         classMethodKeyFixture,

--- a/packages/framework/core/src/guard/decorators/UseGuard.spec.ts
+++ b/packages/framework/core/src/guard/decorators/UseGuard.spec.ts
@@ -39,15 +39,13 @@ describe(UseGuard, () => {
       });
 
       it('should call buildArrayMetadataWithArray()', () => {
-        expect(buildArrayMetadataWithArray).toHaveBeenCalledTimes(1);
-        expect(buildArrayMetadataWithArray).toHaveBeenCalledWith([
+        expect(buildArrayMetadataWithArray).toHaveBeenCalledExactlyOnceWith([
           guardServiceIdentifierFixture,
         ]);
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture,
           classGuardMetadataReflectKey,
           buildEmptyArrayMetadata,
@@ -88,15 +86,13 @@ describe(UseGuard, () => {
       });
 
       it('should call buildArrayMetadataWithArray()', () => {
-        expect(buildArrayMetadataWithArray).toHaveBeenCalledTimes(1);
-        expect(buildArrayMetadataWithArray).toHaveBeenCalledWith([
+        expect(buildArrayMetadataWithArray).toHaveBeenCalledExactlyOnceWith([
           guardServiceIdentifierFixture,
         ]);
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture.constructor,
           classMethodGuardMetadataReflectKey,
           buildEmptyArrayMetadata,

--- a/packages/framework/core/src/interceptor/calculations/getClassInterceptorList.spec.ts
+++ b/packages/framework/core/src/interceptor/calculations/getClassInterceptorList.spec.ts
@@ -25,8 +25,7 @@ describe(getClassInterceptorList, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         classFixture,
         classInterceptorMetadataReflectKey,
       );
@@ -58,8 +57,7 @@ describe(getClassInterceptorList, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         classFixture,
         classInterceptorMetadataReflectKey,
       );

--- a/packages/framework/core/src/interceptor/calculations/getClassMethodInterceptorList.spec.ts
+++ b/packages/framework/core/src/interceptor/calculations/getClassMethodInterceptorList.spec.ts
@@ -30,8 +30,7 @@ describe(getClassMethodInterceptorList, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         classFixture,
         classMethodInterceptorMetadataReflectKey,
         classMethodKeyFixture,
@@ -69,8 +68,7 @@ describe(getClassMethodInterceptorList, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         classFixture,
         classMethodInterceptorMetadataReflectKey,
         classMethodKeyFixture,

--- a/packages/framework/core/src/interceptor/decorators/UseInterceptor.spec.ts
+++ b/packages/framework/core/src/interceptor/decorators/UseInterceptor.spec.ts
@@ -39,15 +39,13 @@ describe(UseInterceptor, () => {
       });
 
       it('should call buildArrayMetadataWithArray()', () => {
-        expect(buildArrayMetadataWithArray).toHaveBeenCalledTimes(1);
-        expect(buildArrayMetadataWithArray).toHaveBeenCalledWith([
+        expect(buildArrayMetadataWithArray).toHaveBeenCalledExactlyOnceWith([
           interceptorServiceIdentifier,
         ]);
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture,
           classInterceptorMetadataReflectKey,
           buildEmptyArrayMetadata,
@@ -88,15 +86,13 @@ describe(UseInterceptor, () => {
       });
 
       it('should call buildArrayMetadataWithArray()', () => {
-        expect(buildArrayMetadataWithArray).toHaveBeenCalledTimes(1);
-        expect(buildArrayMetadataWithArray).toHaveBeenCalledWith([
+        expect(buildArrayMetadataWithArray).toHaveBeenCalledExactlyOnceWith([
           interceptorServiceIdentifier,
         ]);
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture.constructor,
           classMethodInterceptorMetadataReflectKey,
           buildEmptyArrayMetadata,

--- a/packages/framework/core/src/middleware/calculations/getClassMethodMiddlewareList.spec.ts
+++ b/packages/framework/core/src/middleware/calculations/getClassMethodMiddlewareList.spec.ts
@@ -30,8 +30,7 @@ describe(getClassMethodMiddlewareList, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         classFixture,
         classMethodMiddlewareMetadataReflectKey,
         classMethodKeyFixture,
@@ -69,8 +68,7 @@ describe(getClassMethodMiddlewareList, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         classFixture,
         classMethodMiddlewareMetadataReflectKey,
         classMethodKeyFixture,

--- a/packages/framework/core/src/middleware/calculations/getClassMiddlewareList.spec.ts
+++ b/packages/framework/core/src/middleware/calculations/getClassMiddlewareList.spec.ts
@@ -25,8 +25,7 @@ describe(getClassMiddlewareList, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         targetFixture,
         classMiddlewareMetadataReflectKey,
       );
@@ -58,8 +57,7 @@ describe(getClassMiddlewareList, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         targetFixture,
         classMiddlewareMetadataReflectKey,
       );

--- a/packages/framework/core/src/middleware/decorators/ApplyMiddleware.spec.ts
+++ b/packages/framework/core/src/middleware/decorators/ApplyMiddleware.spec.ts
@@ -39,15 +39,13 @@ describe(ApplyMiddleware, () => {
       });
 
       it('should call buildArrayMetadataWithArray()', () => {
-        expect(buildArrayMetadataWithArray).toHaveBeenCalledTimes(1);
-        expect(buildArrayMetadataWithArray).toHaveBeenCalledWith([
+        expect(buildArrayMetadataWithArray).toHaveBeenCalledExactlyOnceWith([
           middlewareServiceIdentifierFixture,
         ]);
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture,
           classMiddlewareMetadataReflectKey,
           buildEmptyArrayMetadata,
@@ -88,15 +86,13 @@ describe(ApplyMiddleware, () => {
       });
 
       it('should call buildArrayMetadataWithArray()', () => {
-        expect(buildArrayMetadataWithArray).toHaveBeenCalledTimes(1);
-        expect(buildArrayMetadataWithArray).toHaveBeenCalledWith([
+        expect(buildArrayMetadataWithArray).toHaveBeenCalledExactlyOnceWith([
           middlewareServiceIdentifierFixture,
         ]);
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           controllerFixture.constructor,
           classMethodMiddlewareMetadataReflectKey,
           buildEmptyArrayMetadata,

--- a/packages/framework/http/libraries/better-auth/src/auth/calculations/buildUserSessionFromExpressRequest.spec.ts
+++ b/packages/framework/http/libraries/better-auth/src/auth/calculations/buildUserSessionFromExpressRequest.spec.ts
@@ -61,13 +61,13 @@ describe(buildUserSessionFromExpressRequest, () => {
       });
 
       it('should call getBetterAuthFromRequest()', () => {
-        expect(getBetterAuthFromRequest).toHaveBeenCalledTimes(1);
-        expect(getBetterAuthFromRequest).toHaveBeenCalledWith(requestFixture);
+        expect(getBetterAuthFromRequest).toHaveBeenCalledExactlyOnceWith(
+          requestFixture,
+        );
       });
 
       it('should call auth.api.getSession()', () => {
-        expect(authMock.api.getSession).toHaveBeenCalledTimes(1);
-        expect(authMock.api.getSession).toHaveBeenCalledWith({
+        expect(authMock.api.getSession).toHaveBeenCalledExactlyOnceWith({
           asResponse: false,
           headers: new Headers(),
         });
@@ -123,8 +123,9 @@ describe(buildUserSessionFromExpressRequest, () => {
       });
 
       it('should call getBetterAuthFromRequest()', () => {
-        expect(getBetterAuthFromRequest).toHaveBeenCalledTimes(1);
-        expect(getBetterAuthFromRequest).toHaveBeenCalledWith(requestFixture);
+        expect(getBetterAuthFromRequest).toHaveBeenCalledExactlyOnceWith(
+          requestFixture,
+        );
       });
 
       it('should call auth.api.getSession()', () => {
@@ -132,8 +133,7 @@ describe(buildUserSessionFromExpressRequest, () => {
 
         headers.append('cookie', requestFixture.headers.cookie as string);
 
-        expect(authMock.api.getSession).toHaveBeenCalledTimes(1);
-        expect(authMock.api.getSession).toHaveBeenCalledWith({
+        expect(authMock.api.getSession).toHaveBeenCalledExactlyOnceWith({
           asResponse: false,
           headers,
         });

--- a/packages/framework/http/libraries/better-auth/src/auth/calculations/buildUserSessionFromFastifyRequest.spec.ts
+++ b/packages/framework/http/libraries/better-auth/src/auth/calculations/buildUserSessionFromFastifyRequest.spec.ts
@@ -61,13 +61,13 @@ describe(buildUserSessionFromFastifyRequest, () => {
       });
 
       it('should call getBetterAuthFromRequest()', () => {
-        expect(getBetterAuthFromRequest).toHaveBeenCalledTimes(1);
-        expect(getBetterAuthFromRequest).toHaveBeenCalledWith(requestFixture);
+        expect(getBetterAuthFromRequest).toHaveBeenCalledExactlyOnceWith(
+          requestFixture,
+        );
       });
 
       it('should call auth.api.getSession()', () => {
-        expect(authMock.api.getSession).toHaveBeenCalledTimes(1);
-        expect(authMock.api.getSession).toHaveBeenCalledWith({
+        expect(authMock.api.getSession).toHaveBeenCalledExactlyOnceWith({
           asResponse: false,
           headers: new Headers(),
         });
@@ -123,8 +123,9 @@ describe(buildUserSessionFromFastifyRequest, () => {
       });
 
       it('should call getBetterAuthFromRequest()', () => {
-        expect(getBetterAuthFromRequest).toHaveBeenCalledTimes(1);
-        expect(getBetterAuthFromRequest).toHaveBeenCalledWith(requestFixture);
+        expect(getBetterAuthFromRequest).toHaveBeenCalledExactlyOnceWith(
+          requestFixture,
+        );
       });
 
       it('should call auth.api.getSession()', () => {
@@ -132,8 +133,7 @@ describe(buildUserSessionFromFastifyRequest, () => {
 
         headers.append('cookie', requestFixture.headers.cookie as string);
 
-        expect(authMock.api.getSession).toHaveBeenCalledTimes(1);
-        expect(authMock.api.getSession).toHaveBeenCalledWith({
+        expect(authMock.api.getSession).toHaveBeenCalledExactlyOnceWith({
           asResponse: false,
           headers,
         });

--- a/packages/framework/http/libraries/better-auth/src/auth/calculations/buildUserSessionFromHonoRequest.spec.ts
+++ b/packages/framework/http/libraries/better-auth/src/auth/calculations/buildUserSessionFromHonoRequest.spec.ts
@@ -60,18 +60,17 @@ describe(buildUserSessionFromHonoRequest, () => {
     });
 
     it('should call getBetterAuthFromRequest()', () => {
-      expect(getBetterAuthFromRequest).toHaveBeenCalledTimes(1);
-      expect(getBetterAuthFromRequest).toHaveBeenCalledWith(requestMock);
+      expect(getBetterAuthFromRequest).toHaveBeenCalledExactlyOnceWith(
+        requestMock,
+      );
     });
 
     it('should call request.header()', () => {
-      expect(requestMock.header).toHaveBeenCalledTimes(1);
-      expect(requestMock.header).toHaveBeenCalledWith('cookie');
+      expect(requestMock.header).toHaveBeenCalledExactlyOnceWith('cookie');
     });
 
     it('should call auth.api.getSession()', () => {
-      expect(authMock.api.getSession).toHaveBeenCalledTimes(1);
-      expect(authMock.api.getSession).toHaveBeenCalledWith({
+      expect(authMock.api.getSession).toHaveBeenCalledExactlyOnceWith({
         asResponse: false,
         headers: new Headers(),
       });
@@ -123,8 +122,9 @@ describe(buildUserSessionFromHonoRequest, () => {
     });
 
     it('should call getBetterAuthFromRequest()', () => {
-      expect(getBetterAuthFromRequest).toHaveBeenCalledTimes(1);
-      expect(getBetterAuthFromRequest).toHaveBeenCalledWith(requestMock);
+      expect(getBetterAuthFromRequest).toHaveBeenCalledExactlyOnceWith(
+        requestMock,
+      );
     });
 
     it('should call auth.api.getSession()', () => {
@@ -132,8 +132,7 @@ describe(buildUserSessionFromHonoRequest, () => {
 
       headers.append('cookie', cookieValueFixture);
 
-      expect(authMock.api.getSession).toHaveBeenCalledTimes(1);
-      expect(authMock.api.getSession).toHaveBeenCalledWith({
+      expect(authMock.api.getSession).toHaveBeenCalledExactlyOnceWith({
         asResponse: false,
         headers,
       });

--- a/packages/framework/http/libraries/better-auth/src/auth/decorators/ExpressUserSession.spec.ts
+++ b/packages/framework/http/libraries/better-auth/src/auth/decorators/ExpressUserSession.spec.ts
@@ -27,8 +27,7 @@ describe(ExpressUserSession, () => {
     });
 
     it('should call createCustomParameterDecorator()', () => {
-      expect(createCustomParameterDecorator).toHaveBeenCalledTimes(1);
-      expect(createCustomParameterDecorator).toHaveBeenCalledWith(
+      expect(createCustomParameterDecorator).toHaveBeenCalledExactlyOnceWith(
         expect.any(Function),
       );
     });

--- a/packages/framework/http/libraries/better-auth/src/auth/decorators/FastifyUserSession.spec.ts
+++ b/packages/framework/http/libraries/better-auth/src/auth/decorators/FastifyUserSession.spec.ts
@@ -27,8 +27,7 @@ describe(FastifyUserSession, () => {
     });
 
     it('should call createCustomParameterDecorator()', () => {
-      expect(createCustomParameterDecorator).toHaveBeenCalledTimes(1);
-      expect(createCustomParameterDecorator).toHaveBeenCalledWith(
+      expect(createCustomParameterDecorator).toHaveBeenCalledExactlyOnceWith(
         expect.any(Function),
       );
     });

--- a/packages/framework/http/libraries/better-auth/src/auth/decorators/HonoUserSession.spec.ts
+++ b/packages/framework/http/libraries/better-auth/src/auth/decorators/HonoUserSession.spec.ts
@@ -27,8 +27,7 @@ describe(HonoUserSession, () => {
     });
 
     it('should call createCustomParameterDecorator()', () => {
-      expect(createCustomParameterDecorator).toHaveBeenCalledTimes(1);
-      expect(createCustomParameterDecorator).toHaveBeenCalledWith(
+      expect(createCustomParameterDecorator).toHaveBeenCalledExactlyOnceWith(
         expect.any(Function),
       );
     });

--- a/packages/framework/http/libraries/better-auth/src/auth/services/BetterAuthExpress4ContainerModule.int.spec.ts
+++ b/packages/framework/http/libraries/better-auth/src/auth/services/BetterAuthExpress4ContainerModule.int.spec.ts
@@ -141,8 +141,9 @@ describe(BetterAuthExpress4ContainerModule, () => {
     });
 
     it('should call transform()', () => {
-      expect(transformMock).toHaveBeenCalledTimes(1);
-      expect(transformMock).toHaveBeenCalledWith(expect.any(Function));
+      expect(transformMock).toHaveBeenCalledExactlyOnceWith(
+        expect.any(Function),
+      );
     });
   });
 });

--- a/packages/framework/http/libraries/better-auth/src/auth/services/BetterAuthExpressContainerModule.int.spec.ts
+++ b/packages/framework/http/libraries/better-auth/src/auth/services/BetterAuthExpressContainerModule.int.spec.ts
@@ -163,8 +163,9 @@ describe(BetterAuthExpressContainerModule, () => {
     });
 
     it('should call transform()', () => {
-      expect(transformMock).toHaveBeenCalledTimes(1);
-      expect(transformMock).toHaveBeenCalledWith(expect.any(Function));
+      expect(transformMock).toHaveBeenCalledExactlyOnceWith(
+        expect.any(Function),
+      );
     });
   });
 });

--- a/packages/framework/http/libraries/better-auth/src/auth/services/BetterAuthFastifyContainerModule.int.spec.ts
+++ b/packages/framework/http/libraries/better-auth/src/auth/services/BetterAuthFastifyContainerModule.int.spec.ts
@@ -163,8 +163,9 @@ describe(BetterAuthFastifyContainerModule, () => {
     });
 
     it('should call transform()', () => {
-      expect(transformMock).toHaveBeenCalledTimes(1);
-      expect(transformMock).toHaveBeenCalledWith(expect.any(Function));
+      expect(transformMock).toHaveBeenCalledExactlyOnceWith(
+        expect.any(Function),
+      );
     });
   });
 });

--- a/packages/framework/http/libraries/better-auth/src/auth/services/BetterAuthHonoContainerModule.int.spec.ts
+++ b/packages/framework/http/libraries/better-auth/src/auth/services/BetterAuthHonoContainerModule.int.spec.ts
@@ -163,8 +163,9 @@ describe(BetterAuthHonoContainerModule, () => {
     });
 
     it('should call transform()', () => {
-      expect(transformMock).toHaveBeenCalledTimes(1);
-      expect(transformMock).toHaveBeenCalledWith(expect.any(Function));
+      expect(transformMock).toHaveBeenCalledExactlyOnceWith(
+        expect.any(Function),
+      );
     });
   });
 });

--- a/packages/framework/http/libraries/core/src/http/actions/setErrorFilterToErrorFilterMap.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/actions/setErrorFilterToErrorFilterMap.spec.ts
@@ -35,8 +35,9 @@ describe(setErrorFilterToErrorFilterMap, () => {
     });
 
     it('should call getCatchErrorMetadata()', () => {
-      expect(getCatchErrorMetadata).toHaveBeenCalledTimes(1);
-      expect(getCatchErrorMetadata).toHaveBeenCalledWith(errorFilterFixture);
+      expect(getCatchErrorMetadata).toHaveBeenCalledExactlyOnceWith(
+        errorFilterFixture,
+      );
     });
 
     it('should set error filters', () => {

--- a/packages/framework/http/libraries/core/src/http/calculations/buildInterceptedHandler.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/calculations/buildInterceptedHandler.spec.ts
@@ -130,15 +130,13 @@ describe(buildInterceptedHandler, () => {
       });
 
       it('should call container.getAsync()', () => {
-        expect(containerMock.getAsync).toHaveBeenCalledTimes(1);
-        expect(containerMock.getAsync).toHaveBeenCalledWith(
+        expect(containerMock.getAsync).toHaveBeenCalledExactlyOnceWith(
           serviceIdentifierFixture,
         );
       });
 
       it('should call buildHandlerParams()', () => {
-        expect(buildHandlerParamsMock).toHaveBeenCalledTimes(1);
-        expect(buildHandlerParamsMock).toHaveBeenCalledWith(
+        expect(buildHandlerParamsMock).toHaveBeenCalledExactlyOnceWith(
           requestFixture,
           responseFixture,
           nextFixture,
@@ -146,8 +144,7 @@ describe(buildInterceptedHandler, () => {
       });
 
       it('should call setHeaders()', () => {
-        expect(setHeadersMock).toHaveBeenCalledTimes(1);
-        expect(setHeadersMock).toHaveBeenCalledWith(
+        expect(setHeadersMock).toHaveBeenCalledExactlyOnceWith(
           requestFixture,
           responseFixture,
           routerExplorerControllerMethodMetadataFixture.headerMetadataList,
@@ -155,15 +152,13 @@ describe(buildInterceptedHandler, () => {
       });
 
       it('should call controller.testMethod()', () => {
-        expect(controllerMock.testMethod).toHaveBeenCalledTimes(1);
-        expect(controllerMock.testMethod).toHaveBeenCalledWith(
+        expect(controllerMock.testMethod).toHaveBeenCalledExactlyOnceWith(
           ...handlerParamsFixture,
         );
       });
 
       it('should call reply()', () => {
-        expect(replyMock).toHaveBeenCalledTimes(1);
-        expect(replyMock).toHaveBeenCalledWith(
+        expect(replyMock).toHaveBeenCalledExactlyOnceWith(
           requestFixture,
           responseFixture,
           controllerResponseFixture,
@@ -207,8 +202,7 @@ describe(buildInterceptedHandler, () => {
       });
 
       it('should call handleError()', () => {
-        expect(handleErrorMock).toHaveBeenCalledTimes(1);
-        expect(handleErrorMock).toHaveBeenCalledWith(
+        expect(handleErrorMock).toHaveBeenCalledExactlyOnceWith(
           requestFixture,
           responseFixture,
           errorFixture,
@@ -349,8 +343,7 @@ describe(buildInterceptedHandler, () => {
       });
 
       it('should call firstInterceptor.intercept()', () => {
-        expect(firstInterceptorMock.intercept).toHaveBeenCalledTimes(1);
-        expect(firstInterceptorMock.intercept).toHaveBeenCalledWith(
+        expect(firstInterceptorMock.intercept).toHaveBeenCalledExactlyOnceWith(
           requestFixture,
           responseFixture,
           expect.any(Function),
@@ -358,8 +351,7 @@ describe(buildInterceptedHandler, () => {
       });
 
       it('should call secondInterceptor.intercept()', () => {
-        expect(secondInterceptorMock.intercept).toHaveBeenCalledTimes(1);
-        expect(secondInterceptorMock.intercept).toHaveBeenCalledWith(
+        expect(secondInterceptorMock.intercept).toHaveBeenCalledExactlyOnceWith(
           requestFixture,
           responseFixture,
           expect.any(Function),
@@ -367,8 +359,7 @@ describe(buildInterceptedHandler, () => {
       });
 
       it('should call buildHandlerParams()', () => {
-        expect(buildHandlerParamsMock).toHaveBeenCalledTimes(1);
-        expect(buildHandlerParamsMock).toHaveBeenCalledWith(
+        expect(buildHandlerParamsMock).toHaveBeenCalledExactlyOnceWith(
           requestFixture,
           responseFixture,
           nextFixture,
@@ -376,8 +367,7 @@ describe(buildInterceptedHandler, () => {
       });
 
       it('should call setHeaders()', () => {
-        expect(setHeadersMock).toHaveBeenCalledTimes(1);
-        expect(setHeadersMock).toHaveBeenCalledWith(
+        expect(setHeadersMock).toHaveBeenCalledExactlyOnceWith(
           requestFixture,
           responseFixture,
           routerExplorerControllerMethodMetadataFixture.headerMetadataList,
@@ -385,15 +375,13 @@ describe(buildInterceptedHandler, () => {
       });
 
       it('should call controller method with handler params', () => {
-        expect(controllerMock.testMethod).toHaveBeenCalledTimes(1);
-        expect(controllerMock.testMethod).toHaveBeenCalledWith(
+        expect(controllerMock.testMethod).toHaveBeenCalledExactlyOnceWith(
           ...handlerParamsFixture,
         );
       });
 
       it('should call reply()', () => {
-        expect(replyMock).toHaveBeenCalledTimes(1);
-        expect(replyMock).toHaveBeenCalledWith(
+        expect(replyMock).toHaveBeenCalledExactlyOnceWith(
           requestFixture,
           responseFixture,
           controllerResponseFixture,
@@ -508,8 +496,7 @@ describe(buildInterceptedHandler, () => {
       });
 
       it('should call firstInterceptor.intercept()', () => {
-        expect(firstInterceptorMock.intercept).toHaveBeenCalledTimes(1);
-        expect(firstInterceptorMock.intercept).toHaveBeenCalledWith(
+        expect(firstInterceptorMock.intercept).toHaveBeenCalledExactlyOnceWith(
           requestFixture,
           responseFixture,
           expect.any(Function),
@@ -517,8 +504,7 @@ describe(buildInterceptedHandler, () => {
       });
 
       it('should call secondInterceptor.intercept()', () => {
-        expect(secondInterceptorMock.intercept).toHaveBeenCalledTimes(1);
-        expect(secondInterceptorMock.intercept).toHaveBeenCalledWith(
+        expect(secondInterceptorMock.intercept).toHaveBeenCalledExactlyOnceWith(
           requestFixture,
           responseFixture,
           expect.any(Function),
@@ -526,8 +512,7 @@ describe(buildInterceptedHandler, () => {
       });
 
       it('should call buildHandlerParams()', () => {
-        expect(buildHandlerParamsMock).toHaveBeenCalledTimes(1);
-        expect(buildHandlerParamsMock).toHaveBeenCalledWith(
+        expect(buildHandlerParamsMock).toHaveBeenCalledExactlyOnceWith(
           requestFixture,
           responseFixture,
           nextFixture,
@@ -535,8 +520,7 @@ describe(buildInterceptedHandler, () => {
       });
 
       it('should call setHeaders()', () => {
-        expect(setHeadersMock).toHaveBeenCalledTimes(1);
-        expect(setHeadersMock).toHaveBeenCalledWith(
+        expect(setHeadersMock).toHaveBeenCalledExactlyOnceWith(
           requestFixture,
           responseFixture,
           routerExplorerControllerMethodMetadataFixture.headerMetadataList,
@@ -544,15 +528,13 @@ describe(buildInterceptedHandler, () => {
       });
 
       it('should call controller method with handler params', () => {
-        expect(controllerMock.testMethod).toHaveBeenCalledTimes(1);
-        expect(controllerMock.testMethod).toHaveBeenCalledWith(
+        expect(controllerMock.testMethod).toHaveBeenCalledExactlyOnceWith(
           ...handlerParamsFixture,
         );
       });
 
       it('should call reply()', () => {
-        expect(replyMock).toHaveBeenCalledTimes(1);
-        expect(replyMock).toHaveBeenCalledWith(
+        expect(replyMock).toHaveBeenCalledExactlyOnceWith(
           requestFixture,
           responseFixture,
           transformedResultFixture,
@@ -608,8 +590,7 @@ describe(buildInterceptedHandler, () => {
       });
 
       it('should call handleError()', () => {
-        expect(handleErrorMock).toHaveBeenCalledTimes(1);
-        expect(handleErrorMock).toHaveBeenCalledWith(
+        expect(handleErrorMock).toHaveBeenCalledExactlyOnceWith(
           requestFixture,
           responseFixture,
           errorFixture,
@@ -682,8 +663,7 @@ describe(buildInterceptedHandler, () => {
       });
 
       it('should call handleError()', () => {
-        expect(handleErrorMock).toHaveBeenCalledTimes(1);
-        expect(handleErrorMock).toHaveBeenCalledWith(
+        expect(handleErrorMock).toHaveBeenCalledExactlyOnceWith(
           requestFixture,
           responseFixture,
           errorFixture,

--- a/packages/framework/http/libraries/core/src/http/calculations/buildRouteParameterDecorator.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/calculations/buildRouteParameterDecorator.spec.ts
@@ -50,8 +50,7 @@ describe(buildRouteParameterDecorator, () => {
           pipeList: parameterPipeListFixture,
         };
 
-        expect(requestParam).toHaveBeenCalledTimes(1);
-        expect(requestParam).toHaveBeenCalledWith(expected);
+        expect(requestParam).toHaveBeenCalledExactlyOnceWith(expected);
       });
 
       it('should return a ParameterDecorator', () => {
@@ -95,8 +94,7 @@ describe(buildRouteParameterDecorator, () => {
           pipeList: [parameterNameOrPipeFixture],
         };
 
-        expect(requestParam).toHaveBeenCalledTimes(1);
-        expect(requestParam).toHaveBeenCalledWith(expected);
+        expect(requestParam).toHaveBeenCalledExactlyOnceWith(expected);
       });
 
       it('should return a ParameterDecorator', () => {
@@ -143,8 +141,7 @@ describe(buildRouteParameterDecorator, () => {
           pipeList: parameterPipeListFixture,
         };
 
-        expect(requestParam).toHaveBeenCalledTimes(1);
-        expect(requestParam).toHaveBeenCalledWith(expected);
+        expect(requestParam).toHaveBeenCalledExactlyOnceWith(expected);
       });
 
       it('should return a ParameterDecorator', () => {

--- a/packages/framework/http/libraries/core/src/http/calculations/createCustomParameterDecorator.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/calculations/createCustomParameterDecorator.spec.ts
@@ -37,8 +37,7 @@ describe(createCustomParameterDecorator, () => {
     });
 
     it('should call requestParamFactory', () => {
-      expect(buildRouteParameterDecorator).toHaveBeenCalledTimes(1);
-      expect(buildRouteParameterDecorator).toHaveBeenCalledWith(
+      expect(buildRouteParameterDecorator).toHaveBeenCalledExactlyOnceWith(
         RequestMethodParameterType.Custom,
         parameterPipeListFixture,
         undefined,

--- a/packages/framework/http/libraries/core/src/http/calculations/requestMethod.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/calculations/requestMethod.spec.ts
@@ -50,13 +50,11 @@ describe(requestMethod, () => {
       });
 
       it('should call buildNormalizedPath()', () => {
-        expect(buildNormalizedPath).toHaveBeenCalledTimes(1);
-        expect(buildNormalizedPath).toHaveBeenCalledWith('/');
+        expect(buildNormalizedPath).toHaveBeenCalledExactlyOnceWith('/');
       });
 
       it('should call buildArrayMetadataWithElement', () => {
-        expect(buildArrayMetadataWithElement).toHaveBeenCalledTimes(1);
-        expect(buildArrayMetadataWithElement).toHaveBeenCalledWith({
+        expect(buildArrayMetadataWithElement).toHaveBeenCalledExactlyOnceWith({
           methodKey: keyFixture,
           path: normalizedPathFixture,
           requestMethodType: RequestMethodType.Get,
@@ -64,8 +62,7 @@ describe(requestMethod, () => {
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture.constructor,
           controllerMethodMetadataReflectKey,
           buildEmptyArrayMetadata,
@@ -111,13 +108,13 @@ describe(requestMethod, () => {
       });
 
       it('should call buildNormalizedPath()', () => {
-        expect(buildNormalizedPath).toHaveBeenCalledTimes(1);
-        expect(buildNormalizedPath).toHaveBeenCalledWith(pathFixture);
+        expect(buildNormalizedPath).toHaveBeenCalledExactlyOnceWith(
+          pathFixture,
+        );
       });
 
       it('should call buildArrayMetadataWithElement', () => {
-        expect(buildArrayMetadataWithElement).toHaveBeenCalledTimes(1);
-        expect(buildArrayMetadataWithElement).toHaveBeenCalledWith({
+        expect(buildArrayMetadataWithElement).toHaveBeenCalledExactlyOnceWith({
           methodKey: keyFixture,
           path: normalizedPathFixture,
           requestMethodType: RequestMethodType.Get,
@@ -125,8 +122,7 @@ describe(requestMethod, () => {
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture.constructor,
           controllerMethodMetadataReflectKey,
           buildEmptyArrayMetadata,

--- a/packages/framework/http/libraries/core/src/http/calculations/requestParam.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/calculations/requestParam.spec.ts
@@ -46,7 +46,7 @@ describe(requestParam, () => {
       });
 
       it('should call setReflectMetadata', () => {
-        expect(setReflectMetadata).toHaveBeenCalledWith(
+        expect(setReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture.constructor,
           controllerMethodUseNativeHandlerMetadataReflectKey,
           true,
@@ -132,16 +132,14 @@ describe(requestParam, () => {
       });
 
       it('should call buildArrayMetadataWithIndex', () => {
-        expect(buildArrayMetadataWithIndex).toHaveBeenCalledTimes(1);
-        expect(buildArrayMetadataWithIndex).toHaveBeenCalledWith(
+        expect(buildArrayMetadataWithIndex).toHaveBeenCalledExactlyOnceWith(
           controllerMethodParameterMetadataFixture,
           indexFixture,
         );
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture.constructor,
           controllerMethodParameterMetadataReflectKey,
           buildEmptyArrayMetadata,

--- a/packages/framework/http/libraries/core/src/http/decorators/All.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/All.spec.ts
@@ -26,8 +26,7 @@ describe(All, () => {
     });
 
     it('should call requestMethod', () => {
-      expect(requestMethod).toHaveBeenCalledTimes(1);
-      expect(requestMethod).toHaveBeenCalledWith(
+      expect(requestMethod).toHaveBeenCalledExactlyOnceWith(
         RequestMethodType.All,
         pathFixture,
       );

--- a/packages/framework/http/libraries/core/src/http/decorators/Body.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Body.spec.ts
@@ -34,8 +34,7 @@ describe(Body, () => {
     });
 
     it('should call buildRouteParameterDecorator()', () => {
-      expect(buildRouteParameterDecorator).toHaveBeenCalledTimes(1);
-      expect(buildRouteParameterDecorator).toHaveBeenCalledWith(
+      expect(buildRouteParameterDecorator).toHaveBeenCalledExactlyOnceWith(
         RequestMethodParameterType.Body,
         parameterPipeListFixture,
         optionsFixture,

--- a/packages/framework/http/libraries/core/src/http/decorators/Controller.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Controller.spec.ts
@@ -63,16 +63,19 @@ describe(Controller, () => {
       });
 
       it('should call buildNormalizedPath()', () => {
-        expect(buildNormalizedPath).toHaveBeenCalledTimes(1);
-        expect(buildNormalizedPath).toHaveBeenCalledWith(pathFixture);
+        expect(buildNormalizedPath).toHaveBeenCalledExactlyOnceWith(
+          pathFixture,
+        );
       });
 
       it('should call injectable', () => {
-        expect(injectable).toHaveBeenCalledWith(undefined);
+        expect(injectable).toHaveBeenCalledExactlyOnceWith(undefined);
       });
 
       it('should call ClassDecorator', () => {
-        expect(classDecoratorMock).toHaveBeenCalledWith(targetFixture);
+        expect(classDecoratorMock).toHaveBeenCalledExactlyOnceWith(
+          targetFixture,
+        );
       });
 
       it('should call buildArrayMetadataWithElement()', () => {
@@ -82,12 +85,13 @@ describe(Controller, () => {
           target: targetFixture,
         };
 
-        expect(buildArrayMetadataWithElement).toHaveBeenCalledTimes(1);
-        expect(buildArrayMetadataWithElement).toHaveBeenCalledWith(expected);
+        expect(buildArrayMetadataWithElement).toHaveBeenCalledExactlyOnceWith(
+          expected,
+        );
       });
 
       it('should set metadata with controller path', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           Reflect,
           controllerMetadataReflectKey,
           buildEmptyArrayMetadata,
@@ -138,8 +142,9 @@ describe(Controller, () => {
       });
 
       it('should call buildNormalizedPath()', () => {
-        expect(buildNormalizedPath).toHaveBeenCalledTimes(1);
-        expect(buildNormalizedPath).toHaveBeenCalledWith(optionsFixture.path);
+        expect(buildNormalizedPath).toHaveBeenCalledExactlyOnceWith(
+          optionsFixture.path,
+        );
       });
 
       it('should call buildArrayMetadataWithElement()', () => {
@@ -149,12 +154,13 @@ describe(Controller, () => {
           target: targetFixture,
         };
 
-        expect(buildArrayMetadataWithElement).toHaveBeenCalledTimes(1);
-        expect(buildArrayMetadataWithElement).toHaveBeenCalledWith(expected);
+        expect(buildArrayMetadataWithElement).toHaveBeenCalledExactlyOnceWith(
+          expected,
+        );
       });
 
       it('should set metadata with controller options', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           Reflect,
           controllerMetadataReflectKey,
           buildEmptyArrayMetadata,
@@ -206,16 +212,21 @@ describe(Controller, () => {
       });
 
       it('should call buildNormalizedPath()', () => {
-        expect(buildNormalizedPath).toHaveBeenCalledTimes(1);
-        expect(buildNormalizedPath).toHaveBeenCalledWith(optionsFixture.path);
+        expect(buildNormalizedPath).toHaveBeenCalledExactlyOnceWith(
+          optionsFixture.path,
+        );
       });
 
       it('should call injectable', () => {
-        expect(injectable).toHaveBeenCalledWith(optionsFixture.scope);
+        expect(injectable).toHaveBeenCalledExactlyOnceWith(
+          optionsFixture.scope,
+        );
       });
 
       it('should call ClassDecorator', () => {
-        expect(classDecoratorMock).toHaveBeenCalledWith(targetFixture);
+        expect(classDecoratorMock).toHaveBeenCalledExactlyOnceWith(
+          targetFixture,
+        );
       });
 
       it('should call buildArrayMetadataWithElement()', () => {
@@ -225,12 +236,13 @@ describe(Controller, () => {
           target: targetFixture,
         };
 
-        expect(buildArrayMetadataWithElement).toHaveBeenCalledTimes(1);
-        expect(buildArrayMetadataWithElement).toHaveBeenCalledWith(expected);
+        expect(buildArrayMetadataWithElement).toHaveBeenCalledExactlyOnceWith(
+          expected,
+        );
       });
 
       it('should set metadata with controller options', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           Reflect,
           controllerMetadataReflectKey,
           buildEmptyArrayMetadata,
@@ -284,16 +296,19 @@ describe(Controller, () => {
       });
 
       it('should call buildNormalizedPath()', () => {
-        expect(buildNormalizedPath).toHaveBeenCalledTimes(1);
-        expect(buildNormalizedPath).toHaveBeenCalledWith('/');
+        expect(buildNormalizedPath).toHaveBeenCalledExactlyOnceWith('/');
       });
 
       it('should call injectable', () => {
-        expect(injectable).toHaveBeenCalledWith(optionsFixture.scope);
+        expect(injectable).toHaveBeenCalledExactlyOnceWith(
+          optionsFixture.scope,
+        );
       });
 
       it('should call ClassDecorator', () => {
-        expect(classDecoratorMock).toHaveBeenCalledWith(targetFixture);
+        expect(classDecoratorMock).toHaveBeenCalledExactlyOnceWith(
+          targetFixture,
+        );
       });
 
       it('should call buildArrayMetadataWithElement()', () => {
@@ -304,12 +319,13 @@ describe(Controller, () => {
           target: targetFixture,
         };
 
-        expect(buildArrayMetadataWithElement).toHaveBeenCalledTimes(1);
-        expect(buildArrayMetadataWithElement).toHaveBeenCalledWith(expected);
+        expect(buildArrayMetadataWithElement).toHaveBeenCalledExactlyOnceWith(
+          expected,
+        );
       });
 
       it('should set metadata with controller options', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           Reflect,
           controllerMetadataReflectKey,
           buildEmptyArrayMetadata,

--- a/packages/framework/http/libraries/core/src/http/decorators/Cookies.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Cookies.spec.ts
@@ -33,8 +33,7 @@ describe(Cookies, () => {
     });
 
     it('should call buildRouteParameterDecorator()', () => {
-      expect(buildRouteParameterDecorator).toHaveBeenCalledTimes(1);
-      expect(buildRouteParameterDecorator).toHaveBeenCalledWith(
+      expect(buildRouteParameterDecorator).toHaveBeenCalledExactlyOnceWith(
         RequestMethodParameterType.Cookies,
         parameterPipeListFixture,
         optionsFixture,

--- a/packages/framework/http/libraries/core/src/http/decorators/Delete.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Delete.spec.ts
@@ -26,8 +26,7 @@ describe(Delete, () => {
     });
 
     it('should call requestMethod', () => {
-      expect(requestMethod).toHaveBeenCalledTimes(1);
-      expect(requestMethod).toHaveBeenCalledWith(
+      expect(requestMethod).toHaveBeenCalledExactlyOnceWith(
         RequestMethodType.Delete,
         pathFixture,
       );

--- a/packages/framework/http/libraries/core/src/http/decorators/Get.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Get.spec.ts
@@ -26,8 +26,7 @@ describe(Get, () => {
     });
 
     it('should call requestMethod', () => {
-      expect(requestMethod).toHaveBeenCalledTimes(1);
-      expect(requestMethod).toHaveBeenCalledWith(
+      expect(requestMethod).toHaveBeenCalledExactlyOnceWith(
         RequestMethodType.Get,
         pathFixture,
       );

--- a/packages/framework/http/libraries/core/src/http/decorators/Head.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Head.spec.ts
@@ -26,8 +26,7 @@ describe(Head, () => {
     });
 
     it('should call requestMethod', () => {
-      expect(requestMethod).toHaveBeenCalledTimes(1);
-      expect(requestMethod).toHaveBeenCalledWith(
+      expect(requestMethod).toHaveBeenCalledExactlyOnceWith(
         RequestMethodType.Head,
         pathFixture,
       );

--- a/packages/framework/http/libraries/core/src/http/decorators/Headers.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Headers.spec.ts
@@ -34,8 +34,7 @@ describe(Headers, () => {
     });
 
     it('should call buildRouteParameterDecorator()', () => {
-      expect(buildRouteParameterDecorator).toHaveBeenCalledTimes(1);
-      expect(buildRouteParameterDecorator).toHaveBeenCalledWith(
+      expect(buildRouteParameterDecorator).toHaveBeenCalledExactlyOnceWith(
         RequestMethodParameterType.Headers,
         parameterPipeListFixture,
         optionsFixture,

--- a/packages/framework/http/libraries/core/src/http/decorators/Next.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Next.spec.ts
@@ -26,8 +26,7 @@ describe(Next, () => {
     });
 
     it('should call buildRouteParameterDecorator()', () => {
-      expect(buildRouteParameterDecorator).toHaveBeenCalledTimes(1);
-      expect(buildRouteParameterDecorator).toHaveBeenCalledWith(
+      expect(buildRouteParameterDecorator).toHaveBeenCalledExactlyOnceWith(
         RequestMethodParameterType.Next,
         [],
       );

--- a/packages/framework/http/libraries/core/src/http/decorators/Options.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Options.spec.ts
@@ -26,8 +26,7 @@ describe(Options, () => {
     });
 
     it('should call requestMethod', () => {
-      expect(requestMethod).toHaveBeenCalledTimes(1);
-      expect(requestMethod).toHaveBeenCalledWith(
+      expect(requestMethod).toHaveBeenCalledExactlyOnceWith(
         RequestMethodType.Options,
         pathFixture,
       );

--- a/packages/framework/http/libraries/core/src/http/decorators/Params.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Params.spec.ts
@@ -33,8 +33,7 @@ describe(Params, () => {
     });
 
     it('should call buildRouteParameterDecorator()', () => {
-      expect(buildRouteParameterDecorator).toHaveBeenCalledTimes(1);
-      expect(buildRouteParameterDecorator).toHaveBeenCalledWith(
+      expect(buildRouteParameterDecorator).toHaveBeenCalledExactlyOnceWith(
         RequestMethodParameterType.Params,
         parameterPipeListFixture,
         optionsFixture,

--- a/packages/framework/http/libraries/core/src/http/decorators/Patch.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Patch.spec.ts
@@ -26,8 +26,7 @@ describe(Patch, () => {
     });
 
     it('should call requestMethod', () => {
-      expect(requestMethod).toHaveBeenCalledTimes(1);
-      expect(requestMethod).toHaveBeenCalledWith(
+      expect(requestMethod).toHaveBeenCalledExactlyOnceWith(
         RequestMethodType.Patch,
         pathFixture,
       );

--- a/packages/framework/http/libraries/core/src/http/decorators/Post.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Post.spec.ts
@@ -26,8 +26,7 @@ describe(Post, () => {
     });
 
     it('should call requestMethod', () => {
-      expect(requestMethod).toHaveBeenCalledTimes(1);
-      expect(requestMethod).toHaveBeenCalledWith(
+      expect(requestMethod).toHaveBeenCalledExactlyOnceWith(
         RequestMethodType.Post,
         pathFixture,
       );

--- a/packages/framework/http/libraries/core/src/http/decorators/Put.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Put.spec.ts
@@ -26,8 +26,7 @@ describe(Put, () => {
     });
 
     it('should call requestMethod', () => {
-      expect(requestMethod).toHaveBeenCalledTimes(1);
-      expect(requestMethod).toHaveBeenCalledWith(
+      expect(requestMethod).toHaveBeenCalledExactlyOnceWith(
         RequestMethodType.Put,
         pathFixture,
       );

--- a/packages/framework/http/libraries/core/src/http/decorators/Query.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Query.spec.ts
@@ -33,8 +33,7 @@ describe(Query, () => {
     });
 
     it('should call buildRouteParameterDecorator()', () => {
-      expect(buildRouteParameterDecorator).toHaveBeenCalledTimes(1);
-      expect(buildRouteParameterDecorator).toHaveBeenCalledWith(
+      expect(buildRouteParameterDecorator).toHaveBeenCalledExactlyOnceWith(
         RequestMethodParameterType.Query,
         parameterPipeListFixture,
         parameterFixture,

--- a/packages/framework/http/libraries/core/src/http/decorators/Request.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Request.spec.ts
@@ -31,8 +31,7 @@ describe(Request, () => {
     });
 
     it('should call buildRouteParameterDecorator()', () => {
-      expect(buildRouteParameterDecorator).toHaveBeenCalledTimes(1);
-      expect(buildRouteParameterDecorator).toHaveBeenCalledWith(
+      expect(buildRouteParameterDecorator).toHaveBeenCalledExactlyOnceWith(
         RequestMethodParameterType.Request,
         parameterPipeListFixture,
       );

--- a/packages/framework/http/libraries/core/src/http/decorators/Response.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/Response.spec.ts
@@ -31,8 +31,7 @@ describe(Response, () => {
     });
 
     it('should call buildRouteParameterDecorator()', () => {
-      expect(buildRouteParameterDecorator).toHaveBeenCalledTimes(1);
-      expect(buildRouteParameterDecorator).toHaveBeenCalledWith(
+      expect(buildRouteParameterDecorator).toHaveBeenCalledExactlyOnceWith(
         RequestMethodParameterType.Response,
         parameterPipeListFixture,
       );

--- a/packages/framework/http/libraries/core/src/http/decorators/SetHeader.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/SetHeader.spec.ts
@@ -51,16 +51,14 @@ describe(SetHeader, () => {
     });
 
     it('should call buildSetHeaderMetadata', () => {
-      expect(buildSetHeaderMetadata).toHaveBeenCalledTimes(1);
-      expect(buildSetHeaderMetadata).toHaveBeenCalledWith(
+      expect(buildSetHeaderMetadata).toHaveBeenCalledExactlyOnceWith(
         keyFixture,
         valueFixture,
       );
     });
 
     it('should call setReflectMetadata', () => {
-      expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         controllerFixture.constructor,
         controllerMethodHeaderMetadataReflectKey,
         buildEmptyMapMetadata,

--- a/packages/framework/http/libraries/core/src/http/decorators/StatusCode.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/decorators/StatusCode.spec.ts
@@ -33,8 +33,7 @@ describe(StatusCode, () => {
     });
 
     it('should call setReflectMetadata', () => {
-      expect(setReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(setReflectMetadata).toHaveBeenCalledWith(
+      expect(setReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         controllerFixture.constructor,
         controllerMethodStatusCodeMetadataReflectKey,
         HttpStatusCode.OK,

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildErrorTypeToErrorFilterMap.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildErrorTypeToErrorFilterMap.spec.ts
@@ -61,16 +61,16 @@ describe(buildErrorTypeToErrorFilterMap, () => {
     });
 
     it('should call getClassMethodErrorFilterMetadata()', () => {
-      expect(getClassMethodErrorFilterMetadata).toHaveBeenCalledTimes(1);
-      expect(getClassMethodErrorFilterMetadata).toHaveBeenCalledWith(
+      expect(getClassMethodErrorFilterMetadata).toHaveBeenCalledExactlyOnceWith(
         targetFixture,
         methodKeyFixture,
       );
     });
 
     it('should call getClassErrorFilterMetadata()', () => {
-      expect(getClassErrorFilterMetadata).toHaveBeenCalledTimes(1);
-      expect(getClassErrorFilterMetadata).toHaveBeenCalledWith(targetFixture);
+      expect(getClassErrorFilterMetadata).toHaveBeenCalledExactlyOnceWith(
+        targetFixture,
+      );
     });
 
     it('should call setErrorFilterToErrorFilterMap()', () => {
@@ -134,21 +134,20 @@ describe(buildErrorTypeToErrorFilterMap, () => {
     });
 
     it('should call getClassMethodErrorFilterMetadata()', () => {
-      expect(getClassMethodErrorFilterMetadata).toHaveBeenCalledTimes(1);
-      expect(getClassMethodErrorFilterMetadata).toHaveBeenCalledWith(
+      expect(getClassMethodErrorFilterMetadata).toHaveBeenCalledExactlyOnceWith(
         targetFixture,
         methodKeyFixture,
       );
     });
 
     it('should call getClassErrorFilterMetadata()', () => {
-      expect(getClassErrorFilterMetadata).toHaveBeenCalledTimes(1);
-      expect(getClassErrorFilterMetadata).toHaveBeenCalledWith(targetFixture);
+      expect(getClassErrorFilterMetadata).toHaveBeenCalledExactlyOnceWith(
+        targetFixture,
+      );
     });
 
     it('should call setErrorFilterToErrorFilterMap() for class filters only', () => {
-      expect(setErrorFilterToErrorFilterMap).toHaveBeenCalledTimes(1);
-      expect(setErrorFilterToErrorFilterMap).toHaveBeenCalledWith(
+      expect(setErrorFilterToErrorFilterMap).toHaveBeenCalledExactlyOnceWith(
         expect.any(Map),
         classErrorFilter1Fixture,
       );

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMetadata.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMetadata.spec.ts
@@ -39,8 +39,7 @@ describe(buildRouterExplorerControllerMetadata, () => {
     });
 
     it('should call getControllerMethodMetadataList', () => {
-      expect(getControllerMethodMetadataList).toHaveBeenCalledTimes(1);
-      expect(getControllerMethodMetadataList).toHaveBeenCalledWith(
+      expect(getControllerMethodMetadataList).toHaveBeenCalledExactlyOnceWith(
         controllerMetadataFixture.target,
       );
     });
@@ -48,10 +47,7 @@ describe(buildRouterExplorerControllerMetadata, () => {
     it('should call buildRouterExplorerControllerMethodMetadataList', () => {
       expect(
         buildRouterExplorerControllerMethodMetadataList,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        buildRouterExplorerControllerMethodMetadataList,
-      ).toHaveBeenCalledWith(
+      ).toHaveBeenCalledExactlyOnceWith(
         controllerMetadataFixture,
         controllerMethodMetadataListFixture,
       );

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMetadataList.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMetadataList.spec.ts
@@ -47,8 +47,7 @@ describe(buildRouterExplorerControllerMetadataList, () => {
     });
 
     it('should call exploreControllers', () => {
-      expect(getControllerMetadataList).toHaveBeenCalledTimes(1);
-      expect(getControllerMetadataList).toHaveBeenCalledWith();
+      expect(getControllerMetadataList).toHaveBeenCalledExactlyOnceWith();
     });
 
     it('should throw an InversifyHttpAdapterError with the correct kind', () => {
@@ -102,22 +101,19 @@ describe(buildRouterExplorerControllerMetadataList, () => {
     });
 
     it('should call getControllerMetadataList()', () => {
-      expect(getControllerMetadataList).toHaveBeenCalledTimes(1);
-      expect(getControllerMetadataList).toHaveBeenCalledWith();
+      expect(getControllerMetadataList).toHaveBeenCalledExactlyOnceWith();
     });
 
     it('should call container.isBound()', () => {
-      expect(containerMock.isBound).toHaveBeenCalledTimes(1);
-      expect(containerMock.isBound).toHaveBeenCalledWith(
+      expect(containerMock.isBound).toHaveBeenCalledExactlyOnceWith(
         controllerMetadataFixture.serviceIdentifier,
       );
     });
 
     it('should call buildRouterExplorerControllerMetadata()', () => {
-      expect(buildRouterExplorerControllerMetadata).toHaveBeenCalledTimes(1);
-      expect(buildRouterExplorerControllerMetadata).toHaveBeenCalledWith(
-        controllerMetadataFixture,
-      );
+      expect(
+        buildRouterExplorerControllerMetadata,
+      ).toHaveBeenCalledExactlyOnceWith(controllerMetadataFixture);
     });
 
     it('should return RouterExplorerControllerMetadata[]', () => {

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadata.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadata.spec.ts
@@ -166,62 +166,58 @@ describe(buildRouterExplorerControllerMethodMetadata, () => {
     });
 
     it('should call getControllerMethodParameterMetadataList()', () => {
-      expect(getControllerMethodParameterMetadataList).toHaveBeenCalledTimes(1);
-      expect(getControllerMethodParameterMetadataList).toHaveBeenCalledWith(
+      expect(
+        getControllerMethodParameterMetadataList,
+      ).toHaveBeenCalledExactlyOnceWith(
         controllerMetadataFixture.target,
         controllerMethodMetadataFixture.methodKey,
       );
     });
 
     it('should call getControllerMethodStatusCodeMetadata()', () => {
-      expect(getControllerMethodStatusCodeMetadata).toHaveBeenCalledTimes(1);
-      expect(getControllerMethodStatusCodeMetadata).toHaveBeenCalledWith(
+      expect(
+        getControllerMethodStatusCodeMetadata,
+      ).toHaveBeenCalledExactlyOnceWith(
         controllerMetadataFixture.target,
         controllerMethodMetadataFixture.methodKey,
       );
     });
 
     it('should call getClassGuardList()', () => {
-      expect(getClassGuardList).toHaveBeenCalledTimes(1);
-      expect(getClassGuardList).toHaveBeenCalledWith(
+      expect(getClassGuardList).toHaveBeenCalledExactlyOnceWith(
         controllerMetadataFixture.target,
       );
     });
 
     it('should call getClassMethodGuardList()', () => {
-      expect(getClassMethodGuardList).toHaveBeenCalledTimes(1);
-      expect(getClassMethodGuardList).toHaveBeenCalledWith(
+      expect(getClassMethodGuardList).toHaveBeenCalledExactlyOnceWith(
         controllerMetadataFixture.target,
         controllerMethodMetadataFixture.methodKey,
       );
     });
 
     it('should call getClassInterceptorList()', () => {
-      expect(getClassInterceptorList).toHaveBeenCalledTimes(1);
-      expect(getClassInterceptorList).toHaveBeenCalledWith(
+      expect(getClassInterceptorList).toHaveBeenCalledExactlyOnceWith(
         controllerMetadataFixture.target,
       );
     });
 
     it('should call getClassMethodInterceptorList()', () => {
-      expect(getClassMethodInterceptorList).toHaveBeenCalledTimes(1);
-      expect(getClassMethodInterceptorList).toHaveBeenCalledWith(
+      expect(getClassMethodInterceptorList).toHaveBeenCalledExactlyOnceWith(
         controllerMetadataFixture.target,
         controllerMethodMetadataFixture.methodKey,
       );
     });
 
     it('should call getClassMethodMiddlewareList()', () => {
-      expect(getClassMethodMiddlewareList).toHaveBeenCalledTimes(1);
-      expect(getClassMethodMiddlewareList).toHaveBeenCalledWith(
+      expect(getClassMethodMiddlewareList).toHaveBeenCalledExactlyOnceWith(
         controllerMetadataFixture.target,
         controllerMethodMetadataFixture.methodKey,
       );
     });
 
     it('should call getClassMiddlewareList()', () => {
-      expect(getClassMiddlewareList).toHaveBeenCalledTimes(1);
-      expect(getClassMiddlewareList).toHaveBeenCalledWith(
+      expect(getClassMiddlewareList).toHaveBeenCalledExactlyOnceWith(
         controllerMetadataFixture.target,
       );
     });
@@ -239,26 +235,25 @@ describe(buildRouterExplorerControllerMethodMetadata, () => {
     });
 
     it('should call getControllerMethodHeaderMetadataList()', () => {
-      expect(getControllerMethodHeaderMetadataList).toHaveBeenCalledTimes(1);
-      expect(getControllerMethodHeaderMetadataList).toHaveBeenCalledWith(
+      expect(
+        getControllerMethodHeaderMetadataList,
+      ).toHaveBeenCalledExactlyOnceWith(
         controllerMetadataFixture.target,
         controllerMethodMetadataFixture.methodKey,
       );
     });
 
     it('should call getControllerMethodUseNativeHandlerMetadata()', () => {
-      expect(getControllerMethodUseNativeHandlerMetadata).toHaveBeenCalledTimes(
-        1,
-      );
-      expect(getControllerMethodUseNativeHandlerMetadata).toHaveBeenCalledWith(
+      expect(
+        getControllerMethodUseNativeHandlerMetadata,
+      ).toHaveBeenCalledExactlyOnceWith(
         controllerMetadataFixture.target,
         controllerMethodMetadataFixture.methodKey,
       );
     });
 
     it('should call buildErrorTypeToErrorFilterMap()', () => {
-      expect(buildErrorTypeToErrorFilterMap).toHaveBeenCalledTimes(1);
-      expect(buildErrorTypeToErrorFilterMap).toHaveBeenCalledWith(
+      expect(buildErrorTypeToErrorFilterMap).toHaveBeenCalledExactlyOnceWith(
         controllerMetadataFixture.target,
         controllerMethodMetadataFixture.methodKey,
       );

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadataList.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadataList.spec.ts
@@ -42,11 +42,9 @@ describe(buildRouterExplorerControllerMethodMetadataList, () => {
     });
 
     it('should call buildRouterExplorerControllerMethodMetadata()', () => {
-      expect(buildRouterExplorerControllerMethodMetadata).toHaveBeenCalledTimes(
-        1,
-      );
-
-      expect(buildRouterExplorerControllerMethodMetadata).toHaveBeenCalledWith(
+      expect(
+        buildRouterExplorerControllerMethodMetadata,
+      ).toHaveBeenCalledExactlyOnceWith(
         controllerMetadataFixture,
         controllerMethodMetadataFixture,
       );

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/getControllerMetadataList.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/getControllerMetadataList.spec.ts
@@ -23,8 +23,7 @@ describe(getControllerMetadataList, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         Reflect,
         controllerMetadataReflectKey,
       );

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/getControllerMethodHeaderMetadataList.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/getControllerMethodHeaderMetadataList.spec.ts
@@ -36,8 +36,7 @@ describe(getControllerMethodHeaderMetadataList, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         controllerFixture,
         controllerMethodHeaderMetadataReflectKey,
         controllerMethodKeyFixture,

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/getControllerMethodMetadataList.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/getControllerMethodMetadataList.spec.ts
@@ -24,8 +24,7 @@ describe(getControllerMethodMetadataList, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         controllerFixture,
         controllerMethodMetadataReflectKey,
       );

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/getControllerMethodParameterMetadataList.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/getControllerMethodParameterMetadataList.spec.ts
@@ -29,8 +29,7 @@ describe(getControllerMethodParameterMetadataList, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         controllerFixture,
         controllerMethodParameterMetadataReflectKey,
         controllerMethodKeyFixture,
@@ -68,8 +67,7 @@ describe(getControllerMethodParameterMetadataList, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         controllerFixture,
         controllerMethodParameterMetadataReflectKey,
         controllerMethodKeyFixture,

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/getControllerMethodStatusCodeMetadata.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/getControllerMethodStatusCodeMetadata.spec.ts
@@ -30,8 +30,7 @@ describe(getControllerMethodStatusCodeMetadata, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         controllerFixture,
         controllerMethodStatusCodeMetadataReflectKey,
         controllerMethodKeyFixture,

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/getControllerMethodUseNativeHandlerMetadata.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/getControllerMethodUseNativeHandlerMetadata.spec.ts
@@ -28,8 +28,7 @@ describe(getControllerMethodUseNativeHandlerMetadata, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         controllerFixture,
         controllerMethodUseNativeHandlerMetadataReflectKey,
         controllerMethodKeyFixture,
@@ -67,8 +66,7 @@ describe(getControllerMethodUseNativeHandlerMetadata, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         controllerFixture,
         controllerMethodUseNativeHandlerMetadataReflectKey,
         controllerMethodKeyFixture,

--- a/packages/framework/http/libraries/open-api/src/metadata/actions/toSchema.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/metadata/actions/toSchema.spec.ts
@@ -58,28 +58,26 @@ describe(toSchema, () => {
     });
 
     it('should call tryBuildSchemaFromWellKnownType()', () => {
-      expect(tryBuildSchemaFromWellKnownTypeMock).toHaveBeenCalledTimes(1);
-      expect(tryBuildSchemaFromWellKnownTypeMock).toHaveBeenCalledWith(
-        typeFixture,
-      );
+      expect(
+        tryBuildSchemaFromWellKnownTypeMock,
+      ).toHaveBeenCalledExactlyOnceWith(typeFixture);
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadataMock).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadataMock).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadataMock).toHaveBeenCalledExactlyOnceWith(
         typeFixture,
         schemaOpenApiMetadataReflectKey,
       );
     });
 
     it('should call updateMetadataReferences()', () => {
-      expect(updateMetadataReferencesMock).toHaveBeenCalledTimes(1);
-      expect(updateMetadataReferencesMock).toHaveBeenCalledWith(typeFixture);
+      expect(updateMetadataReferencesMock).toHaveBeenCalledExactlyOnceWith(
+        typeFixture,
+      );
     });
 
     it('should call escapeJsonPointerFragments()', () => {
-      expect(escapeJsonPointerFragmentsMock).toHaveBeenCalledTimes(1);
-      expect(escapeJsonPointerFragmentsMock).toHaveBeenCalledWith(
+      expect(escapeJsonPointerFragmentsMock).toHaveBeenCalledExactlyOnceWith(
         typeFixture.name,
       );
     });
@@ -122,28 +120,26 @@ describe(toSchema, () => {
     });
 
     it('should call tryBuildSchemaFromWellKnownType()', () => {
-      expect(tryBuildSchemaFromWellKnownTypeMock).toHaveBeenCalledTimes(1);
-      expect(tryBuildSchemaFromWellKnownTypeMock).toHaveBeenCalledWith(
-        typeFixture,
-      );
+      expect(
+        tryBuildSchemaFromWellKnownTypeMock,
+      ).toHaveBeenCalledExactlyOnceWith(typeFixture);
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadataMock).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadataMock).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadataMock).toHaveBeenCalledExactlyOnceWith(
         typeFixture,
         schemaOpenApiMetadataReflectKey,
       );
     });
 
     it('should call updateMetadataReferences()', () => {
-      expect(updateMetadataReferencesMock).toHaveBeenCalledTimes(1);
-      expect(updateMetadataReferencesMock).toHaveBeenCalledWith(typeFixture);
+      expect(updateMetadataReferencesMock).toHaveBeenCalledExactlyOnceWith(
+        typeFixture,
+      );
     });
 
     it('should call escapeJsonPointerFragments()', () => {
-      expect(escapeJsonPointerFragmentsMock).toHaveBeenCalledTimes(1);
-      expect(escapeJsonPointerFragmentsMock).toHaveBeenCalledWith(
+      expect(escapeJsonPointerFragmentsMock).toHaveBeenCalledExactlyOnceWith(
         typeFixture.name,
       );
     });
@@ -188,28 +184,28 @@ describe(toSchema, () => {
     });
 
     it('should call tryBuildSchemaFromWellKnownType()', () => {
-      expect(tryBuildSchemaFromWellKnownTypeMock).toHaveBeenCalledTimes(1);
-      expect(tryBuildSchemaFromWellKnownTypeMock).toHaveBeenCalledWith(
-        typeFixture,
-      );
+      expect(
+        tryBuildSchemaFromWellKnownTypeMock,
+      ).toHaveBeenCalledExactlyOnceWith(typeFixture);
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadataMock).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadataMock).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadataMock).toHaveBeenCalledExactlyOnceWith(
         typeFixture,
         schemaOpenApiMetadataReflectKey,
       );
     });
 
     it('should call updateMetadataReferences()', () => {
-      expect(updateMetadataReferencesMock).toHaveBeenCalledTimes(1);
-      expect(updateMetadataReferencesMock).toHaveBeenCalledWith(typeFixture);
+      expect(updateMetadataReferencesMock).toHaveBeenCalledExactlyOnceWith(
+        typeFixture,
+      );
     });
 
     it('should call escapeJsonPointerFragments()', () => {
-      expect(escapeJsonPointerFragmentsMock).toHaveBeenCalledTimes(1);
-      expect(escapeJsonPointerFragmentsMock).toHaveBeenCalledWith(nameFixture);
+      expect(escapeJsonPointerFragmentsMock).toHaveBeenCalledExactlyOnceWith(
+        nameFixture,
+      );
     });
 
     it('should return an OpenApi3Dot1SchemaObject with $ref using escaped metadata.name', () => {
@@ -241,15 +237,13 @@ describe(toSchema, () => {
     });
 
     it('should call tryBuildSchemaFromWellKnownType()', () => {
-      expect(tryBuildSchemaFromWellKnownTypeMock).toHaveBeenCalledTimes(1);
-      expect(tryBuildSchemaFromWellKnownTypeMock).toHaveBeenCalledWith(
-        typeFixture,
-      );
+      expect(
+        tryBuildSchemaFromWellKnownTypeMock,
+      ).toHaveBeenCalledExactlyOnceWith(typeFixture);
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadataMock).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadataMock).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadataMock).toHaveBeenCalledExactlyOnceWith(
         typeFixture,
         schemaOpenApiMetadataReflectKey,
       );

--- a/packages/framework/http/libraries/open-api/src/metadata/actions/toSchemaInControllerMetadataContext.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/metadata/actions/toSchemaInControllerMetadataContext.spec.ts
@@ -39,8 +39,9 @@ describe(toSchemaInControllerOpenApiMetadataContext, () => {
     });
 
     it('should call toSchema() with a callback function', () => {
-      expect(toSchemaMock).toHaveBeenCalledTimes(1);
-      expect(toSchemaMock).toHaveBeenCalledWith(expect.any(Function));
+      expect(toSchemaMock).toHaveBeenCalledExactlyOnceWith(
+        expect.any(Function),
+      );
     });
 
     it('should return the result from toSchema()', () => {

--- a/packages/framework/http/libraries/open-api/src/metadata/actions/toSchemaInSchemaMetadataContext.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/metadata/actions/toSchemaInSchemaMetadataContext.spec.ts
@@ -39,8 +39,9 @@ describe(toSchemaInSchemaMetadataContext, () => {
     });
 
     it('should call toSchema() with a callback function', () => {
-      expect(toSchemaMock).toHaveBeenCalledTimes(1);
-      expect(toSchemaMock).toHaveBeenCalledWith(expect.any(Function));
+      expect(toSchemaMock).toHaveBeenCalledExactlyOnceWith(
+        expect.any(Function),
+      );
     });
 
     it('should return the result from toSchema()', () => {

--- a/packages/framework/http/libraries/open-api/src/metadata/actions/updateControllerOpenApiMetadataServer.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/metadata/actions/updateControllerOpenApiMetadataServer.spec.ts
@@ -132,8 +132,7 @@ describe(updateControllerOpenApiMetadataServer, () => {
       });
 
       it('should call buildOrGetOperationObject()', () => {
-        expect(buildOrGetOperationObject).toHaveBeenCalledTimes(1);
-        expect(buildOrGetOperationObject).toHaveBeenCalledWith(
+        expect(buildOrGetOperationObject).toHaveBeenCalledExactlyOnceWith(
           metadataFixture,
           keyFixture,
         );
@@ -193,8 +192,7 @@ describe(updateControllerOpenApiMetadataServer, () => {
       });
 
       it('should call buildOrGetOperationObject()', () => {
-        expect(buildOrGetOperationObject).toHaveBeenCalledTimes(1);
-        expect(buildOrGetOperationObject).toHaveBeenCalledWith(
+        expect(buildOrGetOperationObject).toHaveBeenCalledExactlyOnceWith(
           metadataFixture,
           keyFixture,
         );

--- a/packages/framework/http/libraries/open-api/src/metadata/actions/updateControllerOpenApiMetadataSummary.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/metadata/actions/updateControllerOpenApiMetadataSummary.spec.ts
@@ -128,8 +128,7 @@ describe(updateControllerOpenApiMetadataSummary, () => {
       });
 
       it('should call buildOrGetOperationObject()', () => {
-        expect(buildOrGetOperationObject).toHaveBeenCalledTimes(1);
-        expect(buildOrGetOperationObject).toHaveBeenCalledWith(
+        expect(buildOrGetOperationObject).toHaveBeenCalledExactlyOnceWith(
           metadataFixture,
           keyFixture,
         );
@@ -188,8 +187,7 @@ describe(updateControllerOpenApiMetadataSummary, () => {
       });
 
       it('should call buildOrGetOperationObject()', () => {
-        expect(buildOrGetOperationObject).toHaveBeenCalledTimes(1);
-        expect(buildOrGetOperationObject).toHaveBeenCalledWith(
+        expect(buildOrGetOperationObject).toHaveBeenCalledExactlyOnceWith(
           metadataFixture,
           keyFixture,
         );

--- a/packages/framework/http/libraries/open-api/src/metadata/decorators/BaseOasSchemaProperty.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/metadata/decorators/BaseOasSchemaProperty.spec.ts
@@ -64,8 +64,7 @@ describe(BaseOasSchemaProperty, () => {
       });
 
       it('should call updateSchemaMetadataProperty()', () => {
-        expect(updateSchemaMetadataProperty).toHaveBeenCalledTimes(1);
-        expect(updateSchemaMetadataProperty).toHaveBeenCalledWith(
+        expect(updateSchemaMetadataProperty).toHaveBeenCalledExactlyOnceWith(
           propertyKeyFixture,
           requiredFixture,
           undefined,
@@ -73,8 +72,7 @@ describe(BaseOasSchemaProperty, () => {
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetObjectFixture.constructor,
           schemaOpenApiMetadataReflectKey,
           buildDefaultSchemaMetadata,
@@ -130,8 +128,7 @@ describe(BaseOasSchemaProperty, () => {
       });
 
       it('should call updateSchemaMetadataProperty()', () => {
-        expect(updateSchemaMetadataProperty).toHaveBeenCalledTimes(1);
-        expect(updateSchemaMetadataProperty).toHaveBeenCalledWith(
+        expect(updateSchemaMetadataProperty).toHaveBeenCalledExactlyOnceWith(
           propertyKeyFixture,
           requiredFixture,
           schemaFixture,
@@ -139,8 +136,7 @@ describe(BaseOasSchemaProperty, () => {
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetObjectFixture.constructor,
           schemaOpenApiMetadataReflectKey,
           buildDefaultSchemaMetadata,
@@ -208,20 +204,19 @@ describe(BaseOasSchemaProperty, () => {
       });
 
       it('should call toSchema()', () => {
-        expect(toSchemaInSchemaMetadataContext).toHaveBeenCalledTimes(1);
-        expect(toSchemaInSchemaMetadataContext).toHaveBeenCalledWith(
+        expect(toSchemaInSchemaMetadataContext).toHaveBeenCalledExactlyOnceWith(
           targetObjectFixture.constructor,
         );
       });
 
       it('should call build function with toSchema result', () => {
-        expect(buildFunctionFixture).toHaveBeenCalledTimes(1);
-        expect(buildFunctionFixture).toHaveBeenCalledWith(toSchemaFunctionMock);
+        expect(buildFunctionFixture).toHaveBeenCalledExactlyOnceWith(
+          toSchemaFunctionMock,
+        );
       });
 
       it('should call updateSchemaMetadataProperty()', () => {
-        expect(updateSchemaMetadataProperty).toHaveBeenCalledTimes(1);
-        expect(updateSchemaMetadataProperty).toHaveBeenCalledWith(
+        expect(updateSchemaMetadataProperty).toHaveBeenCalledExactlyOnceWith(
           propertyKeyFixture,
           requiredFixture,
           builtSchemaFixture,
@@ -229,8 +224,7 @@ describe(BaseOasSchemaProperty, () => {
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetObjectFixture.constructor,
           schemaOpenApiMetadataReflectKey,
           buildDefaultSchemaMetadata,

--- a/packages/framework/http/libraries/open-api/src/metadata/decorators/OasDeprecated.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/metadata/decorators/OasDeprecated.spec.ts
@@ -62,10 +62,7 @@ describe(OasDeprecated, () => {
       it('should call updateControllerOpenApiMetadataOperationProperty()', () => {
         expect(
           updateControllerOpenApiMetadataOperationProperty,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          updateControllerOpenApiMetadataOperationProperty,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           true,
           targetTypeFixture,
           keyFixture,
@@ -74,8 +71,7 @@ describe(OasDeprecated, () => {
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetTypeFixture,
           controllerOpenApiMetadataReflectKey,
           buildDefaultControllerOpenApiMetadata,

--- a/packages/framework/http/libraries/open-api/src/metadata/decorators/OasDescription.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/metadata/decorators/OasDescription.spec.ts
@@ -64,10 +64,7 @@ describe(OasDescription, () => {
       it('should call updateControllerOpenApiMetadataOperationProperty()', () => {
         expect(
           updateControllerOpenApiMetadataOperationProperty,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          updateControllerOpenApiMetadataOperationProperty,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           contentFixture,
           targetTypeFixture,
           keyFixture,
@@ -76,8 +73,7 @@ describe(OasDescription, () => {
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetTypeFixture,
           controllerOpenApiMetadataReflectKey,
           buildDefaultControllerOpenApiMetadata,

--- a/packages/framework/http/libraries/open-api/src/metadata/decorators/OasExternalDocs.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/metadata/decorators/OasExternalDocs.spec.ts
@@ -69,10 +69,7 @@ describe(OasExternalDocs, () => {
       it('should call updateControllerOpenApiMetadataOperationProperty()', () => {
         expect(
           updateControllerOpenApiMetadataOperationProperty,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          updateControllerOpenApiMetadataOperationProperty,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           contentFixture,
           targetTypeFixture,
           keyFixture,
@@ -81,8 +78,7 @@ describe(OasExternalDocs, () => {
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetTypeFixture,
           controllerOpenApiMetadataReflectKey,
           buildDefaultControllerOpenApiMetadata,

--- a/packages/framework/http/libraries/open-api/src/metadata/decorators/OasOperationId.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/metadata/decorators/OasOperationId.spec.ts
@@ -64,10 +64,7 @@ describe(OasOperationId, () => {
       it('should call updateControllerOpenApiMetadataOperationProperty()', () => {
         expect(
           updateControllerOpenApiMetadataOperationProperty,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          updateControllerOpenApiMetadataOperationProperty,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           contentFixture,
           targetTypeFixture,
           keyFixture,
@@ -76,8 +73,7 @@ describe(OasOperationId, () => {
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetTypeFixture,
           controllerOpenApiMetadataReflectKey,
           buildDefaultControllerOpenApiMetadata,

--- a/packages/framework/http/libraries/open-api/src/metadata/decorators/OasParameter.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/metadata/decorators/OasParameter.spec.ts
@@ -83,15 +83,15 @@ describe(OasParameter, () => {
       it('should call updateControllerOpenApiMetadataOperationArrayProperty()', () => {
         expect(
           updateControllerOpenApiMetadataOperationArrayProperty,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          updateControllerOpenApiMetadataOperationArrayProperty,
-        ).toHaveBeenCalledWith(parameterFixture, keyFixture, 'parameters');
+        ).toHaveBeenCalledExactlyOnceWith(
+          parameterFixture,
+          keyFixture,
+          'parameters',
+        );
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture.constructor,
           controllerOpenApiMetadataReflectKey,
           buildDefaultControllerOpenApiMetadata,
@@ -150,15 +150,15 @@ describe(OasParameter, () => {
       it('should call updateControllerOpenApiMetadataOperationArrayProperty()', () => {
         expect(
           updateControllerOpenApiMetadataOperationArrayProperty,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          updateControllerOpenApiMetadataOperationArrayProperty,
-        ).toHaveBeenCalledWith(referenceFixture, keyFixture, 'parameters');
+        ).toHaveBeenCalledExactlyOnceWith(
+          referenceFixture,
+          keyFixture,
+          'parameters',
+        );
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture.constructor,
           controllerOpenApiMetadataReflectKey,
           buildDefaultControllerOpenApiMetadata,
@@ -238,29 +238,27 @@ describe(OasParameter, () => {
       it('should call toSchemaInControllerOpenApiMetadataContext()', () => {
         expect(
           toSchemaInControllerOpenApiMetadataContext,
-        ).toHaveBeenCalledTimes(1);
-        expect(toSchemaInControllerOpenApiMetadataContext).toHaveBeenCalledWith(
-          targetFixture.constructor,
-        );
+        ).toHaveBeenCalledExactlyOnceWith(targetFixture.constructor);
       });
 
       it('should call build function with toSchema result', () => {
-        expect(buildFunctionFixture).toHaveBeenCalledTimes(1);
-        expect(buildFunctionFixture).toHaveBeenCalledWith(toSchemaFunctionMock);
+        expect(buildFunctionFixture).toHaveBeenCalledExactlyOnceWith(
+          toSchemaFunctionMock,
+        );
       });
 
       it('should call updateControllerOpenApiMetadataOperationArrayProperty()', () => {
         expect(
           updateControllerOpenApiMetadataOperationArrayProperty,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          updateControllerOpenApiMetadataOperationArrayProperty,
-        ).toHaveBeenCalledWith(builtParameterFixture, keyFixture, 'parameters');
+        ).toHaveBeenCalledExactlyOnceWith(
+          builtParameterFixture,
+          keyFixture,
+          'parameters',
+        );
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture.constructor,
           controllerOpenApiMetadataReflectKey,
           buildDefaultControllerOpenApiMetadata,

--- a/packages/framework/http/libraries/open-api/src/metadata/decorators/OasRequestBody.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/metadata/decorators/OasRequestBody.spec.ts
@@ -88,10 +88,7 @@ describe(OasRequestBody, () => {
       it('should call updateControllerOpenApiMetadataOperationProperty()', () => {
         expect(
           updateControllerOpenApiMetadataOperationProperty,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          updateControllerOpenApiMetadataOperationProperty,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           requestBodyFixture,
           targetFixture.constructor,
           keyFixture,
@@ -100,8 +97,7 @@ describe(OasRequestBody, () => {
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture.constructor,
           controllerOpenApiMetadataReflectKey,
           buildDefaultControllerOpenApiMetadata,
@@ -160,10 +156,7 @@ describe(OasRequestBody, () => {
       it('should call updateControllerOpenApiMetadataOperationProperty()', () => {
         expect(
           updateControllerOpenApiMetadataOperationProperty,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          updateControllerOpenApiMetadataOperationProperty,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           referenceFixture,
           targetFixture.constructor,
           keyFixture,
@@ -172,8 +165,7 @@ describe(OasRequestBody, () => {
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture.constructor,
           controllerOpenApiMetadataReflectKey,
           buildDefaultControllerOpenApiMetadata,
@@ -260,24 +252,19 @@ describe(OasRequestBody, () => {
       it('should call toSchemaInControllerOpenApiMetadataContext()', () => {
         expect(
           toSchemaInControllerOpenApiMetadataContext,
-        ).toHaveBeenCalledTimes(1);
-        expect(toSchemaInControllerOpenApiMetadataContext).toHaveBeenCalledWith(
-          targetFixture.constructor,
-        );
+        ).toHaveBeenCalledExactlyOnceWith(targetFixture.constructor);
       });
 
       it('should call build function with toSchema result', () => {
-        expect(buildFunctionFixture).toHaveBeenCalledTimes(1);
-        expect(buildFunctionFixture).toHaveBeenCalledWith(toSchemaFunctionMock);
+        expect(buildFunctionFixture).toHaveBeenCalledExactlyOnceWith(
+          toSchemaFunctionMock,
+        );
       });
 
       it('should call updateControllerOpenApiMetadataOperationProperty()', () => {
         expect(
           updateControllerOpenApiMetadataOperationProperty,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          updateControllerOpenApiMetadataOperationProperty,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           builtRequestBodyFixture,
           targetFixture.constructor,
           keyFixture,
@@ -286,8 +273,7 @@ describe(OasRequestBody, () => {
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture.constructor,
           controllerOpenApiMetadataReflectKey,
           buildDefaultControllerOpenApiMetadata,

--- a/packages/framework/http/libraries/open-api/src/metadata/decorators/OasResponse.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/metadata/decorators/OasResponse.spec.ts
@@ -89,10 +89,7 @@ describe(OasResponse, () => {
       it('should call updateControllerOpenApiMetadataOperationRecordProperty()', () => {
         expect(
           updateControllerOpenApiMetadataOperationRecordProperty,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          updateControllerOpenApiMetadataOperationRecordProperty,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           codeFixture.toString(),
           responseFixture,
           targetFixture.constructor,
@@ -102,8 +99,7 @@ describe(OasResponse, () => {
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture.constructor,
           controllerOpenApiMetadataReflectKey,
           buildDefaultControllerOpenApiMetadata,
@@ -188,24 +184,19 @@ describe(OasResponse, () => {
       it('should call toSchemaInControllerOpenApiMetadataContext()', () => {
         expect(
           toSchemaInControllerOpenApiMetadataContext,
-        ).toHaveBeenCalledTimes(1);
-        expect(toSchemaInControllerOpenApiMetadataContext).toHaveBeenCalledWith(
-          targetFixture.constructor,
-        );
+        ).toHaveBeenCalledExactlyOnceWith(targetFixture.constructor);
       });
 
       it('should call build function with toSchema result', () => {
-        expect(buildFunctionFixture).toHaveBeenCalledTimes(1);
-        expect(buildFunctionFixture).toHaveBeenCalledWith(toSchemaFunctionMock);
+        expect(buildFunctionFixture).toHaveBeenCalledExactlyOnceWith(
+          toSchemaFunctionMock,
+        );
       });
 
       it('should call updateControllerOpenApiMetadataOperationRecordProperty()', () => {
         expect(
           updateControllerOpenApiMetadataOperationRecordProperty,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          updateControllerOpenApiMetadataOperationRecordProperty,
-        ).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           codeFixture.toString(),
           builtResponseFixture,
           targetFixture.constructor,
@@ -215,8 +206,7 @@ describe(OasResponse, () => {
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetFixture.constructor,
           controllerOpenApiMetadataReflectKey,
           buildDefaultControllerOpenApiMetadata,

--- a/packages/framework/http/libraries/open-api/src/metadata/decorators/OasSchema.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/metadata/decorators/OasSchema.spec.ts
@@ -64,16 +64,14 @@ describe(OasSchema, () => {
       });
 
       it('should call updateSchemaMetadataName()', () => {
-        expect(updateSchemaMetadataFromOptions).toHaveBeenCalledTimes(1);
-        expect(updateSchemaMetadataFromOptions).toHaveBeenCalledWith(
+        expect(updateSchemaMetadataFromOptions).toHaveBeenCalledExactlyOnceWith(
           undefined,
           targetTypeFixture,
         );
       });
 
       it('should call updateSchemaMetadata()', () => {
-        expect(updateSchemaMetadataSchema).toHaveBeenCalledTimes(1);
-        expect(updateSchemaMetadataSchema).toHaveBeenCalledWith(
+        expect(updateSchemaMetadataSchema).toHaveBeenCalledExactlyOnceWith(
           undefined,
           targetTypeFixture,
         );
@@ -151,16 +149,14 @@ describe(OasSchema, () => {
       });
 
       it('should call updateSchemaMetadataName()', () => {
-        expect(updateSchemaMetadataFromOptions).toHaveBeenCalledTimes(1);
-        expect(updateSchemaMetadataFromOptions).toHaveBeenCalledWith(
+        expect(updateSchemaMetadataFromOptions).toHaveBeenCalledExactlyOnceWith(
           undefined,
           targetTypeFixture,
         );
       });
 
       it('should call updateSchemaMetadata()', () => {
-        expect(updateSchemaMetadataSchema).toHaveBeenCalledTimes(1);
-        expect(updateSchemaMetadataSchema).toHaveBeenCalledWith(
+        expect(updateSchemaMetadataSchema).toHaveBeenCalledExactlyOnceWith(
           schemaFixture,
           targetTypeFixture,
         );
@@ -243,16 +239,14 @@ describe(OasSchema, () => {
       });
 
       it('should call updateSchemaMetadataName()', () => {
-        expect(updateSchemaMetadataFromOptions).toHaveBeenCalledTimes(1);
-        expect(updateSchemaMetadataFromOptions).toHaveBeenCalledWith(
+        expect(updateSchemaMetadataFromOptions).toHaveBeenCalledExactlyOnceWith(
           optionsFixture,
           targetTypeFixture,
         );
       });
 
       it('should call updateSchemaMetadata()', () => {
-        expect(updateSchemaMetadataSchema).toHaveBeenCalledTimes(1);
-        expect(updateSchemaMetadataSchema).toHaveBeenCalledWith(
+        expect(updateSchemaMetadataSchema).toHaveBeenCalledExactlyOnceWith(
           schemaFixture,
           targetTypeFixture,
         );
@@ -341,28 +335,26 @@ describe(OasSchema, () => {
       });
 
       it('should call updateSchemaMetadataName()', () => {
-        expect(updateSchemaMetadataFromOptions).toHaveBeenCalledTimes(1);
-        expect(updateSchemaMetadataFromOptions).toHaveBeenCalledWith(
+        expect(updateSchemaMetadataFromOptions).toHaveBeenCalledExactlyOnceWith(
           undefined,
           targetTypeFixture,
         );
       });
 
       it('should call toSchema()', () => {
-        expect(toSchemaInSchemaMetadataContext).toHaveBeenCalledTimes(1);
-        expect(toSchemaInSchemaMetadataContext).toHaveBeenCalledWith(
+        expect(toSchemaInSchemaMetadataContext).toHaveBeenCalledExactlyOnceWith(
           targetTypeFixture,
         );
       });
 
       it('should call build function with toSchema result', () => {
-        expect(buildFunctionFixture).toHaveBeenCalledTimes(1);
-        expect(buildFunctionFixture).toHaveBeenCalledWith(toSchemaFunctionMock);
+        expect(buildFunctionFixture).toHaveBeenCalledExactlyOnceWith(
+          toSchemaFunctionMock,
+        );
       });
 
       it('should call updateSchemaMetadata()', () => {
-        expect(updateSchemaMetadataSchema).toHaveBeenCalledTimes(1);
-        expect(updateSchemaMetadataSchema).toHaveBeenCalledWith(
+        expect(updateSchemaMetadataSchema).toHaveBeenCalledExactlyOnceWith(
           builtSchemaFixture,
           targetTypeFixture,
         );
@@ -459,28 +451,26 @@ describe(OasSchema, () => {
       });
 
       it('should call updateSchemaMetadataName()', () => {
-        expect(updateSchemaMetadataFromOptions).toHaveBeenCalledTimes(1);
-        expect(updateSchemaMetadataFromOptions).toHaveBeenCalledWith(
+        expect(updateSchemaMetadataFromOptions).toHaveBeenCalledExactlyOnceWith(
           optionsFixture,
           targetTypeFixture,
         );
       });
 
       it('should call toSchema()', () => {
-        expect(toSchemaInSchemaMetadataContext).toHaveBeenCalledTimes(1);
-        expect(toSchemaInSchemaMetadataContext).toHaveBeenCalledWith(
+        expect(toSchemaInSchemaMetadataContext).toHaveBeenCalledExactlyOnceWith(
           targetTypeFixture,
         );
       });
 
       it('should call build function with toSchema result', () => {
-        expect(buildFunctionFixture).toHaveBeenCalledTimes(1);
-        expect(buildFunctionFixture).toHaveBeenCalledWith(toSchemaFunctionMock);
+        expect(buildFunctionFixture).toHaveBeenCalledExactlyOnceWith(
+          toSchemaFunctionMock,
+        );
       });
 
       it('should call updateSchemaMetadata()', () => {
-        expect(updateSchemaMetadataSchema).toHaveBeenCalledTimes(1);
-        expect(updateSchemaMetadataSchema).toHaveBeenCalledWith(
+        expect(updateSchemaMetadataSchema).toHaveBeenCalledExactlyOnceWith(
           builtSchemaFixture,
           targetTypeFixture,
         );

--- a/packages/framework/http/libraries/open-api/src/metadata/decorators/OasSchemaOptionalProperty.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/metadata/decorators/OasSchemaOptionalProperty.spec.ts
@@ -52,13 +52,13 @@ describe(OasSchemaOptionalProperty, () => {
     });
 
     it('should call BaseOasSchemaProperty()', () => {
-      expect(BaseOasSchemaProperty).toHaveBeenCalledTimes(1);
-      expect(BaseOasSchemaProperty).toHaveBeenCalledWith(false);
+      expect(BaseOasSchemaProperty).toHaveBeenCalledExactlyOnceWith(false);
     });
 
     it('should call the built property decorator function', () => {
-      expect(buildPropertyDecoratorMock).toHaveBeenCalledTimes(1);
-      expect(buildPropertyDecoratorMock).toHaveBeenCalledWith(schemaFixture);
+      expect(buildPropertyDecoratorMock).toHaveBeenCalledExactlyOnceWith(
+        schemaFixture,
+      );
     });
 
     it('should return a property decorator', () => {

--- a/packages/framework/http/libraries/open-api/src/metadata/decorators/OasSchemaProperty.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/metadata/decorators/OasSchemaProperty.spec.ts
@@ -52,13 +52,13 @@ describe(OasSchemaProperty, () => {
     });
 
     it('should call BaseOasSchemaProperty()', () => {
-      expect(BaseOasSchemaProperty).toHaveBeenCalledTimes(1);
-      expect(BaseOasSchemaProperty).toHaveBeenCalledWith(true);
+      expect(BaseOasSchemaProperty).toHaveBeenCalledExactlyOnceWith(true);
     });
 
     it('should call the built property decorator function', () => {
-      expect(buildPropertyDecoratorMock).toHaveBeenCalledTimes(1);
-      expect(buildPropertyDecoratorMock).toHaveBeenCalledWith(schemaFixture);
+      expect(buildPropertyDecoratorMock).toHaveBeenCalledExactlyOnceWith(
+        schemaFixture,
+      );
     });
 
     it('should return a property decorator', () => {

--- a/packages/framework/http/libraries/open-api/src/metadata/decorators/OasSecurity.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/metadata/decorators/OasSecurity.spec.ts
@@ -68,15 +68,15 @@ describe(OasSecurity, () => {
       it('should call updateControllerOpenApiMetadataOperationArrayProperty()', () => {
         expect(
           updateControllerOpenApiMetadataOperationArrayProperty,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          updateControllerOpenApiMetadataOperationArrayProperty,
-        ).toHaveBeenCalledWith(contentFixture, keyFixture, 'security');
+        ).toHaveBeenCalledExactlyOnceWith(
+          contentFixture,
+          keyFixture,
+          'security',
+        );
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetTypeFixture,
           controllerOpenApiMetadataReflectKey,
           buildDefaultControllerOpenApiMetadata,

--- a/packages/framework/http/libraries/open-api/src/metadata/decorators/OasServer.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/metadata/decorators/OasServer.spec.ts
@@ -67,16 +67,13 @@ describe(OasServer, () => {
       });
 
       it('should call updateControllerOpenApiMetadataServer()', () => {
-        expect(updateControllerOpenApiMetadataServer).toHaveBeenCalledTimes(1);
-        expect(updateControllerOpenApiMetadataServer).toHaveBeenCalledWith(
-          serverFixture,
-          undefined,
-        );
+        expect(
+          updateControllerOpenApiMetadataServer,
+        ).toHaveBeenCalledExactlyOnceWith(serverFixture, undefined);
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetTypeFixture,
           controllerOpenApiMetadataReflectKey,
           buildDefaultControllerOpenApiMetadata,
@@ -126,16 +123,13 @@ describe(OasServer, () => {
       });
 
       it('should call updateControllerOpenApiMetadataServer()', () => {
-        expect(updateControllerOpenApiMetadataServer).toHaveBeenCalledTimes(1);
-        expect(updateControllerOpenApiMetadataServer).toHaveBeenCalledWith(
-          serverFixture,
-          keyFixture,
-        );
+        expect(
+          updateControllerOpenApiMetadataServer,
+        ).toHaveBeenCalledExactlyOnceWith(serverFixture, keyFixture);
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetTypeFixture,
           controllerOpenApiMetadataReflectKey,
           buildDefaultControllerOpenApiMetadata,

--- a/packages/framework/http/libraries/open-api/src/metadata/decorators/OasSummary.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/metadata/decorators/OasSummary.spec.ts
@@ -59,8 +59,9 @@ describe(OasSummary, () => {
       });
 
       it('should call updateControllerOpenApiMetadataSummary()', () => {
-        expect(updateControllerOpenApiMetadataSummary).toHaveBeenCalledTimes(1);
-        expect(updateControllerOpenApiMetadataSummary).toHaveBeenCalledWith(
+        expect(
+          updateControllerOpenApiMetadataSummary,
+        ).toHaveBeenCalledExactlyOnceWith(
           summaryFixture,
           targetTypeFixture,
           undefined,
@@ -68,8 +69,7 @@ describe(OasSummary, () => {
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetTypeFixture,
           controllerOpenApiMetadataReflectKey,
           buildDefaultControllerOpenApiMetadata,
@@ -121,8 +121,9 @@ describe(OasSummary, () => {
       });
 
       it('should call updateControllerOpenApiMetadataSummary()', () => {
-        expect(updateControllerOpenApiMetadataSummary).toHaveBeenCalledTimes(1);
-        expect(updateControllerOpenApiMetadataSummary).toHaveBeenCalledWith(
+        expect(
+          updateControllerOpenApiMetadataSummary,
+        ).toHaveBeenCalledExactlyOnceWith(
           summaryFixture,
           targetTypeFixture,
           keyFixture,
@@ -130,8 +131,7 @@ describe(OasSummary, () => {
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetTypeFixture,
           controllerOpenApiMetadataReflectKey,
           buildDefaultControllerOpenApiMetadata,

--- a/packages/framework/http/libraries/open-api/src/metadata/decorators/OasTag.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/metadata/decorators/OasTag.spec.ts
@@ -64,15 +64,11 @@ describe(OasTag, () => {
       it('should call updateControllerOpenApiMetadataOperationArrayProperty()', () => {
         expect(
           updateControllerOpenApiMetadataOperationArrayProperty,
-        ).toHaveBeenCalledTimes(1);
-        expect(
-          updateControllerOpenApiMetadataOperationArrayProperty,
-        ).toHaveBeenCalledWith(contentFixture, keyFixture, 'tags');
+        ).toHaveBeenCalledExactlyOnceWith(contentFixture, keyFixture, 'tags');
       });
 
       it('should call updateOwnReflectMetadata()', () => {
-        expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           targetTypeFixture,
           controllerOpenApiMetadataReflectKey,
           buildDefaultControllerOpenApiMetadata,

--- a/packages/framework/http/libraries/open-api/src/openApi/actions/mergeOpenApiTypeSchema.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/actions/mergeOpenApiTypeSchema.spec.ts
@@ -81,8 +81,9 @@ describe(mergeOpenApiTypeSchema, () => {
         });
 
         it('should call getSchemaMetadata()', () => {
-          expect(getSchemaMetadataMock).toHaveBeenCalledTimes(1);
-          expect(getSchemaMetadataMock).toHaveBeenCalledWith(typeFixture);
+          expect(getSchemaMetadataMock).toHaveBeenCalledExactlyOnceWith(
+            typeFixture,
+          );
         });
 
         it('should not modify schemasObject', () => {
@@ -125,8 +126,9 @@ describe(mergeOpenApiTypeSchema, () => {
         });
 
         it('should call getSchemaMetadata()', () => {
-          expect(getSchemaMetadataMock).toHaveBeenCalledTimes(1);
-          expect(getSchemaMetadataMock).toHaveBeenCalledWith(typeFixture);
+          expect(getSchemaMetadataMock).toHaveBeenCalledExactlyOnceWith(
+            typeFixture,
+          );
         });
 
         it('should modify schemasObject', () => {
@@ -175,8 +177,9 @@ describe(mergeOpenApiTypeSchema, () => {
         });
 
         it('should call getSchemaMetadata()', () => {
-          expect(getSchemaMetadataMock).toHaveBeenCalledTimes(1);
-          expect(getSchemaMetadataMock).toHaveBeenCalledWith(typeFixture);
+          expect(getSchemaMetadataMock).toHaveBeenCalledExactlyOnceWith(
+            typeFixture,
+          );
         });
 
         it('should not modify schemasObject', () => {
@@ -220,8 +223,9 @@ describe(mergeOpenApiTypeSchema, () => {
         });
 
         it('should call getSchemaMetadata()', () => {
-          expect(getSchemaMetadataMock).toHaveBeenCalledTimes(1);
-          expect(getSchemaMetadataMock).toHaveBeenCalledWith(typeFixture);
+          expect(getSchemaMetadataMock).toHaveBeenCalledExactlyOnceWith(
+            typeFixture,
+          );
         });
 
         it('should add schema to schemasObject with merged customAttributes', () => {
@@ -277,8 +281,9 @@ describe(mergeOpenApiTypeSchema, () => {
         });
 
         it('should call getSchemaMetadata()', () => {
-          expect(getSchemaMetadataMock).toHaveBeenCalledTimes(1);
-          expect(getSchemaMetadataMock).toHaveBeenCalledWith(typeFixture);
+          expect(getSchemaMetadataMock).toHaveBeenCalledExactlyOnceWith(
+            typeFixture,
+          );
         });
 
         it('should add schema to schemasObject using the schema directly', () => {
@@ -343,8 +348,9 @@ describe(mergeOpenApiTypeSchema, () => {
         });
 
         it('should call getSchemaMetadata()', () => {
-          expect(getSchemaMetadataMock).toHaveBeenCalledTimes(1);
-          expect(getSchemaMetadataMock).toHaveBeenCalledWith(typeFixture);
+          expect(getSchemaMetadataMock).toHaveBeenCalledExactlyOnceWith(
+            typeFixture,
+          );
         });
 
         it('should add schema to schemasObject with allOf structure', () => {
@@ -409,8 +415,9 @@ describe(mergeOpenApiTypeSchema, () => {
         });
 
         it('should call getSchemaMetadata()', () => {
-          expect(getSchemaMetadataMock).toHaveBeenCalledTimes(1);
-          expect(getSchemaMetadataMock).toHaveBeenCalledWith(typeFixture);
+          expect(getSchemaMetadataMock).toHaveBeenCalledExactlyOnceWith(
+            typeFixture,
+          );
         });
 
         it('should add schema to schemasObject with defined property schemas', () => {
@@ -480,8 +487,9 @@ describe(mergeOpenApiTypeSchema, () => {
         });
 
         it('should call getSchemaMetadata()', () => {
-          expect(getSchemaMetadataMock).toHaveBeenCalledTimes(1);
-          expect(getSchemaMetadataMock).toHaveBeenCalledWith(typeFixture);
+          expect(getSchemaMetadataMock).toHaveBeenCalledExactlyOnceWith(
+            typeFixture,
+          );
         });
 
         it('should add schema to schemasObject with required properties array', () => {
@@ -548,13 +556,13 @@ describe(mergeOpenApiTypeSchema, () => {
         });
 
         it('should call getSchemaMetadata()', () => {
-          expect(getSchemaMetadataMock).toHaveBeenCalledTimes(1);
-          expect(getSchemaMetadataMock).toHaveBeenCalledWith(typeFixture);
+          expect(getSchemaMetadataMock).toHaveBeenCalledExactlyOnceWith(
+            typeFixture,
+          );
         });
 
         it('should call getOwnReflectMetadata()', () => {
-          expect(getOwnReflectMetadataMock).toHaveBeenCalledTimes(1);
-          expect(getOwnReflectMetadataMock).toHaveBeenCalledWith(
+          expect(getOwnReflectMetadataMock).toHaveBeenCalledExactlyOnceWith(
             typeFixture.prototype,
             'design:type',
             'unknownProperty',
@@ -616,13 +624,13 @@ describe(mergeOpenApiTypeSchema, () => {
         });
 
         it('should call getSchemaMetadata()', () => {
-          expect(getSchemaMetadataMock).toHaveBeenCalledTimes(1);
-          expect(getSchemaMetadataMock).toHaveBeenCalledWith(typeFixture);
+          expect(getSchemaMetadataMock).toHaveBeenCalledExactlyOnceWith(
+            typeFixture,
+          );
         });
 
         it('should call getOwnReflectMetadata()', () => {
-          expect(getOwnReflectMetadataMock).toHaveBeenCalledTimes(1);
-          expect(getOwnReflectMetadataMock).toHaveBeenCalledWith(
+          expect(getOwnReflectMetadataMock).toHaveBeenCalledExactlyOnceWith(
             typeFixture.prototype,
             'design:type',
             'stringProperty',
@@ -630,10 +638,9 @@ describe(mergeOpenApiTypeSchema, () => {
         });
 
         it('should call tryBuildSchemaFromWellKnownType()', () => {
-          expect(tryBuildSchemaFromWellKnownTypeMock).toHaveBeenCalledTimes(1);
-          expect(tryBuildSchemaFromWellKnownTypeMock).toHaveBeenCalledWith(
-            propertyTypeFixture,
-          );
+          expect(
+            tryBuildSchemaFromWellKnownTypeMock,
+          ).toHaveBeenCalledExactlyOnceWith(propertyTypeFixture);
         });
 
         it('should add schema to schemasObject with well-known type schema', () => {
@@ -722,8 +729,7 @@ describe(mergeOpenApiTypeSchema, () => {
         });
 
         it('should call getOwnReflectMetadata()', () => {
-          expect(getOwnReflectMetadataMock).toHaveBeenCalledTimes(1);
-          expect(getOwnReflectMetadataMock).toHaveBeenCalledWith(
+          expect(getOwnReflectMetadataMock).toHaveBeenCalledExactlyOnceWith(
             typeFixture.prototype,
             'design:type',
             'customProperty',
@@ -731,17 +737,15 @@ describe(mergeOpenApiTypeSchema, () => {
         });
 
         it('should call tryBuildSchemaFromWellKnownType()', () => {
-          expect(tryBuildSchemaFromWellKnownTypeMock).toHaveBeenCalledTimes(1);
-          expect(tryBuildSchemaFromWellKnownTypeMock).toHaveBeenCalledWith(
-            propertyTypeFixture,
-          );
+          expect(
+            tryBuildSchemaFromWellKnownTypeMock,
+          ).toHaveBeenCalledExactlyOnceWith(propertyTypeFixture);
         });
 
         it('should call escapeJsonPointerFragments()', () => {
-          expect(escapeJsonPointerFragmentsMock).toHaveBeenCalledTimes(1);
-          expect(escapeJsonPointerFragmentsMock).toHaveBeenCalledWith(
-            'CustomPropertyType',
-          );
+          expect(
+            escapeJsonPointerFragmentsMock,
+          ).toHaveBeenCalledExactlyOnceWith('CustomPropertyType');
         });
 
         it('should add schema to schemasObject with property reference', () => {
@@ -832,8 +836,7 @@ describe(mergeOpenApiTypeSchema, () => {
         });
 
         it('should call getOwnReflectMetadata()', () => {
-          expect(getOwnReflectMetadataMock).toHaveBeenCalledTimes(1);
-          expect(getOwnReflectMetadataMock).toHaveBeenCalledWith(
+          expect(getOwnReflectMetadataMock).toHaveBeenCalledExactlyOnceWith(
             typeFixture.prototype,
             'design:type',
             'customProperty',
@@ -841,17 +844,15 @@ describe(mergeOpenApiTypeSchema, () => {
         });
 
         it('should call tryBuildSchemaFromWellKnownType()', () => {
-          expect(tryBuildSchemaFromWellKnownTypeMock).toHaveBeenCalledTimes(1);
-          expect(tryBuildSchemaFromWellKnownTypeMock).toHaveBeenCalledWith(
-            propertyTypeFixture,
-          );
+          expect(
+            tryBuildSchemaFromWellKnownTypeMock,
+          ).toHaveBeenCalledExactlyOnceWith(propertyTypeFixture);
         });
 
         it('should call escapeJsonPointerFragments() with propertyType.name', () => {
-          expect(escapeJsonPointerFragmentsMock).toHaveBeenCalledTimes(1);
-          expect(escapeJsonPointerFragmentsMock).toHaveBeenCalledWith(
-            'CustomPropertyType',
-          );
+          expect(
+            escapeJsonPointerFragmentsMock,
+          ).toHaveBeenCalledExactlyOnceWith('CustomPropertyType');
         });
 
         it('should add schema to schemasObject with property reference using propertyType.name', () => {

--- a/packages/framework/http/libraries/open-api/src/openApi/calculations/getSchemaMetadata.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/calculations/getSchemaMetadata.spec.ts
@@ -45,16 +45,14 @@ describe(getSchemaMetadata, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         typeFixture,
         schemaOpenApiMetadataReflectKey,
       );
     });
 
     it('should call buildDefaultSchemaMetadata()', () => {
-      expect(buildDefaultSchemaMetadata).toHaveBeenCalledTimes(1);
-      expect(buildDefaultSchemaMetadata).toHaveBeenCalledWith();
+      expect(buildDefaultSchemaMetadata).toHaveBeenCalledExactlyOnceWith();
     });
 
     it('should return SchemaMetadata', () => {
@@ -88,8 +86,7 @@ describe(getSchemaMetadata, () => {
     });
 
     it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         typeFixture,
         schemaOpenApiMetadataReflectKey,
       );

--- a/packages/framework/http/libraries/open-api/src/openApi/services/SwaggerUiProvider.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/services/SwaggerUiProvider.spec.ts
@@ -111,18 +111,19 @@ describe(SwaggerUiProvider, () => {
       });
 
       it('should call SwaggerUiProvider._buildControllerType()', () => {
-        expect(buildControllerTypeMock).toHaveBeenCalledTimes(1);
-        expect(buildControllerTypeMock).toHaveBeenCalledWith(optionsFixture);
+        expect(buildControllerTypeMock).toHaveBeenCalledExactlyOnceWith(
+          optionsFixture,
+        );
       });
 
       it('should call bindToFluentSyntax.toSelf()', () => {
-        expect(bindToFluentSyntaxMock.toSelf).toHaveBeenCalledTimes(1);
-        expect(bindToFluentSyntaxMock.toSelf).toHaveBeenCalledWith();
+        expect(bindToFluentSyntaxMock.toSelf).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should call container.bind()', () => {
-        expect(containerMock.bind).toHaveBeenCalledTimes(1);
-        expect(containerMock.bind).toHaveBeenCalledWith(controllerTypeFixture);
+        expect(containerMock.bind).toHaveBeenCalledExactlyOnceWith(
+          controllerTypeFixture,
+        );
       });
 
       it('should return the expected result', () => {
@@ -162,18 +163,19 @@ describe(SwaggerUiProvider, () => {
       });
 
       it('should call SwaggerUiProvider._buildControllerType()', () => {
-        expect(buildControllerTypeMock).toHaveBeenCalledTimes(1);
-        expect(buildControllerTypeMock).toHaveBeenCalledWith(optionsFixture);
+        expect(buildControllerTypeMock).toHaveBeenCalledExactlyOnceWith(
+          optionsFixture,
+        );
       });
 
       it('should call bindToFluentSyntax.toSelf()', () => {
-        expect(bindToFluentSyntaxMock.toSelf).toHaveBeenCalledTimes(1);
-        expect(bindToFluentSyntaxMock.toSelf).toHaveBeenCalledWith();
+        expect(bindToFluentSyntaxMock.toSelf).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should call container.bind()', () => {
-        expect(containerMock.bind).toHaveBeenCalledTimes(1);
-        expect(containerMock.bind).toHaveBeenCalledWith(controllerTypeFixture);
+        expect(containerMock.bind).toHaveBeenCalledExactlyOnceWith(
+          controllerTypeFixture,
+        );
       });
 
       it('should throw an Error', () => {
@@ -226,41 +228,37 @@ describe(SwaggerUiProvider, () => {
       });
 
       it('should call getControllerMetadataList()', () => {
-        expect(getControllerMetadataList).toHaveBeenCalledTimes(1);
-        expect(getControllerMetadataList).toHaveBeenCalledWith();
+        expect(getControllerMetadataList).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should call container.isBound()', () => {
-        expect(containerMock.isBound).toHaveBeenCalledTimes(1);
-        expect(containerMock.isBound).toHaveBeenCalledWith(
+        expect(containerMock.isBound).toHaveBeenCalledExactlyOnceWith(
           (controllerMetadataListFixture[0] as ControllerMetadata)
             .serviceIdentifier,
         );
       });
 
       it('should call getControllerMethodMetadataList()', () => {
-        expect(getControllerMethodMetadataList).toHaveBeenCalledTimes(1);
-        expect(getControllerMethodMetadataList).toHaveBeenCalledWith(
+        expect(getControllerMethodMetadataList).toHaveBeenCalledExactlyOnceWith(
           (controllerMetadataListFixture[0] as ControllerMetadata).target,
         );
       });
 
       it('should call getOwnReflectMetadata()', () => {
-        expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           (controllerMetadataListFixture[0] as ControllerMetadata).target,
           controllerOpenApiMetadataReflectKey,
         );
       });
 
       it('should call container.bind()', () => {
-        expect(containerMock.bind).toHaveBeenCalledTimes(1);
-        expect(containerMock.bind).toHaveBeenCalledWith(controllerTypeFixture);
+        expect(containerMock.bind).toHaveBeenCalledExactlyOnceWith(
+          controllerTypeFixture,
+        );
       });
 
       it('should call bindToFluentSyntax.toSelf()', () => {
-        expect(bindToFluentSyntaxMock.toSelf).toHaveBeenCalledTimes(1);
-        expect(bindToFluentSyntaxMock.toSelf).toHaveBeenCalledWith();
+        expect(bindToFluentSyntaxMock.toSelf).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should return the expected result', () => {
@@ -306,13 +304,11 @@ describe(SwaggerUiProvider, () => {
       });
 
       it('should call getControllerMetadataList()', () => {
-        expect(getControllerMetadataList).toHaveBeenCalledTimes(1);
-        expect(getControllerMetadataList).toHaveBeenCalledWith();
+        expect(getControllerMetadataList).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should call container.isBound()', () => {
-        expect(containerMock.isBound).toHaveBeenCalledTimes(1);
-        expect(containerMock.isBound).toHaveBeenCalledWith(
+        expect(containerMock.isBound).toHaveBeenCalledExactlyOnceWith(
           (controllerMetadataListFixture[0] as ControllerMetadata)
             .serviceIdentifier,
         );
@@ -327,13 +323,13 @@ describe(SwaggerUiProvider, () => {
       });
 
       it('should call container.bind()', () => {
-        expect(containerMock.bind).toHaveBeenCalledTimes(1);
-        expect(containerMock.bind).toHaveBeenCalledWith(controllerTypeFixture);
+        expect(containerMock.bind).toHaveBeenCalledExactlyOnceWith(
+          controllerTypeFixture,
+        );
       });
 
       it('should call bindToFluentSyntax.toSelf()', () => {
-        expect(bindToFluentSyntaxMock.toSelf).toHaveBeenCalledTimes(1);
-        expect(bindToFluentSyntaxMock.toSelf).toHaveBeenCalledWith();
+        expect(bindToFluentSyntaxMock.toSelf).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should return the expected result', () => {
@@ -420,15 +416,15 @@ describe(SwaggerUiProvider, () => {
       });
 
       it('should call buildNormalizedPath()', () => {
-        expect(buildNormalizedPath).toHaveBeenCalledTimes(1);
-        expect(buildNormalizedPath).toHaveBeenCalledWith('/api//test-method');
+        expect(buildNormalizedPath).toHaveBeenCalledExactlyOnceWith(
+          '/api//test-method',
+        );
       });
 
       it('should call mergeOpenApiPathItemObjectIntoOpenApiPaths()', () => {
         expect(
           mergeOpenApiPathItemObjectIntoOpenApiPaths,
-        ).toHaveBeenCalledTimes(1);
-        expect(mergeOpenApiPathItemObjectIntoOpenApiPaths).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           optionsFixture.api.openApiObject,
           '/api/test-method',
           expect.objectContaining({
@@ -439,13 +435,13 @@ describe(SwaggerUiProvider, () => {
       });
 
       it('should call container.bind()', () => {
-        expect(containerMock.bind).toHaveBeenCalledTimes(1);
-        expect(containerMock.bind).toHaveBeenCalledWith(controllerTypeFixture);
+        expect(containerMock.bind).toHaveBeenCalledExactlyOnceWith(
+          controllerTypeFixture,
+        );
       });
 
       it('should call bindToFluentSyntax.toSelf()', () => {
-        expect(bindToFluentSyntaxMock.toSelf).toHaveBeenCalledTimes(1);
-        expect(bindToFluentSyntaxMock.toSelf).toHaveBeenCalledWith();
+        expect(bindToFluentSyntaxMock.toSelf).toHaveBeenCalledExactlyOnceWith();
       });
 
       it('should return the expected result', () => {
@@ -530,8 +526,7 @@ describe(SwaggerUiProvider, () => {
       it('should call mergeOpenApiPathItemObjectIntoOpenApiPaths() with pathItemObject without summary', () => {
         expect(
           mergeOpenApiPathItemObjectIntoOpenApiPaths,
-        ).toHaveBeenCalledTimes(1);
-        expect(mergeOpenApiPathItemObjectIntoOpenApiPaths).toHaveBeenCalledWith(
+        ).toHaveBeenCalledExactlyOnceWith(
           optionsFixture.api.openApiObject,
           '/api/test-method',
           expect.objectContaining({
@@ -934,13 +929,13 @@ describe(SwaggerUiProvider, () => {
       });
 
       it('should call container.bind()', () => {
-        expect(containerMock.bind).toHaveBeenCalledTimes(1);
-        expect(containerMock.bind).toHaveBeenCalledWith(controllerTypeFixture);
+        expect(containerMock.bind).toHaveBeenCalledExactlyOnceWith(
+          controllerTypeFixture,
+        );
       });
 
       it('should call bindToFluentSyntax.toSelf()', () => {
-        expect(bindToFluentSyntaxMock.toSelf).toHaveBeenCalledTimes(1);
-        expect(bindToFluentSyntaxMock.toSelf).toHaveBeenCalledWith();
+        expect(bindToFluentSyntaxMock.toSelf).toHaveBeenCalledExactlyOnceWith();
       });
     });
 

--- a/packages/framework/validation/libraries/ajv/src/decorators/ValidateAjvSchema.spec.ts
+++ b/packages/framework/validation/libraries/ajv/src/decorators/ValidateAjvSchema.spec.ts
@@ -50,16 +50,14 @@ describe(ValidateAjvSchema, () => {
     });
 
     it('should call updateStandardSchemaValidationMetadata()', () => {
-      expect(updateAjvValidationMetadata).toHaveBeenCalledTimes(1);
-      expect(updateAjvValidationMetadata).toHaveBeenCalledWith(
+      expect(updateAjvValidationMetadata).toHaveBeenCalledExactlyOnceWith(
         [schemaFixture],
         indexFixture,
       );
     });
 
     it('should call updateOwnReflectMetadata()', () => {
-      expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         targetFixture.constructor,
         ajvValidationMetadataReflectKey,
         buildEmptyArrayMetadata,

--- a/packages/framework/validation/libraries/ajv/src/pipes/AjvValidationPipe.spec.ts
+++ b/packages/framework/validation/libraries/ajv/src/pipes/AjvValidationPipe.spec.ts
@@ -65,8 +65,7 @@ describe(AjvValidationPipe, () => {
       });
 
       it('should call getOwnReflectMetadata()', () => {
-        expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           metadataFixture.targetClass,
           ajvValidationMetadataReflectKey,
           metadataFixture.methodName,
@@ -74,8 +73,7 @@ describe(AjvValidationPipe, () => {
       });
 
       it('should call ajv.validate()', () => {
-        expect(ajvMock.validate).toHaveBeenCalledTimes(1);
-        expect(ajvMock.validate).toHaveBeenCalledWith(
+        expect(ajvMock.validate).toHaveBeenCalledExactlyOnceWith(
           schemaListElemFixture,
           inputFixture,
         );
@@ -112,8 +110,7 @@ describe(AjvValidationPipe, () => {
       });
 
       it('should call getOwnReflectMetadata()', () => {
-        expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           metadataFixture.targetClass,
           ajvValidationMetadataReflectKey,
           metadataFixture.methodName,
@@ -121,16 +118,14 @@ describe(AjvValidationPipe, () => {
       });
 
       it('should call ajv.validate()', () => {
-        expect(ajvMock.validate).toHaveBeenCalledTimes(1);
-        expect(ajvMock.validate).toHaveBeenCalledWith(
+        expect(ajvMock.validate).toHaveBeenCalledExactlyOnceWith(
           schemaListElemFixture,
           inputFixture,
         );
       });
 
       it('should call stringifyAjvErrors()', () => {
-        expect(stringifyAjvErrors).toHaveBeenCalledTimes(1);
-        expect(stringifyAjvErrors).toHaveBeenCalledWith([]);
+        expect(stringifyAjvErrors).toHaveBeenCalledExactlyOnceWith([]);
       });
 
       it('should throw expected Error', () => {
@@ -165,8 +160,7 @@ describe(AjvValidationPipe, () => {
       });
 
       it('should call getOwnReflectMetadata()', () => {
-        expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           metadataFixture.targetClass,
           ajvValidationMetadataReflectKey,
           metadataFixture.methodName,
@@ -174,8 +168,7 @@ describe(AjvValidationPipe, () => {
       });
 
       it('should call ajv.validate()', () => {
-        expect(ajvMock.validate).toHaveBeenCalledTimes(1);
-        expect(ajvMock.validate).toHaveBeenCalledWith(
+        expect(ajvMock.validate).toHaveBeenCalledExactlyOnceWith(
           schemaListElemFixture,
           inputFixture,
         );
@@ -214,8 +207,7 @@ describe(AjvValidationPipe, () => {
       });
 
       it('should call getOwnReflectMetadata()', () => {
-        expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           metadataFixture.targetClass,
           ajvValidationMetadataReflectKey,
           metadataFixture.methodName,
@@ -223,16 +215,14 @@ describe(AjvValidationPipe, () => {
       });
 
       it('should call ajv.validate()', () => {
-        expect(ajvMock.validate).toHaveBeenCalledTimes(1);
-        expect(ajvMock.validate).toHaveBeenCalledWith(
+        expect(ajvMock.validate).toHaveBeenCalledExactlyOnceWith(
           schemaListElemFixture,
           inputFixture,
         );
       });
 
       it('should call stringifyAjvErrors()', () => {
-        expect(stringifyAjvErrors).toHaveBeenCalledTimes(1);
-        expect(stringifyAjvErrors).toHaveBeenCalledWith([]);
+        expect(stringifyAjvErrors).toHaveBeenCalledExactlyOnceWith([]);
       });
 
       it('should throw expected Error', () => {
@@ -271,8 +261,7 @@ describe(AjvValidationPipe, () => {
       });
 
       it('should call getOwnReflectMetadata()', () => {
-        expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           metadataFixture.targetClass,
           ajvValidationMetadataReflectKey,
           metadataFixture.methodName,

--- a/packages/framework/validation/libraries/class-validator/src/pipes/ClassValidationPipe.spec.ts
+++ b/packages/framework/validation/libraries/class-validator/src/pipes/ClassValidationPipe.spec.ts
@@ -59,8 +59,7 @@ describe(ClassValidationPipe, () => {
       });
 
       it('should call getOwnReflectMetadata()', () => {
-        expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           pipeMetadataFixture.targetClass.prototype,
           'design:paramtypes',
           pipeMetadataFixture.methodName,
@@ -117,8 +116,7 @@ describe(ClassValidationPipe, () => {
       });
 
       it('should call getOwnReflectMetadata()', () => {
-        expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           pipeMetadataFixture.targetClass.prototype,
           'design:paramtypes',
           pipeMetadataFixture.methodName,
@@ -126,13 +124,14 @@ describe(ClassValidationPipe, () => {
       });
 
       it('should call plainToInstance()', () => {
-        expect(plainToInstance).toHaveBeenCalledTimes(1);
-        expect(plainToInstance).toHaveBeenCalledWith(typeFixture, inputFixture);
+        expect(plainToInstance).toHaveBeenCalledExactlyOnceWith(
+          typeFixture,
+          inputFixture,
+        );
       });
 
       it('should call validate()', () => {
-        expect(validate).toHaveBeenCalledTimes(1);
-        expect(validate).toHaveBeenCalledWith(instanceFixture, {
+        expect(validate).toHaveBeenCalledExactlyOnceWith(instanceFixture, {
           forbidNonWhitelisted: true,
           forbidUnknownValues: true,
           skipMissingProperties: false,
@@ -182,8 +181,7 @@ describe(ClassValidationPipe, () => {
       });
 
       it('should call getOwnReflectMetadata()', () => {
-        expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           pipeMetadataFixture.targetClass.prototype,
           'design:paramtypes',
           pipeMetadataFixture.methodName,
@@ -191,8 +189,7 @@ describe(ClassValidationPipe, () => {
       });
 
       it('should call validate()', () => {
-        expect(validate).toHaveBeenCalledTimes(1);
-        expect(validate).toHaveBeenCalledWith(instanceFixture, {
+        expect(validate).toHaveBeenCalledExactlyOnceWith(instanceFixture, {
           forbidNonWhitelisted: true,
           forbidUnknownValues: true,
           skipMissingProperties: false,

--- a/packages/framework/validation/libraries/standard-schema/src/decorators/ValidateStandardSchemaV1.spec.ts
+++ b/packages/framework/validation/libraries/standard-schema/src/decorators/ValidateStandardSchemaV1.spec.ts
@@ -50,16 +50,13 @@ describe(ValidateStandardSchemaV1, () => {
     });
 
     it('should call updateStandardSchemaValidationMetadata()', () => {
-      expect(updateStandardSchemaValidationMetadata).toHaveBeenCalledTimes(1);
-      expect(updateStandardSchemaValidationMetadata).toHaveBeenCalledWith(
-        [typeFixture],
-        indexFixture,
-      );
+      expect(
+        updateStandardSchemaValidationMetadata,
+      ).toHaveBeenCalledExactlyOnceWith([typeFixture], indexFixture);
     });
 
     it('should call updateOwnReflectMetadata()', () => {
-      expect(updateOwnReflectMetadata).toHaveBeenCalledTimes(1);
-      expect(updateOwnReflectMetadata).toHaveBeenCalledWith(
+      expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         targetFixture.constructor,
         standardSchemaValidationMetadataReflectKey,
         buildEmptyArrayMetadata,

--- a/packages/framework/validation/libraries/standard-schema/src/pipes/StandardSchemaValidationPipe.spec.ts
+++ b/packages/framework/validation/libraries/standard-schema/src/pipes/StandardSchemaValidationPipe.spec.ts
@@ -83,8 +83,7 @@ describe(StandardSchemaValidationPipe, () => {
       });
 
       it('should call getOwnReflectMetadata()', () => {
-        expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           metadataFixture.targetClass,
           standardSchemaValidationMetadataReflectKey,
           metadataFixture.methodName,
@@ -92,19 +91,15 @@ describe(StandardSchemaValidationPipe, () => {
       });
 
       it('should call type["~standard"].validate()', () => {
-        expect(schemaMock['~standard'].validate).toHaveBeenCalledTimes(1);
-        expect(schemaMock['~standard'].validate).toHaveBeenCalledWith(
-          inputFixture,
-        );
+        expect(
+          schemaMock['~standard'].validate,
+        ).toHaveBeenCalledExactlyOnceWith(inputFixture);
       });
 
       it('should call parameterType["~standard"].validate()', () => {
-        expect(parameterSchemaMock['~standard'].validate).toHaveBeenCalledTimes(
-          1,
-        );
-        expect(parameterSchemaMock['~standard'].validate).toHaveBeenCalledWith(
-          inputFixture,
-        );
+        expect(
+          parameterSchemaMock['~standard'].validate,
+        ).toHaveBeenCalledExactlyOnceWith(inputFixture);
       });
 
       it('should return expected value', () => {
@@ -175,8 +170,7 @@ describe(StandardSchemaValidationPipe, () => {
       });
 
       it('should call getOwnReflectMetadata()', () => {
-        expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
-        expect(getOwnReflectMetadata).toHaveBeenCalledWith(
+        expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
           metadataFixture.targetClass,
           standardSchemaValidationMetadataReflectKey,
           metadataFixture.methodName,
@@ -184,10 +178,9 @@ describe(StandardSchemaValidationPipe, () => {
       });
 
       it('should call type["~standard"].validate()', () => {
-        expect(schemaMock['~standard'].validate).toHaveBeenCalledTimes(1);
-        expect(schemaMock['~standard'].validate).toHaveBeenCalledWith(
-          inputFixture,
-        );
+        expect(
+          schemaMock['~standard'].validate,
+        ).toHaveBeenCalledExactlyOnceWith(inputFixture);
       });
 
       it('should throw InversifyValidationError', () => {

--- a/packages/logger/src/logger/modules/LoggerAdapter.spec.ts
+++ b/packages/logger/src/logger/modules/LoggerAdapter.spec.ts
@@ -70,8 +70,7 @@ describe(LoggerAdapter, () => {
       });
 
       it('should call printLog with LogType.INFO', () => {
-        expect(printLogMock).toHaveBeenCalledTimes(1);
-        expect(printLogMock).toHaveBeenCalledWith(
+        expect(printLogMock).toHaveBeenCalledExactlyOnceWith(
           LogLevel.INFO,
           messageFixture,
           contextMetadataFixture,
@@ -105,8 +104,7 @@ describe(LoggerAdapter, () => {
       });
 
       it('should call printLog with LogType.HTTP', () => {
-        expect(printLogMock).toHaveBeenCalledTimes(1);
-        expect(printLogMock).toHaveBeenCalledWith(
+        expect(printLogMock).toHaveBeenCalledExactlyOnceWith(
           LogLevel.HTTP,
           messageFixture,
           contextMetadataFixture,
@@ -140,8 +138,7 @@ describe(LoggerAdapter, () => {
       });
 
       it('should call printLog with LogType.SILLY', () => {
-        expect(printLogMock).toHaveBeenCalledTimes(1);
-        expect(printLogMock).toHaveBeenCalledWith(
+        expect(printLogMock).toHaveBeenCalledExactlyOnceWith(
           LogLevel.SILLY,
           messageFixture,
           contextMetadataFixture,
@@ -175,8 +172,7 @@ describe(LoggerAdapter, () => {
       });
 
       it('should call printLog with LogType.ERROR', () => {
-        expect(printLogMock).toHaveBeenCalledTimes(1);
-        expect(printLogMock).toHaveBeenCalledWith(
+        expect(printLogMock).toHaveBeenCalledExactlyOnceWith(
           LogLevel.ERROR,
           messageFixture,
           contextMetadataFixture,
@@ -210,8 +206,7 @@ describe(LoggerAdapter, () => {
       });
 
       it('should call printLog with LogType.WARN', () => {
-        expect(printLogMock).toHaveBeenCalledTimes(1);
-        expect(printLogMock).toHaveBeenCalledWith(
+        expect(printLogMock).toHaveBeenCalledExactlyOnceWith(
           LogLevel.WARN,
           messageFixture,
           contextMetadataFixture,
@@ -245,8 +240,7 @@ describe(LoggerAdapter, () => {
       });
 
       it('should call printLog with LogType.DEBUG', () => {
-        expect(printLogMock).toHaveBeenCalledTimes(1);
-        expect(printLogMock).toHaveBeenCalledWith(
+        expect(printLogMock).toHaveBeenCalledExactlyOnceWith(
           LogLevel.DEBUG,
           messageFixture,
           contextMetadataFixture,
@@ -280,8 +274,7 @@ describe(LoggerAdapter, () => {
       });
 
       it('should call printLog with LogType.VERBOSE', () => {
-        expect(printLogMock).toHaveBeenCalledTimes(1);
-        expect(printLogMock).toHaveBeenCalledWith(
+        expect(printLogMock).toHaveBeenCalledExactlyOnceWith(
           LogLevel.VERBOSE,
           messageFixture,
           contextMetadataFixture,
@@ -321,8 +314,7 @@ describe(LoggerAdapter, () => {
       });
 
       it('should call printLog with the provided parameters', () => {
-        expect(printLogMock).toHaveBeenCalledTimes(1);
-        expect(printLogMock).toHaveBeenCalledWith(
+        expect(printLogMock).toHaveBeenCalledExactlyOnceWith(
           logTypeFixture,
           messageFixture,
           contextMetadataFixture,
@@ -398,8 +390,7 @@ describe(LoggerAdapter, () => {
         });
 
         it('should call printLog with context from constructor', () => {
-          expect(printLogMock).toHaveBeenCalledTimes(1);
-          expect(printLogMock).toHaveBeenCalledWith(
+          expect(printLogMock).toHaveBeenCalledExactlyOnceWith(
             logTypeFixture,
             messageFixture,
             { context: contextFixture },
@@ -444,8 +435,7 @@ describe(LoggerAdapter, () => {
         });
 
         it('should call printLog with the explicit context', () => {
-          expect(printLogMock).toHaveBeenCalledTimes(1);
-          expect(printLogMock).toHaveBeenCalledWith(
+          expect(printLogMock).toHaveBeenCalledExactlyOnceWith(
             logTypeFixture,
             messageFixture,
             { context: explicitContextFixture },


### PR DESCRIPTION
### Changed
- Updated tests to rely on `toHaveBeenCalledExactlyOnceWith`.

### Context
- Most changes have been made using the regex `expect\((?:[\n\s]|[^\)]*)\)\.toHaveBeenCalledTimes\([\n\s]*1,?[\n\s]*\);\n\s*expect\(([\n\s]|[^\)]*)\)\.toHaveBeenCalledWith\(([\n\s]|[^\)]*)\);` replacing `expect($1).toHaveBeenCalledExactlyOnceWith($2);`