### PR TITLE
Update HTTP adapters with _sendBodySeparator

### DIFF
--- a/.changeset/solid-goats-admire.md
+++ b/.changeset/solid-goats-admire.md
@@ -1,0 +1,10 @@
+---
+"@inversifyjs/http-uwebsockets": minor
+"@inversifyjs/http-express-v4": minor
+"@inversifyjs/http-express": minor
+"@inversifyjs/http-fastify": minor
+"@inversifyjs/http-core": minor
+"@inversifyjs/http-hono": minor
+---
+
+- Updated HTTP adapter with `_sendBodySeparator`

--- a/packages/framework/http/libraries/core/src/http/adapter/InversifyHttpAdapter.ts
+++ b/packages/framework/http/libraries/core/src/http/adapter/InversifyHttpAdapter.ts
@@ -949,6 +949,11 @@ export abstract class InversifyHttpAdapter<
     value: Readable,
   ): TResult | Promise<TResult>;
 
+  protected abstract _sendBodySeparator(
+    request: TRequest,
+    response: TResponse,
+  ): void | Promise<void>;
+
   protected abstract _setStatus(
     request: TRequest,
     response: TResponse,

--- a/packages/framework/http/libraries/express-v4/src/adapter/InversifyExpressHttpAdapter.ts
+++ b/packages/framework/http/libraries/express-v4/src/adapter/InversifyExpressHttpAdapter.ts
@@ -109,6 +109,10 @@ export class InversifyExpressHttpAdapter extends InversifyHttpAdapter<
     value.pipe(response);
   }
 
+  protected _sendBodySeparator(_request: Request, response: Response): void {
+    response.flushHeaders();
+  }
+
   protected _setStatus(
     _request: Request,
     response: Response,

--- a/packages/framework/http/libraries/express/src/adapter/InversifyExpressHttpAdapter.ts
+++ b/packages/framework/http/libraries/express/src/adapter/InversifyExpressHttpAdapter.ts
@@ -109,6 +109,10 @@ export class InversifyExpressHttpAdapter extends InversifyHttpAdapter<
     value.pipe(response);
   }
 
+  protected _sendBodySeparator(_request: Request, response: Response): void {
+    response.flushHeaders();
+  }
+
   protected _setStatus(
     _request: Request,
     response: Response,

--- a/packages/framework/http/libraries/fastify/src/adapter/InversifyFastifyHttpAdapter.ts
+++ b/packages/framework/http/libraries/fastify/src/adapter/InversifyFastifyHttpAdapter.ts
@@ -149,6 +149,13 @@ export class InversifyFastifyHttpAdapter extends InversifyHttpAdapter<
     await response.send(value);
   }
 
+  protected _sendBodySeparator(
+    _request: FastifyRequest,
+    response: FastifyReply,
+  ): void {
+    response.raw.flushHeaders();
+  }
+
   protected _setStatus(
     _request: FastifyRequest,
     response: FastifyReply,

--- a/packages/framework/http/libraries/hono/package.json
+++ b/packages/framework/http/libraries/hono/package.json
@@ -8,6 +8,7 @@
     "@inversifyjs/http-core": "workspace:*"
   },
   "devDependencies": {
+    "@hono/node-server": "1.19.6",
     "@stryker-mutator/core": "9.3.0",
     "@stryker-mutator/typescript-checker": "9.3.0",
     "@stryker-mutator/vitest-runner": "9.3.0",

--- a/packages/framework/http/libraries/uwebsockets/src/adapter/InversifyUwebSocketsHttpAdapter.ts
+++ b/packages/framework/http/libraries/uwebsockets/src/adapter/InversifyUwebSocketsHttpAdapter.ts
@@ -132,6 +132,22 @@ export class InversifyUwebSocketsHttpAdapter extends InversifyHttpAdapter<
     );
   }
 
+  protected _sendBodySeparator(
+    _request: HttpRequest,
+    _response: HttpResponse,
+  ): void {
+    /*
+     * Once https://github.com/uNetworking/uWebSockets/pull/1897 is merged and released,
+     * we can implement this method to use `response.beginWrite()`.
+     * For now, we log a warning if logger is enabled.
+     */
+    if (this.httpAdapterOptions.logger !== false) {
+      this._logger.warn(
+        'Unable to send body separator, raw response is not defined. Headers will be delivered with the first chunk of the body.',
+      );
+    }
+  }
+
   protected _setStatus(
     _request: HttpRequest,
     response: HttpResponse,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple HTTP adapter libraries (uWebSockets, Express v4, Express, Fastify, and Hono).
  * Enhanced HTTP response handling with improved body separator mechanisms across all supported adapters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->