### PR TITLE
Update InversifyExpressHttpAdapter to handle url encoded bodies

### DIFF
--- a/.changeset/seven-crabs-stop.md
+++ b/.changeset/seven-crabs-stop.md
@@ -1,0 +1,7 @@
+---
+"@inversifyjs/http-express-v4": minor
+"@inversifyjs/http-express": minor
+---
+
+- Updated `InversifyExpressHttpAdapter` to handle url encoded bodies
+- Updated `ExpressHttpAdapterOptions` with `useUrlEncoded`

--- a/packages/framework/http/libraries/express-v4/src/adapter/InversifyExpressHttpAdapter.ts
+++ b/packages/framework/http/libraries/express-v4/src/adapter/InversifyExpressHttpAdapter.ts
@@ -40,6 +40,7 @@ export class InversifyExpressHttpAdapter extends InversifyHttpAdapter<
         useCookies: false,
         useJson: true,
         useText: false,
+        useUrlEncoded: false,
       },
       httpAdapterOptions,
     );
@@ -177,6 +178,15 @@ export class InversifyExpressHttpAdapter extends InversifyHttpAdapter<
 
     if (this.httpAdapterOptions.useText) {
       app.use(express.text({ type: 'text/*' }));
+    }
+
+    if (this.httpAdapterOptions.useUrlEncoded) {
+      app.use(
+        express.urlencoded({
+          extended: false,
+          type: 'application/x-www-form-urlencoded',
+        }),
+      );
     }
 
     return app;

--- a/packages/framework/http/libraries/express-v4/src/models/ExpressHttpAdapterOptions.ts
+++ b/packages/framework/http/libraries/express-v4/src/models/ExpressHttpAdapterOptions.ts
@@ -4,4 +4,5 @@ export interface ExpressHttpAdapterOptions extends HttpAdapterOptions {
   useCookies?: boolean;
   useJson?: boolean;
   useText?: boolean;
+  useUrlEncoded?: boolean;
 }

--- a/packages/framework/http/libraries/express/src/adapter/InversifyExpressHttpAdapter.ts
+++ b/packages/framework/http/libraries/express/src/adapter/InversifyExpressHttpAdapter.ts
@@ -40,6 +40,7 @@ export class InversifyExpressHttpAdapter extends InversifyHttpAdapter<
         useCookies: false,
         useJson: true,
         useText: false,
+        useUrlEncoded: false,
       },
       httpAdapterOptions,
     );
@@ -177,6 +178,15 @@ export class InversifyExpressHttpAdapter extends InversifyHttpAdapter<
 
     if (this.httpAdapterOptions.useText) {
       app.use(express.text({ type: 'text/*' }));
+    }
+
+    if (this.httpAdapterOptions.useUrlEncoded) {
+      app.use(
+        express.urlencoded({
+          extended: false,
+          type: 'application/x-www-form-urlencoded',
+        }),
+      );
     }
 
     return app;

--- a/packages/framework/http/libraries/express/src/models/ExpressHttpAdapterOptions.ts
+++ b/packages/framework/http/libraries/express/src/models/ExpressHttpAdapterOptions.ts
@@ -4,4 +4,5 @@ export interface ExpressHttpAdapterOptions extends HttpAdapterOptions {
   useCookies?: boolean;
   useJson?: boolean;
   useText?: boolean;
+  useUrlEncoded?: boolean;
 }

--- a/packages/framework/http/tools/e2e-tests/features/body.feature
+++ b/packages/framework/http/tools/e2e-tests/features/body.feature
@@ -189,3 +189,41 @@ The body decorator allows extracting the body from HTTP requests
           | "uwebsockets" | "PATCH"  |
           | "uwebsockets" | "POST"   |
           | "uwebsockets" | "PUT"    |
