### PR TITLE
Update CustomParameterDecoratorHandler with options param

### DIFF
--- a/.changeset/metal-shirts-enjoy.md
+++ b/.changeset/metal-shirts-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/http-core": minor
+---
+
+- Updated `CustomParameterDecoratorHandler` with options param

--- a/packages/foundation/tools/rollup-config/lib/index.js
+++ b/packages/foundation/tools/rollup-config/lib/index.js
@@ -79,6 +79,11 @@ export function buildBundleConfig(
       plugins,
     },
     {
+      external: [
+        NODE_REGEX,
+        ...packageDependencies,
+        ...packagePeerDependencies,
+      ],
       input: declarationFilePath,
       output: [{ file: declarationFilePath, format: 'es' }],
       plugins: [
@@ -135,6 +140,11 @@ export function buildMultiBundleConfig(inputFiles, outputDir) {
       ],
     },
     {
+      external: [
+        NODE_REGEX,
+        ...packageDependencies,
+        ...packagePeerDependencies,
+      ],
       input: declarationFilePath,
       output: [{ file: declarationFilePath, format: 'es' }],
       plugins: [

--- a/packages/framework/http/libraries/core/src/http/calculations/buildInterceptedHandler.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/calculations/buildInterceptedHandler.spec.ts
@@ -86,7 +86,7 @@ describe(buildInterceptedHandler, () => {
         callRouteHandlerMock.mockResolvedValueOnce(controllerResponseFixture);
         replyMock.mockReturnValueOnce(replyResultFixture);
 
-        const handler: RequestHandler<unknown, unknown, () => void, string> =
+        const handler: RequestHandler<unknown, unknown, () => void, unknown> =
           buildInterceptedHandler(
             routerExplorerControllerMethodMetadataFixture,
             containerMock,
@@ -136,7 +136,7 @@ describe(buildInterceptedHandler, () => {
         callRouteHandlerMock.mockRejectedValueOnce(errorFixture);
         handleErrorMock.mockResolvedValueOnce(errorResultFixture);
 
-        const handler: RequestHandler<unknown, unknown, () => void, string> =
+        const handler: RequestHandler<unknown, unknown, () => void, unknown> =
           buildInterceptedHandler(
             routerExplorerControllerMethodMetadataFixture,
             containerMock,
@@ -250,7 +250,7 @@ describe(buildInterceptedHandler, () => {
 
         replyMock.mockReturnValueOnce(replyResultFixture);
 
-        const handler: RequestHandler<unknown, unknown, () => void, string> =
+        const handler: RequestHandler<unknown, unknown, () => void, unknown> =
           buildInterceptedHandler(
             routerExplorerControllerMethodMetadataFixture,
             containerMock,
@@ -374,7 +374,7 @@ describe(buildInterceptedHandler, () => {
 
         replyMock.mockReturnValueOnce(replyResultFixture);
 
-        const handler: RequestHandler<unknown, unknown, () => void, string> =
+        const handler: RequestHandler<unknown, unknown, () => void, unknown> =
           buildInterceptedHandler(
             routerExplorerControllerMethodMetadataFixture,
             containerMock,
@@ -464,7 +464,7 @@ describe(buildInterceptedHandler, () => {
         containerMock.getAsync.mockResolvedValueOnce(firstInterceptorMock);
         handleErrorMock.mockResolvedValueOnce(errorResultFixture);
 
-        const handler: RequestHandler<unknown, unknown, () => void, string> =
+        const handler: RequestHandler<unknown, unknown, () => void, unknown> =
           buildInterceptedHandler(
             routerExplorerControllerMethodMetadataFixture,
             containerMock,
@@ -530,7 +530,7 @@ describe(buildInterceptedHandler, () => {
         callRouteHandlerMock.mockRejectedValueOnce(errorFixture);
         handleErrorMock.mockResolvedValueOnce(errorResultFixture);
 
-        const handler: RequestHandler<unknown, unknown, () => void, string> =
+        const handler: RequestHandler<unknown, unknown, () => void, unknown> =
           buildInterceptedHandler(
             routerExplorerControllerMethodMetadataFixture,
             containerMock,

--- a/packages/framework/http/libraries/core/src/http/calculations/buildInterceptedHandler.ts
+++ b/packages/framework/http/libraries/core/src/http/calculations/buildInterceptedHandler.ts
@@ -18,7 +18,7 @@ export function buildInterceptedHandler<
   routerExplorerControllerMethodMetadata: RouterExplorerControllerMethodMetadata<
     TRequest,
     TResponse,
-    unknown
+    TResult
   >,
   container: Container,
   callRouteHandler: (

--- a/packages/framework/http/libraries/core/src/http/models/CustomParameterDecoratorHandler.ts
+++ b/packages/framework/http/libraries/core/src/http/models/CustomParameterDecoratorHandler.ts
@@ -1,6 +1,12 @@
+import { CustomParameterDecoratorHandlerOptions } from './CustomParameterDecoratorHandlerOptions';
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export type CustomParameterDecoratorHandler<
   TRequest = any,
   TResponse = any,
   TResult = any,
-> = (request: TRequest, response: TResponse) => Promise<TResult> | TResult;
+> = (
+  request: TRequest,
+  response: TResponse,
+  options: CustomParameterDecoratorHandlerOptions<TRequest, TResponse>,
+) => Promise<TResult> | TResult;

--- a/packages/framework/http/libraries/core/src/http/models/CustomParameterDecoratorHandlerOptions.ts
+++ b/packages/framework/http/libraries/core/src/http/models/CustomParameterDecoratorHandlerOptions.ts
@@ -1,0 +1,28 @@
+import { HttpStatusCode } from './HttpStatusCode';
+
+export interface CustomParameterDecoratorHandlerOptions<TRequest, TResponse> {
+  getBody: (
+    request: TRequest,
+    response: TResponse,
+    parameterName?: string,
+  ) => unknown;
+  getCookies: (
+    request: TRequest,
+    response: TResponse,
+    parameterName?: string,
+  ) => unknown;
+  getHeaders: (request: TRequest, parameterName?: string) => unknown;
+  getParams: (request: TRequest, parameterName?: string) => unknown;
+  getQuery: (request: TRequest, parameterName?: string) => unknown;
+  setHeader(
+    request: TRequest,
+    response: TResponse,
+    key: string,
+    value: string,
+  ): void;
+  setStatus(
+    request: TRequest,
+    response: TResponse,
+    statusCode: HttpStatusCode,
+  ): void;
+}

--- a/packages/framework/http/libraries/core/src/index.ts
+++ b/packages/framework/http/libraries/core/src/index.ts
@@ -37,6 +37,8 @@ import { Request } from './http/decorators/Request';
 import { Response } from './http/decorators/Response';
 import { SetHeader } from './http/decorators/SetHeader';
 import { StatusCode } from './http/decorators/StatusCode';
+import { CustomParameterDecoratorHandler } from './http/models/CustomParameterDecoratorHandler';
+import { CustomParameterDecoratorHandlerOptions } from './http/models/CustomParameterDecoratorHandlerOptions';
 import { HttpAdapterOptions } from './http/models/HttpAdapterOptions';
 import { HttpStatusCode } from './http/models/HttpStatusCode';
 import { MiddlewareHandler } from './http/models/MiddlewareHandler';
@@ -88,6 +90,8 @@ export type {
   CatchErrorOptions,
   ControllerMetadata,
   ControllerMethodMetadata,
+  CustomParameterDecoratorHandler,
+  CustomParameterDecoratorHandlerOptions,
   ErrorFilter,
   Guard,
   HttpAdapterOptions,

--- a/packages/framework/http/libraries/express-v4/src/adapter/InversifyExpressHttpAdapter.ts
+++ b/packages/framework/http/libraries/express-v4/src/adapter/InversifyExpressHttpAdapter.ts
@@ -137,19 +137,46 @@ export class InversifyExpressHttpAdapter extends InversifyHttpAdapter<
         request.body[parameterName];
   }
 
-  protected _getParams(request: Request, parameterName?: string): unknown {
+  protected _getParams(request: express.Request): Record<string, string>;
+  protected _getParams(
+    request: express.Request,
+    parameterName: string,
+  ): string | undefined;
+  protected _getParams(
+    request: express.Request,
+    parameterName?: string,
+  ): Record<string, string> | string | undefined {
     return parameterName === undefined
       ? request.params
       : request.params[parameterName];
   }
 
-  protected _getQuery(request: Request, parameterName?: string): unknown {
+  protected _getQuery(request: express.Request): Record<string, unknown>;
+  protected _getQuery(request: express.Request, parameterName: string): unknown;
+  protected _getQuery(
+    request: express.Request,
+    parameterName?: string,
+  ): unknown {
     return parameterName === undefined
       ? request.query
       : request.query[parameterName];
   }
 
-  protected _getHeaders(request: Request, parameterName?: string): unknown {
+  protected _getHeaders(
+    request: express.Request,
+  ): Record<string, string | string[] | undefined>;
+  protected _getHeaders(
+    request: express.Request,
+    parameterName: string,
+  ): string | string[] | undefined;
+  protected _getHeaders(
+    request: express.Request,
+    parameterName?: string,
+  ):
+    | Record<string, string | string[] | undefined>
+    | string
+    | string[]
+    | undefined {
     return parameterName === undefined
       ? request.headers
       : request.headers[parameterName];

--- a/packages/framework/http/libraries/express/src/adapter/InversifyExpressHttpAdapter.ts
+++ b/packages/framework/http/libraries/express/src/adapter/InversifyExpressHttpAdapter.ts
@@ -137,19 +137,46 @@ export class InversifyExpressHttpAdapter extends InversifyHttpAdapter<
         request.body[parameterName];
   }
 
-  protected _getParams(request: Request, parameterName?: string): unknown {
+  protected _getParams(request: express.Request): Record<string, string>;
+  protected _getParams(
+    request: express.Request,
+    parameterName: string,
+  ): string | undefined;
+  protected _getParams(
+    request: express.Request,
+    parameterName?: string,
+  ): Record<string, string> | string | undefined {
     return parameterName === undefined
       ? request.params
       : request.params[parameterName];
   }
 
-  protected _getQuery(request: Request, parameterName?: string): unknown {
+  protected _getQuery(request: express.Request): Record<string, unknown>;
+  protected _getQuery(request: express.Request, parameterName: string): unknown;
+  protected _getQuery(
+    request: express.Request,
+    parameterName?: string,
+  ): unknown {
     return parameterName === undefined
       ? request.query
       : request.query[parameterName];
   }
 
-  protected _getHeaders(request: Request, parameterName?: string): unknown {
+  protected _getHeaders(
+    request: express.Request,
+  ): Record<string, string | string[] | undefined>;
+  protected _getHeaders(
+    request: express.Request,
+    parameterName: string,
+  ): string | string[] | undefined;
+  protected _getHeaders(
+    request: express.Request,
+    parameterName?: string,
+  ):
+    | Record<string, string | string[] | undefined>
+    | string
+    | string[]
+    | undefined {
     return parameterName === undefined
       ? request.headers
       : request.headers[parameterName];

--- a/packages/framework/http/libraries/fastify/src/adapter/InversifyFastifyHttpAdapter.ts
+++ b/packages/framework/http/libraries/fastify/src/adapter/InversifyFastifyHttpAdapter.ts
@@ -71,14 +71,21 @@ export class InversifyFastifyHttpAdapter extends InversifyHttpAdapter<
     }
   }
 
+  protected _getParams(request: FastifyRequest): Record<string, string>;
+  protected _getParams(
+    request: FastifyRequest,
+    parameterName: string,
+  ): string | undefined;
   protected _getParams(
     request: FastifyRequest,
     parameterName?: string,
-  ): unknown {
+  ): Record<string, string> | string | undefined {
     return parameterName === undefined
-      ? request.params
-      : (request.params as Record<string, unknown>)[parameterName];
+      ? (request.params as Record<string, string>)
+      : (request.params as Record<string, string>)[parameterName];
   }
+  protected _getQuery(request: FastifyRequest): Record<string, unknown>;
+  protected _getQuery(request: FastifyRequest, parameterName: string): unknown;
   protected _getQuery(
     request: FastifyRequest,
     parameterName?: string,
@@ -90,11 +97,22 @@ export class InversifyFastifyHttpAdapter extends InversifyHttpAdapter<
 
   protected _getHeaders(
     request: FastifyRequest,
+  ): Record<string, string | string[] | undefined>;
+  protected _getHeaders(
+    request: FastifyRequest,
+    parameterName: string,
+  ): string | string[] | undefined;
+  protected _getHeaders(
+    request: FastifyRequest,
     parameterName?: string,
-  ): unknown {
+  ):
+    | Record<string, string | string[] | undefined>
+    | string
+    | string[]
+    | undefined {
     return parameterName === undefined
       ? request.headers
-      : (request.headers as Record<string, unknown>)[parameterName];
+      : request.headers[parameterName];
   }
 
   protected _getCookies(
@@ -104,7 +122,7 @@ export class InversifyFastifyHttpAdapter extends InversifyHttpAdapter<
   ): unknown {
     return parameterName === undefined
       ? request.cookies
-      : (request.cookies as Record<string, unknown>)[parameterName];
+      : request.cookies[parameterName];
   }
 
   protected _replyText(

--- a/packages/framework/http/libraries/hono/src/adapter/InversifyHonoHttpAdapter.ts
+++ b/packages/framework/http/libraries/hono/src/adapter/InversifyHonoHttpAdapter.ts
@@ -117,19 +117,43 @@ export class InversifyHonoHttpAdapter extends InversifyHttpAdapter<
       : (body as Record<string, unknown>)[parameterName];
   }
 
-  protected _getParams(request: HonoRequest, parameterName?: string): unknown {
+  protected _getParams(request: HonoRequest): Record<string, string>;
+  protected _getParams(
+    request: HonoRequest,
+    parameterName: string,
+  ): string | undefined;
+  protected _getParams(
+    request: HonoRequest,
+    parameterName?: string,
+  ): Record<string, string> | string | undefined {
     return parameterName === undefined
       ? request.param()
       : request.param(parameterName);
   }
 
+  protected _getQuery(request: HonoRequest): Record<string, unknown>;
+  protected _getQuery(request: HonoRequest, parameterName: string): unknown;
   protected _getQuery(request: HonoRequest, parameterName?: string): unknown {
     return parameterName === undefined
       ? request.query()
       : request.query(parameterName);
   }
 
-  protected _getHeaders(request: HonoRequest, parameterName?: string): unknown {
+  protected _getHeaders(
+    request: HonoRequest,
+  ): Record<string, string | string[] | undefined>;
+  protected _getHeaders(
+    request: HonoRequest,
+    parameterName: string,
+  ): string | string[] | undefined;
+  protected _getHeaders(
+    request: HonoRequest,
+    parameterName?: string,
+  ):
+    | Record<string, string | string[] | undefined>
+    | string
+    | string[]
+    | undefined {
     return parameterName === undefined
       ? request.header()
       : request.header(parameterName);

--- a/packages/framework/http/libraries/uwebsockets/src/adapter/InversifyUwebSocketsHttpAdapter.ts
+++ b/packages/framework/http/libraries/uwebsockets/src/adapter/InversifyUwebSocketsHttpAdapter.ts
@@ -173,7 +173,15 @@ export class InversifyUwebSocketsHttpAdapter extends InversifyHttpAdapter<
     return (body as Record<string, unknown>)[parameterName];
   }
 
-  protected _getParams(request: HttpRequest, parameterName?: string): unknown {
+  protected _getParams(request: HttpRequest): Record<string, string>;
+  protected _getParams(
+    request: HttpRequest,
+    parameterName: string,
+  ): string | undefined;
+  protected _getParams(
+    request: HttpRequest,
+    parameterName?: string,
+  ): Record<string, string> | string | undefined {
     if (parameterName === undefined) {
       throw new Error(
         'Getting all route parameters is not supported in uWebSockets.js adapter.',
@@ -183,13 +191,29 @@ export class InversifyUwebSocketsHttpAdapter extends InversifyHttpAdapter<
     return request.getParameter(parameterName);
   }
 
+  protected _getQuery(request: HttpRequest): Record<string, unknown>;
+  protected _getQuery(request: HttpRequest, parameterName: string): unknown;
   protected _getQuery(request: HttpRequest, parameterName?: string): unknown {
     return parameterName === undefined
       ? this.#parseQuery(request)
       : request.getQuery(parameterName);
   }
 
-  protected _getHeaders(request: HttpRequest, parameterName?: string): unknown {
+  protected _getHeaders(
+    request: HttpRequest,
+  ): Record<string, string | string[] | undefined>;
+  protected _getHeaders(
+    request: HttpRequest,
+    parameterName: string,
+  ): string | string[] | undefined;
+  protected _getHeaders(
+    request: HttpRequest,
+    parameterName?: string,
+  ):
+    | Record<string, string | string[] | undefined>
+    | string
+    | string[]
+    | undefined {
     return parameterName === undefined
       ? this.#parseHeaders(request)
       : request.getHeader(parameterName);


### PR DESCRIPTION
### Changed
- Updated `CustomParameterDecoratorHandler` with `options` param.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `CustomParameterDecoratorHandlerOptions` type providing standardized access to request/response utilities including body, cookies, headers, params, and query accessors, plus status/header setters.

* **Changes**
  * Updated `CustomParameterDecoratorHandler` signature to accept an `options` parameter alongside request and response.
  * Enhanced type safety across HTTP adapters with improved method overloads for parameter, query, and header retrieval.

* **Chores**
  * Updated build configuration for improved dependency handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->