### PR TITLE
Update http adapter docs with warning

### DIFF
--- a/packages/docs/services/inversify-framework-site/docs/api/inversify-http-adapter/inversify-http-adapter.mdx
+++ b/packages/docs/services/inversify-framework-site/docs/api/inversify-http-adapter/inversify-http-adapter.mdx
@@ -54,6 +54,11 @@ Creates an adapter instance bound to a DI container. Adapters typically invoke t
 
 ## Public methods
 
+:::warning[Global context]
+Some of this methods set global middleware, guards, pipes, interceptors, or error filters that apply to all routes managed by this adapter instance.
+Routes not managed by this adapter (e.g., routes added directly to the underlying server) are unaffected.
+:::
+
 ### applyGlobalMiddleware
 
 ```ts


### PR DESCRIPTION
### Changed
- Updated `InversifyHttpAdapter` docs with warning regarding the global scope of the adapter.

### Context
See #1216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification on the global scope behavior of adapter methods, noting that middleware, guards, pipes, interceptors, and error filters set through these methods apply to routes managed by the adapter only, not external routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->