### PR TITLE
Update migrating from v6 docs with missing sections

### DIFF
--- a/packages/docs/services/inversify-site/docs/guides/migrating-from-v6.mdx
+++ b/packages/docs/services/inversify-site/docs/guides/migrating-from-v6.mdx
@@ -9,6 +9,10 @@ import containerApiGetNamedSource from '@inversifyjs/code-examples/generated/exa
 import containerModuleApiExampleSource from '@inversifyjs/code-examples/generated/examples/v7/containerModuleApiExample.ts.txt';
 import diHierarchySource from '@inversifyjs/code-examples/generated/examples/v7/diHierarchy.ts.txt';
 import fundamentalsAutobindingSource from '@inversifyjs/code-examples/generated/examples/v7/fundamentalsAutobinding.ts.txt';
+import migrationToAutoFactorySource from '@inversifyjs/code-examples/generated/examples/v7/migrationToAutoFactory.ts.txt';
+import migrationToAutoNamedFactorySource from '@inversifyjs/code-examples/generated/examples/v7/migrationToAutoNamedFactory.ts.txt';
+import migrationToConstructorSource from '@inversifyjs/code-examples/generated/examples/v7/migrationToConstructor.ts.txt';
+import migrationToFunctionSource from '@inversifyjs/code-examples/generated/examples/v7/migrationToFunction.ts.txt';
 import CodeBlock from '@theme/CodeBlock';
 
 # Migrating from v6
@@ -38,6 +42,10 @@ The following table summarizes the key changes from v6 to v7:
 | `container.rebind`                    | `await container.rebind` or `container.rebindSync` | Now async, with a sync alternative                     |
 | `container.unbind`                    | `await container.unbind` or `container.unbindSync` | Now async, with a sync alternative                     |
 | `container.createChild()`             | `new Container({ parent: container })`   | Child containers created via constructor                         |
+| `.toAutoFactory(X)`                   | `.toFactory((ctx) => () => ctx.get(X))`  | Use `toFactory` with `ResolutionContext.get()`                   |
+| `.toAutoNamedFactory(X)`              | `.toFactory((ctx) => (name) => ctx.get(X, { name }))` | Use `toFactory` with named resolution         |
+| `.toConstructor(X)`                   | `.toConstantValue(X)`                    | Bind constructors as constant values                             |
+| `.toFunction(fn)`                     | `.toConstantValue(fn)`                   | Bind functions as constant values                                |
 | `interfaces.Context`                  | `ResolutionContext`                      | Updated context parameter type in the binding API                |
 | `interfaces.Request`                  | `BindingConstraints`                     | Updated binding constraint parameter type                        |
 | `interfaces.Provider<T>`              | `Provider<T>`                            | Directly exported, no longer under `interfaces` namespace        |
@@ -125,6 +133,34 @@ The `Context` class has been replaced by `ResolutionContext` to simplify the API
 The `Request` object has been replaced by `BindingConstraints` to simplify the API and hide internal data structures.
 
 <CodeBlock language="ts">{bindingWhenSyntaxApiWhenSource}</CodeBlock>
+
+### Removed Binding Methods
+
+Several binding methods have been removed in v7 to simplify the API. Here's how to migrate each one:
+
+#### `toAutoFactory`
+
+The `toAutoFactory` method has been removed. Use `toFactory` with `ResolutionContext.get()` instead:
+
+<CodeBlock language="ts">{migrationToAutoFactorySource}</CodeBlock>
+
+#### `toAutoNamedFactory`
+
+Similarly, `toAutoNamedFactory` has been removed. Use `toFactory` with named resolution:
+
+<CodeBlock language="ts">{migrationToAutoNamedFactorySource}</CodeBlock>
+
+#### `toConstructor`
+
+The `toConstructor` method has been removed. Since a constructor is just a value (a callable one), use `toConstantValue` instead:
+
+<CodeBlock language="ts">{migrationToConstructorSource}</CodeBlock>
+
+#### `toFunction`
+
+The `toFunction` method has been removed. Since a function is just a value, use `toConstantValue` instead:
+
+<CodeBlock language="ts">{migrationToFunctionSource}</CodeBlock>
 
 ## Decorators API
 