+
+    Rule: body decorator allows extracting HTTP request URL-encoded body
+      Scenario: HTTP request URL-encoded body is correctly extracted with body decorator without parameter name
+
+        Given a warrior controller with urlencoded body decorator without parameter name for <method> method
+        And a <server_kind> server from container
+        And a <method> warriors HTTP request with urlencoded body
+        When the request is send
+        Then the response status code is Ok-ish
+        Then the response contains the correct body data
+
+        Examples:
+          | server_kind   | method   |
+          | "express"     | "DELETE" |
+          | "express"     | "OPTIONS"|
+          | "express"     | "PATCH"  |
+          | "express"     | "POST"   |
+          | "express"     | "PUT"    |
+          | "express4"    | "DELETE" |
+          | "express4"    | "OPTIONS"|
+          | "express4"    | "PATCH"  |
+          | "express4"    | "POST"   |
+          | "express4"    | "PUT"    |
+          | "fastify"     | "DELETE" |
+          | "fastify"     | "OPTIONS"|
+          | "fastify"     | "PATCH"  |
+          | "fastify"     | "POST"   |
+          | "fastify"     | "PUT"    |
+          | "hono"        | "DELETE" |
+          | "hono"        | "OPTIONS"|
+          | "hono"        | "PATCH"  |
+          | "hono"        | "POST"   |
+          | "hono"        | "PUT"    |
+          | "uwebsockets" | "DELETE" |
+          | "uwebsockets" | "OPTIONS"|
+          | "uwebsockets" | "PATCH"  |
+          | "uwebsockets" | "POST"   |
+          | "uwebsockets" | "PUT"    |

--- a/packages/framework/http/tools/e2e-tests/src/server/step-definitions/givenDefinitions.ts
+++ b/packages/framework/http/tools/e2e-tests/src/server/step-definitions/givenDefinitions.ts
@@ -25,7 +25,7 @@ import { ServerKind } from '../models/ServerKind';
 async function buildExpressServer(container: Container): Promise<Server> {
   const adapter: InversifyExpressHttpAdapter = new InversifyExpressHttpAdapter(
     container,
-    { logger: true, useJson: true, useText: true },
+    { logger: true, useJson: true, useText: true, useUrlEncoded: true },
   );
 
   const application: express.Application = await adapter.build();
@@ -75,6 +75,7 @@ async function buildExpress4Server(container: Container): Promise<Server> {
       logger: true,
       useJson: true,
       useText: true,
+      useUrlEncoded: true,
     });
 
   const application: express4.Application = await adapter.build();
