### PR TITLE
feat: support request method inheritance

### DIFF
--- a/.changeset/empty-sloths-ring.md
+++ b/.changeset/empty-sloths-ring.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/http-core": minor
+---
+
+Modify implementation of request method decorators so endpoints are inherited from base implementations.

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/getControllerMethodMetadataList.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/getControllerMethodMetadataList.spec.ts
@@ -2,14 +2,14 @@ import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
 
 vitest.mock('@inversifyjs/reflect-metadata-utils');
 
-import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+import { getReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
 
 import { controllerMethodMetadataReflectKey } from '../../reflectMetadata/data/controllerMethodMetadataReflectKey';
 import { ControllerMethodMetadata } from '../model/ControllerMethodMetadata';
 import { getControllerMethodMetadataList } from './getControllerMethodMetadataList';
 
 describe(getControllerMethodMetadataList, () => {
-  describe('when called, and getOwnReflectMetadata() returns undefined', () => {
+  describe('when called, and getReflectMetadata() returns undefined', () => {
     let controllerFixture: NewableFunction;
     let result: unknown;
 
@@ -23,8 +23,8 @@ describe(getControllerMethodMetadataList, () => {
       vitest.clearAllMocks();
     });
 
-    it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
+    it('should call getReflectMetadata()', () => {
+      expect(getReflectMetadata).toHaveBeenCalledExactlyOnceWith(
         controllerFixture,
         controllerMethodMetadataReflectKey,
       );
@@ -35,7 +35,7 @@ describe(getControllerMethodMetadataList, () => {
     });
   });
 
-  describe('when called, and getOwnReflectMetadata() returns ControllerMethodMetadata[]', () => {
+  describe('when called, and getReflectMetadata() returns ControllerMethodMetadata[]', () => {
     let controllerFixture: NewableFunction;
     let controllerMethodMetadataFixtures: ControllerMethodMetadata[];
     let result: unknown;
@@ -47,7 +47,7 @@ describe(getControllerMethodMetadataList, () => {
       ];
 
       vitest
-        .mocked(getOwnReflectMetadata)
+        .mocked(getReflectMetadata)
         .mockReturnValueOnce(controllerMethodMetadataFixtures);
 
       result = getControllerMethodMetadataList(controllerFixture);
@@ -57,8 +57,8 @@ describe(getControllerMethodMetadataList, () => {
       vitest.clearAllMocks();
     });
 
-    it('should call getOwnReflectMetadata()', () => {
-      expect(getOwnReflectMetadata).toHaveBeenCalledTimes(1);
+    it('should call getReflectMetadata()', () => {
+      expect(getReflectMetadata).toHaveBeenCalledTimes(1);
     });
 
     it('should return an array', () => {

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/getControllerMethodMetadataList.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/getControllerMethodMetadataList.ts
@@ -1,4 +1,4 @@
-import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+import { getReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
 
 import { controllerMethodMetadataReflectKey } from '../../reflectMetadata/data/controllerMethodMetadataReflectKey';
 import { ControllerMethodMetadata } from '../model/ControllerMethodMetadata';
@@ -7,7 +7,7 @@ export function getControllerMethodMetadataList(
   controllerConstructor: NewableFunction,
 ): ControllerMethodMetadata[] {
   return (
-    getOwnReflectMetadata(
+    getReflectMetadata(
       controllerConstructor,
       controllerMethodMetadataReflectKey,
     ) ?? []


### PR DESCRIPTION
Addresses issue #1185 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated reflection utilities; no API signature changes.
  * Request method decorators now inherit endpoints from base implementations (behavioral change noted).
* **Tests**
  * Test suites updated to reflect the new reflection utility usage.
* **Chores**
  * Added a changeset documenting a minor version bump and the decorator inheritance behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->