--- a/packages/docs/services/inversify-site/versioned_docs/version-7.x/guides/migrating-from-v6.mdx
+++ b/packages/docs/services/inversify-site/versioned_docs/version-7.x/guides/migrating-from-v6.mdx
@@ -9,6 +9,10 @@ import containerApiGetNamedSource from '@inversifyjs/code-examples/generated/exa
 import containerModuleApiExampleSource from '@inversifyjs/code-examples/generated/examples/v7/containerModuleApiExample.ts.txt';
 import diHierarchySource from '@inversifyjs/code-examples/generated/examples/v7/diHierarchy.ts.txt';
 import fundamentalsAutobindingSource from '@inversifyjs/code-examples/generated/examples/v7/fundamentalsAutobinding.ts.txt';
+import migrationToAutoFactorySource from '@inversifyjs/code-examples/generated/examples/v7/migrationToAutoFactory.ts.txt';
+import migrationToAutoNamedFactorySource from '@inversifyjs/code-examples/generated/examples/v7/migrationToAutoNamedFactory.ts.txt';
+import migrationToConstructorSource from '@inversifyjs/code-examples/generated/examples/v7/migrationToConstructor.ts.txt';
+import migrationToFunctionSource from '@inversifyjs/code-examples/generated/examples/v7/migrationToFunction.ts.txt';
 import CodeBlock from '@theme/CodeBlock';
 
 # Migrating from v6
@@ -38,6 +42,10 @@ The following table summarizes the key changes from v6 to v7:
 | `container.rebind`                    | `await container.rebind` or `container.rebindSync` | Now async, with a sync alternative                     |
 | `container.unbind`                    | `await container.unbind` or `container.unbindSync` | Now async, with a sync alternative                     |
 | `container.createChild()`             | `new Container({ parent: container })`   | Child containers created via constructor                         |
+| `.toAutoFactory(X)`                   | `.toFactory((ctx) => () => ctx.get(X))`  | Use `toFactory` with `ResolutionContext.get()`                   |
+| `.toAutoNamedFactory(X)`              | `.toFactory((ctx) => (name) => ctx.get(X, { name }))` | Use `toFactory` with named resolution         |
+| `.toConstructor(X)`                   | `.toConstantValue(X)`                    | Bind constructors as constant values                             |
+| `.toFunction(fn)`                     | `.toConstantValue(fn)`                   | Bind functions as constant values                                |
 | `interfaces.Context`                  | `ResolutionContext`                      | Updated context parameter type in the binding API                |
 | `interfaces.Request`                  | `BindingConstraints`                     | Updated binding constraint parameter type                        |
 | `interfaces.Provider<T>`              | `Provider<T>`                            | Directly exported, no longer under `interfaces` namespace        |
@@ -125,6 +133,34 @@ The `Context` class has been replaced by `ResolutionContext` to simplify the API
 The `Request` object has been replaced by `BindingConstraints` to simplify the API and hide internal data structures.
 
 <CodeBlock language="ts">{bindingWhenSyntaxApiWhenSource}</CodeBlock>
+
+### Removed Binding Methods
+
+Several binding methods have been removed in v7 to simplify the API. Here's how to migrate each one:
+
+#### `toAutoFactory`
+
+The `toAutoFactory` method has been removed. Use `toFactory` with `ResolutionContext.get()` instead:
+
+<CodeBlock language="ts">{migrationToAutoFactorySource}</CodeBlock>
+
+#### `toAutoNamedFactory`
+
+Similarly, `toAutoNamedFactory` has been removed. Use `toFactory` with named resolution:
+
+<CodeBlock language="ts">{migrationToAutoNamedFactorySource}</CodeBlock>
+
+#### `toConstructor`
+
+The `toConstructor` method has been removed. Since a constructor is just a value (a callable one), use `toConstantValue` instead:
+
+<CodeBlock language="ts">{migrationToConstructorSource}</CodeBlock>
+
+#### `toFunction`
+
+The `toFunction` method has been removed. Since a function is just a value, use `toConstantValue` instead:
+
+<CodeBlock language="ts">{migrationToFunctionSource}</CodeBlock>
 
 ## Decorators API
 

