### PR TITLE
Update InversifyHttpAdapter to set http response elements in right order

### DIFF
--- a/packages/framework/http/libraries/core/src/http/calculations/buildInterceptedHandler.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/calculations/buildInterceptedHandler.spec.ts
@@ -36,13 +36,6 @@ describe(buildInterceptedHandler, () => {
   let replyMock: Mock<
     (req: unknown, res: unknown, value: ControllerResponse) => string
   >;
-  let setHeadersMock: Mock<
-    (
-      request: unknown,
-      response: unknown,
-      headerList: [string, string][],
-    ) => void
-  >;
 
   let requestFixture: unknown;
   let responseFixture: unknown;
@@ -62,7 +55,6 @@ describe(buildInterceptedHandler, () => {
     buildHandlerParamsMock = vitest.fn();
     handleErrorMock = vitest.fn();
     replyMock = vitest.fn();
-    setHeadersMock = vitest.fn();
 
     requestFixture = { url: '/test' };
     responseFixture = { status: 200 };
@@ -119,7 +111,6 @@ describe(buildInterceptedHandler, () => {
             buildHandlerParamsMock,
             handleErrorMock,
             replyMock,
-            setHeadersMock,
           );
 
         result = await handler(requestFixture, responseFixture, nextFixture);
@@ -140,14 +131,6 @@ describe(buildInterceptedHandler, () => {
           requestFixture,
           responseFixture,
           nextFixture,
-        );
-      });
-
-      it('should call setHeaders()', () => {
-        expect(setHeadersMock).toHaveBeenCalledExactlyOnceWith(
-          requestFixture,
-          responseFixture,
-          routerExplorerControllerMethodMetadataFixture.headerMetadataList,
         );
       });
 
@@ -191,7 +174,6 @@ describe(buildInterceptedHandler, () => {
             buildHandlerParamsMock,
             handleErrorMock,
             replyMock,
-            setHeadersMock,
           );
 
         result = await handler(requestFixture, responseFixture, nextFixture);
@@ -316,7 +298,6 @@ describe(buildInterceptedHandler, () => {
             buildHandlerParamsMock,
             handleErrorMock,
             replyMock,
-            setHeadersMock,
           );
 
         result = await handler(requestFixture, responseFixture, nextFixture);
@@ -363,14 +344,6 @@ describe(buildInterceptedHandler, () => {
           requestFixture,
           responseFixture,
           nextFixture,
-        );
-      });
-
-      it('should call setHeaders()', () => {
-        expect(setHeadersMock).toHaveBeenCalledExactlyOnceWith(
-          requestFixture,
-          responseFixture,
-          routerExplorerControllerMethodMetadataFixture.headerMetadataList,
         );
       });
 
@@ -469,7 +442,6 @@ describe(buildInterceptedHandler, () => {
             buildHandlerParamsMock,
             handleErrorMock,
             replyMock,
-            setHeadersMock,
           );
 
         result = await handler(requestFixture, responseFixture, nextFixture);
@@ -516,14 +488,6 @@ describe(buildInterceptedHandler, () => {
           requestFixture,
           responseFixture,
           nextFixture,
-        );
-      });
-
-      it('should call setHeaders()', () => {
-        expect(setHeadersMock).toHaveBeenCalledExactlyOnceWith(
-          requestFixture,
-          responseFixture,
-          routerExplorerControllerMethodMetadataFixture.headerMetadataList,
         );
       });
 
@@ -579,7 +543,6 @@ describe(buildInterceptedHandler, () => {
             buildHandlerParamsMock,
             handleErrorMock,
             replyMock,
-            setHeadersMock,
           );
 
         result = await handler(requestFixture, responseFixture, nextFixture);
@@ -652,7 +615,6 @@ describe(buildInterceptedHandler, () => {
             buildHandlerParamsMock,
             handleErrorMock,
             replyMock,
-            setHeadersMock,
           );
 
         result = await handler(requestFixture, responseFixture, nextFixture);

--- a/packages/framework/http/libraries/core/src/http/calculations/buildInterceptedHandler.ts
+++ b/packages/framework/http/libraries/core/src/http/calculations/buildInterceptedHandler.ts
@@ -38,11 +38,6 @@ export function buildInterceptedHandler<
     res: TResponse,
     value: ControllerResponse,
   ) => TResult | Promise<TResult>,
-  setHeaders: (
-    request: TRequest,
-    response: TResponse,
-    headerList: [string, string][],
-  ) => void,
 ): RequestHandler<TRequest, TResponse, TNextFunction, TResult> {
   if (routerExplorerControllerMethodMetadata.interceptorList.length === 0) {
     return async (
@@ -58,12 +53,6 @@ export function buildInterceptedHandler<
           request,
           response,
           next,
-        );
-
-        setHeaders(
-          request,
-          response,
-          routerExplorerControllerMethodMetadata.headerMetadataList,
         );
 
         const value: ControllerResponse = await controller[
@@ -125,12 +114,6 @@ export function buildInterceptedHandler<
             request,
             response,
             next,
-          );
-
-          setHeaders(
-            request,
-            response,
-            routerExplorerControllerMethodMetadata.headerMetadataList,
           );
 
           handlerResult = await controller[

--- a/packages/framework/http/tools/e2e-tests/features/setHeader.feature
+++ b/packages/framework/http/tools/e2e-tests/features/setHeader.feature
@@ -48,3 +48,46 @@ The setHeader decorator allows set response headers
           | "uwebsockets" | "PATCH"   |
           | "uwebsockets" | "POST"    |
           | "uwebsockets" | "PUT"     |
+
+    Rule: setHeader decorator allows set response headers with custom status codes
+      Scenario: HTTP headers are correctly set with custom status codes
+
+        Given a warrior controller with both setHeader and statusCode decorators for <method> method
+        And a <server_kind> server from container
+        And a <method> warriors HTTP request with headers
+        When the request is send
+        Then the response status code is ACCEPTED
+        Then the response contains the correct header
+
+        Examples:
+          | server_kind   | method    |
+          | "express"     | "DELETE"  |
+          | "express"     | "GET"     |
+          | "express"     | "OPTIONS" |
+          | "express"     | "PATCH"   |
+          | "express"     | "POST"    |
+          | "express"     | "PUT"     |
+          | "express4"    | "DELETE"  |
+          | "express4"    | "GET"     |
+          | "express4"    | "OPTIONS" |
+          | "express4"    | "PATCH"   |
+          | "express4"    | "POST"    |
+          | "express4"    | "PUT"     |
+          | "fastify"     | "DELETE"  |
+          | "fastify"     | "GET"     |
+          | "fastify"     | "OPTIONS" |
+          | "fastify"     | "PATCH"   |
+          | "fastify"     | "POST"    |
+          | "fastify"     | "PUT"     |
+          | "hono"        | "DELETE"  |
+          | "hono"        | "GET"     |
+          | "hono"        | "OPTIONS" |
+          | "hono"        | "PATCH"   |
+          | "hono"        | "POST"    |
+          | "hono"        | "PUT"     |
+          | "uwebsockets" | "DELETE"  |
+          | "uwebsockets" | "GET"     |
+          | "uwebsockets" | "OPTIONS" |
+          | "uwebsockets" | "PATCH"   |
+          | "uwebsockets" | "POST"    |
+          | "uwebsockets" | "PUT"     |

--- a/packages/framework/http/tools/e2e-tests/src/warrior/set-header/controllers/WarriorsDeleteSetHeaderWithStatusCodeController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/set-header/controllers/WarriorsDeleteSetHeaderWithStatusCodeController.ts
@@ -1,0 +1,15 @@
+import {
+  Controller,
+  Delete,
+  HttpStatusCode,
+  SetHeader,
+  StatusCode,
+} from '@inversifyjs/http-core';
+
+@Controller('/warriors')
+export class WarriorsDeleteSetHeaderWithStatusCodeController {
+  @StatusCode(HttpStatusCode.ACCEPTED)
+  @SetHeader('x-test-header', 'test-value')
+  @Delete()
+  public async deleteWarrior(): Promise<void> {}
+}

--- a/packages/framework/http/tools/e2e-tests/src/warrior/set-header/controllers/WarriorsGetSetHeaderWithStatusCodeController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/set-header/controllers/WarriorsGetSetHeaderWithStatusCodeController.ts
@@ -1,0 +1,15 @@
+import {
+  Controller,
+  Get,
+  HttpStatusCode,
+  SetHeader,
+  StatusCode,
+} from '@inversifyjs/http-core';
+
+@Controller('/warriors')
+export class WarriorsGetSetHeaderWithStatusCodeController {
+  @StatusCode(HttpStatusCode.ACCEPTED)
+  @SetHeader('x-test-header', 'test-value')
+  @Get()
+  public async getWarrior(): Promise<void> {}
+}

--- a/packages/framework/http/tools/e2e-tests/src/warrior/set-header/controllers/WarriorsOptionsSetHeaderWithStatusCodeController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/set-header/controllers/WarriorsOptionsSetHeaderWithStatusCodeController.ts
@@ -1,0 +1,15 @@
+import {
+  Controller,
+  HttpStatusCode,
+  Options,
+  SetHeader,
+  StatusCode,
+} from '@inversifyjs/http-core';
+
+@Controller('/warriors')
+export class WarriorsOptionsSetHeaderWithStatusCodeController {
+  @StatusCode(HttpStatusCode.ACCEPTED)
+  @SetHeader('x-test-header', 'test-value')
+  @Options()
+  public async optionsWarrior(): Promise<void> {}
+}

--- a/packages/framework/http/tools/e2e-tests/src/warrior/set-header/controllers/WarriorsPatchSetHeaderWithStatusCodeController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/set-header/controllers/WarriorsPatchSetHeaderWithStatusCodeController.ts
@@ -1,0 +1,15 @@
+import {
+  Controller,
+  HttpStatusCode,
+  Patch,
+  SetHeader,
+  StatusCode,
+} from '@inversifyjs/http-core';
+
+@Controller('/warriors')
+export class WarriorsPatchSetHeaderWithStatusCodeController {
+  @StatusCode(HttpStatusCode.ACCEPTED)
+  @SetHeader('x-test-header', 'test-value')
+  @Patch()
+  public async patchWarrior(): Promise<void> {}
+}

--- a/packages/framework/http/tools/e2e-tests/src/warrior/set-header/controllers/WarriorsPostSetHeaderWithStatusCodeController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/set-header/controllers/WarriorsPostSetHeaderWithStatusCodeController.ts
@@ -1,0 +1,15 @@
+import {
+  Controller,
+  HttpStatusCode,
+  Post,
+  SetHeader,
+  StatusCode,
+} from '@inversifyjs/http-core';
+
+@Controller('/warriors')
+export class WarriorsPostSetHeaderWithStatusCodeController {
+  @StatusCode(HttpStatusCode.ACCEPTED)
+  @SetHeader('x-test-header', 'test-value')
+  @Post()
+  public async postWarrior(): Promise<void> {}
+}

--- a/packages/framework/http/tools/e2e-tests/src/warrior/set-header/controllers/WarriorsPutSetHeaderWithStatusCodeController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/set-header/controllers/WarriorsPutSetHeaderWithStatusCodeController.ts
@@ -1,0 +1,15 @@
+import {
+  Controller,
+  HttpStatusCode,
+  Put,
+  SetHeader,
+  StatusCode,
+} from '@inversifyjs/http-core';
+
+@Controller('/warriors')
+export class WarriorsPutSetHeaderWithStatusCodeController {
+  @StatusCode(HttpStatusCode.ACCEPTED)
+  @SetHeader('x-test-header', 'test-value')
+  @Put()
+  public async putWarrior(): Promise<void> {}
+}

--- a/packages/framework/http/tools/e2e-tests/src/warrior/set-header/step-definitions/givenDefinitions.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/set-header/step-definitions/givenDefinitions.ts
@@ -6,11 +6,17 @@ import { InversifyHttpWorld } from '../../../common/models/InversifyHttpWorld';
 import { getContainerOrFail } from '../../../container/calculations/getContainerOrFail';
 import { HttpMethod } from '../../../http/models/HttpMethod';
 import { WarriorsDeleteSetHeaderController } from '../controllers/WarriorsDeleteSetHeaderController';
+import { WarriorsDeleteSetHeaderWithStatusCodeController } from '../controllers/WarriorsDeleteSetHeaderWithStatusCodeController';
 import { WarriorsGetSetHeaderController } from '../controllers/WarriorsGetSetHeaderController';
+import { WarriorsGetSetHeaderWithStatusCodeController } from '../controllers/WarriorsGetSetHeaderWithStatusCodeController';
 import { WarriorsOptionsSetHeaderController } from '../controllers/WarriorsOptionsSetHeaderController';
+import { WarriorsOptionsSetHeaderWithStatusCodeController } from '../controllers/WarriorsOptionsSetHeaderWithStatusCodeController';
 import { WarriorsPatchSetHeaderController } from '../controllers/WarriorsPatchSetHeaderController';
+import { WarriorsPatchSetHeaderWithStatusCodeController } from '../controllers/WarriorsPatchSetHeaderWithStatusCodeController';
 import { WarriorsPostSetHeaderController } from '../controllers/WarriorsPostSetHeaderController';
+import { WarriorsPostSetHeaderWithStatusCodeController } from '../controllers/WarriorsPostSetHeaderWithStatusCodeController';
 import { WarriorsPutSetHeaderController } from '../controllers/WarriorsPutSetHeaderController';
+import { WarriorsPutSetHeaderWithStatusCodeController } from '../controllers/WarriorsPutSetHeaderWithStatusCodeController';
 
 function getMethodWarriorSetHeaderController(
   method: HttpMethod,
@@ -31,6 +37,25 @@ function getMethodWarriorSetHeaderController(
   }
 }
 
+function getMethodWarriorSetHeaderWithStatusCodeController(
+  method: HttpMethod,
+): NewableFunction {
+  switch (method) {
+    case HttpMethod.delete:
+      return WarriorsDeleteSetHeaderWithStatusCodeController;
+    case HttpMethod.get:
+      return WarriorsGetSetHeaderWithStatusCodeController;
+    case HttpMethod.options:
+      return WarriorsOptionsSetHeaderWithStatusCodeController;
+    case HttpMethod.patch:
+      return WarriorsPatchSetHeaderWithStatusCodeController;
+    case HttpMethod.post:
+      return WarriorsPostSetHeaderWithStatusCodeController;
+    case HttpMethod.put:
+      return WarriorsPutSetHeaderWithStatusCodeController;
+  }
+}
+
 function givenWarriorSetHeaderControllerForContainer(
   this: InversifyHttpWorld,
   method: HttpMethod,
@@ -46,9 +71,33 @@ function givenWarriorSetHeaderControllerForContainer(
   container.bind(controller).toSelf().inSingletonScope();
 }
 
+function givenWarriorSetHeaderWithStatusCodeControllerForContainer(
+  this: InversifyHttpWorld,
+  method: HttpMethod,
+  containerAlias?: string,
+): void {
+  const parsedContainerAlias: string = containerAlias ?? defaultAlias;
+  const container: Container =
+    getContainerOrFail.bind(this)(parsedContainerAlias);
+
+  const controller: NewableFunction =
+    getMethodWarriorSetHeaderWithStatusCodeController(method);
+
+  container.bind(controller).toSelf().inSingletonScope();
+}
+
 Given<InversifyHttpWorld>(
   'a warrior controller with setHeader decorator for "{httpMethod}" method',
   function (this: InversifyHttpWorld, httpMethod: HttpMethod): void {
     givenWarriorSetHeaderControllerForContainer.bind(this)(httpMethod);
+  },
+);
+
+Given<InversifyHttpWorld>(
+  'a warrior controller with both setHeader and statusCode decorators for "{httpMethod}" method',
+  function (this: InversifyHttpWorld, httpMethod: HttpMethod): void {
+    givenWarriorSetHeaderWithStatusCodeControllerForContainer.bind(this)(
+      httpMethod,
+    );
   },
 );


### PR DESCRIPTION
### Changed
- Some adapters like `uwebsockets` requires sending http elements in the right order in order to deliver expected responses. `InversifyHttpAdapter` has been updated accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced HTTP response header application to work correctly with custom status codes.

* **Tests**
  * Added comprehensive end-to-end test coverage for custom headers combined with custom status codes across all HTTP methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->