@@ -166,7 +167,7 @@ async function buildHonoServer(container: Container): Promise<Server> {
 async function buildFastifyServer(container: Container): Promise<Server> {
   const adapter: InversifyFastifyHttpAdapter = new InversifyFastifyHttpAdapter(
     container,
-    { logger: true },
+    { logger: true, useFormUrlEncoded: true },
   );
 
   const application: FastifyInstance = await adapter.build();

--- a/packages/framework/http/tools/e2e-tests/src/warrior/body/controllers/WarriorsDeleteUrlEncodedBodyController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/body/controllers/WarriorsDeleteUrlEncodedBodyController.ts
@@ -1,0 +1,21 @@
+import { Body, Controller, Delete } from '@inversifyjs/http-core';
+
+import { WarriorCreationResponse } from '../models/WarriorCreationResponse';
+import { WarriorRequest } from '../models/WarriorRequest';
+
+@Controller('/warriors')
+export class WarriorsDeleteUrlEncodedBodyController {
+  @Delete()
+  public async deleteWarrior(
+    @Body() body: WarriorRequest,
+  ): Promise<WarriorCreationResponse> {
+    return {
+      damage: 10,
+      health: 100,
+      name: body.name,
+      range: 1,
+      speed: 10,
+      type: body.type,
+    };
+  }
+}

--- a/packages/framework/http/tools/e2e-tests/src/warrior/body/controllers/WarriorsOptionsUrlEncodedBodyController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/body/controllers/WarriorsOptionsUrlEncodedBodyController.ts
@@ -1,0 +1,21 @@
+import { Body, Controller, Options } from '@inversifyjs/http-core';
+
+import { WarriorCreationResponse } from '../models/WarriorCreationResponse';
+import { WarriorRequest } from '../models/WarriorRequest';
+
+@Controller('/warriors')
+export class WarriorsOptionsUrlEncodedBodyController {
+  @Options()
+  public async optionsWarrior(
+    @Body() body: WarriorRequest,
+  ): Promise<WarriorCreationResponse> {
+    return {
+      damage: 10,
+      health: 100,
+      name: body.name,
+      range: 1,
+      speed: 10,
+      type: body.type,
+    };
+  }
+}

--- a/packages/framework/http/tools/e2e-tests/src/warrior/body/controllers/WarriorsPatchUrlEncodedBodyController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/body/controllers/WarriorsPatchUrlEncodedBodyController.ts
@@ -1,0 +1,21 @@
+import { Body, Controller, Patch } from '@inversifyjs/http-core';
+
+import { WarriorCreationResponse } from '../models/WarriorCreationResponse';
+import { WarriorRequest } from '../models/WarriorRequest';
+
+@Controller('/warriors')
+export class WarriorsPatchUrlEncodedBodyController {
+  @Patch()
+  public async updateWarrior(
+    @Body() body: WarriorRequest,
+  ): Promise<WarriorCreationResponse> {
+    return {
+      damage: 10,
+      health: 100,
+      name: body.name,
+      range: 1,
+      speed: 10,
+      type: body.type,
+    };
+  }
+}

--- a/packages/framework/http/tools/e2e-tests/src/warrior/body/controllers/WarriorsPostUrlEncodedBodyController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/body/controllers/WarriorsPostUrlEncodedBodyController.ts
@@ -1,0 +1,21 @@
+import { Body, Controller, Post } from '@inversifyjs/http-core';
+
+import { WarriorCreationResponse } from '../models/WarriorCreationResponse';
+import { WarriorRequest } from '../models/WarriorRequest';
+
+@Controller('/warriors')
+export class WarriorsPostUrlEncodedBodyController {
+  @Post()
+  public async createWarrior(
+    @Body() body: WarriorRequest,
+  ): Promise<WarriorCreationResponse> {
+    return {
+      damage: 10,
+      health: 100,
+      name: body.name,
+      range: 1,
+      speed: 10,
+      type: body.type,
+    };
+  }
+}

--- a/packages/framework/http/tools/e2e-tests/src/warrior/body/controllers/WarriorsPutUrlEncodedBodyController.ts
+++ b/packages/framework/http/tools/e2e-tests/src/warrior/body/controllers/WarriorsPutUrlEncodedBodyController.ts
@@ -1,0 +1,21 @@
+import { Body, Controller, Put } from '@inversifyjs/http-core';
+
+import { WarriorCreationResponse } from '../models/WarriorCreationResponse';
+import { WarriorRequest } from '../models/WarriorRequest';
+
+@Controller('/warriors')
+export class WarriorsPutUrlEncodedBodyController {
+  @Put()
+  public async updateWarrior(
+    @Body() body: WarriorRequest,
+  ): Promise<WarriorCreationResponse> {
+    return {
+      damage: 10,
+      health: 100,
+      name: body.name,
+      range: 1,
+      speed: 10,
+      type: body.type,
+    };
+  }
+}


### PR DESCRIPTION
### Added
- Added `e2e` tests to cover url encoded body handle scenarios.

### Changed
- Updated `InversifyExpressHttpAdapter` to handle url encoded bodies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional URL-encoded request body parsing support for Express and Express v4 adapters via a new configuration flag.

* **Tests**
  * Added comprehensive end-to-end test coverage for URL-encoded body handling across multiple HTTP methods (POST, PUT, PATCH, DELETE, OPTIONS).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->