--- a/packages/docs/tools/inversify-code-examples/src/examples/v7/migrationToAutoFactory.int.spec.ts
+++ b/packages/docs/tools/inversify-code-examples/src/examples/v7/migrationToAutoFactory.int.spec.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import { container, Ninja } from './migrationToAutoFactory';
+
+describe('Migration (toAutoFactory)', () => {
+  it('should provide ninja', () => {
+    const ninja: Ninja = container.get(Ninja);
+
+    expect(ninja.fight()).toBe('hit!');
+  });
+});

--- a/packages/docs/tools/inversify-code-examples/src/examples/v7/migrationToAutoFactory.ts
+++ b/packages/docs/tools/inversify-code-examples/src/examples/v7/migrationToAutoFactory.ts
@@ -1,0 +1,42 @@
+// Is-inversify-import-example
+import { Container, inject, injectable, ResolutionContext } from 'inversify7';
+
+interface Weapon {
+  damage: number;
+}
+
+export class Katana implements Weapon {
+  public readonly damage: number = 10;
+
+  public hit(): string {
+    return 'hit!';
+  }
+}
+
+// Begin-example
+@injectable()
+export class Ninja {
+  readonly #katana: Katana;
+
+  constructor(@inject('Factory<Katana>') katanaFactory: () => Katana) {
+    this.#katana = katanaFactory();
+  }
+
+  public fight(): string {
+    return this.#katana.hit();
+  }
+}
+
+export const container: Container = new Container();
+
+container.bind('Katana').to(Katana);
+
+// v6: container.bind('Factory<Katana>').toAutoFactory<Katana>('Katana');
+container
+  .bind<() => Katana>('Factory<Katana>')
+  .toFactory(
+    (context: ResolutionContext) => () => context.get<Katana>('Katana'),
+  );
+
+container.bind(Ninja).toSelf();
+// End-example

--- a/packages/docs/tools/inversify-code-examples/src/examples/v7/migrationToAutoNamedFactory.int.spec.ts
+++ b/packages/docs/tools/inversify-code-examples/src/examples/v7/migrationToAutoNamedFactory.int.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import { container, Ninja } from './migrationToAutoNamedFactory';
+
+describe('Migration (toAutoNamedFactory)', () => {
+  it('should provide ninja', () => {
+    const ninja: Ninja = container.get(Ninja);
+
+    expect(ninja.fight()).toBe('hit!');
+    expect(ninja.sneak()).toBe('throw!');
+  });
+});

--- a/packages/docs/tools/inversify-code-examples/src/examples/v7/migrationToAutoNamedFactory.ts
+++ b/packages/docs/tools/inversify-code-examples/src/examples/v7/migrationToAutoNamedFactory.ts
@@ -1,0 +1,67 @@
+// Is-inversify-import-example
+import {
+  Container,
+  inject,
+  injectable,
+  MetadataName,
+  ResolutionContext,
+} from 'inversify7';
+
+interface Weapon {
+  damage: number;
+}
+
+export class Katana implements Weapon {
+  public readonly damage: number = 10;
+
+  public hit(): string {
+    return 'hit!';
+  }
+}
+
+export class Shuriken implements Weapon {
+  public readonly damage: number = 5;
+
+  public throw(): string {
+    return 'throw!';
+  }
+}
+
+// Begin-example
+@injectable()
+export class Ninja {
+  readonly #katana: Katana;
+  readonly #shuriken: Shuriken;
+
+  constructor(
+    @inject('Factory<Weapon>')
+    weaponFactory: (name: MetadataName) => Weapon,
+  ) {
+    this.#katana = weaponFactory('katana') as Katana;
+    this.#shuriken = weaponFactory('shuriken') as Shuriken;
+  }
+
+  public fight(): string {
+    return this.#katana.hit();
+  }
+
+  public sneak(): string {
+    return this.#shuriken.throw();
+  }
+}
+
+export const container: Container = new Container();
+
+container.bind<Weapon>('Weapon').to(Katana).whenNamed('katana');
+container.bind<Weapon>('Weapon').to(Shuriken).whenNamed('shuriken');
+
+// v6: container.bind('Factory<Weapon>').toAutoNamedFactory<Weapon>('Weapon');
+container
+  .bind<(name: MetadataName) => Weapon>('Factory<Weapon>')
+  .toFactory(
+    (context: ResolutionContext) => (name: MetadataName) =>
+      context.get<Weapon>('Weapon', { name }),
+  );
+
+container.bind(Ninja).toSelf();
+// End-example

