### PR TITLE
Rename Container.load and Container.loadSync

### DIFF
--- a/.changeset/deep-groups-mix.md
+++ b/.changeset/deep-groups-mix.md
@@ -1,0 +1,7 @@
+---
+"@inversifyjs/container": major
+"inversify": major
+---
+
+- Renamed `Container.load` to `loadAsync`
+- Renamed `Container.loadSync` to `load`

--- a/packages/container/libraries/container/src/container/services/Container.int.spec.ts
+++ b/packages/container/libraries/container/src/container/services/Container.int.spec.ts
@@ -157,7 +157,7 @@ Binding constraints:
             },
           );
 
-          await container.load(module);
+          await container.loadAsync(module);
 
           // Second call to get Arsenal
           arsenal = container.get(Arsenal);
@@ -188,7 +188,7 @@ Binding constraints:
             },
           );
 
-          await container.load(module);
+          await container.loadAsync(module);
 
           // Second call to get Arsenal
           arsenal = container.get(Arsenal);
@@ -202,7 +202,7 @@ Binding constraints:
         });
       });
 
-      describe('when container.get is called twice and gun binding is added using a ContainerModule with loadSync in the middle', () => {
+      describe('when container.get is called twice and gun binding is added using a ContainerModule with load in the middle', () => {
         let container: Container;
         let arsenal: Arsenal;
 
@@ -221,7 +221,7 @@ Binding constraints:
             },
           );
 
-          container.loadSync(module);
+          container.load(module);
 
           // Second call to get Arsenal
           arsenal = container.get(Arsenal);
@@ -235,7 +235,7 @@ Binding constraints:
         });
       });
 
