### PR TITLE
Update OpenApiValidationPipe with cache service

### DIFF
--- a/packages/framework/http/libraries/openapi-validation/src/validation/calculations/buildCompositeValidationHandler.spec.ts
+++ b/packages/framework/http/libraries/openapi-validation/src/validation/calculations/buildCompositeValidationHandler.spec.ts
@@ -31,6 +31,7 @@ describe(buildCompositeValidationHandler, () => {
           Symbol() as unknown as Ajv,
           Symbol(),
           inputParam,
+          vitest.fn(),
         );
       });
 
@@ -55,6 +56,7 @@ describe(buildCompositeValidationHandler, () => {
           Symbol() as unknown as Ajv,
           Symbol(),
           inputParam,
+          vitest.fn(),
         );
       });
 
@@ -79,6 +81,7 @@ describe(buildCompositeValidationHandler, () => {
           Symbol() as unknown as Ajv,
           Symbol(),
           inputParam,
+          vitest.fn(),
         );
       });
 
@@ -100,9 +103,11 @@ describe(buildCompositeValidationHandler, () => {
         unknown,
         ValidationInputParam & {
           type: symbol;
-        }
+        },
+        unknown
       >
     >;
+    let getEntryMock: Mock;
     let inputParam: unknown;
     let openApiObjectFixture: unknown;
 
@@ -112,6 +117,7 @@ describe(buildCompositeValidationHandler, () => {
       handlerMock = vitest.fn();
       discriminatorHandlerPair = [discriminatorValue, handlerMock];
       ajvFixture = Symbol() as unknown as Ajv;
+      getEntryMock = vitest.fn();
       inputParam = {
         type: discriminatorValue,
       };
@@ -132,6 +138,7 @@ describe(buildCompositeValidationHandler, () => {
           ajvFixture,
           openApiObjectFixture,
           inputParam,
+          getEntryMock,
         );
       });
 
@@ -144,6 +151,7 @@ describe(buildCompositeValidationHandler, () => {
           ajvFixture,
           openApiObjectFixture,
           inputParam,
+          getEntryMock,
         );
       });
 

--- a/packages/framework/http/libraries/openapi-validation/src/validation/calculations/buildCompositeValidationHandler.ts
+++ b/packages/framework/http/libraries/openapi-validation/src/validation/calculations/buildCompositeValidationHandler.ts
@@ -9,27 +9,41 @@ type DiscriminatorValidationHandlerPair<
   TValidatedDecoratorResult extends ValidationInputParam & {
     type: TDiscriminatorValue;
   },
+  TValidationCacheEntry,
 > = [
   TDiscriminatorValue,
-  ValidationHandler<TOpenApiObject, TValidatedDecoratorResult>,
+  ValidationHandler<
+    TOpenApiObject,
+    TValidatedDecoratorResult,
+    TValidationCacheEntry
+  >,
 ];
 
-export function buildCompositeValidationHandler<TOpenApiObject>(
+export function buildCompositeValidationHandler<
+  TOpenApiObject,
+  TValidationCacheEntry,
+>(
   discriminatorHandlerPairs: DiscriminatorValidationHandlerPair<
     symbol,
     TOpenApiObject,
-    ValidationInputParam
+    ValidationInputParam,
+    TValidationCacheEntry
   >[],
 ) {
   const handlerMap: Map<
     symbol,
-    ValidationHandler<TOpenApiObject, ValidationInputParam>
+    ValidationHandler<
+      TOpenApiObject,
+      ValidationInputParam,
+      TValidationCacheEntry
+    >
   > = new Map(discriminatorHandlerPairs);
 
   return (
     ajv: Ajv,
     openApiObject: TOpenApiObject,
     inputParam: unknown,
+    getEntry: (path: string, method: string) => TValidationCacheEntry,
   ): unknown => {
     if (inputParam === null || typeof inputParam !== 'object') {
       return inputParam;
@@ -40,11 +54,20 @@ export function buildCompositeValidationHandler<TOpenApiObject>(
     ).type;
 
     const handler:
-      | ValidationHandler<TOpenApiObject, ValidationInputParam>
+      | ValidationHandler<
+          TOpenApiObject,
+          ValidationInputParam,
+          TValidationCacheEntry
+        >
       | undefined = handlerMap.get(discriminatorValue as symbol);
     if (handler === undefined) {
       return inputParam;
     }
-    return handler(ajv, openApiObject, inputParam as ValidationInputParam);
+    return handler(
+      ajv,
+      openApiObject,
+      inputParam as ValidationInputParam,
+      getEntry,
+    );
   };
 }

--- a/packages/framework/http/libraries/openapi-validation/src/validation/calculations/v3Dot1/handleBodyValidation.spec.ts
+++ b/packages/framework/http/libraries/openapi-validation/src/validation/calculations/v3Dot1/handleBodyValidation.spec.ts
@@ -4,6 +4,7 @@ import {
   describe,
   expect,
   it,
+  type Mock,
   type Mocked,
   vitest,
 } from 'vitest';
@@ -29,6 +30,7 @@ import { type ValidateFunction } from 'ajv';
 
 import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
 import { SCHEMA_ID } from '../../models/v3Dot1/schemaId.js';
+import { type ValidationCacheEntry } from '../../models/v3Dot1/ValidationCacheEntry.js';
 import { getPath } from '../getPath.js';
 import { getOperationObject } from './getOperationObject.js';
 import { getRequestBodyObject } from './getRequestBodyObject.js';
@@ -69,8 +71,12 @@ describe(handleBodyValidation, () => {
       escapedPointerFixture = `paths/${pathFixture}/${methodFixture}/requestBody/content/${contentTypeFixture}/schema`;
     });
 
-    describe('when called, and ajv.getSchema() returns undefined', () => {
+    describe('when called, and getEntry() returns empty entry and ajv.getSchema() returns undefined', () => {
       let ajvMock: Mocked<Ajv>;
+      let getEntryMock: Mock<
+        (path: string, method: string) => ValidationCacheEntry
+      >;
+      let validationCacheEntryFixture: ValidationCacheEntry;
       let schemaPointerFixture: string;
       let result: unknown;
 
@@ -80,6 +86,14 @@ describe(handleBodyValidation, () => {
         } as Partial<Mocked<Ajv>> as Mocked<Ajv>;
 
         schemaPointerFixture = `${SCHEMA_ID}#/${escapedPointerFixture}`;
+
+        validationCacheEntryFixture = {
+          body: new Map(),
+        };
+
+        getEntryMock = vitest
+          .fn<(path: string, method: string) => ValidationCacheEntry>()
+          .mockReturnValueOnce(validationCacheEntryFixture);
 
         vitest.mocked(getPath).mockReturnValueOnce(pathFixture);
         vitest
@@ -97,6 +111,7 @@ describe(handleBodyValidation, () => {
             ajvMock,
             openApiObjectFixture,
             inputParamFixture,
+            getEntryMock,
           );
         } catch (error: unknown) {
           result = error;
@@ -109,6 +124,13 @@ describe(handleBodyValidation, () => {
 
       it('should call getPath()', () => {
         expect(getPath).toHaveBeenCalledExactlyOnceWith(inputParamFixture.url);
+      });
+
+      it('should call getEntry()', () => {
+        expect(getEntryMock).toHaveBeenCalledExactlyOnceWith(
+          pathFixture,
+          methodFixture,
+        );
       });
 
       it('should call getOperationObject()', () => {
@@ -161,8 +183,12 @@ describe(handleBodyValidation, () => {
       });
     });
 
-    describe('when called, and validation succeeds', () => {
+    describe('when called, and getEntry() returns empty entry and validation succeeds', () => {
       let ajvMock: Mocked<Ajv>;
+      let getEntryMock: Mock<
+        (path: string, method: string) => ValidationCacheEntry
+      >;
+      let validationCacheEntryFixture: ValidationCacheEntry;
       let result: unknown;
 
       beforeAll(() => {
@@ -174,6 +200,14 @@ describe(handleBodyValidation, () => {
         ajvMock = {
           getSchema: vitest.fn().mockReturnValueOnce(validateMock),
         } as Partial<Mocked<Ajv>> as Mocked<Ajv>;
+
+        validationCacheEntryFixture = {
+          body: new Map(),
+        };
+
+        getEntryMock = vitest
+          .fn<(path: string, method: string) => ValidationCacheEntry>()
+          .mockReturnValueOnce(validationCacheEntryFixture);
 
         vitest.mocked(getPath).mockReturnValueOnce(pathFixture);
         vitest
@@ -190,6 +224,7 @@ describe(handleBodyValidation, () => {
           ajvMock,
           openApiObjectFixture,
           inputParamFixture,
+          getEntryMock,
         );
       });
 
@@ -199,6 +234,13 @@ describe(handleBodyValidation, () => {
 
       it('should call getPath()', () => {
         expect(getPath).toHaveBeenCalledExactlyOnceWith(inputParamFixture.url);
+      });
+
+      it('should call getEntry()', () => {
+        expect(getEntryMock).toHaveBeenCalledExactlyOnceWith(
+          pathFixture,
+          methodFixture,
+        );
       });
 
       it('should call getOperationObject()', () => {
@@ -223,8 +265,12 @@ describe(handleBodyValidation, () => {
       });
     });
 
-    describe('when called, and validation fails', () => {
+    describe('when called, and getEntry() returns empty entry and validation fails', () => {
       let ajvMock: Mocked<Ajv>;
+      let getEntryMock: Mock<
+        (path: string, method: string) => ValidationCacheEntry
+      >;
+      let validationCacheEntryFixture: ValidationCacheEntry;
       let result: unknown;
 
       beforeAll(() => {
@@ -248,6 +294,14 @@ describe(handleBodyValidation, () => {
           getSchema: vitest.fn().mockReturnValueOnce(validateMock),
         } as Partial<Mocked<Ajv>> as Mocked<Ajv>;
 
+        validationCacheEntryFixture = {
+          body: new Map(),
+        };
+
+        getEntryMock = vitest
+          .fn<(path: string, method: string) => ValidationCacheEntry>()
+          .mockReturnValueOnce(validationCacheEntryFixture);
+
         vitest.mocked(getPath).mockReturnValueOnce(pathFixture);
         vitest
           .mocked(getOperationObject)
@@ -264,6 +318,7 @@ describe(handleBodyValidation, () => {
             ajvMock,
             openApiObjectFixture,
             inputParamFixture,
+            getEntryMock,
           );
         } catch (error: unknown) {
           result = error;
@@ -275,19 +330,14 @@ describe(handleBodyValidation, () => {
       });
 
       it('should throw an InversifyValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyValidationError> = {
+          kind: InversifyValidationErrorKind.validationFailed,
+          message:
+            '[schema: #/properties/name/type, instance: /name]: "must be string"',
+        };
+
         expect(result).toBeInstanceOf(InversifyValidationError);
-      });
-
-      it('should throw an error with validationFailed kind', () => {
-        expect((result as InversifyValidationError).kind).toBe(
-          InversifyValidationErrorKind.validationFailed,
-        );
-      });
-
-      it('should throw an error with expected message', () => {
-        expect((result as InversifyValidationError).message).toBe(
-          '[schema: #/properties/name/type, instance: /name]: "must be string"',
-        );
+        expect(result).toMatchObject(expectedErrorProperties);
       });
     });
   });
@@ -319,8 +369,12 @@ describe(handleBodyValidation, () => {
       escapedPointerFixture = `paths/${pathFixture}/${methodFixture}/requestBody/content/${inferredContentTypeFixture}/schema`;
     });
 
-    describe('when called, and validation succeeds', () => {
+    describe('when called, and getEntry() returns empty entry and validation succeeds', () => {
       let ajvMock: Mocked<Ajv>;
+      let getEntryMock: Mock<
+        (path: string, method: string) => ValidationCacheEntry
+      >;
+      let validationCacheEntryFixture: ValidationCacheEntry;
       let result: unknown;
 
       beforeAll(() => {
@@ -332,6 +386,14 @@ describe(handleBodyValidation, () => {
         ajvMock = {
           getSchema: vitest.fn().mockReturnValueOnce(validateMock),
         } as Partial<Mocked<Ajv>> as Mocked<Ajv>;
+
+        validationCacheEntryFixture = {
+          body: new Map(),
+        };
+
+        getEntryMock = vitest
+          .fn<(path: string, method: string) => ValidationCacheEntry>()
+          .mockReturnValueOnce(validationCacheEntryFixture);
 
         vitest.mocked(getPath).mockReturnValueOnce(pathFixture);
         vitest
@@ -351,6 +413,7 @@ describe(handleBodyValidation, () => {
           ajvMock,
           openApiObjectFixture,
           inputParamFixture,
+          getEntryMock,
         );
       });
 

--- a/packages/framework/http/libraries/openapi-validation/src/validation/calculations/v3Dot1/handleBodyValidation.ts
+++ b/packages/framework/http/libraries/openapi-validation/src/validation/calculations/v3Dot1/handleBodyValidation.ts
@@ -13,20 +13,19 @@ import { type ErrorObject, type ValidateFunction } from 'ajv';
 
 import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
 import { SCHEMA_ID } from '../../models/v3Dot1/schemaId.js';
+import { type ValidationCacheEntry } from '../../models/v3Dot1/ValidationCacheEntry.js';
 import { getPath } from '../getPath.js';
 import { getOperationObject } from './getOperationObject.js';
 import { getRequestBodyObject } from './getRequestBodyObject.js';
 import { inferContentType } from './inferContentType.js';
 
-export function handleBodyValidation(
+function getValidateFunction(
   ajv: Ajv,
   openApiObject: OpenApi3Dot1Object,
-  inputParam: BodyValidationInputParam<unknown>,
-): unknown {
-  const path: string = getPath(inputParam.url);
-  const method: string = inputParam.method.toLowerCase();
-  const contentType: string | undefined = inputParam.contentType;
-
+  path: string,
+  method: string,
+  contentType: string | undefined,
+): ValidateFunction {
   const operationObject: OpenApi3Dot1OperationObject = getOperationObject(
     openApiObject,
     method,
@@ -56,6 +55,36 @@ export function handleBodyValidation(
       InversifyValidationErrorKind.validationFailed,
       `Unable to find schema for pointer: ${schemaPointer}`,
     );
+  }
+
+  return validate;
+}
+
+export function handleBodyValidation(
+  ajv: Ajv,
+  openApiObject: OpenApi3Dot1Object,
+  inputParam: BodyValidationInputParam<unknown>,
+  getEntry: (path: string, method: string) => ValidationCacheEntry,
+): unknown {
+  const path: string = getPath(inputParam.url);
+  const method: string = inputParam.method.toLowerCase();
+  const contentType: string | undefined = inputParam.contentType;
+
+  const validationCacheEntry: ValidationCacheEntry = getEntry(path, method);
+
+  let validate: ValidateFunction | undefined =
+    validationCacheEntry.body.get(contentType);
+
+  if (validate === undefined) {
+    validate = getValidateFunction(
+      ajv,
+      openApiObject,
+      path,
+      method,
+      contentType,
+    );
+
+    validationCacheEntry.body.set(contentType, validate);
   }
 
   const valid: boolean = validate(inputParam.body);

--- a/packages/framework/http/libraries/openapi-validation/src/validation/calculations/v3Dot2/handleBodyValidation.spec.ts
+++ b/packages/framework/http/libraries/openapi-validation/src/validation/calculations/v3Dot2/handleBodyValidation.spec.ts
@@ -4,6 +4,7 @@ import {
   describe,
   expect,
   it,
+  type Mock,
   type Mocked,
   vitest,
 } from 'vitest';
@@ -29,6 +30,7 @@ import { type ValidateFunction } from 'ajv';
 
 import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
 import { SCHEMA_ID } from '../../models/v3Dot2/schemaId.js';
+import { type ValidationCacheEntry } from '../../models/v3Dot2/ValidationCacheEntry.js';
 import { getPath } from '../getPath.js';
 import { getOperationObject } from './getOperationObject.js';
 import { getRequestBodyObject } from './getRequestBodyObject.js';
@@ -69,8 +71,12 @@ describe(handleBodyValidation, () => {
       escapedPointerFixture = `paths/${pathFixture}/${methodFixture}/requestBody/content/${contentTypeFixture}/schema`;
     });
 
-    describe('when called, and ajv.getSchema() returns undefined', () => {
+    describe('when called, and getEntry() returns empty entry and ajv.getSchema() returns undefined', () => {
       let ajvMock: Mocked<Ajv>;
+      let getEntryMock: Mock<
+        (path: string, method: string) => ValidationCacheEntry
+      >;
+      let validationCacheEntryFixture: ValidationCacheEntry;
       let schemaPointerFixture: string;
       let result: unknown;
 
@@ -80,6 +86,14 @@ describe(handleBodyValidation, () => {
         } as Partial<Mocked<Ajv>> as Mocked<Ajv>;
 
         schemaPointerFixture = `${SCHEMA_ID}#/${escapedPointerFixture}`;
+
+        validationCacheEntryFixture = {
+          body: new Map(),
+        };
+
+        getEntryMock = vitest
+          .fn<(path: string, method: string) => ValidationCacheEntry>()
+          .mockReturnValueOnce(validationCacheEntryFixture);
 
         vitest.mocked(getPath).mockReturnValueOnce(pathFixture);
         vitest
@@ -97,6 +111,7 @@ describe(handleBodyValidation, () => {
             ajvMock,
             openApiObjectFixture,
             inputParamFixture,
+            getEntryMock,
           );
         } catch (error: unknown) {
           result = error;
@@ -109,6 +124,13 @@ describe(handleBodyValidation, () => {
 
       it('should call getPath()', () => {
         expect(getPath).toHaveBeenCalledExactlyOnceWith(inputParamFixture.url);
+      });
+
+      it('should call getEntry()', () => {
+        expect(getEntryMock).toHaveBeenCalledExactlyOnceWith(
+          pathFixture,
+          methodFixture,
+        );
       });
 
       it('should call getOperationObject()', () => {
@@ -161,8 +183,12 @@ describe(handleBodyValidation, () => {
       });
     });
 
-    describe('when called, and validation succeeds', () => {
+    describe('when called, and getEntry() returns empty entry and validation succeeds', () => {
       let ajvMock: Mocked<Ajv>;
+      let getEntryMock: Mock<
+        (path: string, method: string) => ValidationCacheEntry
+      >;
+      let validationCacheEntryFixture: ValidationCacheEntry;
       let result: unknown;
 
       beforeAll(() => {
@@ -174,6 +200,14 @@ describe(handleBodyValidation, () => {
         ajvMock = {
           getSchema: vitest.fn().mockReturnValueOnce(validateMock),
         } as Partial<Mocked<Ajv>> as Mocked<Ajv>;
+
+        validationCacheEntryFixture = {
+          body: new Map(),
+        };
+
+        getEntryMock = vitest
+          .fn<(path: string, method: string) => ValidationCacheEntry>()
+          .mockReturnValueOnce(validationCacheEntryFixture);
 
         vitest.mocked(getPath).mockReturnValueOnce(pathFixture);
         vitest
@@ -190,6 +224,7 @@ describe(handleBodyValidation, () => {
           ajvMock,
           openApiObjectFixture,
           inputParamFixture,
+          getEntryMock,
         );
       });
 
@@ -199,6 +234,13 @@ describe(handleBodyValidation, () => {
 
       it('should call getPath()', () => {
         expect(getPath).toHaveBeenCalledExactlyOnceWith(inputParamFixture.url);
+      });
+
+      it('should call getEntry()', () => {
+        expect(getEntryMock).toHaveBeenCalledExactlyOnceWith(
+          pathFixture,
+          methodFixture,
+        );
       });
 
       it('should call getOperationObject()', () => {
@@ -223,8 +265,12 @@ describe(handleBodyValidation, () => {
       });
     });
 
-    describe('when called, and validation fails', () => {
+    describe('when called, and getEntry() returns empty entry and validation fails', () => {
       let ajvMock: Mocked<Ajv>;
+      let getEntryMock: Mock<
+        (path: string, method: string) => ValidationCacheEntry
+      >;
+      let validationCacheEntryFixture: ValidationCacheEntry;
       let result: unknown;
 
       beforeAll(() => {
@@ -248,6 +294,14 @@ describe(handleBodyValidation, () => {
           getSchema: vitest.fn().mockReturnValueOnce(validateMock),
         } as Partial<Mocked<Ajv>> as Mocked<Ajv>;
 
+        validationCacheEntryFixture = {
+          body: new Map(),
+        };
+
+        getEntryMock = vitest
+          .fn<(path: string, method: string) => ValidationCacheEntry>()
+          .mockReturnValueOnce(validationCacheEntryFixture);
+
         vitest.mocked(getPath).mockReturnValueOnce(pathFixture);
         vitest
           .mocked(getOperationObject)
@@ -264,6 +318,7 @@ describe(handleBodyValidation, () => {
             ajvMock,
             openApiObjectFixture,
             inputParamFixture,
+            getEntryMock,
           );
         } catch (error: unknown) {
           result = error;
@@ -275,19 +330,14 @@ describe(handleBodyValidation, () => {
       });
 
       it('should throw an InversifyValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyValidationError> = {
+          kind: InversifyValidationErrorKind.validationFailed,
+          message:
+            '[schema: #/properties/name/type, instance: /name]: "must be string"',
+        };
+
         expect(result).toBeInstanceOf(InversifyValidationError);
-      });
-
-      it('should throw an error with validationFailed kind', () => {
-        expect((result as InversifyValidationError).kind).toBe(
-          InversifyValidationErrorKind.validationFailed,
-        );
-      });
-
-      it('should throw an error with expected message', () => {
-        expect((result as InversifyValidationError).message).toBe(
-          '[schema: #/properties/name/type, instance: /name]: "must be string"',
-        );
+        expect(result).toMatchObject(expectedErrorProperties);
       });
     });
   });
@@ -319,8 +369,12 @@ describe(handleBodyValidation, () => {
       escapedPointerFixture = `paths/${pathFixture}/${methodFixture}/requestBody/content/${inferredContentTypeFixture}/schema`;
     });
 
-    describe('when called, and validation succeeds', () => {
+    describe('when called, and getEntry() returns empty entry and validation succeeds', () => {
       let ajvMock: Mocked<Ajv>;
+      let getEntryMock: Mock<
+        (path: string, method: string) => ValidationCacheEntry
+      >;
+      let validationCacheEntryFixture: ValidationCacheEntry;
       let result: unknown;
 
       beforeAll(() => {
@@ -332,6 +386,14 @@ describe(handleBodyValidation, () => {
         ajvMock = {
           getSchema: vitest.fn().mockReturnValueOnce(validateMock),
         } as Partial<Mocked<Ajv>> as Mocked<Ajv>;
+
+        validationCacheEntryFixture = {
+          body: new Map(),
+        };
+
+        getEntryMock = vitest
+          .fn<(path: string, method: string) => ValidationCacheEntry>()
+          .mockReturnValueOnce(validationCacheEntryFixture);
 
         vitest.mocked(getPath).mockReturnValueOnce(pathFixture);
         vitest
@@ -351,6 +413,7 @@ describe(handleBodyValidation, () => {
           ajvMock,
           openApiObjectFixture,
           inputParamFixture,
+          getEntryMock,
         );
       });
 

--- a/packages/framework/http/libraries/openapi-validation/src/validation/calculations/v3Dot2/handleBodyValidation.ts
+++ b/packages/framework/http/libraries/openapi-validation/src/validation/calculations/v3Dot2/handleBodyValidation.ts
@@ -13,20 +13,19 @@ import { type ErrorObject, type ValidateFunction } from 'ajv';
 
 import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
 import { SCHEMA_ID } from '../../models/v3Dot2/schemaId.js';
+import { type ValidationCacheEntry } from '../../models/v3Dot2/ValidationCacheEntry.js';
 import { getPath } from '../getPath.js';
 import { getOperationObject } from './getOperationObject.js';
 import { getRequestBodyObject } from './getRequestBodyObject.js';
 import { inferContentType } from './inferContentType.js';
 
-export function handleBodyValidation(
+function getValidateFunction(
   ajv: Ajv,
   openApiObject: OpenApi3Dot2Object,
-  inputParam: BodyValidationInputParam<unknown>,
-): unknown {
-  const path: string = getPath(inputParam.url);
-  const method: string = inputParam.method.toLowerCase();
-  const contentType: string | undefined = inputParam.contentType;
-
+  path: string,
+  method: string,
+  contentType: string | undefined,
+): ValidateFunction {
   const operationObject: OpenApi3Dot2OperationObject = getOperationObject(
     openApiObject,
     method,
@@ -56,6 +55,36 @@ export function handleBodyValidation(
       InversifyValidationErrorKind.validationFailed,
       `Unable to find schema for pointer: ${schemaPointer}`,
     );
+  }
+
+  return validate;
+}
+
+export function handleBodyValidation(
+  ajv: Ajv,
+  openApiObject: OpenApi3Dot2Object,
+  inputParam: BodyValidationInputParam<unknown>,
+  getEntry: (path: string, method: string) => ValidationCacheEntry,
+): unknown {
+  const path: string = getPath(inputParam.url);
+  const method: string = inputParam.method.toLowerCase();
+  const contentType: string | undefined = inputParam.contentType;
+
+  const validationCacheEntry: ValidationCacheEntry = getEntry(path, method);
+
+  let validate: ValidateFunction | undefined =
+    validationCacheEntry.body.get(contentType);
+
+  if (validate === undefined) {
+    validate = getValidateFunction(
+      ajv,
+      openApiObject,
+      path,
+      method,
+      contentType,
+    );
+
+    validationCacheEntry.body.set(contentType, validate);
   }
 
   const valid: boolean = validate(inputParam.body);

--- a/packages/framework/http/libraries/openapi-validation/src/validation/models/DiscriminatorValidationHandlerPair.ts
+++ b/packages/framework/http/libraries/openapi-validation/src/validation/models/DiscriminatorValidationHandlerPair.ts
@@ -7,7 +7,12 @@ export type DiscriminatorValidationHandlerPair<
   TValidatedDecoratorResult extends ValidationInputParam & {
     type: TDiscriminatorValue;
   },
+  TValidationCacheEntry = unknown,
 > = [
   TDiscriminatorValue,
-  ValidationHandler<TOpenApiObject, TValidatedDecoratorResult>,
+  ValidationHandler<
+    TOpenApiObject,
+    TValidatedDecoratorResult,
+    TValidationCacheEntry
+  >,
 ];

--- a/packages/framework/http/libraries/openapi-validation/src/validation/models/ValidationHandler.ts
+++ b/packages/framework/http/libraries/openapi-validation/src/validation/models/ValidationHandler.ts
@@ -3,10 +3,12 @@ import type Ajv from 'ajv';
 import { type ValidationInputParam } from './ValidatedDecoratorResult.js';
 
 export type ValidationHandler<
-  in TOpenApiObject,
-  in TValidatedDecoratorResult extends ValidationInputParam,
+  TOpenApiObject,
+  TValidatedDecoratorResult extends ValidationInputParam,
+  TValidationCacheEntry,
 > = (
   ajv: Ajv,
   openApiObject: TOpenApiObject,
   inputParam: TValidatedDecoratorResult,
+  getEntry: (path: string, method: string) => TValidationCacheEntry,
 ) => unknown;

--- a/packages/framework/http/libraries/openapi-validation/src/validation/models/v3Dot1/ValidationCacheEntry.ts
+++ b/packages/framework/http/libraries/openapi-validation/src/validation/models/v3Dot1/ValidationCacheEntry.ts
@@ -1,0 +1,5 @@
+import { type ValidateFunction } from 'ajv';
+
+export interface ValidationCacheEntry {
+  body: Map<string | undefined, ValidateFunction>;
+}

--- a/packages/framework/http/libraries/openapi-validation/src/validation/models/v3Dot2/ValidationCacheEntry.ts
+++ b/packages/framework/http/libraries/openapi-validation/src/validation/models/v3Dot2/ValidationCacheEntry.ts
@@ -1,0 +1,5 @@
+import { type ValidateFunction } from 'ajv';
+
+export interface ValidationCacheEntry {
+  body: Map<string | undefined, ValidateFunction>;
+}

--- a/packages/framework/http/libraries/openapi-validation/src/validation/pipes/v3Dot1/OpenApiValidationPipe.ts
+++ b/packages/framework/http/libraries/openapi-validation/src/validation/pipes/v3Dot1/OpenApiValidationPipe.ts
@@ -12,23 +12,29 @@ import { openApiValidationMetadataReflectKey } from '../../../metadata/models/op
 import { buildCompositeValidationHandler } from '../../calculations/buildCompositeValidationHandler.js';
 import { handleBodyValidation } from '../../calculations/v3Dot1/handleBodyValidation.js';
 import { SCHEMA_ID } from '../../models/v3Dot1/schemaId.js';
+import { type ValidationCacheEntry } from '../../models/v3Dot1/ValidationCacheEntry.js';
 import { validatedInputParamBodyType } from '../../models/validatedInputParamTypes.js';
+import { ValidationCache } from '../../services/v3Dot1/ValidationCache.js';
 
 const handler: (
   ajv: Ajv,
   openApiObject: OpenApi3Dot1Object,
   inputParam: unknown,
-) => unknown = buildCompositeValidationHandler<OpenApi3Dot1Object>([
-  [validatedInputParamBodyType, handleBodyValidation],
-]);
+  getEntry: (path: string, method: string) => ValidationCacheEntry,
+) => unknown = buildCompositeValidationHandler<
+  OpenApi3Dot1Object,
+  ValidationCacheEntry
+>([[validatedInputParamBodyType, handleBodyValidation]]);
 
 export class OpenApiValidationPipe implements Pipe {
   readonly #openApiObject: OpenApi3Dot1Object;
+  readonly #validationCache: ValidationCache;
 
   #ajv: Ajv | undefined;
 
   constructor(openApiObject: OpenApi3Dot1Object) {
     this.#openApiObject = openApiObject;
+    this.#validationCache = new ValidationCache();
     this.#ajv = undefined;
   }
 
@@ -72,7 +78,12 @@ export class OpenApiValidationPipe implements Pipe {
 
     const ajv: Ajv = this.#getOrInitAjv();
 
-    return handler(ajv, this.#openApiObject, awaitedInput);
+    return handler(
+      ajv,
+      this.#openApiObject,
+      awaitedInput,
+      this.#validationCache.getOrCreate.bind(this.#validationCache),
+    );
   }
 
   #getOrInitAjv(): Ajv {

--- a/packages/framework/http/libraries/openapi-validation/src/validation/pipes/v3Dot2/OpenApiValidationPipe.ts
+++ b/packages/framework/http/libraries/openapi-validation/src/validation/pipes/v3Dot2/OpenApiValidationPipe.ts
@@ -12,23 +12,29 @@ import { openApiValidationMetadataReflectKey } from '../../../metadata/models/op
 import { buildCompositeValidationHandler } from '../../calculations/buildCompositeValidationHandler.js';
 import { handleBodyValidation } from '../../calculations/v3Dot2/handleBodyValidation.js';
 import { SCHEMA_ID } from '../../models/v3Dot2/schemaId.js';
+import { type ValidationCacheEntry } from '../../models/v3Dot2/ValidationCacheEntry.js';
 import { validatedInputParamBodyType } from '../../models/validatedInputParamTypes.js';
+import { ValidationCache } from '../../services/v3Dot2/ValidationCache.js';
 
 const handler: (
   ajv: Ajv,
   openApiObject: OpenApi3Dot2Object,
   inputParam: unknown,
-) => unknown = buildCompositeValidationHandler<OpenApi3Dot2Object>([
-  [validatedInputParamBodyType, handleBodyValidation],
-]);
+  getEntry: (path: string, method: string) => ValidationCacheEntry,
+) => unknown = buildCompositeValidationHandler<
+  OpenApi3Dot2Object,
+  ValidationCacheEntry
+>([[validatedInputParamBodyType, handleBodyValidation]]);
 
 export class OpenApiValidationPipe implements Pipe {
   readonly #openApiObject: OpenApi3Dot2Object;
+  readonly #validationCache: ValidationCache;
 
   #ajv: Ajv | undefined;
 
   constructor(openApiObject: OpenApi3Dot2Object) {
     this.#openApiObject = openApiObject;
+    this.#validationCache = new ValidationCache();
     this.#ajv = undefined;
   }
 
@@ -72,7 +78,12 @@ export class OpenApiValidationPipe implements Pipe {
 
     const ajv: Ajv = this.#getOrInitAjv();
 
-    return handler(ajv, this.#openApiObject, awaitedInput);
+    return handler(
+      ajv,
+      this.#openApiObject,
+      awaitedInput,
+      this.#validationCache.getOrCreate.bind(this.#validationCache),
+    );
   }
 
   #getOrInitAjv(): Ajv {

--- a/packages/framework/http/libraries/openapi-validation/src/validation/services/ValidationCache.spec.ts
+++ b/packages/framework/http/libraries/openapi-validation/src/validation/services/ValidationCache.spec.ts
@@ -1,0 +1,229 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  type Mock,
+  vitest,
+} from 'vitest';
+
+import { ValidationCache } from './ValidationCache.js';
+
+class ValidationCacheMock extends ValidationCache<unknown> {
+  readonly #createCacheEntryMock: Mock<() => unknown>;
+
+  constructor(createCacheEntryMock: Mock<() => unknown>) {
+    super();
+
+    this.#createCacheEntryMock = createCacheEntryMock;
+  }
+
+  protected override _createCacheEntry(): unknown {
+    return this.#createCacheEntryMock();
+  }
+}
+
+describe(ValidationCache, () => {
+  let createCacheEntryMock: Mock<() => unknown>;
+  let validationCache: ValidationCacheMock;
+
+  beforeAll(() => {
+    createCacheEntryMock = vitest.fn();
+    validationCache = new ValidationCacheMock(createCacheEntryMock);
+  });
+
+  describe('.get', () => {
+    describe('having a cache with no entries', () => {
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = validationCache.get('/path', 'get');
+        });
+
+        it('should return undefined', () => {
+          expect(result).toBeUndefined();
+        });
+      });
+    });
+
+    describe('having a cache with an entry', () => {
+      let pathFixture: string;
+      let methodFixture: string;
+      let cacheEntryFixture: unknown;
+
+      beforeAll(() => {
+        pathFixture = '/users';
+        methodFixture = 'post';
+        cacheEntryFixture = Symbol();
+
+        validationCache.set(pathFixture, methodFixture, cacheEntryFixture);
+      });
+
+      describe('when called with matching path and method', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = validationCache.get(pathFixture, methodFixture);
+        });
+
+        it('should return the cache entry', () => {
+          expect(result).toBe(cacheEntryFixture);
+        });
+      });
+
+      describe('when called with non-matching path', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = validationCache.get('/other', methodFixture);
+        });
+
+        it('should return undefined', () => {
+          expect(result).toBeUndefined();
+        });
+      });
+
+      describe('when called with non-matching method', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = validationCache.get(pathFixture, 'delete');
+        });
+
+        it('should return undefined', () => {
+          expect(result).toBeUndefined();
+        });
+      });
+    });
+  });
+
+  describe('.set', () => {
+    describe('when called', () => {
+      let pathFixture: string;
+      let methodFixture: string;
+      let cacheEntryFixture: unknown;
+
+      beforeAll(() => {
+        pathFixture = '/items';
+        methodFixture = 'put';
+        cacheEntryFixture = Symbol();
+
+        validationCache.set(pathFixture, methodFixture, cacheEntryFixture);
+      });
+
+      it('should store the entry retrievable via get', () => {
+        expect(validationCache.get(pathFixture, methodFixture)).toBe(
+          cacheEntryFixture,
+        );
+      });
+    });
+
+    describe('when called with existing path but new method', () => {
+      let pathFixture: string;
+      let firstMethodFixture: string;
+      let secondMethodFixture: string;
+      let firstEntryFixture: unknown;
+      let secondEntryFixture: unknown;
+
+      beforeAll(() => {
+        pathFixture = '/products';
+        firstMethodFixture = 'get';
+        secondMethodFixture = 'post';
+        firstEntryFixture = Symbol();
+        secondEntryFixture = Symbol();
+
+        validationCache.set(pathFixture, firstMethodFixture, firstEntryFixture);
+        validationCache.set(
+          pathFixture,
+          secondMethodFixture,
+          secondEntryFixture,
+        );
+      });
+
+      it('should store both entries', () => {
+        expect(validationCache.get(pathFixture, firstMethodFixture)).toBe(
+          firstEntryFixture,
+        );
+        expect(validationCache.get(pathFixture, secondMethodFixture)).toBe(
+          secondEntryFixture,
+        );
+      });
+    });
+  });
+
+  describe('.getOrCreate', () => {
+    let freshCache: ValidationCacheMock;
+    let freshCreateCacheEntryMock: Mock<() => unknown>;
+
+    beforeAll(() => {
+      freshCreateCacheEntryMock = vitest.fn();
+      freshCache = new ValidationCacheMock(freshCreateCacheEntryMock);
+    });
+
+    describe('when called, and no entry exists', () => {
+      let pathFixture: string;
+      let methodFixture: string;
+      let createdEntryFixture: unknown;
+      let result: unknown;
+
+      beforeAll(() => {
+        pathFixture = '/orders';
+        methodFixture = 'post';
+        createdEntryFixture = Symbol();
+
+        freshCreateCacheEntryMock.mockReturnValueOnce(createdEntryFixture);
+
+        result = freshCache.getOrCreate(pathFixture, methodFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call _createCacheEntry()', () => {
+        expect(freshCreateCacheEntryMock).toHaveBeenCalledExactlyOnceWith();
+      });
+
+      it('should return the created entry', () => {
+        expect(result).toBe(createdEntryFixture);
+      });
+
+      it('should store the created entry in the cache', () => {
+        expect(freshCache.get(pathFixture, methodFixture)).toBe(
+          createdEntryFixture,
+        );
+      });
+    });
+
+    describe('when called, and an entry already exists', () => {
+      let pathFixture: string;
+      let methodFixture: string;
+      let existingEntryFixture: unknown;
+      let result: unknown;
+
+      beforeAll(() => {
+        pathFixture = '/existing';
+        methodFixture = 'get';
+        existingEntryFixture = Symbol();
+
+        freshCache.set(pathFixture, methodFixture, existingEntryFixture);
+
+        result = freshCache.getOrCreate(pathFixture, methodFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should not call _createCacheEntry()', () => {
+        expect(freshCreateCacheEntryMock).not.toHaveBeenCalled();
+      });
+
+      it('should return the existing entry', () => {
+        expect(result).toBe(existingEntryFixture);
+      });
+    });
+  });
+});

--- a/packages/framework/http/libraries/openapi-validation/src/validation/services/ValidationCache.ts
+++ b/packages/framework/http/libraries/openapi-validation/src/validation/services/ValidationCache.ts
@@ -1,0 +1,35 @@
+export abstract class ValidationCache<TCacheEntry> {
+  readonly #cache: Map<string, Map<string, TCacheEntry>>;
+
+  constructor() {
+    this.#cache = new Map();
+  }
+
+  public get(path: string, method: string): TCacheEntry | undefined {
+    return this.#cache.get(path)?.get(method);
+  }
+
+  public getOrCreate(path: string, method: string): TCacheEntry {
+    let cacheEntry: TCacheEntry | undefined = this.get(path, method);
+
+    if (cacheEntry === undefined) {
+      cacheEntry = this._createCacheEntry();
+      this.set(path, method, cacheEntry);
+    }
+
+    return cacheEntry;
+  }
+
+  public set(path: string, method: string, cacheEntry: TCacheEntry): void {
+    let methodMap: Map<string, TCacheEntry> | undefined = this.#cache.get(path);
+
+    if (methodMap === undefined) {
+      methodMap = new Map();
+      this.#cache.set(path, methodMap);
+    }
+
+    methodMap.set(method, cacheEntry);
+  }
+
+  protected abstract _createCacheEntry(): TCacheEntry;
+}

--- a/packages/framework/http/libraries/openapi-validation/src/validation/services/v3Dot1/ValidationCache.ts
+++ b/packages/framework/http/libraries/openapi-validation/src/validation/services/v3Dot1/ValidationCache.ts
@@ -1,0 +1,10 @@
+import { type ValidationCacheEntry } from '../../models/v3Dot1/ValidationCacheEntry.js';
+import { ValidationCache as BaseValidationCache } from '../ValidationCache.js';
+
+export class ValidationCache extends BaseValidationCache<ValidationCacheEntry> {
+  protected _createCacheEntry(): ValidationCacheEntry {
+    return {
+      body: new Map(),
+    };
+  }
+}

--- a/packages/framework/http/libraries/openapi-validation/src/validation/services/v3Dot2/ValidationCache.ts
+++ b/packages/framework/http/libraries/openapi-validation/src/validation/services/v3Dot2/ValidationCache.ts
@@ -1,0 +1,10 @@
+import { type ValidationCacheEntry } from '../../models/v3Dot2/ValidationCacheEntry.js';
+import { ValidationCache as BaseValidationCache } from '../ValidationCache.js';
+
+export class ValidationCache extends BaseValidationCache<ValidationCacheEntry> {
+  protected _createCacheEntry(): ValidationCacheEntry {
+    return {
+      body: new Map(),
+    };
+  }
+}


### PR DESCRIPTION
### Changed
- Updated `OpenApiValidationPipe` with cache service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation caching mechanism to store and reuse OpenAPI validators during request processing.

* **Tests**
  * Added comprehensive test coverage for the validation caching service and updated existing validation tests to support caching integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->