### PR TITLE
Remove swc plugin from vitest config

### DIFF
--- a/packages/foundation/tools/vitest-config/lib/index.js
+++ b/packages/foundation/tools/vitest-config/lib/index.js
@@ -1,4 +1,3 @@
-import swc from 'unplugin-swc';
 import { defineConfig } from 'vitest/config';
 
 export const defaultConfig = defineConfig({
@@ -9,11 +8,6 @@ export const defaultConfig = defineConfig({
     passWithNoTests: true,
     projects: [
       {
-        plugins: [
-          swc.vite({
-            tsconfigFile: 'tsconfig.esm.json',
-          }),
-        ],
         test: {
           exclude: ['src/**/*.int.spec.ts'],
           include: ['src/**/*.spec.ts'],
@@ -21,22 +15,12 @@ export const defaultConfig = defineConfig({
         },
       },
       {
-        plugins: [
-          swc.vite({
-            tsconfigFile: 'tsconfig.esm.json',
-          }),
-        ],
         test: {
           include: ['src/**/*.int.spec.ts'],
           name: 'Integration',
         },
       },
       {
-        plugins: [
-          swc.vite({
-            tsconfigFile: 'tsconfig.esm.json',
-          }),
-        ],
         test: {
           include: ['src/**/*.spec-d.ts'],
           name: 'Type',
@@ -50,11 +34,6 @@ export const defaultConfig = defineConfig({
 });
 
 export const strykerConfig = defineConfig({
-  plugins: [
-    swc.vite({
-      tsconfigFile: 'tsconfig.esm.json',
-    }),
-  ],
   test: {
     exclude: ['src/**/*.int.spec.ts'],
     include: ['src/**/*.spec.ts'],

--- a/packages/foundation/tools/vitest-config/package.json
+++ b/packages/foundation/tools/vitest-config/package.json
@@ -5,8 +5,6 @@
   },
   "description": "Common vitest config for inversify monorepo packages",
   "dependencies": {
-    "@swc/core": "^1.15.21",
-    "unplugin-swc": "^1.5.9",
     "vitest": "4.1.1"
   },
   "devDependencies": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,6 @@ onlyBuiltDependencies:
   - '@fission-ai/openspec'
   - '@nestjs/core'
   - '@prisma/engines'
-  - '@swc/core'
   - better-sqlite3
   - core-js
   - core-js-pure


### PR DESCRIPTION
### Changed
- Removed `swc` plugin from vitest config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed SWC compiler from test tooling configuration and package dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->