### PR TITLE
Update InversifyHttpAdapter to bind server

### DIFF
--- a/.changeset/cool-keys-like.md
+++ b/.changeset/cool-keys-like.md
@@ -1,0 +1,6 @@
+---
+"@inversifyjs/http-core": minor
+---
+
+- Added `httpServerServiceIdentifier`
+- Updated `InversifyHttpAdapter.build` to inject http server

--- a/packages/framework/http/libraries/core/src/http/models/httpServerServiceIdentifier.ts
+++ b/packages/framework/http/libraries/core/src/http/models/httpServerServiceIdentifier.ts
@@ -1,0 +1,3 @@
+export const httpServerServiceIdentifier: unique symbol = Symbol.for(
+  '@inversifyjs/http-core/httpServer',
+);

--- a/packages/framework/http/libraries/core/src/index.ts
+++ b/packages/framework/http/libraries/core/src/index.ts
@@ -45,6 +45,7 @@ import { CustomNativeParameterDecoratorHandlerOptions } from './http/models/Cust
 import { CustomParameterDecoratorHandler } from './http/models/CustomParameterDecoratorHandler';
 import { CustomParameterDecoratorHandlerOptions } from './http/models/CustomParameterDecoratorHandlerOptions';
 import { HttpAdapterOptions } from './http/models/HttpAdapterOptions';
+import { httpServerServiceIdentifier } from './http/models/httpServerServiceIdentifier';
 import { HttpStatusCode } from './http/models/HttpStatusCode';
 import { MiddlewareHandler } from './http/models/MiddlewareHandler';
 import { RequestHandler } from './http/models/RequestHandler';
@@ -150,6 +151,7 @@ export {
   Head,
   Headers,
   HttpResponse,
+  httpServerServiceIdentifier,
   HttpStatusCode,
   HttpVersionNotSupportedHttpResponse,
   InsufficientStorageHttpResponse,


### PR DESCRIPTION
### Changed
- Updated `InversifyHttpAdapter` to bind http server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `httpServerServiceIdentifier` for dependency injection of HTTP server instances in the core HTTP framework.
  * Enhanced HTTP adapter initialization with improved server binding and dependency management.

* **Chores**
  * Minor version bump for @inversifyjs/http-core.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->