### PR TITLE
Update BindToFluentSyntax.toResolvedValue to allow async factories

### DIFF
--- a/.changeset/dry-hornets-arrive.md
+++ b/.changeset/dry-hornets-arrive.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/container": patch
+---
+
+- Updated `BindToFluentSyntax.toResolvedValue` to allow async factories

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntax.spec-d.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntax.spec-d.ts
@@ -29,6 +29,43 @@ describe('BindToFluentSyntax', () => {
   });
 
   describe('.toResolvedValue', () => {
+    describe('having an async factory with no arguments', () => {
+      let factoryFixture: () => Promise<unknown>;
+
+      beforeAll(() => {
+        factoryFixture = async (): Promise<unknown> => undefined;
+      });
+
+      it('when called, with no inject options, should not throw a syntax error', () => {
+        expectTypeOf(
+          bindToFluentSyntaxMock.toResolvedValue(factoryFixture),
+        ).toEqualTypeOf<BindInWhenOnFluentSyntax<unknown>>();
+      });
+    });
+
+    describe('having an async factory with a fixed number of primitive arguments', () => {
+      let factoryFixture: (arg1: string, arg2: number) => Promise<unknown>;
+
+      beforeAll(() => {
+        factoryFixture = async (
+          _arg1: string,
+          _arg2: number,
+        ): Promise<unknown> => undefined;
+      });
+
+      it('when called, with as many right service identifier inject options as function parameters, should not throw a syntax error', () => {
+        const firstServiceIdentifier: ServiceIdentifier<string> = Symbol();
+        const secondServiceIdentifier: ServiceIdentifier<number> = Symbol();
+
+        expectTypeOf(
+          bindToFluentSyntaxMock.toResolvedValue(factoryFixture, [
+            firstServiceIdentifier,
+            secondServiceIdentifier,
+          ]),
+        ).toEqualTypeOf<BindInWhenOnFluentSyntax<unknown>>();
+      });
+    });
+
     describe('having a factory with a fixed number of primitive arguments', () => {
       let factoryFixture: (arg1: string, arg2: number) => unknown;
 

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntax.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntax.ts
@@ -40,10 +40,10 @@ export interface BindToFluentSyntax<T> {
       ? (context: ResolutionContext) => T
       : never,
   ): BindWhenOnFluentSyntax<T>;
-  toResolvedValue(factory: () => T): BindInWhenOnFluentSyntax<T>;
+  toResolvedValue(factory: () => T | Promise<T>): BindInWhenOnFluentSyntax<T>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   toResolvedValue<TArgs extends unknown[] = any[]>(
-    factory: (...args: TArgs) => T,
+    factory: (...args: TArgs) => T | Promise<T>,
     injectOptions: MapToResolvedValueInjectOptions<TArgs>,
   ): BindInWhenOnFluentSyntax<T>;
   toService(service: ServiceIdentifier<T>): void;

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntaxImplementation.ts
@@ -209,13 +209,15 @@ export class BindToFluentSyntaxImplementation<T>
     return new BindInWhenOnFluentSyntaxImplementation(binding);
   }
 
-  public toResolvedValue(factory: () => T): BindInWhenOnFluentSyntax<T>;
+  public toResolvedValue(
+    factory: () => T | Promise<T>,
+  ): BindInWhenOnFluentSyntax<T>;
   public toResolvedValue<TArgs extends unknown[]>(
-    factory: (...args: TArgs) => T,
+    factory: (...args: TArgs) => T | Promise<T>,
     injectOptions: MapToResolvedValueInjectOptions<TArgs>,
   ): BindInWhenOnFluentSyntax<T>;
   public toResolvedValue<TArgs extends unknown[]>(
-    factory: (...args: TArgs) => T,
+    factory: (...args: TArgs) => T | Promise<T>,
     injectOptions?: MapToResolvedValueInjectOptions<TArgs>,
   ): BindInWhenOnFluentSyntax<T> {
     const binding: ResolvedValueBinding<T> = {


### PR DESCRIPTION
### Changed
- Updated `BindToFluentSyntax.toResolvedValue` to allow async factories.

### Context
- Related to #1156.