### PR TITLE
Update setErrorFilterToErrorFilterMap to throw a warning

### DIFF
--- a/packages/framework/http/libraries/core/src/http/actions/setErrorFilterToErrorFilterMap.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/actions/setErrorFilterToErrorFilterMap.spec.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, vitest } from 'vitest';
+import { beforeAll, describe, expect, it, Mocked, vitest } from 'vitest';
 
 vitest.mock('@inversifyjs/framework-core');
 
@@ -6,11 +6,20 @@ import {
   ErrorFilter,
   getCatchErrorMetadata,
 } from '@inversifyjs/framework-core';
+import { Logger } from '@inversifyjs/logger';
 import { Newable } from 'inversify';
 
 import { setErrorFilterToErrorFilterMap } from './setErrorFilterToErrorFilterMap';
 
 describe(setErrorFilterToErrorFilterMap, () => {
+  let loggerMock: Mocked<Logger>;
+
+  beforeAll(() => {
+    loggerMock = {
+      warn: vitest.fn(),
+    } as Partial<Mocked<Logger>> as Mocked<Logger>;
+  });
+
   describe('when called', () => {
     let errorTypeToGlobalErrorFilterMapFixture: Map<
       Newable<Error> | null,
@@ -29,6 +38,7 @@ describe(setErrorFilterToErrorFilterMap, () => {
         .mockReturnValueOnce(errorTypesFixture);
 
       setErrorFilterToErrorFilterMap(
+        loggerMock,
         errorTypeToGlobalErrorFilterMapFixture,
         errorFilterFixture,
       );
@@ -76,6 +86,7 @@ describe(setErrorFilterToErrorFilterMap, () => {
         .mockReturnValueOnce(errorTypesFixture);
 
       setErrorFilterToErrorFilterMap(
+        loggerMock,
         errorTypeToGlobalErrorFilterMapFixture,
         errorFilterFixture,
       );
@@ -116,6 +127,7 @@ describe(setErrorFilterToErrorFilterMap, () => {
         .mockReturnValueOnce(errorTypesFixture);
 
       setErrorFilterToErrorFilterMap(
+        loggerMock,
         errorTypeToGlobalErrorFilterMapFixture,
         errorFilterFixture,
       );

--- a/packages/framework/http/libraries/core/src/http/actions/setErrorFilterToErrorFilterMap.ts
+++ b/packages/framework/http/libraries/core/src/http/actions/setErrorFilterToErrorFilterMap.ts
@@ -2,9 +2,11 @@ import {
   ErrorFilter,
   getCatchErrorMetadata,
 } from '@inversifyjs/framework-core';
+import { Logger } from '@inversifyjs/logger';
 import { Newable } from 'inversify';
 
 export function setErrorFilterToErrorFilterMap(
+  logger: Logger,
   errorTypeToErrorFilterMap: Map<
     Newable<Error> | null,
     ErrorFilter | Newable<ErrorFilter>
@@ -20,6 +22,12 @@ export function setErrorFilterToErrorFilterMap(
 
     if (existingErrorFilter === undefined) {
       errorTypeToErrorFilterMap.set(errorType, errorFilter);
+    } else {
+      const errorTypeName: string =
+        errorType === null ? 'null (catch-all)' : errorType.name;
+      logger.warn(
+        `Error filter '${errorFilter.name}' was not registered for error type '${errorTypeName}' because an error filter is already registered for this error type.`,
+      );
     }
   }
 }

--- a/packages/framework/http/libraries/core/src/http/adapter/InversifyHttpAdapter.ts
+++ b/packages/framework/http/libraries/core/src/http/adapter/InversifyHttpAdapter.ts
@@ -200,7 +200,10 @@ export abstract class InversifyHttpAdapter<
       TRequest,
       TResponse,
       TResult
-    >[] = buildRouterExplorerControllerMetadataList(this.#container);
+    >[] = buildRouterExplorerControllerMetadataList(
+      this.#container,
+      this.#logger,
+    );
 
     for (const routerExplorerControllerMetadata of routerExplorerControllerMetadataList) {
       await this._buildRouter({
@@ -729,6 +732,7 @@ export abstract class InversifyHttpAdapter<
 
   #setGlobalErrorFilter(errorFilter: Newable<ErrorFilter>): void {
     setErrorFilterToErrorFilterMap(
+      this.#logger,
       this.#errorTypeToGlobalErrorFilterMap,
       errorFilter,
     );

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildErrorTypeToErrorFilterMap.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildErrorTypeToErrorFilterMap.spec.ts
@@ -8,15 +8,24 @@ import {
   getClassErrorFilterMetadata,
   getClassMethodErrorFilterMetadata,
 } from '@inversifyjs/framework-core';
+import { Logger } from '@inversifyjs/logger';
 import { Newable } from 'inversify';
 
 import { setErrorFilterToErrorFilterMap } from '../../http/actions/setErrorFilterToErrorFilterMap';
 import { buildErrorTypeToErrorFilterMap } from './buildErrorTypeToErrorFilterMap';
 
 describe(buildErrorTypeToErrorFilterMap, () => {
+  let targetFixture: NewableFunction;
+  let methodKeyFixture: string;
+  let loggerFixture: Logger;
+
+  beforeAll(() => {
+    targetFixture = class TestController {};
+    methodKeyFixture = 'testMethod';
+    loggerFixture = Symbol() as unknown as Logger;
+  });
+
   describe('when called', () => {
-    let targetFixture: NewableFunction;
-    let methodKeyFixture: string;
     let methodErrorFilterSetFixture: Set<Newable<ErrorFilter>>;
     let classErrorFilterSetFixture: Set<Newable<ErrorFilter>>;
     let methodErrorFilter1Fixture: Newable<ErrorFilter>;
@@ -26,8 +35,6 @@ describe(buildErrorTypeToErrorFilterMap, () => {
     let result: unknown;
 
     beforeAll(() => {
-      targetFixture = class TestController {};
-      methodKeyFixture = 'testMethod';
       methodErrorFilter1Fixture =
         class MethodErrorFilter1 {} as Newable<ErrorFilter>;
       methodErrorFilter2Fixture =
@@ -53,7 +60,11 @@ describe(buildErrorTypeToErrorFilterMap, () => {
         .mocked(getClassErrorFilterMetadata)
         .mockReturnValueOnce(classErrorFilterSetFixture);
 
-      result = buildErrorTypeToErrorFilterMap(targetFixture, methodKeyFixture);
+      result = buildErrorTypeToErrorFilterMap(
+        loggerFixture,
+        targetFixture,
+        methodKeyFixture,
+      );
     });
 
     afterAll(() => {
@@ -77,21 +88,25 @@ describe(buildErrorTypeToErrorFilterMap, () => {
       expect(setErrorFilterToErrorFilterMap).toHaveBeenCalledTimes(4);
       expect(setErrorFilterToErrorFilterMap).toHaveBeenNthCalledWith(
         1,
+        loggerFixture,
         expect.any(Map),
         methodErrorFilter1Fixture,
       );
       expect(setErrorFilterToErrorFilterMap).toHaveBeenNthCalledWith(
         2,
+        loggerFixture,
         expect.any(Map),
         methodErrorFilter2Fixture,
       );
       expect(setErrorFilterToErrorFilterMap).toHaveBeenNthCalledWith(
         3,
+        loggerFixture,
         expect.any(Map),
         classErrorFilter1Fixture,
       );
       expect(setErrorFilterToErrorFilterMap).toHaveBeenNthCalledWith(
         4,
+        loggerFixture,
         expect.any(Map),
         classErrorFilter2Fixture,
       );
@@ -103,16 +118,12 @@ describe(buildErrorTypeToErrorFilterMap, () => {
   });
 
   describe('when called, and getClassMethodErrorFilterMetadata() returns an empty Set', () => {
-    let targetFixture: NewableFunction;
-    let methodKeyFixture: string;
     let methodErrorFilterSetFixture: Set<Newable<ErrorFilter>>;
     let classErrorFilterSetFixture: Set<Newable<ErrorFilter>>;
     let classErrorFilter1Fixture: Newable<ErrorFilter>;
     let result: unknown;
 
     beforeAll(() => {
-      targetFixture = class TestController {};
-      methodKeyFixture = 'testMethod';
       methodErrorFilterSetFixture = new Set();
       classErrorFilter1Fixture =
         class ClassErrorFilter1 {} as Newable<ErrorFilter>;
@@ -126,7 +137,11 @@ describe(buildErrorTypeToErrorFilterMap, () => {
         .mocked(getClassErrorFilterMetadata)
         .mockReturnValueOnce(classErrorFilterSetFixture);
 
-      result = buildErrorTypeToErrorFilterMap(targetFixture, methodKeyFixture);
+      result = buildErrorTypeToErrorFilterMap(
+        loggerFixture,
+        targetFixture,
+        methodKeyFixture,
+      );
     });
 
     afterAll(() => {
@@ -148,6 +163,7 @@ describe(buildErrorTypeToErrorFilterMap, () => {
 
     it('should call setErrorFilterToErrorFilterMap() for class filters only', () => {
       expect(setErrorFilterToErrorFilterMap).toHaveBeenCalledExactlyOnceWith(
+        loggerFixture,
         expect.any(Map),
         classErrorFilter1Fixture,
       );
@@ -159,15 +175,11 @@ describe(buildErrorTypeToErrorFilterMap, () => {
   });
 
   describe('when called, and both getClassMethodErrorFilterMetadata() and getClassErrorFilterMetadata() return empty Sets', () => {
-    let targetFixture: NewableFunction;
-    let methodKeyFixture: string;
     let methodErrorFilterSetFixture: Set<Newable<ErrorFilter>>;
     let classErrorFilterSetFixture: Set<Newable<ErrorFilter>>;
     let result: unknown;
 
     beforeAll(() => {
-      targetFixture = class TestController {};
-      methodKeyFixture = 'testMethod';
       methodErrorFilterSetFixture = new Set();
       classErrorFilterSetFixture = new Set();
 
@@ -179,7 +191,11 @@ describe(buildErrorTypeToErrorFilterMap, () => {
         .mocked(getClassErrorFilterMetadata)
         .mockReturnValueOnce(classErrorFilterSetFixture);
 
-      result = buildErrorTypeToErrorFilterMap(targetFixture, methodKeyFixture);
+      result = buildErrorTypeToErrorFilterMap(
+        loggerFixture,
+        targetFixture,
+        methodKeyFixture,
+      );
     });
 
     afterAll(() => {

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildErrorTypeToErrorFilterMap.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildErrorTypeToErrorFilterMap.ts
@@ -3,11 +3,13 @@ import {
   getClassErrorFilterMetadata,
   getClassMethodErrorFilterMetadata,
 } from '@inversifyjs/framework-core';
+import { Logger } from '@inversifyjs/logger';
 import { Newable } from 'inversify';
 
 import { setErrorFilterToErrorFilterMap } from '../../http/actions/setErrorFilterToErrorFilterMap';
 
 export function buildErrorTypeToErrorFilterMap(
+  logger: Logger,
   target: NewableFunction,
   methodKey: string | symbol,
 ): Map<Newable<Error> | null, Newable<ErrorFilter>> {
@@ -20,11 +22,19 @@ export function buildErrorTypeToErrorFilterMap(
     target,
     methodKey,
   )) {
-    setErrorFilterToErrorFilterMap(errorTypeToErrorFilterMap, errorFilter);
+    setErrorFilterToErrorFilterMap(
+      logger,
+      errorTypeToErrorFilterMap,
+      errorFilter,
+    );
   }
 
   for (const errorFilter of getClassErrorFilterMetadata(target)) {
-    setErrorFilterToErrorFilterMap(errorTypeToErrorFilterMap, errorFilter);
+    setErrorFilterToErrorFilterMap(
+      logger,
+      errorTypeToErrorFilterMap,
+      errorFilter,
+    );
   }
 
   return errorTypeToErrorFilterMap;

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMetadata.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMetadata.spec.ts
@@ -3,6 +3,8 @@ import { beforeAll, describe, expect, it, vitest } from 'vitest';
 vitest.mock('./getControllerMethodMetadataList');
 vitest.mock('./buildRouterExplorerControllerMethodMetadataList');
 
+import { Logger } from '@inversifyjs/logger';
+
 import { ControllerMetadata } from '../model/ControllerMetadata';
 import { ControllerMethodMetadata } from '../model/ControllerMethodMetadata';
 import { RouterExplorerControllerMetadata } from '../model/RouterExplorerControllerMetadata';
@@ -12,18 +14,25 @@ import { buildRouterExplorerControllerMethodMetadataList } from './buildRouterEx
 import { getControllerMethodMetadataList } from './getControllerMethodMetadataList';
 
 describe(buildRouterExplorerControllerMetadata, () => {
+  let loggerFixture: Logger;
+  let controllerMetadataFixture: ControllerMetadata;
+
+  beforeAll(() => {
+    loggerFixture = Symbol() as unknown as Logger;
+
+    controllerMetadataFixture = {
+      path: '/test',
+      serviceIdentifier: Symbol(),
+      target: class TestController {},
+    };
+  });
+
   describe('when called', () => {
-    let controllerMetadataFixture: ControllerMetadata;
     let controllerMethodMetadataListFixture: ControllerMethodMetadata[];
     let routerExplorerControllerMethodMetadataListFixture: RouterExplorerControllerMethodMetadata[];
     let result: unknown;
 
     beforeAll(() => {
-      controllerMetadataFixture = {
-        path: '/test',
-        serviceIdentifier: Symbol(),
-        target: class TestController {},
-      };
       controllerMethodMetadataListFixture = [];
       routerExplorerControllerMethodMetadataListFixture = [];
 
@@ -35,7 +44,10 @@ describe(buildRouterExplorerControllerMetadata, () => {
         .mocked(buildRouterExplorerControllerMethodMetadataList)
         .mockReturnValueOnce(routerExplorerControllerMethodMetadataListFixture);
 
-      result = buildRouterExplorerControllerMetadata(controllerMetadataFixture);
+      result = buildRouterExplorerControllerMetadata(
+        loggerFixture,
+        controllerMetadataFixture,
+      );
     });
 
     it('should call getControllerMethodMetadataList', () => {
@@ -48,6 +60,7 @@ describe(buildRouterExplorerControllerMetadata, () => {
       expect(
         buildRouterExplorerControllerMethodMetadataList,
       ).toHaveBeenCalledExactlyOnceWith(
+        loggerFixture,
         controllerMetadataFixture,
         controllerMethodMetadataListFixture,
       );

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMetadata.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMetadata.ts
@@ -1,3 +1,5 @@
+import { Logger } from '@inversifyjs/logger';
+
 import { ControllerMetadata } from '../model/ControllerMetadata';
 import { ControllerMethodMetadata } from '../model/ControllerMethodMetadata';
 import { RouterExplorerControllerMetadata } from '../model/RouterExplorerControllerMetadata';
@@ -9,6 +11,7 @@ export function buildRouterExplorerControllerMetadata<
   TResponse,
   TResult,
 >(
+  logger: Logger,
   controllerMetadata: ControllerMetadata,
 ): RouterExplorerControllerMetadata<TRequest, TResponse, TResult> {
   const controllerMethodMetadataList: ControllerMethodMetadata[] =
@@ -17,6 +20,7 @@ export function buildRouterExplorerControllerMetadata<
   return {
     controllerMethodMetadataList:
       buildRouterExplorerControllerMethodMetadataList(
+        logger,
         controllerMetadata,
         controllerMethodMetadataList,
       ),

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMetadataList.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMetadataList.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@inversifyjs/logger';
 import { Container } from 'inversify';
 
 import { InversifyHttpAdapterError } from '../../error/models/InversifyHttpAdapterError';
@@ -13,6 +14,7 @@ export function buildRouterExplorerControllerMetadataList<
   TResult,
 >(
   container: Container,
+  logger: Logger,
 ): RouterExplorerControllerMetadata<TRequest, TResponse, TResult>[] {
   const controllerMetadataList: ControllerMetadata[] | undefined =
     getControllerMetadataList();
@@ -33,7 +35,7 @@ export function buildRouterExplorerControllerMetadataList<
   for (const controllerMetadata of controllerMetadataList) {
     if (container.isBound(controllerMetadata.serviceIdentifier)) {
       routerExplorerControllerMetadataList.push(
-        buildRouterExplorerControllerMetadata(controllerMetadata),
+        buildRouterExplorerControllerMetadata(logger, controllerMetadata),
       );
     }
   }

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadata.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadata.spec.ts
@@ -22,6 +22,7 @@ import {
   Middleware,
   MiddlewareOptions,
 } from '@inversifyjs/framework-core';
+import { Logger } from '@inversifyjs/logger';
 import { Newable, ServiceIdentifier } from 'inversify';
 
 import { RequestMethodType } from '../../http/models/RequestMethodType';
@@ -37,9 +38,26 @@ import { getControllerMethodStatusCodeMetadata } from './getControllerMethodStat
 import { getControllerMethodUseNativeHandlerMetadata } from './getControllerMethodUseNativeHandlerMetadata';
 
 describe(buildRouterExplorerControllerMethodMetadata, () => {
+  let loggerFixture: Logger;
+  let controllerMetadataFixture: ControllerMetadata;
+  let controllerMethodMetadataFixture: ControllerMethodMetadata;
+
+  beforeAll(() => {
+    loggerFixture = Symbol() as unknown as Logger;
+
+    controllerMetadataFixture = {
+      path: '/',
+      serviceIdentifier: Symbol(),
+      target: class TestController {},
+    };
+    controllerMethodMetadataFixture = {
+      methodKey: 'testMethod',
+      path: '/test',
+      requestMethodType: RequestMethodType.Get,
+    };
+  });
+
   describe('when called', () => {
-    let controllerMetadataFixture: ControllerMetadata;
-    let controllerMethodMetadataFixture: ControllerMethodMetadata;
     let controllerMethodParameterMetadataListFixture: (
       | ControllerMethodParameterMetadata
       | undefined
@@ -64,16 +82,6 @@ describe(buildRouterExplorerControllerMethodMetadata, () => {
     let result: unknown;
 
     beforeAll(() => {
-      controllerMetadataFixture = {
-        path: '/',
-        serviceIdentifier: Symbol(),
-        target: class TestController {},
-      };
-      controllerMethodMetadataFixture = {
-        methodKey: 'testMethod',
-        path: '/test',
-        requestMethodType: RequestMethodType.Get,
-      };
       controllerMethodParameterMetadataListFixture = [];
       controllerMethodStatusCodeMetadataFixture = undefined;
       classGuardListFixture = [Symbol() as unknown as Newable<Guard>];
@@ -156,6 +164,7 @@ describe(buildRouterExplorerControllerMethodMetadata, () => {
         .mockReturnValueOnce(errorTypeToErrorFilterMapFixture);
 
       result = buildRouterExplorerControllerMethodMetadata(
+        loggerFixture,
         controllerMetadataFixture,
         controllerMethodMetadataFixture,
       );
@@ -254,6 +263,7 @@ describe(buildRouterExplorerControllerMethodMetadata, () => {
 
     it('should call buildErrorTypeToErrorFilterMap()', () => {
       expect(buildErrorTypeToErrorFilterMap).toHaveBeenCalledExactlyOnceWith(
+        loggerFixture,
         controllerMetadataFixture.target,
         controllerMethodMetadataFixture.methodKey,
       );

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadata.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadata.ts
@@ -13,6 +13,7 @@ import {
   Middleware,
   MiddlewareOptions,
 } from '@inversifyjs/framework-core';
+import { Logger } from '@inversifyjs/logger';
 import { Newable, ServiceIdentifier } from 'inversify';
 
 import { HttpStatusCode } from '../../http/models/HttpStatusCode';
@@ -31,6 +32,7 @@ export function buildRouterExplorerControllerMethodMetadata<
   TResponse,
   TResult,
 >(
+  logger: Logger,
   controllerMetadata: ControllerMetadata,
   controllerMethodMetadata: ControllerMethodMetadata,
 ): RouterExplorerControllerMethodMetadata<TRequest, TResponse, TResult> {
@@ -88,6 +90,7 @@ export function buildRouterExplorerControllerMethodMetadata<
     Newable<Error> | null,
     Newable<ErrorFilter>
   > = buildErrorTypeToErrorFilterMap(
+    logger,
     controllerMetadata.target,
     controllerMethodMetadata.methodKey,
   );

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadataList.spec.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadataList.spec.ts
@@ -2,6 +2,8 @@ import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
 
 vitest.mock('./buildRouterExplorerControllerMethodMetadata');
 
+import { Logger } from '@inversifyjs/logger';
+
 import { ControllerMetadata } from '../model/ControllerMetadata';
 import { ControllerMethodMetadata } from '../model/ControllerMethodMetadata';
 import { RouterExplorerControllerMethodMetadata } from '../model/RouterExplorerControllerMethodMetadata';
@@ -9,20 +11,26 @@ import { buildRouterExplorerControllerMethodMetadata } from './buildRouterExplor
 import { buildRouterExplorerControllerMethodMetadataList } from './buildRouterExplorerControllerMethodMetadataList';
 
 describe(buildRouterExplorerControllerMethodMetadataList, () => {
+  let loggerFixture: Logger;
+  let controllerMetadataFixture: ControllerMetadata;
+  let controllerMethodMetadataFixture: ControllerMethodMetadata;
+
+  beforeAll(() => {
+    loggerFixture = Symbol() as unknown as Logger;
+    controllerMetadataFixture = {
+      path: '/',
+      serviceIdentifier: Symbol(),
+      target: class Test {},
+    };
+    controllerMethodMetadataFixture = {} as ControllerMethodMetadata;
+  });
+
   describe('when called', () => {
-    let controllerMetadataFixture: ControllerMetadata;
-    let controllerMethodMetadataFixture: ControllerMethodMetadata;
     let controllerMethodMetadataListFixture: ControllerMethodMetadata[];
     let routerExplorerControllerMethodMetadataFixture: RouterExplorerControllerMethodMetadata;
     let result: unknown;
 
     beforeAll(() => {
-      controllerMetadataFixture = {
-        path: '/',
-        serviceIdentifier: Symbol(),
-        target: class Test {},
-      };
-      controllerMethodMetadataFixture = {} as ControllerMethodMetadata;
       controllerMethodMetadataListFixture = [controllerMethodMetadataFixture];
       routerExplorerControllerMethodMetadataFixture =
         {} as RouterExplorerControllerMethodMetadata;
@@ -32,6 +40,7 @@ describe(buildRouterExplorerControllerMethodMetadataList, () => {
         .mockReturnValueOnce(routerExplorerControllerMethodMetadataFixture);
 
       result = buildRouterExplorerControllerMethodMetadataList(
+        loggerFixture,
         controllerMetadataFixture,
         controllerMethodMetadataListFixture,
       );
@@ -45,6 +54,7 @@ describe(buildRouterExplorerControllerMethodMetadataList, () => {
       expect(
         buildRouterExplorerControllerMethodMetadata,
       ).toHaveBeenCalledExactlyOnceWith(
+        loggerFixture,
         controllerMetadataFixture,
         controllerMethodMetadataFixture,
       );

--- a/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadataList.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/calculations/buildRouterExplorerControllerMethodMetadataList.ts
@@ -1,3 +1,5 @@
+import { Logger } from '@inversifyjs/logger';
+
 import { ControllerMetadata } from '../model/ControllerMetadata';
 import { ControllerMethodMetadata } from '../model/ControllerMethodMetadata';
 import { RouterExplorerControllerMethodMetadata } from '../model/RouterExplorerControllerMethodMetadata';
@@ -8,12 +10,14 @@ export function buildRouterExplorerControllerMethodMetadataList<
   TResponse,
   TResult,
 >(
+  logger: Logger,
   controllerMetadata: ControllerMetadata,
   controllerMethodMetadataList: ControllerMethodMetadata[],
 ): RouterExplorerControllerMethodMetadata<TRequest, TResponse, TResult>[] {
   return controllerMethodMetadataList.map(
     (controllerMethodMetadata: ControllerMethodMetadata) =>
       buildRouterExplorerControllerMethodMetadata(
+        logger,
         controllerMetadata,
         controllerMethodMetadata,
       ),


### PR DESCRIPTION
### Changed
- Updated `setErrorFilterToErrorFilterMap` to throw a warning on collision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal logging infrastructure throughout the HTTP framework to improve observability and debugging capabilities
  * Updated routing metadata builders and error filter registration to propagate logging across framework operations
  * Improved visibility into framework processes to better support monitoring and troubleshooting of application behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->