--- a/packages/docs/tools/inversify-code-examples/src/examples/v7/migrationToConstructor.int.spec.ts
+++ b/packages/docs/tools/inversify-code-examples/src/examples/v7/migrationToConstructor.int.spec.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import { Katana, weapon, weaponClass } from './migrationToConstructor';
+
+describe('Migration (toConstructor)', () => {
+  it('should bind Katana weapon constructor', () => {
+    expect(weaponClass).toBe(Katana);
+    expect(weapon).toBeInstanceOf(Katana);
+    expect(weapon.damage).toBe(10);
+  });
+});

--- a/packages/docs/tools/inversify-code-examples/src/examples/v7/migrationToConstructor.ts
+++ b/packages/docs/tools/inversify-code-examples/src/examples/v7/migrationToConstructor.ts
@@ -1,0 +1,22 @@
+// Is-inversify-import-example
+import { Container, Newable } from 'inversify7';
+
+interface Weapon {
+  damage: number;
+}
+
+export class Katana implements Weapon {
+  public readonly damage: number = 10;
+}
+
+// Begin-example
+const container: Container = new Container();
+
+// v6: container.bind('WeaponConstructor').toConstructor(Katana);
+container.bind<Newable<Weapon>>('WeaponConstructor').toConstantValue(Katana);
+
+export const weaponClass: Newable<Weapon> =
+  container.get<Newable<Weapon>>('WeaponConstructor');
+
+export const weapon: Weapon = new weaponClass();
+// End-example

--- a/packages/docs/tools/inversify-code-examples/src/examples/v7/migrationToFunction.int.spec.ts
+++ b/packages/docs/tools/inversify-code-examples/src/examples/v7/migrationToFunction.int.spec.ts
@@ -1,0 +1,11 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import { greetFn, greeting } from './migrationToFunction';
+
+describe('Migration (toFunction)', () => {
+  it('should bind function as constant value', () => {
+    expectTypeOf(greetFn).toBeFunction();
+
+    expect(greeting).toBe('Hello, World!');
+  });
+});

--- a/packages/docs/tools/inversify-code-examples/src/examples/v7/migrationToFunction.ts
+++ b/packages/docs/tools/inversify-code-examples/src/examples/v7/migrationToFunction.ts
@@ -1,0 +1,17 @@
+// Is-inversify-import-example
+import { Container } from 'inversify7';
+
+// Begin-example
+function greet(name: string): string {
+  return `Hello, ${name}!`;
+}
+
+const container: Container = new Container();
+
+// v6: container.bind('greet').toFunction(greet);
+container.bind<typeof greet>('greet').toConstantValue(greet);
+
+export const greetFn: (name: string) => string = container.get('greet');
+
+export const greeting: string = greetFn('World');
+// End-example


### PR DESCRIPTION
### Changed
- Updated migration docs.

### Context
See #1501.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration guides with new binding method migration paths and code examples for transitioning from v6 to v7
  * Added comprehensive documentation for four deprecated binding methods with recommended alternatives

* **Tests**
  * Added integration and unit tests for migration examples

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->