### PR TITLE
Update sponsor section to be responsive

### DIFF
--- a/packages/docs/services/inversify-framework-site/src/components/HomepageSponsors/index.tsx
+++ b/packages/docs/services/inversify-framework-site/src/components/HomepageSponsors/index.tsx
@@ -18,6 +18,7 @@ export default function HomepageSponsors(): React.JSX.Element {
         data={SponsorsSvg}
         type="image/svg+xml"
         aria-label="Sponsors"
+        className={styles.sponsorsObject}
       ></object>
     </div>
   );

--- a/packages/docs/services/inversify-framework-site/src/components/HomepageSponsors/styles.module.css
+++ b/packages/docs/services/inversify-framework-site/src/components/HomepageSponsors/styles.module.css
@@ -14,3 +14,7 @@
   margin-bottom: 2rem;
   font-size: 1.1rem;
 }
+
+.sponsorsObject {
+  max-width: 100%;
+}

--- a/packages/docs/services/inversify-site/src/components/HomepageSponsors/index.tsx
+++ b/packages/docs/services/inversify-site/src/components/HomepageSponsors/index.tsx
@@ -18,6 +18,7 @@ export default function HomepageSponsors(): React.JSX.Element {
         data={SponsorsSvg}
         type="image/svg+xml"
         aria-label="Sponsors"
+        className={styles.sponsorsObject}
       ></object>
     </div>
   );

--- a/packages/docs/services/inversify-site/src/components/HomepageSponsors/styles.module.css
+++ b/packages/docs/services/inversify-site/src/components/HomepageSponsors/styles.module.css
@@ -14,3 +14,7 @@
   margin-bottom: 2rem;
   font-size: 1.1rem;
 }
+
+.sponsorsObject {
+  max-width: 100%;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sponsors section display on the homepage to ensure it respects container width constraints and prevents overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->