### PR TITLE
Add createCustomNativeParameterDecorator

### DIFF
--- a/.changeset/calm-friends-win.md
+++ b/.changeset/calm-friends-win.md
@@ -1,0 +1,10 @@
+---
+"@inversifyjs/http-uwebsockets": patch
+"@inversifyjs/http-express-v4": patch
+"@inversifyjs/http-express": patch
+"@inversifyjs/http-fastify": patch
+"@inversifyjs/http-core": patch
+"@inversifyjs/http-hono": patch
+---
+
+Add support for custom native parameter decorators

--- a/packages/framework/http/libraries/core/src/http/adapter/InversifyHttpAdapter.ts
+++ b/packages/framework/http/libraries/core/src/http/adapter/InversifyHttpAdapter.ts
@@ -35,6 +35,7 @@ import { getErrorFilterForError } from '../calculations/getErrorFilterForError';
 import { Controller } from '../models/Controller';
 import { ControllerFunction } from '../models/ControllerFunction';
 import { ControllerResponse } from '../models/ControllerResponse';
+import { CustomNativeParameterDecoratorHandlerOptions } from '../models/CustomNativeParameterDecoratorHandlerOptions';
 import { CustomParameterDecoratorHandlerOptions } from '../models/CustomParameterDecoratorHandlerOptions';
 import { HttpAdapterOptions } from '../models/HttpAdapterOptions';
 import { HttpStatusCode } from '../models/HttpStatusCode';
@@ -62,6 +63,10 @@ export abstract class InversifyHttpAdapter<
   protected readonly _logger: Logger;
   readonly #awaitableRequestMethodParamTypes: Set<RequestMethodParameterType>;
   readonly #container: Container;
+  readonly #customNativeParameterDecoratorHandlerOptions: CustomNativeParameterDecoratorHandlerOptions<
+    TRequest,
+    TResponse
+  >;
   readonly #customParameterDecoratorHandlerOptions: CustomParameterDecoratorHandlerOptions<
     TRequest,
     TResponse
@@ -94,6 +99,8 @@ export abstract class InversifyHttpAdapter<
     this.#container = container;
     this.#customParameterDecoratorHandlerOptions =
       this.#buildCustomParameterDecoratorHandlerOptions();
+    this.#customNativeParameterDecoratorHandlerOptions =
+      this.#buildCustomNativeParameterDecoratorHandlerOptions();
     this.httpAdapterOptions = this.#parseHttpAdapterOptions(
       defaultHttpAdapterOptions,
       httpAdapterOptions,
@@ -208,6 +215,23 @@ export abstract class InversifyHttpAdapter<
       getHeaders: this._getHeaders.bind(this),
       getParams: this._getParams.bind(this),
       getQuery: this._getQuery.bind(this),
+      setHeader: this._setHeader.bind(this),
+      setStatus: this._setStatus.bind(this),
+    };
+  }
+
+  #buildCustomNativeParameterDecoratorHandlerOptions(): CustomNativeParameterDecoratorHandlerOptions<
+    TRequest,
+    TResponse
+  > {
+    return {
+      getBody: this._getBody.bind(this),
+      getCookies: this._getCookies.bind(this),
+      getHeaders: this._getHeaders.bind(this),
+      getParams: this._getParams.bind(this),
+      getQuery: this._getQuery.bind(this),
+      send: this.#reply.bind(this),
+      sendBodySeparator: this._sendBodySeparator.bind(this),
       setHeader: this._setHeader.bind(this),
       setStatus: this._setStatus.bind(this),
     };
@@ -456,6 +480,13 @@ export abstract class InversifyHttpAdapter<
                 request,
                 response,
                 this.#customParameterDecoratorHandlerOptions,
+              );
+          case RequestMethodParameterType.CustomNative:
+            return (request: TRequest, response: TResponse): unknown =>
+              controllerMethodParameterMetadata.customParameterDecoratorHandler(
+                request,
+                response,
+                this.#customNativeParameterDecoratorHandlerOptions,
               );
           case RequestMethodParameterType.Headers:
             return (request: TRequest): unknown =>

