### PR TITLE
Update OpenApiValidationPipe

### DIFF
--- a/packages/framework/validation/libraries/openapi/package.json
+++ b/packages/framework/validation/libraries/openapi/package.json
@@ -9,6 +9,8 @@
     "@inversifyjs/http-core": "workspace:*",
     "@inversifyjs/http-open-api": "workspace:*",
     "@inversifyjs/json-schema-pointer": "workspace:*",
+    "@inversifyjs/json-schema-utils": "workspace:*",
+    "@inversifyjs/open-api-utils": "workspace:*",
     "@inversifyjs/reflect-metadata-utils": "1.5.0",
     "@inversifyjs/validation-common": "workspace:*"
   },

--- a/packages/framework/validation/libraries/openapi/src/metadata/decorators/ValidatedBody.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/metadata/decorators/ValidatedBody.spec.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
 vitest.mock(import('@inversifyjs/http-core'));
 vitest.mock(import('../actions/setValidateMetadata.js'));
 vitest.mock(import('../../validation/calculations/getMimeType.js'));
+vitest.mock(import('../../validation/calculations/getPath.js'));
 
 import {
   createCustomParameterDecorator,
@@ -10,6 +11,7 @@ import {
 } from '@inversifyjs/http-core';
 
 import { getMimeType } from '../../validation/calculations/getMimeType.js';
+import { getPath } from '../../validation/calculations/getPath.js';
 import { type BodyValidationInputParam } from '../../validation/models/BodyValidationInputParam.js';
 import { validatedInputParamBodyType } from '../../validation/models/validatedInputParamTypes.js';
 import { setValidateMetadata } from '../actions/setValidateMetadata.js';
@@ -113,6 +115,7 @@ describe(ValidatedBody, () => {
       let bodyFixture: object;
       let methodFixture: string;
       let urlFixture: string;
+      let pathFixture: string;
       let mimeTypeFixture: string;
       let result: unknown;
 
@@ -122,9 +125,11 @@ describe(ValidatedBody, () => {
         bodyFixture = { name: 'test' };
         methodFixture = 'POST';
         urlFixture = '/users';
+        pathFixture = '/users';
         mimeTypeFixture = 'application/json';
 
         vitest.mocked(getMimeType).mockReturnValueOnce(mimeTypeFixture);
+        vitest.mocked(getPath).mockReturnValueOnce(pathFixture);
 
         result = await handler(requestFixture, responseFixture, {
           getBody: vitest.fn().mockResolvedValueOnce(bodyFixture),
@@ -153,9 +158,9 @@ describe(ValidatedBody, () => {
         const expected: BodyValidationInputParam<unknown> = {
           body: bodyFixture,
           contentType: mimeTypeFixture,
-          method: methodFixture,
+          method: methodFixture.toLowerCase(),
+          path: pathFixture,
           type: validatedInputParamBodyType,
-          url: urlFixture,
         };
 
         expect(result).toStrictEqual(expected);
@@ -168,6 +173,7 @@ describe(ValidatedBody, () => {
       let bodyFixture: object;
       let methodFixture: string;
       let urlFixture: string;
+      let pathFixture: string;
       let mimeTypeFixture: string;
       let result: unknown;
 
@@ -177,9 +183,11 @@ describe(ValidatedBody, () => {
         bodyFixture = { name: 'test' };
         methodFixture = 'PUT';
         urlFixture = '/items';
+        pathFixture = '/items';
         mimeTypeFixture = 'text/plain';
 
         vitest.mocked(getMimeType).mockReturnValueOnce(mimeTypeFixture);
+        vitest.mocked(getPath).mockReturnValueOnce(pathFixture);
 
         result = await handler(requestFixture, responseFixture, {
           getBody: vitest.fn().mockResolvedValueOnce(bodyFixture),
@@ -204,9 +212,9 @@ describe(ValidatedBody, () => {
         const expected: BodyValidationInputParam<unknown> = {
           body: bodyFixture,
           contentType: mimeTypeFixture,
-          method: methodFixture,
+          method: methodFixture.toLowerCase(),
+          path: pathFixture,
           type: validatedInputParamBodyType,
-          url: urlFixture,
         };
 
         expect(result).toStrictEqual(expected);
@@ -219,6 +227,7 @@ describe(ValidatedBody, () => {
       let bodyFixture: object;
       let methodFixture: string;
       let urlFixture: string;
+      let pathFixture: string;
       let result: unknown;
 
       beforeAll(async () => {
@@ -227,6 +236,9 @@ describe(ValidatedBody, () => {
         bodyFixture = { name: 'test' };
         methodFixture = 'PATCH';
         urlFixture = '/items/1';
+        pathFixture = '/items/1';
+
+        vitest.mocked(getPath).mockReturnValueOnce(pathFixture);
 
         result = await handler(requestFixture, responseFixture, {
           getBody: vitest.fn().mockResolvedValueOnce(bodyFixture),
@@ -251,9 +263,9 @@ describe(ValidatedBody, () => {
         const expected: BodyValidationInputParam<unknown> = {
           body: bodyFixture,
           contentType: undefined,
-          method: methodFixture,
+          method: methodFixture.toLowerCase(),
+          path: pathFixture,
           type: validatedInputParamBodyType,
-          url: urlFixture,
         };
 
         expect(result).toStrictEqual(expected);
@@ -266,6 +278,7 @@ describe(ValidatedBody, () => {
       let bodyFixture: object;
       let methodFixture: string;
       let urlFixture: string;
+      let pathFixture: string;
       let result: unknown;
 
       beforeAll(async () => {
@@ -274,6 +287,9 @@ describe(ValidatedBody, () => {
         bodyFixture = { name: 'test' };
         methodFixture = 'DELETE';
         urlFixture = '/items/2';
+        pathFixture = '/items/2';
+
+        vitest.mocked(getPath).mockReturnValueOnce(pathFixture);
 
         result = await handler(requestFixture, responseFixture, {
           getBody: vitest.fn().mockResolvedValueOnce(bodyFixture),
@@ -298,9 +314,9 @@ describe(ValidatedBody, () => {
         const expected: BodyValidationInputParam<unknown> = {
           body: bodyFixture,
           contentType: undefined,
-          method: methodFixture,
+          method: methodFixture.toLowerCase(),
+          path: pathFixture,
           type: validatedInputParamBodyType,
-          url: urlFixture,
         };
 
         expect(result).toStrictEqual(expected);
@@ -313,6 +329,7 @@ describe(ValidatedBody, () => {
       let bodyFixture: object;
       let methodFixture: string;
       let urlFixture: string;
+      let pathFixture: string;
       let result: unknown;
 
       beforeAll(async () => {
@@ -321,6 +338,9 @@ describe(ValidatedBody, () => {
         bodyFixture = {};
         methodFixture = 'POST';
         urlFixture = '/empty';
+        pathFixture = '/empty';
+
+        vitest.mocked(getPath).mockReturnValueOnce(pathFixture);
 
         result = await handler(requestFixture, responseFixture, {
           getBody: vitest.fn().mockResolvedValueOnce(bodyFixture),
@@ -345,9 +365,9 @@ describe(ValidatedBody, () => {
         const expected: BodyValidationInputParam<unknown> = {
           body: bodyFixture,
           contentType: undefined,
-          method: methodFixture,
+          method: methodFixture.toLowerCase(),
+          path: pathFixture,
           type: validatedInputParamBodyType,
-          url: urlFixture,
         };
 
         expect(result).toStrictEqual(expected);

--- a/packages/framework/validation/libraries/openapi/src/metadata/decorators/ValidatedBody.ts
+++ b/packages/framework/validation/libraries/openapi/src/metadata/decorators/ValidatedBody.ts
@@ -4,6 +4,7 @@ import {
 } from '@inversifyjs/http-core';
 
 import { getMimeType } from '../../validation/calculations/getMimeType.js';
+import { getPath } from '../../validation/calculations/getPath.js';
 import { type BodyValidationInputParam } from '../../validation/models/BodyValidationInputParam.js';
 import { validatedInputParamBodyType } from '../../validation/models/validatedInputParamTypes.js';
 import { setValidateMetadata } from '../actions/setValidateMetadata.js';
@@ -30,7 +31,7 @@ export function ValidatedBody(): ParameterDecorator {
 
         const body: unknown = await options.getBody(request, response);
 
-        const method: string = options.getMethod(request);
+        const method: string = options.getMethod(request).toLowerCase();
         const url: string = options.getUrl(request);
 
         const contentType: string | undefined =
@@ -46,8 +47,8 @@ export function ValidatedBody(): ParameterDecorator {
           body,
           contentType,
           method,
+          path: getPath(url),
           type: validatedInputParamBodyType,
-          url,
         };
       },
     )(target, key, index);

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/buildCompositeValidationHandler.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/buildCompositeValidationHandler.spec.ts
@@ -13,6 +13,7 @@ import type Ajv from 'ajv';
 import { type DiscriminatorValidationHandlerPair } from '../models/DiscriminatorValidationHandlerPair.js';
 import { type ValidationInputParam } from '../models/ValidatedDecoratorResult.js';
 import { type ValidationHandler } from '../models/ValidationHandler.js';
+import { type OpenApiResolver } from '../services/OpenApiResolver.js';
 import { buildCompositeValidationHandler } from './buildCompositeValidationHandler.js';
 
 describe(buildCompositeValidationHandler, () => {
@@ -30,6 +31,7 @@ describe(buildCompositeValidationHandler, () => {
         result = buildCompositeValidationHandler([])(
           Symbol() as unknown as Ajv,
           Symbol(),
+          Symbol() as unknown as OpenApiResolver,
           inputParam,
           vitest.fn(),
         );
@@ -55,6 +57,7 @@ describe(buildCompositeValidationHandler, () => {
         result = buildCompositeValidationHandler([])(
           Symbol() as unknown as Ajv,
           Symbol(),
+          Symbol() as unknown as OpenApiResolver,
           inputParam,
           vitest.fn(),
         );
@@ -80,6 +83,7 @@ describe(buildCompositeValidationHandler, () => {
         result = buildCompositeValidationHandler([])(
           Symbol() as unknown as Ajv,
           Symbol(),
+          Symbol() as unknown as OpenApiResolver,
           inputParam,
           vitest.fn(),
         );
@@ -110,6 +114,7 @@ describe(buildCompositeValidationHandler, () => {
     let getEntryMock: Mock;
     let inputParam: unknown;
     let openApiObjectFixture: unknown;
+    let openApiResolverFixture: OpenApiResolver;
 
     beforeAll(() => {
       const discriminatorValue: symbol = Symbol();
@@ -122,6 +127,7 @@ describe(buildCompositeValidationHandler, () => {
         type: discriminatorValue,
       };
       openApiObjectFixture = Symbol();
+      openApiResolverFixture = Symbol() as unknown as OpenApiResolver;
     });
 
     describe('when called', () => {
@@ -137,6 +143,7 @@ describe(buildCompositeValidationHandler, () => {
         result = buildCompositeValidationHandler([discriminatorHandlerPair])(
           ajvFixture,
           openApiObjectFixture,
+          openApiResolverFixture,
           inputParam,
           getEntryMock,
         );
@@ -150,6 +157,7 @@ describe(buildCompositeValidationHandler, () => {
         expect(handlerMock).toHaveBeenCalledExactlyOnceWith(
           ajvFixture,
           openApiObjectFixture,
+          openApiResolverFixture,
           inputParam,
           getEntryMock,
         );

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/buildCompositeValidationHandler.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/buildCompositeValidationHandler.ts
@@ -2,6 +2,7 @@ import type Ajv from 'ajv';
 
 import { type ValidationInputParam } from '../models/ValidatedDecoratorResult.js';
 import { type ValidationHandler } from '../models/ValidationHandler.js';
+import { type OpenApiResolver } from '../services/OpenApiResolver.js';
 
 type DiscriminatorValidationHandlerPair<
   TDiscriminatorValue extends symbol,
@@ -42,6 +43,7 @@ export function buildCompositeValidationHandler<
   return (
     ajv: Ajv,
     openApiObject: TOpenApiObject,
+    openApiResolver: OpenApiResolver,
     inputParam: unknown,
     getEntry: (path: string, method: string) => TValidationCacheEntry,
   ): unknown => {
@@ -66,6 +68,7 @@ export function buildCompositeValidationHandler<
     return handler(
       ajv,
       openApiObject,
+      openApiResolver,
       inputParam as ValidationInputParam,
       getEntry,
     );

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getRequestBodyObject.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getRequestBodyObject.spec.ts
@@ -1,10 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
 
-vitest.mock(import('@inversifyjs/json-schema-pointer'));
-
-import { resolveJsonPointer } from '@inversifyjs/json-schema-pointer';
 import {
-  type OpenApi3Dot1Object,
   type OpenApi3Dot1OperationObject,
   type OpenApi3Dot1RequestBodyObject,
 } from '@inversifyjs/open-api-types/v3Dot1';
@@ -13,17 +9,26 @@ import {
   InversifyValidationErrorKind,
 } from '@inversifyjs/validation-common';
 
+import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
 import { getRequestBodyObject } from './getRequestBodyObject.js';
 
 describe(getRequestBodyObject, () => {
-  let openApiObjectFixture: OpenApi3Dot1Object;
-  let methodFixture: string;
-  let pathFixture: string;
+  let openApiResolverMock: OpenApiResolver;
+  let inputParamFixture: BodyValidationInputParam<unknown>;
 
   beforeAll(() => {
-    openApiObjectFixture = Symbol() as unknown as OpenApi3Dot1Object;
-    methodFixture = 'post';
-    pathFixture = '/users';
+    openApiResolverMock = {
+      deepResolveReference: vitest.fn(),
+      resolveReference: vitest.fn(),
+    };
+    inputParamFixture = {
+      body: { name: 'test' },
+      contentType: 'application/json',
+      method: 'post',
+      path: '/users',
+      type: Symbol() as unknown as BodyValidationInputParam<unknown>['type'],
+    };
   });
 
   describe('having an operationObject with no requestBody', () => {
@@ -41,10 +46,9 @@ describe(getRequestBodyObject, () => {
       beforeAll(() => {
         try {
           getRequestBodyObject(
-            openApiObjectFixture,
+            openApiResolverMock,
             operationObjectFixture,
-            methodFixture,
-            pathFixture,
+            inputParamFixture,
           );
         } catch (error: unknown) {
           result = error;
@@ -54,7 +58,7 @@ describe(getRequestBodyObject, () => {
       it('should throw an InversifyValidationError', () => {
         const expectedErrorProperties: Partial<InversifyValidationError> = {
           kind: InversifyValidationErrorKind.validationFailed,
-          message: `No requestBody found for method ${methodFixture} for path ${pathFixture}`,
+          message: `No requestBody found for method ${inputParamFixture.method} for path ${inputParamFixture.path}`,
         };
 
         expect(result).toBeInstanceOf(InversifyValidationError);
@@ -84,10 +88,9 @@ describe(getRequestBodyObject, () => {
 
       beforeAll(() => {
         result = getRequestBodyObject(
-          openApiObjectFixture,
+          openApiResolverMock,
           operationObjectFixture,
-          methodFixture,
-          pathFixture,
+          inputParamFixture,
         );
       });
 
@@ -115,14 +118,15 @@ describe(getRequestBodyObject, () => {
       let result: unknown;
 
       beforeAll(() => {
-        vitest.mocked(resolveJsonPointer).mockReturnValueOnce(undefined);
+        vitest
+          .mocked(openApiResolverMock.deepResolveReference)
+          .mockReturnValueOnce(undefined);
 
         try {
           getRequestBodyObject(
-            openApiObjectFixture,
+            openApiResolverMock,
             operationObjectFixture,
-            methodFixture,
-            pathFixture,
+            inputParamFixture,
           );
         } catch (error: unknown) {
           result = error;
@@ -133,11 +137,10 @@ describe(getRequestBodyObject, () => {
         vitest.clearAllMocks();
       });
 
-      it('should call resolveJsonPointer()', () => {
-        expect(resolveJsonPointer).toHaveBeenCalledExactlyOnceWith(
-          openApiObjectFixture,
-          refFixture,
-        );
+      it('should call openApiResolver.deepResolveReference()', () => {
+        expect(
+          openApiResolverMock.deepResolveReference,
+        ).toHaveBeenCalledExactlyOnceWith(refFixture);
       });
 
       it('should throw an InversifyValidationError', () => {
@@ -170,14 +173,15 @@ describe(getRequestBodyObject, () => {
       let result: unknown;
 
       beforeAll(() => {
-        vitest.mocked(resolveJsonPointer).mockReturnValueOnce(null);
+        vitest
+          .mocked(openApiResolverMock.deepResolveReference)
+          .mockReturnValueOnce(null);
 
         try {
           getRequestBodyObject(
-            openApiObjectFixture,
+            openApiResolverMock,
             operationObjectFixture,
-            methodFixture,
-            pathFixture,
+            inputParamFixture,
           );
         } catch (error: unknown) {
           result = error;
@@ -188,11 +192,10 @@ describe(getRequestBodyObject, () => {
         vitest.clearAllMocks();
       });
 
-      it('should call resolveJsonPointer()', () => {
-        expect(resolveJsonPointer).toHaveBeenCalledExactlyOnceWith(
-          openApiObjectFixture,
-          refFixture,
-        );
+      it('should call openApiResolver.deepResolveReference()', () => {
+        expect(
+          openApiResolverMock.deepResolveReference,
+        ).toHaveBeenCalledExactlyOnceWith(refFixture);
       });
 
       it('should throw an InversifyValidationError', () => {
@@ -225,14 +228,15 @@ describe(getRequestBodyObject, () => {
       let result: unknown;
 
       beforeAll(() => {
-        vitest.mocked(resolveJsonPointer).mockReturnValueOnce([]);
+        vitest
+          .mocked(openApiResolverMock.deepResolveReference)
+          .mockReturnValueOnce([]);
 
         try {
           getRequestBodyObject(
-            openApiObjectFixture,
+            openApiResolverMock,
             operationObjectFixture,
-            methodFixture,
-            pathFixture,
+            inputParamFixture,
           );
         } catch (error: unknown) {
           result = error;
@@ -243,11 +247,10 @@ describe(getRequestBodyObject, () => {
         vitest.clearAllMocks();
       });
 
-      it('should call resolveJsonPointer()', () => {
-        expect(resolveJsonPointer).toHaveBeenCalledExactlyOnceWith(
-          openApiObjectFixture,
-          refFixture,
-        );
+      it('should call openApiResolver.deepResolveReference()', () => {
+        expect(
+          openApiResolverMock.deepResolveReference,
+        ).toHaveBeenCalledExactlyOnceWith(refFixture);
       });
 
       it('should throw an InversifyValidationError', () => {
@@ -287,18 +290,17 @@ describe(getRequestBodyObject, () => {
 
       beforeAll(() => {
         vitest
-          .mocked(resolveJsonPointer)
+          .mocked(openApiResolverMock.deepResolveReference)
           .mockReturnValueOnce(
             resolvedObjectFixture as unknown as ReturnType<
-              typeof resolveJsonPointer
+              typeof openApiResolverMock.deepResolveReference
             >,
           );
 
         result = getRequestBodyObject(
-          openApiObjectFixture,
+          openApiResolverMock,
           operationObjectFixture,
-          methodFixture,
-          pathFixture,
+          inputParamFixture,
         );
       });
 
@@ -306,11 +308,10 @@ describe(getRequestBodyObject, () => {
         vitest.clearAllMocks();
       });
 
-      it('should call resolveJsonPointer()', () => {
-        expect(resolveJsonPointer).toHaveBeenCalledExactlyOnceWith(
-          openApiObjectFixture,
-          refFixture,
-        );
+      it('should call openApiResolver.deepResolveReference()', () => {
+        expect(
+          openApiResolverMock.deepResolveReference,
+        ).toHaveBeenCalledExactlyOnceWith(refFixture);
       });
 
       it('should return expected result', () => {

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getRequestBodyObject.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getRequestBodyObject.ts
@@ -1,10 +1,8 @@
-import { resolveJsonPointer } from '@inversifyjs/json-schema-pointer';
 import {
   type JsonValue,
   type JsonValueObject,
 } from '@inversifyjs/json-schema-types';
 import {
-  type OpenApi3Dot1Object,
   type OpenApi3Dot1OperationObject,
   type OpenApi3Dot1ReferenceObject,
   type OpenApi3Dot1RequestBodyObject,
@@ -14,11 +12,13 @@ import {
   InversifyValidationErrorKind,
 } from '@inversifyjs/validation-common';
 
+import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
+
 export function getRequestBodyObject(
-  openApiObject: OpenApi3Dot1Object,
+  openApiResolver: OpenApiResolver,
   operationObject: OpenApi3Dot1OperationObject,
-  method: string,
-  path: string,
+  inputParam: BodyValidationInputParam<unknown>,
 ): OpenApi3Dot1RequestBodyObject {
   const requestBodyObject:
     | OpenApi3Dot1RequestBodyObject
@@ -28,22 +28,20 @@ export function getRequestBodyObject(
   if (requestBodyObject === undefined) {
     throw new InversifyValidationError(
       InversifyValidationErrorKind.validationFailed,
-      `No requestBody found for method ${method} for path ${path}`,
+      `No requestBody found for method ${inputParam.method} for path ${inputParam.path}`,
     );
   }
 
-  let ref: string | undefined = (
+  const ref: string | undefined = (
     requestBodyObject as Partial<OpenApi3Dot1ReferenceObject>
   ).$ref;
 
   let derreferencedRequestBodyObject: JsonValueObject | undefined =
     requestBodyObject as unknown as JsonValueObject;
 
-  while (ref !== undefined) {
-    const resolvedRef: JsonValue | undefined = resolveJsonPointer(
-      openApiObject as unknown as JsonValue,
-      ref,
-    );
+  if (ref !== undefined) {
+    const resolvedRef: JsonValue | undefined =
+      openApiResolver.deepResolveReference(ref);
 
     if (resolvedRef === undefined) {
       throw new InversifyValidationError(
@@ -64,10 +62,6 @@ export function getRequestBodyObject(
     }
 
     derreferencedRequestBodyObject = resolvedRef;
-
-    ref = (
-      derreferencedRequestBodyObject as Partial<OpenApi3Dot1ReferenceObject>
-    ).$ref;
   }
 
   return derreferencedRequestBodyObject as unknown as OpenApi3Dot1RequestBodyObject;

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleBodyValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleBodyValidation.spec.ts
@@ -10,7 +10,6 @@ import {
 } from 'vitest';
 
 vitest.mock(import('@inversifyjs/json-schema-pointer'));
-vitest.mock(import('../getPath.js'));
 vitest.mock(import('./getOperationObject.js'));
 vitest.mock(import('./getRequestBodyObject.js'));
 vitest.mock(import('./inferContentType.js'));
@@ -31,7 +30,7 @@ import { type ValidateFunction } from 'ajv';
 import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
 import { SCHEMA_ID } from '../../models/v3Dot1/schemaId.js';
 import { type ValidationCacheEntry } from '../../models/v3Dot1/ValidationCacheEntry.js';
-import { getPath } from '../getPath.js';
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
 import { getOperationObject } from './getOperationObject.js';
 import { getRequestBodyObject } from './getRequestBodyObject.js';
 import { handleBodyValidation } from './handleBodyValidation.js';
@@ -39,9 +38,11 @@ import { inferContentType } from './inferContentType.js';
 
 describe(handleBodyValidation, () => {
   let openApiObjectFixture: OpenApi3Dot1Object;
+  let openApiResolverFixture: OpenApiResolver;
 
   beforeAll(() => {
     openApiObjectFixture = Symbol() as unknown as OpenApi3Dot1Object;
+    openApiResolverFixture = Symbol() as unknown as OpenApiResolver;
   });
 
   describe('having an inputParam with contentType', () => {
@@ -60,9 +61,9 @@ describe(handleBodyValidation, () => {
       inputParamFixture = {
         body: { name: 'test' },
         contentType: contentTypeFixture,
-        method: 'POST',
+        method: methodFixture,
+        path: pathFixture,
         type: Symbol() as unknown as BodyValidationInputParam<unknown>['type'],
-        url: '/users?page=1',
       };
       operationObjectFixture =
         Symbol() as unknown as OpenApi3Dot1OperationObject;
@@ -95,7 +96,6 @@ describe(handleBodyValidation, () => {
           .fn<(path: string, method: string) => ValidationCacheEntry>()
           .mockReturnValueOnce(validationCacheEntryFixture);
 
-        vitest.mocked(getPath).mockReturnValueOnce(pathFixture);
         vitest
           .mocked(getOperationObject)
           .mockReturnValueOnce(operationObjectFixture);
@@ -110,6 +110,7 @@ describe(handleBodyValidation, () => {
           handleBodyValidation(
             ajvMock,
             openApiObjectFixture,
+            openApiResolverFixture,
             inputParamFixture,
             getEntryMock,
           );
@@ -120,10 +121,6 @@ describe(handleBodyValidation, () => {
 
       afterAll(() => {
         vitest.clearAllMocks();
-      });
-
-      it('should call getPath()', () => {
-        expect(getPath).toHaveBeenCalledExactlyOnceWith(inputParamFixture.url);
       });
 
       it('should call getEntry()', () => {
@@ -143,10 +140,9 @@ describe(handleBodyValidation, () => {
 
       it('should call getRequestBodyObject()', () => {
         expect(getRequestBodyObject).toHaveBeenCalledExactlyOnceWith(
-          openApiObjectFixture,
+          openApiResolverFixture,
           operationObjectFixture,
-          methodFixture,
-          pathFixture,
+          inputParamFixture,
         );
       });
 
@@ -209,7 +205,6 @@ describe(handleBodyValidation, () => {
           .fn<(path: string, method: string) => ValidationCacheEntry>()
           .mockReturnValueOnce(validationCacheEntryFixture);
 
-        vitest.mocked(getPath).mockReturnValueOnce(pathFixture);
         vitest
           .mocked(getOperationObject)
           .mockReturnValueOnce(operationObjectFixture);
@@ -223,6 +218,7 @@ describe(handleBodyValidation, () => {
         result = handleBodyValidation(
           ajvMock,
           openApiObjectFixture,
+          openApiResolverFixture,
           inputParamFixture,
           getEntryMock,
         );
@@ -230,10 +226,6 @@ describe(handleBodyValidation, () => {
 
       afterAll(() => {
         vitest.clearAllMocks();
-      });
-
-      it('should call getPath()', () => {
-        expect(getPath).toHaveBeenCalledExactlyOnceWith(inputParamFixture.url);
       });
 
       it('should call getEntry()', () => {
@@ -253,10 +245,9 @@ describe(handleBodyValidation, () => {
 
       it('should call getRequestBodyObject()', () => {
         expect(getRequestBodyObject).toHaveBeenCalledExactlyOnceWith(
-          openApiObjectFixture,
+          openApiResolverFixture,
           operationObjectFixture,
-          methodFixture,
-          pathFixture,
+          inputParamFixture,
         );
       });
 
@@ -302,7 +293,6 @@ describe(handleBodyValidation, () => {
           .fn<(path: string, method: string) => ValidationCacheEntry>()
           .mockReturnValueOnce(validationCacheEntryFixture);
 
-        vitest.mocked(getPath).mockReturnValueOnce(pathFixture);
         vitest
           .mocked(getOperationObject)
           .mockReturnValueOnce(operationObjectFixture);
@@ -317,6 +307,7 @@ describe(handleBodyValidation, () => {
           handleBodyValidation(
             ajvMock,
             openApiObjectFixture,
+            openApiResolverFixture,
             inputParamFixture,
             getEntryMock,
           );
@@ -358,9 +349,9 @@ describe(handleBodyValidation, () => {
       inputParamFixture = {
         body: { name: 'test' },
         contentType: undefined,
-        method: 'POST',
+        method: methodFixture,
+        path: pathFixture,
         type: Symbol() as unknown as BodyValidationInputParam<unknown>['type'],
-        url: '/users',
       };
       operationObjectFixture =
         Symbol() as unknown as OpenApi3Dot1OperationObject;
@@ -395,7 +386,6 @@ describe(handleBodyValidation, () => {
           .fn<(path: string, method: string) => ValidationCacheEntry>()
           .mockReturnValueOnce(validationCacheEntryFixture);
 
-        vitest.mocked(getPath).mockReturnValueOnce(pathFixture);
         vitest
           .mocked(getOperationObject)
           .mockReturnValueOnce(operationObjectFixture);
@@ -412,6 +402,7 @@ describe(handleBodyValidation, () => {
         result = handleBodyValidation(
           ajvMock,
           openApiObjectFixture,
+          openApiResolverFixture,
           inputParamFixture,
           getEntryMock,
         );

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleBodyValidation.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleBodyValidation.ts
@@ -14,7 +14,7 @@ import { type ErrorObject, type ValidateFunction } from 'ajv';
 import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
 import { SCHEMA_ID } from '../../models/v3Dot1/schemaId.js';
 import { type ValidationCacheEntry } from '../../models/v3Dot1/ValidationCacheEntry.js';
-import { getPath } from '../getPath.js';
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
 import { getOperationObject } from './getOperationObject.js';
 import { getRequestBodyObject } from './getRequestBodyObject.js';
 import { inferContentType } from './inferContentType.js';
@@ -22,26 +22,26 @@ import { inferContentType } from './inferContentType.js';
 function getValidateFunction(
   ajv: Ajv,
   openApiObject: OpenApi3Dot1Object,
-  path: string,
-  method: string,
-  contentType: string | undefined,
+  openApiResolver: OpenApiResolver,
+  inputParam: BodyValidationInputParam<unknown>,
 ): ValidateFunction {
   const operationObject: OpenApi3Dot1OperationObject = getOperationObject(
     openApiObject,
-    method,
-    path,
+    inputParam.method,
+    inputParam.path,
   );
 
   const openApi3Dot1RequestBodyObject: OpenApi3Dot1RequestBodyObject =
-    getRequestBodyObject(openApiObject, operationObject, method, path);
+    getRequestBodyObject(openApiResolver, operationObject, inputParam);
 
   const inferredContentType: string =
-    contentType ?? inferContentType(openApi3Dot1RequestBodyObject, method);
+    inputParam.contentType ??
+    inferContentType(openApi3Dot1RequestBodyObject, inputParam.method);
 
   const schemaPointer: string = `${SCHEMA_ID}#/${escapeJsonPointerFragments(
     'paths',
-    path,
-    method,
+    inputParam.path,
+    inputParam.method,
     'requestBody',
     'content',
     inferredContentType,
@@ -63,14 +63,16 @@ function getValidateFunction(
 export function handleBodyValidation(
   ajv: Ajv,
   openApiObject: OpenApi3Dot1Object,
+  openApiResolver: OpenApiResolver,
   inputParam: BodyValidationInputParam<unknown>,
   getEntry: (path: string, method: string) => ValidationCacheEntry,
 ): unknown {
-  const path: string = getPath(inputParam.url);
-  const method: string = inputParam.method.toLowerCase();
   const contentType: string | undefined = inputParam.contentType;
 
-  const validationCacheEntry: ValidationCacheEntry = getEntry(path, method);
+  const validationCacheEntry: ValidationCacheEntry = getEntry(
+    inputParam.path,
+    inputParam.method,
+  );
 
   let validate: ValidateFunction | undefined =
     validationCacheEntry.body.get(contentType);
@@ -79,9 +81,8 @@ export function handleBodyValidation(
     validate = getValidateFunction(
       ajv,
       openApiObject,
-      path,
-      method,
-      contentType,
+      openApiResolver,
+      inputParam,
     );
 
     validationCacheEntry.body.set(contentType, validate);

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getRequestBodyObject.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getRequestBodyObject.spec.ts
@@ -1,10 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
 
-vitest.mock(import('@inversifyjs/json-schema-pointer'));
-
-import { resolveJsonPointer } from '@inversifyjs/json-schema-pointer';
 import {
-  type OpenApi3Dot2Object,
   type OpenApi3Dot2OperationObject,
   type OpenApi3Dot2RequestBodyObject,
 } from '@inversifyjs/open-api-types/v3Dot2';
@@ -13,17 +9,26 @@ import {
   InversifyValidationErrorKind,
 } from '@inversifyjs/validation-common';
 
+import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
 import { getRequestBodyObject } from './getRequestBodyObject.js';
 
 describe(getRequestBodyObject, () => {
-  let openApiObjectFixture: OpenApi3Dot2Object;
-  let methodFixture: string;
-  let pathFixture: string;
+  let openApiResolverMock: OpenApiResolver;
+  let inputParamFixture: BodyValidationInputParam<unknown>;
 
   beforeAll(() => {
-    openApiObjectFixture = Symbol() as unknown as OpenApi3Dot2Object;
-    methodFixture = 'post';
-    pathFixture = '/users';
+    openApiResolverMock = {
+      deepResolveReference: vitest.fn(),
+      resolveReference: vitest.fn(),
+    };
+    inputParamFixture = {
+      body: { name: 'test' },
+      contentType: 'application/json',
+      method: 'post',
+      path: '/users',
+      type: Symbol() as unknown as BodyValidationInputParam<unknown>['type'],
+    };
   });
 
   describe('having an operationObject with no requestBody', () => {
@@ -41,10 +46,9 @@ describe(getRequestBodyObject, () => {
       beforeAll(() => {
         try {
           getRequestBodyObject(
-            openApiObjectFixture,
+            openApiResolverMock,
             operationObjectFixture,
-            methodFixture,
-            pathFixture,
+            inputParamFixture,
           );
         } catch (error: unknown) {
           result = error;
@@ -54,7 +58,7 @@ describe(getRequestBodyObject, () => {
       it('should throw an InversifyValidationError', () => {
         const expectedErrorProperties: Partial<InversifyValidationError> = {
           kind: InversifyValidationErrorKind.validationFailed,
-          message: `No requestBody found for method ${methodFixture} for path ${pathFixture}`,
+          message: `No requestBody found for method ${inputParamFixture.method} for path ${inputParamFixture.path}`,
         };
 
         expect(result).toBeInstanceOf(InversifyValidationError);
@@ -84,10 +88,9 @@ describe(getRequestBodyObject, () => {
 
       beforeAll(() => {
         result = getRequestBodyObject(
-          openApiObjectFixture,
+          openApiResolverMock,
           operationObjectFixture,
-          methodFixture,
-          pathFixture,
+          inputParamFixture,
         );
       });
 
@@ -115,14 +118,15 @@ describe(getRequestBodyObject, () => {
       let result: unknown;
 
       beforeAll(() => {
-        vitest.mocked(resolveJsonPointer).mockReturnValueOnce(undefined);
+        vitest
+          .mocked(openApiResolverMock.deepResolveReference)
+          .mockReturnValueOnce(undefined);
 
         try {
           getRequestBodyObject(
-            openApiObjectFixture,
+            openApiResolverMock,
             operationObjectFixture,
-            methodFixture,
-            pathFixture,
+            inputParamFixture,
           );
         } catch (error: unknown) {
           result = error;
@@ -133,11 +137,10 @@ describe(getRequestBodyObject, () => {
         vitest.clearAllMocks();
       });
 
-      it('should call resolveJsonPointer()', () => {
-        expect(resolveJsonPointer).toHaveBeenCalledExactlyOnceWith(
-          openApiObjectFixture,
-          refFixture,
-        );
+      it('should call openApiResolver.deepResolveReference()', () => {
+        expect(
+          openApiResolverMock.deepResolveReference,
+        ).toHaveBeenCalledExactlyOnceWith(refFixture);
       });
 
       it('should throw an InversifyValidationError', () => {
@@ -170,14 +173,15 @@ describe(getRequestBodyObject, () => {
       let result: unknown;
 
       beforeAll(() => {
-        vitest.mocked(resolveJsonPointer).mockReturnValueOnce(null);
+        vitest
+          .mocked(openApiResolverMock.deepResolveReference)
+          .mockReturnValueOnce(null);
 
         try {
           getRequestBodyObject(
-            openApiObjectFixture,
+            openApiResolverMock,
             operationObjectFixture,
-            methodFixture,
-            pathFixture,
+            inputParamFixture,
           );
         } catch (error: unknown) {
           result = error;
@@ -188,11 +192,10 @@ describe(getRequestBodyObject, () => {
         vitest.clearAllMocks();
       });
 
-      it('should call resolveJsonPointer()', () => {
-        expect(resolveJsonPointer).toHaveBeenCalledExactlyOnceWith(
-          openApiObjectFixture,
-          refFixture,
-        );
+      it('should call openApiResolver.deepResolveReference()', () => {
+        expect(
+          openApiResolverMock.deepResolveReference,
+        ).toHaveBeenCalledExactlyOnceWith(refFixture);
       });
 
       it('should throw an InversifyValidationError', () => {
@@ -225,14 +228,15 @@ describe(getRequestBodyObject, () => {
       let result: unknown;
 
       beforeAll(() => {
-        vitest.mocked(resolveJsonPointer).mockReturnValueOnce([]);
+        vitest
+          .mocked(openApiResolverMock.deepResolveReference)
+          .mockReturnValueOnce([]);
 
         try {
           getRequestBodyObject(
-            openApiObjectFixture,
+            openApiResolverMock,
             operationObjectFixture,
-            methodFixture,
-            pathFixture,
+            inputParamFixture,
           );
         } catch (error: unknown) {
           result = error;
@@ -243,11 +247,10 @@ describe(getRequestBodyObject, () => {
         vitest.clearAllMocks();
       });
 
-      it('should call resolveJsonPointer()', () => {
-        expect(resolveJsonPointer).toHaveBeenCalledExactlyOnceWith(
-          openApiObjectFixture,
-          refFixture,
-        );
+      it('should call openApiResolver.deepResolveReference()', () => {
+        expect(
+          openApiResolverMock.deepResolveReference,
+        ).toHaveBeenCalledExactlyOnceWith(refFixture);
       });
 
       it('should throw an InversifyValidationError', () => {
@@ -287,18 +290,17 @@ describe(getRequestBodyObject, () => {
 
       beforeAll(() => {
         vitest
-          .mocked(resolveJsonPointer)
+          .mocked(openApiResolverMock.deepResolveReference)
           .mockReturnValueOnce(
             resolvedObjectFixture as unknown as ReturnType<
-              typeof resolveJsonPointer
+              typeof openApiResolverMock.deepResolveReference
             >,
           );
 
         result = getRequestBodyObject(
-          openApiObjectFixture,
+          openApiResolverMock,
           operationObjectFixture,
-          methodFixture,
-          pathFixture,
+          inputParamFixture,
         );
       });
 
@@ -306,11 +308,10 @@ describe(getRequestBodyObject, () => {
         vitest.clearAllMocks();
       });
 
-      it('should call resolveJsonPointer()', () => {
-        expect(resolveJsonPointer).toHaveBeenCalledExactlyOnceWith(
-          openApiObjectFixture,
-          refFixture,
-        );
+      it('should call openApiResolver.deepResolveReference()', () => {
+        expect(
+          openApiResolverMock.deepResolveReference,
+        ).toHaveBeenCalledExactlyOnceWith(refFixture);
       });
 
       it('should return expected result', () => {

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getRequestBodyObject.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getRequestBodyObject.ts
@@ -1,10 +1,8 @@
-import { resolveJsonPointer } from '@inversifyjs/json-schema-pointer';
 import {
   type JsonValue,
   type JsonValueObject,
 } from '@inversifyjs/json-schema-types';
 import {
-  type OpenApi3Dot2Object,
   type OpenApi3Dot2OperationObject,
   type OpenApi3Dot2ReferenceObject,
   type OpenApi3Dot2RequestBodyObject,
@@ -14,11 +12,13 @@ import {
   InversifyValidationErrorKind,
 } from '@inversifyjs/validation-common';
 
+import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
+
 export function getRequestBodyObject(
-  openApiObject: OpenApi3Dot2Object,
+  openApiResolver: OpenApiResolver,
   operationObject: OpenApi3Dot2OperationObject,
-  method: string,
-  path: string,
+  inputParam: BodyValidationInputParam<unknown>,
 ): OpenApi3Dot2RequestBodyObject {
   const requestBodyObject:
     | OpenApi3Dot2RequestBodyObject
@@ -28,22 +28,20 @@ export function getRequestBodyObject(
   if (requestBodyObject === undefined) {
     throw new InversifyValidationError(
       InversifyValidationErrorKind.validationFailed,
-      `No requestBody found for method ${method} for path ${path}`,
+      `No requestBody found for method ${inputParam.method} for path ${inputParam.path}`,
     );
   }
 
-  let ref: string | undefined = (
+  const ref: string | undefined = (
     requestBodyObject as Partial<OpenApi3Dot2ReferenceObject>
   ).$ref;
 
   let derreferencedRequestBodyObject: JsonValueObject | undefined =
     requestBodyObject as unknown as JsonValueObject;
 
-  while (ref !== undefined) {
-    const resolvedRef: JsonValue | undefined = resolveJsonPointer(
-      openApiObject as unknown as JsonValue,
-      ref,
-    );
+  if (ref !== undefined) {
+    const resolvedRef: JsonValue | undefined =
+      openApiResolver.deepResolveReference(ref);
 
     if (resolvedRef === undefined) {
       throw new InversifyValidationError(
@@ -64,10 +62,6 @@ export function getRequestBodyObject(
     }
 
     derreferencedRequestBodyObject = resolvedRef;
-
-    ref = (
-      derreferencedRequestBodyObject as Partial<OpenApi3Dot2ReferenceObject>
-    ).$ref;
   }
 
   return derreferencedRequestBodyObject as unknown as OpenApi3Dot2RequestBodyObject;

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleBodyValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleBodyValidation.spec.ts
@@ -10,7 +10,6 @@ import {
 } from 'vitest';
 
 vitest.mock(import('@inversifyjs/json-schema-pointer'));
-vitest.mock(import('../getPath.js'));
 vitest.mock(import('./getOperationObject.js'));
 vitest.mock(import('./getRequestBodyObject.js'));
 vitest.mock(import('./inferContentType.js'));
@@ -31,7 +30,7 @@ import { type ValidateFunction } from 'ajv';
 import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
 import { SCHEMA_ID } from '../../models/v3Dot2/schemaId.js';
 import { type ValidationCacheEntry } from '../../models/v3Dot2/ValidationCacheEntry.js';
-import { getPath } from '../getPath.js';
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
 import { getOperationObject } from './getOperationObject.js';
 import { getRequestBodyObject } from './getRequestBodyObject.js';
 import { handleBodyValidation } from './handleBodyValidation.js';
@@ -39,9 +38,11 @@ import { inferContentType } from './inferContentType.js';
 
 describe(handleBodyValidation, () => {
   let openApiObjectFixture: OpenApi3Dot2Object;
+  let openApiResolverFixture: OpenApiResolver;
 
   beforeAll(() => {
     openApiObjectFixture = Symbol() as unknown as OpenApi3Dot2Object;
+    openApiResolverFixture = Symbol() as unknown as OpenApiResolver;
   });
 
   describe('having an inputParam with contentType', () => {
@@ -60,9 +61,9 @@ describe(handleBodyValidation, () => {
       inputParamFixture = {
         body: { name: 'test' },
         contentType: contentTypeFixture,
-        method: 'POST',
+        method: methodFixture,
+        path: pathFixture,
         type: Symbol() as unknown as BodyValidationInputParam<unknown>['type'],
-        url: '/users?page=1',
       };
       operationObjectFixture =
         Symbol() as unknown as OpenApi3Dot2OperationObject;
@@ -95,7 +96,6 @@ describe(handleBodyValidation, () => {
           .fn<(path: string, method: string) => ValidationCacheEntry>()
           .mockReturnValueOnce(validationCacheEntryFixture);
 
-        vitest.mocked(getPath).mockReturnValueOnce(pathFixture);
         vitest
           .mocked(getOperationObject)
           .mockReturnValueOnce(operationObjectFixture);
@@ -110,6 +110,7 @@ describe(handleBodyValidation, () => {
           handleBodyValidation(
             ajvMock,
             openApiObjectFixture,
+            openApiResolverFixture,
             inputParamFixture,
             getEntryMock,
           );
@@ -120,10 +121,6 @@ describe(handleBodyValidation, () => {
 
       afterAll(() => {
         vitest.clearAllMocks();
-      });
-
-      it('should call getPath()', () => {
-        expect(getPath).toHaveBeenCalledExactlyOnceWith(inputParamFixture.url);
       });
 
       it('should call getEntry()', () => {
@@ -143,10 +140,9 @@ describe(handleBodyValidation, () => {
 
       it('should call getRequestBodyObject()', () => {
         expect(getRequestBodyObject).toHaveBeenCalledExactlyOnceWith(
-          openApiObjectFixture,
+          openApiResolverFixture,
           operationObjectFixture,
-          methodFixture,
-          pathFixture,
+          inputParamFixture,
         );
       });
 
@@ -209,7 +205,6 @@ describe(handleBodyValidation, () => {
           .fn<(path: string, method: string) => ValidationCacheEntry>()
           .mockReturnValueOnce(validationCacheEntryFixture);
 
-        vitest.mocked(getPath).mockReturnValueOnce(pathFixture);
         vitest
           .mocked(getOperationObject)
           .mockReturnValueOnce(operationObjectFixture);
@@ -223,6 +218,7 @@ describe(handleBodyValidation, () => {
         result = handleBodyValidation(
           ajvMock,
           openApiObjectFixture,
+          openApiResolverFixture,
           inputParamFixture,
           getEntryMock,
         );
@@ -230,10 +226,6 @@ describe(handleBodyValidation, () => {
 
       afterAll(() => {
         vitest.clearAllMocks();
-      });
-
-      it('should call getPath()', () => {
-        expect(getPath).toHaveBeenCalledExactlyOnceWith(inputParamFixture.url);
       });
 
       it('should call getEntry()', () => {
@@ -253,10 +245,9 @@ describe(handleBodyValidation, () => {
 
       it('should call getRequestBodyObject()', () => {
         expect(getRequestBodyObject).toHaveBeenCalledExactlyOnceWith(
-          openApiObjectFixture,
+          openApiResolverFixture,
           operationObjectFixture,
-          methodFixture,
-          pathFixture,
+          inputParamFixture,
         );
       });
 
@@ -302,7 +293,6 @@ describe(handleBodyValidation, () => {
           .fn<(path: string, method: string) => ValidationCacheEntry>()
           .mockReturnValueOnce(validationCacheEntryFixture);
 
-        vitest.mocked(getPath).mockReturnValueOnce(pathFixture);
         vitest
           .mocked(getOperationObject)
           .mockReturnValueOnce(operationObjectFixture);
@@ -317,6 +307,7 @@ describe(handleBodyValidation, () => {
           handleBodyValidation(
             ajvMock,
             openApiObjectFixture,
+            openApiResolverFixture,
             inputParamFixture,
             getEntryMock,
           );
@@ -358,9 +349,9 @@ describe(handleBodyValidation, () => {
       inputParamFixture = {
         body: { name: 'test' },
         contentType: undefined,
-        method: 'POST',
+        method: methodFixture,
+        path: pathFixture,
         type: Symbol() as unknown as BodyValidationInputParam<unknown>['type'],
-        url: '/users',
       };
       operationObjectFixture =
         Symbol() as unknown as OpenApi3Dot2OperationObject;
@@ -395,7 +386,6 @@ describe(handleBodyValidation, () => {
           .fn<(path: string, method: string) => ValidationCacheEntry>()
           .mockReturnValueOnce(validationCacheEntryFixture);
 
-        vitest.mocked(getPath).mockReturnValueOnce(pathFixture);
         vitest
           .mocked(getOperationObject)
           .mockReturnValueOnce(operationObjectFixture);
@@ -412,6 +402,7 @@ describe(handleBodyValidation, () => {
         result = handleBodyValidation(
           ajvMock,
           openApiObjectFixture,
+          openApiResolverFixture,
           inputParamFixture,
           getEntryMock,
         );

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleBodyValidation.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleBodyValidation.ts
@@ -14,7 +14,7 @@ import { type ErrorObject, type ValidateFunction } from 'ajv';
 import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
 import { SCHEMA_ID } from '../../models/v3Dot2/schemaId.js';
 import { type ValidationCacheEntry } from '../../models/v3Dot2/ValidationCacheEntry.js';
-import { getPath } from '../getPath.js';
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
 import { getOperationObject } from './getOperationObject.js';
 import { getRequestBodyObject } from './getRequestBodyObject.js';
 import { inferContentType } from './inferContentType.js';
@@ -22,26 +22,26 @@ import { inferContentType } from './inferContentType.js';
 function getValidateFunction(
   ajv: Ajv,
   openApiObject: OpenApi3Dot2Object,
-  path: string,
-  method: string,
-  contentType: string | undefined,
+  openApiResolver: OpenApiResolver,
+  inputParam: BodyValidationInputParam<unknown>,
 ): ValidateFunction {
   const operationObject: OpenApi3Dot2OperationObject = getOperationObject(
     openApiObject,
-    method,
-    path,
+    inputParam.method,
+    inputParam.path,
   );
 
   const openApi3Dot2RequestBodyObject: OpenApi3Dot2RequestBodyObject =
-    getRequestBodyObject(openApiObject, operationObject, method, path);
+    getRequestBodyObject(openApiResolver, operationObject, inputParam);
 
   const inferredContentType: string =
-    contentType ?? inferContentType(openApi3Dot2RequestBodyObject, method);
+    inputParam.contentType ??
+    inferContentType(openApi3Dot2RequestBodyObject, inputParam.method);
 
   const schemaPointer: string = `${SCHEMA_ID}#/${escapeJsonPointerFragments(
     'paths',
-    path,
-    method,
+    inputParam.path,
+    inputParam.method,
     'requestBody',
     'content',
     inferredContentType,
@@ -63,28 +63,28 @@ function getValidateFunction(
 export function handleBodyValidation(
   ajv: Ajv,
   openApiObject: OpenApi3Dot2Object,
+  openApiResolver: OpenApiResolver,
   inputParam: BodyValidationInputParam<unknown>,
   getEntry: (path: string, method: string) => ValidationCacheEntry,
 ): unknown {
-  const path: string = getPath(inputParam.url);
-  const method: string = inputParam.method.toLowerCase();
-  const contentType: string | undefined = inputParam.contentType;
+  const validationCacheEntry: ValidationCacheEntry = getEntry(
+    inputParam.path,
+    inputParam.method,
+  );
 
-  const validationCacheEntry: ValidationCacheEntry = getEntry(path, method);
-
-  let validate: ValidateFunction | undefined =
-    validationCacheEntry.body.get(contentType);
+  let validate: ValidateFunction | undefined = validationCacheEntry.body.get(
+    inputParam.contentType,
+  );
 
   if (validate === undefined) {
     validate = getValidateFunction(
       ajv,
       openApiObject,
-      path,
-      method,
-      contentType,
+      openApiResolver,
+      inputParam,
     );
 
-    validationCacheEntry.body.set(contentType, validate);
+    validationCacheEntry.body.set(inputParam.contentType, validate);
   }
 
   const valid: boolean = validate(inputParam.body);

--- a/packages/framework/validation/libraries/openapi/src/validation/models/BodyValidationInputParam.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/models/BodyValidationInputParam.ts
@@ -4,6 +4,6 @@ export interface BodyValidationInputParam<TBody> {
   body: TBody;
   contentType: string | undefined;
   method: string;
+  path: string;
   type: typeof validatedInputParamBodyType;
-  url: string;
 }

--- a/packages/framework/validation/libraries/openapi/src/validation/models/ValidationHandler.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/models/ValidationHandler.ts
@@ -1,5 +1,6 @@
 import type Ajv from 'ajv';
 
+import { type OpenApiResolver } from '../services/OpenApiResolver.js';
 import { type ValidationInputParam } from './ValidatedDecoratorResult.js';
 
 export type ValidationHandler<
@@ -9,6 +10,7 @@ export type ValidationHandler<
 > = (
   ajv: Ajv,
   openApiObject: TOpenApiObject,
+  openApiResolver: OpenApiResolver,
   inputParam: TValidatedDecoratorResult,
   getEntry: (path: string, method: string) => TValidationCacheEntry,
 ) => unknown;

--- a/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot1/OpenApiValidationPipe.int.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot1/OpenApiValidationPipe.int.spec.ts
@@ -309,4 +309,100 @@ describe(OpenApiValidationPipe, () => {
       });
     });
   });
+
+  describe('having an OpenApiValidationPipe (v3.1) with content-type ambiguity and schema id references', () => {
+    interface Item {
+      label: string;
+    }
+
+    @Controller('/items')
+    class ItemController {
+      @OasRequestBody({
+        content: {
+          'application/json': {
+            schema: {
+              $ref: 'https://example.com/schemas/Item.json',
+            },
+          },
+          'application/xml': {
+            schema: {
+              $ref: 'https://example.com/schemas/Item.json',
+            },
+          },
+        },
+      })
+      @Post()
+      public async createItem(@ValidatedBody() item: Item): Promise<Item> {
+        return item;
+      }
+    }
+
+    let server: Server;
+
+    beforeAll(async () => {
+      const container: Container = new Container();
+
+      container.bind(ValidationErrorFilter).toSelf().inSingletonScope();
+      container.bind(ItemController).toSelf().inSingletonScope();
+
+      const openApiObject: OpenApi3Dot1Object = {
+        components: {
+          schemas: {
+            Item: {
+              $id: 'https://example.com/schemas/Item.json',
+              properties: { label: { type: 'string' } },
+              required: ['label'],
+              type: 'object',
+            },
+          },
+        },
+        info: { title: 'Test API', version: '1.0.0' },
+        openapi: '3.1.0',
+      };
+
+      const swaggerProvider: SwaggerUiProvider = new SwaggerUiProvider({
+        api: {
+          openApiObject,
+          path: '/docs',
+        },
+      });
+
+      swaggerProvider.provide(container);
+
+      server = await buildExpressServer(
+        container,
+        [ValidationErrorFilter],
+        [new OpenApiValidationPipe(swaggerProvider.openApiObject)],
+      );
+    });
+
+    afterAll(async () => {
+      await server.shutdown();
+    });
+
+    describe('when a POST /items request is made with Content-Type header', () => {
+      let response: Response;
+
+      beforeAll(async () => {
+        response = await fetch(
+          `http://${server.host}:${server.port.toString()}/items`,
+          {
+            body: JSON.stringify({ label: 'My Item' }),
+            headers: { 'Content-Type': 'application/json' },
+            method: 'POST',
+          },
+        );
+      });
+
+      it('should return expected Response', async () => {
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toStrictEqual(
+          expect.stringContaining('application/json'),
+        );
+        await expect(response.json()).resolves.toStrictEqual({
+          label: 'My Item',
+        });
+      });
+    });
+  });
 });

--- a/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot1/OpenApiValidationPipe.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot1/OpenApiValidationPipe.ts
@@ -14,11 +14,14 @@ import { handleBodyValidation } from '../../calculations/v3Dot1/handleBodyValida
 import { SCHEMA_ID } from '../../models/v3Dot1/schemaId.js';
 import { type ValidationCacheEntry } from '../../models/v3Dot1/ValidationCacheEntry.js';
 import { validatedInputParamBodyType } from '../../models/validatedInputParamTypes.js';
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
+import { DefaultOpenApiResolver } from '../../services/v3Dot1/DefaultOpenApiResolver.js';
 import { ValidationCache } from '../../services/v3Dot1/ValidationCache.js';
 
 const handler: (
   ajv: Ajv,
   openApiObject: OpenApi3Dot1Object,
+  openApiResolver: OpenApiResolver,
   inputParam: unknown,
   getEntry: (path: string, method: string) => ValidationCacheEntry,
 ) => unknown = buildCompositeValidationHandler<
@@ -28,12 +31,14 @@ const handler: (
 
 export class OpenApiValidationPipe implements Pipe {
   readonly #openApiObject: OpenApi3Dot1Object;
+  readonly #openApiResolver: OpenApiResolver;
   readonly #validationCache: ValidationCache;
 
   #ajv: Ajv | undefined;
 
   constructor(openApiObject: OpenApi3Dot1Object) {
     this.#openApiObject = openApiObject;
+    this.#openApiResolver = new DefaultOpenApiResolver(openApiObject);
     this.#validationCache = new ValidationCache();
     this.#ajv = undefined;
   }
@@ -78,6 +83,7 @@ export class OpenApiValidationPipe implements Pipe {
     return handler(
       ajv,
       this.#openApiObject,
+      this.#openApiResolver,
       input,
       this.#validationCache.getOrCreate.bind(this.#validationCache),
     );

--- a/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot2/OpenApiValidationPipe.int.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot2/OpenApiValidationPipe.int.spec.ts
@@ -309,4 +309,100 @@ describe(OpenApiValidationPipe, () => {
       });
     });
   });
+
+  describe('having an OpenApiValidationPipe (v3.2) with content-type ambiguity and schema id references', () => {
+    interface Item {
+      label: string;
+    }
+
+    @Controller('/items')
+    class ItemController {
+      @OasRequestBody({
+        content: {
+          'application/json': {
+            schema: {
+              $ref: 'https://example.com/schemas/Item.json',
+            },
+          },
+          'application/xml': {
+            schema: {
+              $ref: 'https://example.com/schemas/Item.json',
+            },
+          },
+        },
+      })
+      @Post()
+      public async createItem(@ValidatedBody() item: Item): Promise<Item> {
+        return item;
+      }
+    }
+
+    let server: Server;
+
+    beforeAll(async () => {
+      const container: Container = new Container();
+
+      container.bind(ValidationErrorFilter).toSelf().inSingletonScope();
+      container.bind(ItemController).toSelf().inSingletonScope();
+
+      const openApiObject: OpenApi3Dot2Object = {
+        components: {
+          schemas: {
+            Item: {
+              $id: 'https://example.com/schemas/Item.json',
+              properties: { label: { type: 'string' } },
+              required: ['label'],
+              type: 'object',
+            },
+          },
+        },
+        info: { title: 'Test API', version: '1.0.0' },
+        openapi: '3.2.0',
+      };
+
+      const swaggerProvider: SwaggerUiProvider = new SwaggerUiProvider({
+        api: {
+          openApiObject,
+          path: '/docs',
+        },
+      });
+
+      swaggerProvider.provide(container);
+
+      server = await buildExpressServer(
+        container,
+        [ValidationErrorFilter],
+        [new OpenApiValidationPipe(swaggerProvider.openApiObject)],
+      );
+    });
+
+    afterAll(async () => {
+      await server.shutdown();
+    });
+
+    describe('when a POST /items request is made with Content-Type header', () => {
+      let response: Response;
+
+      beforeAll(async () => {
+        response = await fetch(
+          `http://${server.host}:${server.port.toString()}/items`,
+          {
+            body: JSON.stringify({ label: 'My Item' }),
+            headers: { 'Content-Type': 'application/json' },
+            method: 'POST',
+          },
+        );
+      });
+
+      it('should return expected Response', async () => {
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toStrictEqual(
+          expect.stringContaining('application/json'),
+        );
+        await expect(response.json()).resolves.toStrictEqual({
+          label: 'My Item',
+        });
+      });
+    });
+  });
 });

--- a/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot2/OpenApiValidationPipe.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot2/OpenApiValidationPipe.ts
@@ -14,11 +14,14 @@ import { handleBodyValidation } from '../../calculations/v3Dot2/handleBodyValida
 import { SCHEMA_ID } from '../../models/v3Dot2/schemaId.js';
 import { type ValidationCacheEntry } from '../../models/v3Dot2/ValidationCacheEntry.js';
 import { validatedInputParamBodyType } from '../../models/validatedInputParamTypes.js';
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
+import { DefaultOpenApiResolver } from '../../services/v3Dot2/DefaultOpenApiResolver.js';
 import { ValidationCache } from '../../services/v3Dot2/ValidationCache.js';
 
 const handler: (
   ajv: Ajv,
   openApiObject: OpenApi3Dot2Object,
+  openApiResolver: OpenApiResolver,
   inputParam: unknown,
   getEntry: (path: string, method: string) => ValidationCacheEntry,
 ) => unknown = buildCompositeValidationHandler<
@@ -28,12 +31,14 @@ const handler: (
 
 export class OpenApiValidationPipe implements Pipe {
   readonly #openApiObject: OpenApi3Dot2Object;
+  readonly #openApiResolver: OpenApiResolver;
   readonly #validationCache: ValidationCache;
 
   #ajv: Ajv | undefined;
 
   constructor(openApiObject: OpenApi3Dot2Object) {
     this.#openApiObject = openApiObject;
+    this.#openApiResolver = new DefaultOpenApiResolver(openApiObject);
     this.#validationCache = new ValidationCache();
     this.#ajv = undefined;
   }
@@ -78,6 +83,7 @@ export class OpenApiValidationPipe implements Pipe {
     return handler(
       ajv,
       this.#openApiObject,
+      this.#openApiResolver,
       input,
       this.#validationCache.getOrCreate.bind(this.#validationCache),
     );

--- a/packages/framework/validation/libraries/openapi/src/validation/services/BaseOpenApiResolver.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/services/BaseOpenApiResolver.ts
@@ -1,0 +1,52 @@
+import { resolveJsonPointer } from '@inversifyjs/json-schema-pointer';
+import { type JsonValue } from '@inversifyjs/json-schema-types';
+
+import { type OpenApiResolver } from './OpenApiResolver.js';
+
+const URI_SPLIT_BY_FRAGMENT_PARTS_COUNT: number = 2;
+
+export abstract class BaseOpenApiResolver implements OpenApiResolver {
+  public deepResolveReference(reference: string): JsonValue | undefined {
+    let resolved: JsonValue | undefined = this.resolveReference(reference);
+
+    while (this.#isReferenceObject(resolved)) {
+      resolved = this.resolveReference(resolved.$ref);
+    }
+
+    return resolved;
+  }
+
+  public resolveReference(reference: string): JsonValue | undefined {
+    const uriParts: [string, string?] = reference.split('#') as [
+      string,
+      string?,
+    ];
+
+    if (uriParts.length > URI_SPLIT_BY_FRAGMENT_PARTS_COUNT) {
+      throw new Error(
+        `Invalid reference "${reference}". A reference must be a URI with at most one fragment identifier.`,
+      );
+    }
+
+    const [id, fragment]: [string, string?] = uriParts;
+
+    const idSchema: JsonValue | undefined = this._resolveId(id);
+
+    if (idSchema === undefined || fragment === undefined) {
+      return idSchema;
+    }
+
+    return resolveJsonPointer(idSchema, fragment);
+  }
+
+  #isReferenceObject(object: unknown): object is { $ref: string } {
+    return (
+      typeof object === 'object' &&
+      object !== null &&
+      '$ref' in object &&
+      typeof (object as { $ref: unknown }).$ref === 'string'
+    );
+  }
+
+  protected abstract _resolveId(id: string): JsonValue | undefined;
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/services/OpenApiResolver.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/services/OpenApiResolver.ts
@@ -1,0 +1,6 @@
+import { type JsonValue } from '@inversifyjs/json-schema-types';
+
+export interface OpenApiResolver {
+  deepResolveReference(reference: string): JsonValue | undefined;
+  resolveReference(reference: string): JsonValue | undefined;
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot1/DefaultOpenApiResolver.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot1/DefaultOpenApiResolver.ts
@@ -1,0 +1,39 @@
+import { type JsonValue } from '@inversifyjs/json-schema-types';
+import { type TraverseJsonSchemaParams } from '@inversifyjs/json-schema-utils/2020-12';
+import { type OpenApi3Dot1Object } from '@inversifyjs/open-api-types/v3Dot1';
+import { traverseOpenApiObjectJsonSchemas } from '@inversifyjs/open-api-utils/v3Dot1';
+
+import { BaseOpenApiResolver } from '../BaseOpenApiResolver.js';
+
+export class DefaultOpenApiResolver extends BaseOpenApiResolver {
+  readonly #idToSchemaMap: Map<string, JsonValue>;
+
+  constructor(openApiObject: OpenApi3Dot1Object) {
+    super();
+
+    this.#idToSchemaMap = new Map();
+
+    this.#populateIdToSchemaMap(openApiObject);
+  }
+
+  protected _resolveId(id: string): JsonValue | undefined {
+    return this.#idToSchemaMap.get(id);
+  }
+
+  #populateIdToSchemaMap(openApiObject: OpenApi3Dot1Object): void {
+    this.#idToSchemaMap.set('', openApiObject as unknown as JsonValue);
+
+    traverseOpenApiObjectJsonSchemas(
+      openApiObject,
+      (params: TraverseJsonSchemaParams) => {
+        if (
+          params.schema !== true &&
+          params.schema !== false &&
+          params.schema.$id !== undefined
+        ) {
+          this.#idToSchemaMap.set(params.schema.$id, params.schema);
+        }
+      },
+    );
+  }
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot2/DefaultOpenApiResolver.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot2/DefaultOpenApiResolver.ts
@@ -1,0 +1,39 @@
+import { type JsonValue } from '@inversifyjs/json-schema-types';
+import { type TraverseJsonSchemaParams } from '@inversifyjs/json-schema-utils/2020-12';
+import { type OpenApi3Dot2Object } from '@inversifyjs/open-api-types/v3Dot2';
+import { traverseOpenApiObjectJsonSchemas } from '@inversifyjs/open-api-utils/v3Dot2';
+
+import { BaseOpenApiResolver } from '../BaseOpenApiResolver.js';
+
+export class DefaultOpenApiResolver extends BaseOpenApiResolver {
+  readonly #idToSchemaMap: Map<string, JsonValue>;
+
+  constructor(openApiObject: OpenApi3Dot2Object) {
+    super();
+
+    this.#idToSchemaMap = new Map();
+
+    this.#populateIdToSchemaMap(openApiObject);
+  }
+
+  protected _resolveId(id: string): JsonValue | undefined {
+    return this.#idToSchemaMap.get(id);
+  }
+
+  #populateIdToSchemaMap(openApiObject: OpenApi3Dot2Object): void {
+    this.#idToSchemaMap.set('', openApiObject as unknown as JsonValue);
+
+    traverseOpenApiObjectJsonSchemas(
+      openApiObject,
+      (params: TraverseJsonSchemaParams) => {
+        if (
+          params.schema !== true &&
+          params.schema !== false &&
+          params.schema.$id !== undefined
+        ) {
+          this.#idToSchemaMap.set(params.schema.$id, params.schema);
+        }
+      },
+    );
+  }
+}


### PR DESCRIPTION
### Changed
- Updated pipe to properly resolve id related refs.
- Updated custom decorator with more convenient data.
- Updated `OpenApiValidationPipe` testswith  ref based use cases.

### Context
See #1701.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenAPI validation handling of schema references in request body validation, including complex edge cases with content-type ambiguity.
  * Enhanced handling of referenced schema definitions for more reliable content-type determination during validation.

* **Refactor**
  * Refactored internal validation system to improve consistency and reliability of path handling and schema reference resolution mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->