### PR TITLE
Update `ServiceIdentifier` without `Function`

### DIFF
--- a/.changeset/lovely-hotels-enjoy.md
+++ b/.changeset/lovely-hotels-enjoy.md
@@ -1,0 +1,6 @@
+---
+"@inversifyjs/common": major
+"inversify": major
+---
+
+- Updated `ServiceIdentifier` type. Now, a `Function` is a valid `ServiceIdentifier<T>` if and only if it satisfies `AbstractNewable<T> | Newable<T>`

--- a/packages/container/libraries/common/src/services/models/ServiceIdentifier.spec-d.ts
+++ b/packages/container/libraries/common/src/services/models/ServiceIdentifier.spec-d.ts
@@ -20,6 +20,7 @@ describe('ServiceIdentifier', () => {
     }
 
     it('should be a valid ServiceIdentifier', () => {
+      // @ts-expect-error :: Type 'typeof AbstractFoo' is not assignable to type 'ServiceIdentifier'.
       const identifier: ServiceIdentifier = AbstractFoo;
 
       expect(identifier).toBeInstanceOf(Function);
@@ -42,6 +43,7 @@ describe('ServiceIdentifier', () => {
     }
 
     it('should be a valid ServiceIdentifier', () => {
+      // @ts-expect-error :: Type 'typeof Foo' is not assignable to type 'ServiceIdentifier'.
       const identifier: ServiceIdentifier = Foo;
 
       expect(identifier).toBeInstanceOf(Function);

--- a/packages/container/libraries/common/src/services/models/ServiceIdentifier.ts
+++ b/packages/container/libraries/common/src/services/models/ServiceIdentifier.ts
@@ -5,6 +5,4 @@ export type ServiceIdentifier<TInstance = unknown> =
   | string
   | symbol
   | Newable<TInstance>
-  | AbstractNewable<TInstance>
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  | Function;
+  | AbstractNewable<TInstance>;

--- a/packages/container/libraries/container/src/binding/models/BindingFluentSyntax.spec-d.ts
+++ b/packages/container/libraries/container/src/binding/models/BindingFluentSyntax.spec-d.ts
@@ -140,7 +140,9 @@ describe('BindToFluentSyntax', () => {
 
         expectTypeOf(
           bindToFluentSyntaxMock.toResolvedValue(factoryFixture, [
+            // @ts-expect-error :: 'ServiceIdentifier<number>' is not assignable to type 'ResolvedValueInjectOptions<string>'
             firstServiceIdentifier,
+            // @ts-expect-error :: 'Newable<object>' is not assignable to type 'ResolvedValueInjectOptions<number>'
             secondServiceIdentifier,
           ]),
         ).toEqualTypeOf<BindInWhenOnFluentSyntax<unknown>>();
@@ -212,7 +214,7 @@ describe('BindToFluentSyntax', () => {
         factoryFixture = (arg1: string[]): unknown => arg1;
       });
 
-      it('when called, with as many "wrong" resolve value inject options as function parameters, should not throw a syntax error', () => {
+      it('when called, with as many "wrong" resolve value inject options as function parameters, should throw a syntax error', () => {
         const firstServiceIdentifier: ResolvedValueMetadataInjectOptions<
           string[]
         > = {
@@ -252,6 +254,7 @@ describe('BindToFluentSyntax', () => {
 
         assertType(
           bindToFluentSyntaxMock.toResolvedValue(factoryFixture, [
+            // @ts-expect-error :: Type 'OptionalResolvedValueMetadataInjectOptions<string[] | undefined>' is not assignable to type 'ResolvedValueInjectOptions<string[]>'
             secondServiceIdentifier,
           ]),
         );

--- a/packages/container/libraries/core/src/binding/calculations/buildInstanceBinding.ts
+++ b/packages/container/libraries/core/src/binding/calculations/buildInstanceBinding.ts
@@ -10,7 +10,7 @@ import { InstanceBinding } from '../models/InstanceBinding';
 
 export function buildInstanceBinding<TResolved = unknown>(
   autobindOptions: AutobindOptions,
-  serviceIdentifier: Newable,
+  serviceIdentifier: Newable<TResolved>,
 ): InstanceBinding<TResolved> {
   const classMetadata: ClassMetadata = getClassMetadata(serviceIdentifier);
   const scope: BindingScope = classMetadata.scope ?? autobindOptions.scope;
@@ -21,7 +21,7 @@ export function buildInstanceBinding<TResolved = unknown>(
       value: undefined,
     },
     id: getBindingId(),
-    implementationType: serviceIdentifier as Newable<TResolved>,
+    implementationType: serviceIdentifier,
     isSatisfiedBy: () => true,
     moduleId: undefined,
     onActivation: undefined,

--- a/packages/container/libraries/core/src/binding/services/BindingService.ts
+++ b/packages/container/libraries/core/src/binding/services/BindingService.ts
@@ -217,7 +217,7 @@ export class BindingService implements Cloneable<BindingService> {
 
     const binding: InstanceBinding<TResolved> = buildInstanceBinding(
       this.#autobindOptions,
-      serviceIdentifier as Newable,
+      serviceIdentifier as Newable<TResolved>,
     );
 
     this.set(binding);


### PR DESCRIPTION
### Changed
- Updated `ServiceIdentifier` without `Function`.

### Context
See #1071.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Major version update introducing stricter type constraints for service identifiers
  * Service identifier validation now enforces enhanced type requirements, ensuring greater type safety in dependency injection configuration
  * Tighter type constraints for valid service identifiers throughout the framework

<!-- end of auto-generated comment: release notes by coderabbit.ai -->