### PR TITLE
Update InversifyHttpAdapter to properly await for custom decorator params

### DIFF
--- a/.changeset/sour-baths-shake.md
+++ b/.changeset/sour-baths-shake.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/http-core": patch
+---
+
+- Updated `InversifyHttpAdapter` to properly await for custom decorator params

--- a/packages/docs/services/inversify-framework-site/docs/api/decorators.mdx
+++ b/packages/docs/services/inversify-framework-site/docs/api/decorators.mdx
@@ -518,7 +518,7 @@ Assuming an auth middleware lets user details in a `user` property of a given `r
 `createCustomNativeParameterDecorator` allows you to define your own decorators to be used in route handler parameters.
 
 :::warning[Native mode]
-  Using a custom native parameter decorator in a route handler forces the native mode.
+  Using a custom native parameter decorator in a route handler forces the [native mode](../../fundamentals/controller#2-native-types-advanced).
 :::
 
 ```ts

--- a/packages/framework/http/libraries/core/src/http/adapter/InversifyHttpAdapter.ts
+++ b/packages/framework/http/libraries/core/src/http/adapter/InversifyHttpAdapter.ts
@@ -103,9 +103,11 @@ export abstract class InversifyHttpAdapter<
       | undefined,
     customApp?: TApp,
   ) {
-    this.#awaitableRequestMethodParamTypes = new Set(
-      awaitableRequestMethodParamTypes,
-    );
+    this.#awaitableRequestMethodParamTypes = new Set([
+      ...(awaitableRequestMethodParamTypes ?? []),
+      RequestMethodParameterType.Custom,
+      RequestMethodParameterType.CustomNative,
+    ]);
     this.#container = container;
     this.#customParameterDecoratorHandlerOptions =
       this.#buildCustomParameterDecoratorHandlerOptions();

--- a/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot1/OpenApiValidationPipe.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot1/OpenApiValidationPipe.ts
@@ -42,9 +42,6 @@ export class OpenApiValidationPipe implements Pipe {
     input: unknown,
     metadata: PipeMetadata,
   ): Promise<unknown> {
-    // TODO: Implement async custom decorators, then remove this workaround
-    const awaitedInput: unknown = await input;
-
     const parameterMetadataList: (
       | ControllerMethodParameterMetadata
       | undefined
@@ -57,7 +54,7 @@ export class OpenApiValidationPipe implements Pipe {
       parameterMetadataList[metadata.parameterIndex];
 
     if (parameterMetadata === undefined) {
-      return awaitedInput;
+      return input;
     }
 
     const validateMarkers: boolean[] | undefined = getOwnReflectMetadata<
@@ -69,11 +66,11 @@ export class OpenApiValidationPipe implements Pipe {
     );
 
     if (validateMarkers?.[metadata.parameterIndex] !== true) {
-      return awaitedInput;
+      return input;
     }
 
-    if (awaitedInput === null || typeof awaitedInput !== 'object') {
-      return awaitedInput;
+    if (input === null || typeof input !== 'object') {
+      return input;
     }
 
     const ajv: Ajv = this.#getOrInitAjv();
@@ -81,7 +78,7 @@ export class OpenApiValidationPipe implements Pipe {
     return handler(
       ajv,
       this.#openApiObject,
-      awaitedInput,
+      input,
       this.#validationCache.getOrCreate.bind(this.#validationCache),
     );
   }

--- a/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot2/OpenApiValidationPipe.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot2/OpenApiValidationPipe.ts
@@ -42,9 +42,6 @@ export class OpenApiValidationPipe implements Pipe {
     input: unknown,
     metadata: PipeMetadata,
   ): Promise<unknown> {
-    // TODO: Implement async custom decorators, then remove this workaround
-    const awaitedInput: unknown = await input;
-
     const parameterMetadataList: (
       | ControllerMethodParameterMetadata
       | undefined
@@ -57,7 +54,7 @@ export class OpenApiValidationPipe implements Pipe {
       parameterMetadataList[metadata.parameterIndex];
 
     if (parameterMetadata === undefined) {
-      return awaitedInput;
+      return input;
     }
 
     const validateMarkers: boolean[] | undefined = getOwnReflectMetadata<
@@ -69,11 +66,11 @@ export class OpenApiValidationPipe implements Pipe {
     );
 
     if (validateMarkers?.[metadata.parameterIndex] !== true) {
-      return awaitedInput;
+      return input;
     }
 
-    if (awaitedInput === null || typeof awaitedInput !== 'object') {
-      return awaitedInput;
+    if (input === null || typeof input !== 'object') {
+      return input;
     }
 
     const ajv: Ajv = this.#getOrInitAjv();
@@ -81,7 +78,7 @@ export class OpenApiValidationPipe implements Pipe {
     return handler(
       ajv,
       this.#openApiObject,
-      awaitedInput,
+      input,
       this.#validationCache.getOrCreate.bind(this.#validationCache),
     );
   }


### PR DESCRIPTION
### Changed
- Updated `InversifyHttpAdapter` to properly await for custom decorator params.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `InversifyHttpAdapter` to correctly await custom decorator parameters during request processing.
  * Fixed `OpenApiValidationPipe` to properly handle input parameter values without unnecessary awaiting.

* **Documentation**
  * Enhanced decorator documentation with improved internal linking for better navigation and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->