-      describe('when Container.loadSync() is called and Container.unloadSync() is called to remove a module', () => {
+      describe('when Container.load() is called and Container.unloadSync() is called to remove a module', () => {
         let container: Container;
         let arsenal: Arsenal;
         let module: ContainerModule;
@@ -252,7 +252,7 @@ Binding constraints:
             },
           );
 
-          container.loadSync(module);
+          container.load(module);
 
           // First call to get Arsenal
           arsenal = container.get(Arsenal);

--- a/packages/container/libraries/container/src/container/services/Container.spec.ts
+++ b/packages/container/libraries/container/src/container/services/Container.spec.ts
@@ -136,7 +136,7 @@ describe(Container, () => {
     } as Partial<Mocked<BindingService>> as Mocked<BindingService>;
     containerModuleManagerMock = {
       load: vitest.fn(),
-      loadSync: vitest.fn(),
+      loadAsync: vitest.fn(),
       unload: vitest.fn(),
       unloadSync: vitest.fn(),
     } as Partial<
@@ -145,10 +145,10 @@ describe(Container, () => {
     containerModuleManagerClassMock = class implements Partial<
       Mocked<ContainerModuleManager>
     > {
+      public loadAsync: Mocked<ContainerModuleManager>['loadAsync'] =
+        containerModuleManagerMock.loadAsync;
       public load: Mocked<ContainerModuleManager>['load'] =
         containerModuleManagerMock.load;
-      public loadSync: Mocked<ContainerModuleManager>['loadSync'] =
-        containerModuleManagerMock.loadSync;
       public unload: Mocked<ContainerModuleManager>['unload'] =
         containerModuleManagerMock.unload;
       public unloadSync: Mocked<ContainerModuleManager>['unloadSync'] =
@@ -847,6 +847,38 @@ describe(Container, () => {
     });
   });
 
+  describe('.loadAsync', () => {
+    let containerModuleMock: Mocked<ContainerModule>;
+
+    beforeAll(() => {
+      containerModuleMock = {
+        loadAsync: vitest.fn().mockReturnValue(undefined),
+      } as Partial<Mocked<ContainerModule>> as Mocked<ContainerModule>;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(async () => {
+        result = await new Container().loadAsync(containerModuleMock);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call containerModuleManager.load', () => {
+        expect(
+          containerModuleManagerMock.loadAsync,
+        ).toHaveBeenCalledExactlyOnceWith(containerModuleMock);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
   describe('.load', () => {
     let containerModuleMock: Mocked<ContainerModule>;
 
@@ -859,8 +891,8 @@ describe(Container, () => {
     describe('when called', () => {
       let result: unknown;
 
-      beforeAll(async () => {
-        result = await new Container().load(containerModuleMock);
+      beforeAll(() => {
+        result = new Container().load(containerModuleMock);
       });
 
       afterAll(() => {
@@ -871,38 +903,6 @@ describe(Container, () => {
         expect(containerModuleManagerMock.load).toHaveBeenCalledExactlyOnceWith(
           containerModuleMock,
         );
-      });
-
-      it('should return undefined', () => {
-        expect(result).toBeUndefined();
-      });
-    });
-  });
-
-  describe('.loadSync', () => {
-    let containerModuleMock: Mocked<ContainerModule>;
-
-    beforeAll(() => {
-      containerModuleMock = {
-        load: vitest.fn().mockReturnValue(undefined),
-      } as Partial<Mocked<ContainerModule>> as Mocked<ContainerModule>;
-    });
-
-    describe('when called', () => {
-      let result: unknown;
-
-      beforeAll(() => {
-        result = new Container().loadSync(containerModuleMock);
-      });
-
-      afterAll(() => {
-        vitest.clearAllMocks();
-      });
-
-      it('should call containerModuleManager.loadSync', () => {
-        expect(
-          containerModuleManagerMock.loadSync,
-        ).toHaveBeenCalledExactlyOnceWith(containerModuleMock);
       });
 
       it('should return undefined', () => {

--- a/packages/container/libraries/container/src/container/services/Container.ts
+++ b/packages/container/libraries/container/src/container/services/Container.ts
@@ -157,12 +157,12 @@ export class Container {
     return this.#bindingManager.isCurrentBound(serviceIdentifier, options);
   }
 
-  public async load(...modules: ContainerModule[]): Promise<void> {
-    return this.#containerModuleManager.load(...modules);
+  public async loadAsync(...modules: ContainerModule[]): Promise<void> {
+    return this.#containerModuleManager.loadAsync(...modules);
   }
 
-  public loadSync(...modules: ContainerModule[]): void {
-    this.#containerModuleManager.loadSync(...modules);
+  public load(...modules: ContainerModule[]): void {
+    this.#containerModuleManager.load(...modules);
   }
 
   public onActivation<T>(

--- a/packages/container/libraries/container/src/container/services/ContainerModuleManager.spec.ts
+++ b/packages/container/libraries/container/src/container/services/ContainerModuleManager.spec.ts
@@ -78,7 +78,7 @@ describe(ContainerModuleManager, () => {
     > as Mocked<ServiceReferenceManager>;
   });
 
-  describe('.load', () => {
+  describe('.loadAsync', () => {
     let asyncContainerModuleMock: Mocked<ContainerModule>;
     let syncContainerModuleMock: Mocked<ContainerModule>;
 
@@ -102,7 +102,7 @@ describe(ContainerModuleManager, () => {
           defaultScopeFixture,
           planResultCacheManagerMock,
           serviceReferenceManagerMock,
-        ).load(asyncContainerModuleMock);
+        ).loadAsync(asyncContainerModuleMock);
       });
 
       afterAll(() => {
@@ -160,7 +160,7 @@ describe(ContainerModuleManager, () => {
           defaultScopeFixture,
           planResultCacheManagerMock,
           serviceReferenceManagerMock,
-        ).load(syncContainerModuleMock);
+        ).loadAsync(syncContainerModuleMock);
       });
 
       afterAll(() => {
@@ -209,7 +209,7 @@ describe(ContainerModuleManager, () => {
     });
   });
 
-  describe('.loadSync', () => {
+  describe('.load', () => {
     let syncContainerModuleMock: Mocked<ContainerModule>;
     let asyncContainerModuleMock: Mocked<ContainerModule>;
 
@@ -233,7 +233,7 @@ describe(ContainerModuleManager, () => {
           defaultScopeFixture,
           planResultCacheManagerMock,
           serviceReferenceManagerMock,
-        ).loadSync(syncContainerModuleMock);
+        ).load(syncContainerModuleMock);
       });
 
       afterAll(() => {
@@ -292,7 +292,7 @@ describe(ContainerModuleManager, () => {
             defaultScopeFixture,
             planResultCacheManagerMock,
             serviceReferenceManagerMock,
-          ).loadSync(asyncContainerModuleMock);
+          ).load(asyncContainerModuleMock);
         } catch (error: unknown) {
           result = error;
         }
@@ -342,7 +342,7 @@ describe(ContainerModuleManager, () => {
         const expectedErrorProperties: Partial<InversifyContainerError> = {
           kind: InversifyContainerErrorKind.invalidOperation,
           message:
-            'Unexpected asynchronous module load. Consider using Container.load() instead.',
+            'Unexpected asynchronous module load. Consider using container.loadAsync() instead.',
         };
 
         expect(result).toBeInstanceOf(InversifyContainerError);

--- a/packages/container/libraries/container/src/container/services/ContainerModuleManager.ts
+++ b/packages/container/libraries/container/src/container/services/ContainerModuleManager.ts
@@ -42,19 +42,19 @@ export class ContainerModuleManager {
     this.#serviceReferenceManager = serviceReferenceManager;
   }
 
-  public async load(...modules: ContainerModule[]): Promise<void> {
+  public async loadAsync(...modules: ContainerModule[]): Promise<void> {
     // eslint-disable-next-line @typescript-eslint/await-thenable
     await Promise.all(this.#load(...modules));
   }
 
-  public loadSync(...modules: ContainerModule[]): void {
+  public load(...modules: ContainerModule[]): void {
     const results: (void | Promise<void>)[] = this.#load(...modules);
 
     for (const result of results) {
       if (result !== undefined) {
         throw new InversifyContainerError(
           InversifyContainerErrorKind.invalidOperation,
-          'Unexpected asynchronous module load. Consider using Container.load() instead.',
+          'Unexpected asynchronous module load. Consider using container.loadAsync() instead.',
         );
       }
     }

--- a/packages/container/libraries/inversify/src/test/container/container_module.int.spec.ts
+++ b/packages/container/libraries/inversify/src/test/container/container_module.int.spec.ts
@@ -45,7 +45,7 @@ describe(ContainerModule, () => {
       },
     );
 
-    await container.load(warriors);
+    await container.loadAsync(warriors);
 
     expect(container.get<string>('A')).to.eql('2');
     expect(container.get<string>('B')).to.eql('3');
@@ -67,7 +67,7 @@ describe(ContainerModule, () => {
       },
     );
 
-    await container.load(warriors);
+    await container.loadAsync(warriors);
   });
 
   it('Should be able to override a binding using rebind within a container module', async () => {
@@ -92,7 +92,7 @@ describe(ContainerModule, () => {
       },
     );
 
-    await container.load(module1);
+    await container.loadAsync(module1);
 
     const values1: unknown[] = container.getAll(TYPES.someType);
 
@@ -100,7 +100,7 @@ describe(ContainerModule, () => {
 
     expect(values1[1]).to.eq(2);
 
-    await container.load(module2);
+    await container.loadAsync(module2);
 
     const values2: unknown[] = container.getAll(TYPES.someType);
 
@@ -134,7 +134,7 @@ describe(ContainerModule, () => {
       },
     );
 
-    await container.load(moduleOne, moduleTwo);
+    await container.loadAsync(moduleOne, moduleTwo);
 
     const aIsBound: boolean = container.isBound(A);
 
@@ -161,7 +161,7 @@ describe(ContainerModule, () => {
       },
     );
 
-    await container.load(module);
+    await container.loadAsync(module);
 
     expect(container.get<string>('A')).to.eql('B');
     expect(container.get('B')).to.eql('C');
@@ -180,7 +180,7 @@ describe(ContainerModule, () => {
       },
     );
 
-    await container.load(warriors);
+    await container.loadAsync(warriors);
     container.get('A');
     await container.unbind('A');
 
@@ -201,7 +201,7 @@ describe(ContainerModule, () => {
       },
     );
 
-    await container.load(warriors);
+    await container.loadAsync(warriors);
 
     container.get('A');
 
@@ -229,7 +229,7 @@ describe(ContainerModule, () => {
 
     container.get(serviceIdentifier);
 
-    await container.load(containerModule);
+    await container.loadAsync(containerModule);
     await container.unbind(serviceIdentifier);
 
     expect(onActivationHandlerMock).toHaveBeenCalledTimes(2);
@@ -245,7 +245,7 @@ describe(ContainerModule, () => {
       },
     );
 
-    await container.load(module);
+    await container.loadAsync(module);
 
     expect(container.getAll(sid)).toStrictEqual(['Not module', 'Module']);
 
@@ -273,7 +273,7 @@ describe(ContainerModule, () => {
       },
     );
 
-    await container.load(module);
+    await container.loadAsync(module);
 
     container.get(sid);
 
@@ -316,7 +316,7 @@ describe(ContainerModule, () => {
       },
     );
 
-    await container.load(module);
+    await container.loadAsync(module);
     await container.unload(module);
 
     container.get(sid);
@@ -342,7 +342,7 @@ describe(ContainerModule, () => {
       },
     );
 
-    await container.load(module);
+    await container.loadAsync(module);
     let values: unknown[] = container.getAll(sid);
 
     expect(values).toStrictEqual(['Not module', 'Module']);
@@ -373,7 +373,7 @@ describe(ContainerModule, () => {
       },
     );
 
-    await container.load(module);
+    await container.loadAsync(module);
     container.get(sid);
 
     await container.unload(module);
@@ -416,7 +416,7 @@ describe(ContainerModule, () => {
       },
     );
 
-    await container.load(module);
+    await container.loadAsync(module);
     await container.unload(module);
 
     container.get(sid);
@@ -448,7 +448,7 @@ describe(ContainerModule, () => {
     });
 
     container.getAll(sid);
-    await container.load(module);
+    await container.loadAsync(module);
 
     expect(deactivated).toStrictEqual(['Value', 'Value2']);
     //bindings removed

--- a/packages/container/libraries/inversify/src/test/inversify.int.spec.ts
+++ b/packages/container/libraries/inversify/src/test/inversify.int.spec.ts
@@ -400,7 +400,7 @@ describe('InversifyJS', () => {
     const container: Container = new Container();
 
     // load
-    await container.load(warriors, weapons);
+    await container.loadAsync(warriors, weapons);
 
     const ninja: Ninja = container.get('Ninja');
 


### PR DESCRIPTION
### Changed
- Renamed `Container.load` to `loadAsync`.
- Renamed `Container.loadSync` to `load`.

Completes #1049.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Major version bump for @inversifyjs/container and inversify packages
  * Container module loading methods renamed for clarity: `loadAsync()` for asynchronous loading and `load()` for synchronous loading
  * Migration required from previous `load()` and `loadSync()` method names

<!-- end of auto-generated comment: release notes by coderabbit.ai -->