--- a/packages/framework/http/libraries/core/src/http/calculations/buildCustomNativeControllerMethodParameterMetadata.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/calculations/buildCustomNativeControllerMethodParameterMetadata.spec.ts
@@ -1,0 +1,77 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { Pipe } from '@inversifyjs/framework-core';
+import { ServiceIdentifier } from 'inversify';
+
+import { ControllerMethodParameterMetadata } from '../../routerExplorer/model/ControllerMethodParameterMetadata';
+import { CustomNativeParameterDecoratorHandler } from '../models/CustomNativeParameterDecoratorHandler';
+import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
+import { buildCustomNativeControllerMethodParameterMetadata } from './buildCustomNativeControllerMethodParameterMetadata';
+
+describe(buildCustomNativeControllerMethodParameterMetadata, () => {
+  describe('having a handler and pipes', () => {
+    describe('when called', () => {
+      let parameterPipeListFixture: (ServiceIdentifier<Pipe> | Pipe)[];
+      let handlerFixture: CustomNativeParameterDecoratorHandler;
+      let result: unknown;
+
+      beforeAll(() => {
+        parameterPipeListFixture = [
+          Symbol() as unknown as Pipe,
+          Symbol() as unknown as Pipe,
+        ];
+        handlerFixture =
+          Symbol() as unknown as CustomNativeParameterDecoratorHandler;
+
+        result = buildCustomNativeControllerMethodParameterMetadata(
+          parameterPipeListFixture,
+          handlerFixture,
+        );
+      });
+
+      it('should return expected result', () => {
+        const expected: ControllerMethodParameterMetadata = {
+          customParameterDecoratorHandler: handlerFixture,
+          parameterName: undefined,
+          parameterType: RequestMethodParameterType.CustomNative,
+          pipeList: parameterPipeListFixture,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having ServiceIdentifier pipes', () => {
+    describe('when called', () => {
+      let parameterPipeListFixture: (ServiceIdentifier<Pipe> | Pipe)[];
+      let handlerFixture: CustomNativeParameterDecoratorHandler;
+      let result: unknown;
+
+      beforeAll(() => {
+        parameterPipeListFixture = [
+          Symbol() as ServiceIdentifier<Pipe>,
+          'PipeClass' as ServiceIdentifier<Pipe>,
+        ];
+        handlerFixture =
+          Symbol() as unknown as CustomNativeParameterDecoratorHandler;
+
+        result = buildCustomNativeControllerMethodParameterMetadata(
+          parameterPipeListFixture,
+          handlerFixture,
+        );
+      });
+
+      it('should return expected result', () => {
+        const expected: ControllerMethodParameterMetadata = {
+          customParameterDecoratorHandler: handlerFixture,
+          parameterName: undefined,
+          parameterType: RequestMethodParameterType.CustomNative,
+          pipeList: parameterPipeListFixture,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+});

--- a/packages/framework/http/libraries/core/src/http/calculations/buildCustomNativeControllerMethodParameterMetadata.ts
+++ b/packages/framework/http/libraries/core/src/http/calculations/buildCustomNativeControllerMethodParameterMetadata.ts
@@ -1,0 +1,18 @@
+import { Pipe } from '@inversifyjs/framework-core';
+import { ServiceIdentifier } from 'inversify';
+
+import { ControllerMethodParameterMetadata } from '../../routerExplorer/model/ControllerMethodParameterMetadata';
+import { CustomNativeParameterDecoratorHandler } from '../models/CustomNativeParameterDecoratorHandler';
+import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
+
+export function buildCustomNativeControllerMethodParameterMetadata(
+  parameterPipeList: (ServiceIdentifier<Pipe> | Pipe)[],
+  handler: CustomNativeParameterDecoratorHandler,
+): ControllerMethodParameterMetadata {
+  return {
+    customParameterDecoratorHandler: handler,
+    parameterName: undefined,
+    parameterType: RequestMethodParameterType.CustomNative,
+    pipeList: parameterPipeList,
+  };
+}

--- a/packages/framework/http/libraries/core/src/http/calculations/createCustomNativeParameterDecorator.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/calculations/createCustomNativeParameterDecorator.spec.ts
@@ -1,0 +1,56 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+vitest.mock('./requestParam');
+
+import { Pipe } from '@inversifyjs/framework-core';
+import { ServiceIdentifier } from 'inversify';
+
+import { ControllerMethodParameterMetadata } from '../../routerExplorer/model/ControllerMethodParameterMetadata';
+import { CustomNativeParameterDecoratorHandler } from '../models/CustomNativeParameterDecoratorHandler';
+import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
+import { createCustomNativeParameterDecorator } from './createCustomNativeParameterDecorator';
+import { requestParam } from './requestParam';
+
+describe(createCustomNativeParameterDecorator, () => {
+  describe('when called', () => {
+    let handlerFixture: CustomNativeParameterDecoratorHandler;
+    let parameterPipeListFixture: (ServiceIdentifier<Pipe> | Pipe)[];
+    let parameterDecoratorFixture: ParameterDecorator;
+    let result: unknown;
+
+    beforeAll(() => {
+      handlerFixture =
+        Symbol() as unknown as CustomNativeParameterDecoratorHandler;
+      parameterPipeListFixture = [Symbol()];
+      parameterDecoratorFixture = {} as ParameterDecorator;
+
+      vitest
+        .mocked(requestParam)
+        .mockReturnValueOnce(parameterDecoratorFixture);
+
+      result = createCustomNativeParameterDecorator(
+        handlerFixture,
+        ...parameterPipeListFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call requestParam()', () => {
+      const expected: ControllerMethodParameterMetadata = {
+        customParameterDecoratorHandler: handlerFixture,
+        parameterName: undefined,
+        parameterType: RequestMethodParameterType.CustomNative,
+        pipeList: parameterPipeListFixture,
+      };
+
+      expect(requestParam).toHaveBeenCalledExactlyOnceWith(expected);
+    });
+
+    it('should return expected result', () => {
+      expect(result).toBe(parameterDecoratorFixture);
+    });
+  });
+});

--- a/packages/framework/http/libraries/core/src/http/calculations/createCustomNativeParameterDecorator.ts
+++ b/packages/framework/http/libraries/core/src/http/calculations/createCustomNativeParameterDecorator.ts
@@ -1,0 +1,22 @@
+import { Pipe } from '@inversifyjs/framework-core';
+import { ServiceIdentifier } from 'inversify';
+
+import { CustomNativeParameterDecoratorHandler } from '../models/CustomNativeParameterDecoratorHandler';
+import { buildCustomNativeControllerMethodParameterMetadata } from './buildCustomNativeControllerMethodParameterMetadata';
+import { requestParam } from './requestParam';
+
+export function createCustomNativeParameterDecorator<
+  TRequest,
+  TResponse,
+  TResult,
+>(
+  handler: CustomNativeParameterDecoratorHandler<TRequest, TResponse, TResult>,
+  ...parameterPipeList: (ServiceIdentifier<Pipe> | Pipe)[]
+): ParameterDecorator {
+  return requestParam(
+    buildCustomNativeControllerMethodParameterMetadata(
+      parameterPipeList,
+      handler,
+    ),
+  );
+}

--- a/packages/framework/http/libraries/core/src/http/calculations/requestParam.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/calculations/requestParam.spec.ts
@@ -5,14 +5,12 @@ vitest.mock('@inversifyjs/reflect-metadata-utils');
 import {
   buildArrayMetadataWithIndex,
   buildEmptyArrayMetadata,
-  setReflectMetadata,
   updateOwnReflectMetadata,
 } from '@inversifyjs/reflect-metadata-utils';
 
 import { InversifyHttpAdapterError } from '../../error/models/InversifyHttpAdapterError';
 import { InversifyHttpAdapterErrorKind } from '../../error/models/InversifyHttpAdapterErrorKind';
 import { controllerMethodParameterMetadataReflectKey } from '../../reflectMetadata/data/controllerMethodParameterMetadataReflectKey';
-import { controllerMethodUseNativeHandlerMetadataReflectKey } from '../../reflectMetadata/data/controllerMethodUseNativeHandlerMetadataReflectKey';
 import { ControllerMethodParameterMetadata } from '../../routerExplorer/model/ControllerMethodParameterMetadata';
 import { RequestMethodParameterType } from '../models/RequestMethodParameterType';
 import { requestParam } from './requestParam';

--- a/packages/framework/http/libraries/core/src/http/models/CustomNativeParameterDecoratorHandler.ts
+++ b/packages/framework/http/libraries/core/src/http/models/CustomNativeParameterDecoratorHandler.ts
@@ -1,0 +1,17 @@
+import { CustomNativeParameterDecoratorHandlerOptions } from './CustomNativeParameterDecoratorHandlerOptions';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type CustomNativeParameterDecoratorHandler<
+  TRequest = any,
+  TResponse = any,
+  TDecoratorResult = any,
+  TResult = any,
+> = (
+  request: TRequest,
+  response: TResponse,
+  options: CustomNativeParameterDecoratorHandlerOptions<
+    TRequest,
+    TResponse,
+    TResult
+  >,
+) => Promise<TDecoratorResult> | TDecoratorResult;

--- a/packages/framework/http/libraries/core/src/http/models/CustomNativeParameterDecoratorHandlerOptions.ts
+++ b/packages/framework/http/libraries/core/src/http/models/CustomNativeParameterDecoratorHandlerOptions.ts
@@ -1,0 +1,19 @@
+import { ControllerResponse } from './ControllerResponse';
+import { CustomParameterDecoratorHandlerOptions } from './CustomParameterDecoratorHandlerOptions';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export interface CustomNativeParameterDecoratorHandlerOptions<
+  TRequest = any,
+  TResponse = any,
+  TResult = any,
+> extends CustomParameterDecoratorHandlerOptions<TRequest, TResponse> {
+  send(
+    request: TRequest,
+    response: TResponse,
+    value: ControllerResponse,
+  ): TResult | Promise<TResult>;
+  sendBodySeparator(
+    request: TRequest,
+    response: TResponse,
+  ): void | Promise<void>;
+}

--- a/packages/framework/http/libraries/core/src/http/models/RequestMethodParameterType.ts
+++ b/packages/framework/http/libraries/core/src/http/models/RequestMethodParameterType.ts
@@ -2,6 +2,7 @@ export enum RequestMethodParameterType {
   Body = 'body',
   Cookies = 'cookies',
   Custom = 'custom',
+  CustomNative = 'customNative',
   Headers = 'headers',
   Next = 'next',
   Params = 'params',
@@ -10,9 +11,7 @@ export enum RequestMethodParameterType {
   Query = 'query',
 }
 
-export type CustomRequestMethodParameterType =
-  RequestMethodParameterType.Custom;
 export type NonCustomRequestMethodParameterType = Exclude<
   RequestMethodParameterType,
-  CustomRequestMethodParameterType
+  RequestMethodParameterType.Custom | RequestMethodParameterType.CustomNative
 >;

--- a/packages/framework/http/libraries/core/src/index.ts
+++ b/packages/framework/http/libraries/core/src/index.ts
@@ -17,6 +17,7 @@ import {
 
 import { InversifyHttpAdapter } from './http/adapter/InversifyHttpAdapter';
 import { buildNormalizedPath } from './http/calculations/buildNormalizedPath';
+import { createCustomNativeParameterDecorator } from './http/calculations/createCustomNativeParameterDecorator';
 import { createCustomParameterDecorator } from './http/calculations/createCustomParameterDecorator';
 import { All } from './http/decorators/All';
 import { Body } from './http/decorators/Body';
@@ -39,6 +40,8 @@ import { SetHeader } from './http/decorators/SetHeader';
 import { StatusCode } from './http/decorators/StatusCode';
 import { ControllerOptions } from './http/models/ControllerOptions';
 import { ControllerResponse } from './http/models/ControllerResponse';
+import { CustomNativeParameterDecoratorHandler } from './http/models/CustomNativeParameterDecoratorHandler';
+import { CustomNativeParameterDecoratorHandlerOptions } from './http/models/CustomNativeParameterDecoratorHandlerOptions';
 import { CustomParameterDecoratorHandler } from './http/models/CustomParameterDecoratorHandler';
 import { CustomParameterDecoratorHandlerOptions } from './http/models/CustomParameterDecoratorHandlerOptions';
 import { HttpAdapterOptions } from './http/models/HttpAdapterOptions';
@@ -97,6 +100,8 @@ export type {
   ControllerMethodMetadata,
   ControllerOptions,
   ControllerResponse,
+  CustomNativeParameterDecoratorHandler,
+  CustomNativeParameterDecoratorHandlerOptions,
   CustomParameterDecoratorHandler,
   CustomParameterDecoratorHandlerOptions,
   ErrorFilter,
@@ -129,6 +134,7 @@ export {
   ContentDifferentHttpResponse,
   Controller,
   Cookies,
+  createCustomNativeParameterDecorator,
   createCustomParameterDecorator,
   CreatedHttpResponse,
   Delete,

--- a/packages/framework/http/libraries/core/src/routerExplorer/model/ControllerMethodParameterMetadata.ts
+++ b/packages/framework/http/libraries/core/src/routerExplorer/model/ControllerMethodParameterMetadata.ts
@@ -2,9 +2,9 @@
 import { Pipe } from '@inversifyjs/framework-core';
 import { ServiceIdentifier } from 'inversify';
 
+import { CustomNativeParameterDecoratorHandler } from '../../http/models/CustomNativeParameterDecoratorHandler';
 import { CustomParameterDecoratorHandler } from '../../http/models/CustomParameterDecoratorHandler';
 import {
-  CustomRequestMethodParameterType,
   NonCustomRequestMethodParameterType,
   RequestMethodParameterType,
 } from '../../http/models/RequestMethodParameterType';
@@ -21,8 +21,20 @@ interface ControllerMethodCustomParameterMetadata<
   TRequest = any,
   TResponse = any,
   TResult = any,
-> extends BaseControllerMethodParameterMetadata<CustomRequestMethodParameterType> {
+> extends BaseControllerMethodParameterMetadata<RequestMethodParameterType.Custom> {
   customParameterDecoratorHandler: CustomParameterDecoratorHandler<
+    TRequest,
+    TResponse,
+    TResult
+  >;
+}
+
+interface ControllerMethodCustomNativeParameterMetadata<
+  TRequest = any,
+  TResponse = any,
+  TResult = any,
+> extends BaseControllerMethodParameterMetadata<RequestMethodParameterType.CustomNative> {
+  customParameterDecoratorHandler: CustomNativeParameterDecoratorHandler<
     TRequest,
     TResponse,
     TResult
@@ -35,4 +47,5 @@ export type ControllerMethodParameterMetadata<
   TResult = any,
 > =
   | BaseControllerMethodParameterMetadata<NonCustomRequestMethodParameterType>
+  | ControllerMethodCustomNativeParameterMetadata<TRequest, TResponse, TResult>
   | ControllerMethodCustomParameterMetadata<TRequest, TResponse, TResult>;


### PR DESCRIPTION
### Added
- Added `createCustomNativeParameterDecorator`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom native parameter decorators, enabling direct access to request and response objects in custom parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->