### PR TITLE
Update OpenApiValidationPipe

### DIFF
--- a/.changeset/slick-eagles-hear.md
+++ b/.changeset/slick-eagles-hear.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/open-api-validation": minor
+---
+
+- Updated `OpenApiValidationPipe` to handle param validation

--- a/.changeset/smooth-carrots-cheat.md
+++ b/.changeset/smooth-carrots-cheat.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/open-api-validation": patch
+---
+
+- Updated `OpenApiValidationPipe` to properly handle param related operations

--- a/.changeset/soft-buses-beg.md
+++ b/.changeset/soft-buses-beg.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/http-open-api": patch
+---
+
+- Updated `SwaggerUiProvider` to properly build param related operations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+Follow instructions at [Agents](./AGENTS.md) file.

--- a/packages/docs/tools/inversify-http-open-api-code-examples/src/examples/v1/decorators/decoratorApiOasComprehensive.int.spec.ts
+++ b/packages/docs/tools/inversify-http-open-api-code-examples/src/examples/v1/decorators/decoratorApiOasComprehensive.int.spec.ts
@@ -42,7 +42,7 @@ describe.each<[(container: Container) => Promise<Server>]>([
       // Check that the OpenAPI spec was generated successfully
       expect(docsSpecResponseBody.paths).toBeDefined();
       expect(docsSpecResponseBody.paths?.['/products']).toBeDefined();
-      expect(docsSpecResponseBody.paths?.['/products/:id']).toBeDefined();
+      expect(docsSpecResponseBody.paths?.['/products/{id}']).toBeDefined();
       expect(docsSpecResponseBody.paths?.['/products/legacy']).toBeDefined();
 
       // Check that schemas were generated

--- a/packages/framework/http/libraries/open-api/package.json
+++ b/packages/framework/http/libraries/open-api/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@inversifyjs/http-core": "workspace:*",
     "@inversifyjs/json-schema-pointer": "workspace:*",
+    "@inversifyjs/logger": "workspace:*",
     "@inversifyjs/reflect-metadata-utils": "1.5.0",
     "mime-types": "^3.0.2",
     "swagger-ui-dist": "^5.32.4"

--- a/packages/framework/http/libraries/open-api/src/openApi/calculations/buildOperationFromPath.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/calculations/buildOperationFromPath.spec.ts
@@ -1,0 +1,75 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { tryBuildOperationFromPath } from './buildOperationFromPath.js';
+
+describe(tryBuildOperationFromPath, () => {
+  describe('having a path with no params and no wildcard', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = tryBuildOperationFromPath('/users');
+      });
+
+      it('should return the path as-is', () => {
+        expect(result).toBe('/users');
+      });
+    });
+  });
+
+  describe('having a path with a single param', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = tryBuildOperationFromPath('/users/:userId');
+      });
+
+      it('should replace the param with OpenAPI curly-brace syntax', () => {
+        expect(result).toBe('/users/{userId}');
+      });
+    });
+  });
+
+  describe('having a path with multiple params', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = tryBuildOperationFromPath('/users/:userId/posts/:postId');
+      });
+
+      it('should replace all params with OpenAPI curly-brace syntax', () => {
+        expect(result).toBe('/users/{userId}/posts/{postId}');
+      });
+    });
+  });
+
+  describe('having a path with a wildcard', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = tryBuildOperationFromPath('/files/*');
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a root path', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = tryBuildOperationFromPath('/');
+      });
+
+      it('should return the path as-is', () => {
+        expect(result).toBe('/');
+      });
+    });
+  });
+});

--- a/packages/framework/http/libraries/open-api/src/openApi/calculations/buildOperationFromPath.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/calculations/buildOperationFromPath.spec.ts
@@ -45,6 +45,20 @@ describe(tryBuildOperationFromPath, () => {
     });
   });
 
+  describe('having a path with multiple params in the same segment', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = tryBuildOperationFromPath('/flights/:from-:to');
+      });
+
+      it('should replace all params with OpenAPI curly-brace syntax', () => {
+        expect(result).toBe('/flights/{from}-{to}');
+      });
+    });
+  });
+
   describe('having a path with a wildcard', () => {
     describe('when called', () => {
       let result: unknown;

--- a/packages/framework/http/libraries/open-api/src/openApi/calculations/buildOperationFromPath.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/calculations/buildOperationFromPath.ts
@@ -1,0 +1,9 @@
+const PATH_PARAM_REGEXP: RegExp = /:([^/]+)/g;
+
+export function tryBuildOperationFromPath(path: string): string | undefined {
+  if (path.includes('*')) {
+    return undefined;
+  }
+
+  return path.replaceAll(PATH_PARAM_REGEXP, '{$1}');
+}

--- a/packages/framework/http/libraries/open-api/src/openApi/calculations/buildOperationFromPath.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/calculations/buildOperationFromPath.ts
@@ -1,4 +1,4 @@
-const PATH_PARAM_REGEXP: RegExp = /:([^/]+)/g;
+const PATH_PARAM_REGEXP: RegExp = /:([A-Za-z0-9_]+)/g;
 
 export function tryBuildOperationFromPath(path: string): string | undefined {
   if (path.includes('*')) {

--- a/packages/framework/http/libraries/open-api/src/openApi/calculations/resolveLogger.spec.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/calculations/resolveLogger.spec.ts
@@ -1,0 +1,65 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { ConsoleLogger, type Logger } from '@inversifyjs/logger';
+
+import { resolveLogger } from './resolveLogger.js';
+
+describe(resolveLogger, () => {
+  describe('having option false', () => {
+    describe('when called', () => {
+      let result: Logger | undefined;
+
+      beforeAll(() => {
+        result = resolveLogger(false);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having option true', () => {
+    describe('when called', () => {
+      let result: Logger | undefined;
+
+      beforeAll(() => {
+        result = resolveLogger(true);
+      });
+
+      it('should return a ConsoleLogger instance', () => {
+        expect(result).toBeInstanceOf(ConsoleLogger);
+      });
+    });
+  });
+
+  describe('having option undefined', () => {
+    describe('when called', () => {
+      let result: Logger | undefined;
+
+      beforeAll(() => {
+        result = resolveLogger(undefined);
+      });
+
+      it('should return a ConsoleLogger instance', () => {
+        expect(result).toBeInstanceOf(ConsoleLogger);
+      });
+    });
+  });
+
+  describe('having a Logger instance', () => {
+    describe('when called', () => {
+      let loggerFixture: Logger;
+      let result: Logger | undefined;
+
+      beforeAll(() => {
+        loggerFixture = new ConsoleLogger();
+        result = resolveLogger(loggerFixture);
+      });
+
+      it('should return the same Logger instance', () => {
+        expect(result).toBe(loggerFixture);
+      });
+    });
+  });
+});

--- a/packages/framework/http/libraries/open-api/src/openApi/calculations/resolveLogger.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/calculations/resolveLogger.ts
@@ -1,0 +1,15 @@
+import { ConsoleLogger, type Logger } from '@inversifyjs/logger';
+
+export function resolveLogger(
+  option: Logger | boolean | undefined,
+): Logger | undefined {
+  if (option === false) {
+    return undefined;
+  }
+
+  if (option === true || option === undefined) {
+    return new ConsoleLogger();
+  }
+
+  return option;
+}

--- a/packages/framework/http/libraries/open-api/src/openApi/models/SwaggerUiProviderOptions.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/models/SwaggerUiProviderOptions.ts
@@ -1,7 +1,10 @@
+import { type Logger } from '@inversifyjs/logger';
+
 import { type BaseSwaggerUiProviderApiOptions } from './BaseSwaggerUiProviderApiOptions.js';
 import { type SwaggerUiProviderUiOptions } from './SwaggerUiProviderUiOptions.js';
 
 export interface BaseSwaggerUiProviderOptions<TOpenApiObject> {
   api: BaseSwaggerUiProviderApiOptions<TOpenApiObject>;
+  logger?: Logger | boolean | undefined;
   ui?: SwaggerUiProviderUiOptions;
 }

--- a/packages/framework/http/libraries/open-api/src/openApi/services/v3Dot1/SwaggerUiProvider.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/services/v3Dot1/SwaggerUiProvider.ts
@@ -21,6 +21,7 @@ import { mergeOpenApiPathItemObjectIntoOpenApiPaths } from '../../../metadata/ac
 import { type ControllerOpenApiMetadata } from '../../../metadata/models/v3Dot1/ControllerOpenApiMetadata.js';
 import { controllerOpenApiMetadataReflectKey } from '../../../reflectMetadata/data/v3Dot1/controllerOpenApiMetadataReflectKey.js';
 import { mergeOpenApiTypeSchema } from '../../actions/v3Dot1/mergeOpenApiTypeSchema.js';
+import { tryBuildOperationFromPath } from '../../calculations/buildOperationFromPath.js';
 import { buildSwaggerUiController } from '../../calculations/buildSwaggerUiController.js';
 import { type BaseSwaggerUiController } from '../../controllers/BaseSwagggerUiController.js';
 import { type SwaggerUiProviderOptions } from '../../models/v3Dot1/SwaggerUiProviderOptions.js';
@@ -236,29 +237,34 @@ export class SwaggerUiProvider {
       );
 
     if (operationObject !== undefined) {
-      const path: string = buildNormalizedPath(
-        `${controllerMetadata.path}/${methodMetadata.path}`,
+      const path: string | undefined = tryBuildOperationFromPath(
+        buildNormalizedPath(
+          `${controllerMetadata.path}/${methodMetadata.path}`,
+        ),
       );
 
-      const openApi3Dot1PathItemObject: OpenApi3Dot1PathItemObject =
-        this.#buildOrGetPathItemObject(pathToPathItemObjectMap, path);
+      if (path !== undefined) {
+        const openApi3Dot1PathItemObject: OpenApi3Dot1PathItemObject =
+          this.#buildOrGetPathItemObject(pathToPathItemObjectMap, path);
 
-      if (controllerOpenApiMetadata.servers !== undefined) {
-        openApi3Dot1PathItemObject.servers = [
-          ...controllerOpenApiMetadata.servers,
-        ];
+        if (controllerOpenApiMetadata.servers !== undefined) {
+          openApi3Dot1PathItemObject.servers = [
+            ...controllerOpenApiMetadata.servers,
+          ];
+        }
+
+        if (controllerOpenApiMetadata.summary !== undefined) {
+          openApi3Dot1PathItemObject.summary =
+            controllerOpenApiMetadata.summary;
+        }
+
+        this.#setPathItemObjectOperations(
+          openApi3Dot1PathItemObject,
+          methodMetadata.requestMethodType,
+          operationObject,
+          path,
+        );
       }
-
-      if (controllerOpenApiMetadata.summary !== undefined) {
-        openApi3Dot1PathItemObject.summary = controllerOpenApiMetadata.summary;
-      }
-
-      this.#setPathItemObjectOperations(
-        openApi3Dot1PathItemObject,
-        methodMetadata.requestMethodType,
-        operationObject,
-        path,
-      );
     }
   }
 

--- a/packages/framework/http/libraries/open-api/src/openApi/services/v3Dot1/SwaggerUiProvider.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/services/v3Dot1/SwaggerUiProvider.ts
@@ -7,7 +7,7 @@ import {
   RequestMethodType,
 } from '@inversifyjs/http-core';
 import { escapeJsonPointerFragments } from '@inversifyjs/json-schema-pointer';
-import { ConsoleLogger, type Logger } from '@inversifyjs/logger';
+import { type Logger } from '@inversifyjs/logger';
 import {
   type OpenApi3Dot1Object,
   type OpenApi3Dot1OperationObject,
@@ -24,6 +24,7 @@ import { controllerOpenApiMetadataReflectKey } from '../../../reflectMetadata/da
 import { mergeOpenApiTypeSchema } from '../../actions/v3Dot1/mergeOpenApiTypeSchema.js';
 import { tryBuildOperationFromPath } from '../../calculations/buildOperationFromPath.js';
 import { buildSwaggerUiController } from '../../calculations/buildSwaggerUiController.js';
+import { resolveLogger } from '../../calculations/resolveLogger.js';
 import { type BaseSwaggerUiController } from '../../controllers/BaseSwagggerUiController.js';
 import { type SwaggerUiProviderOptions } from '../../models/v3Dot1/SwaggerUiProviderOptions.js';
 
@@ -66,12 +67,7 @@ export class SwaggerUiProvider {
   #provided: boolean;
 
   constructor(options: SwaggerUiProviderOptions) {
-    this.#logger =
-      options.logger === true
-        ? new ConsoleLogger()
-        : options.logger === false
-          ? undefined
-          : (options.logger ?? new ConsoleLogger());
+    this.#logger = resolveLogger(options.logger);
     this.#options = options;
     this.#provided = false;
   }
@@ -254,7 +250,7 @@ export class SwaggerUiProvider {
 
       if (path === undefined) {
         this.#logger?.warn(
-          `Skipping metadata for path ${normalizedPath}. Path contains wildcard character which is not supported in OpenAPI specification`,
+          `Skipping metadata for path ${normalizedPath}. The framework-level wildcard segment (*) has no equivalent in OpenAPI path templates, therefore metadata is skipped`,
         );
       } else {
         const openApi3Dot1PathItemObject: OpenApi3Dot1PathItemObject =

--- a/packages/framework/http/libraries/open-api/src/openApi/services/v3Dot1/SwaggerUiProvider.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/services/v3Dot1/SwaggerUiProvider.ts
@@ -7,6 +7,7 @@ import {
   RequestMethodType,
 } from '@inversifyjs/http-core';
 import { escapeJsonPointerFragments } from '@inversifyjs/json-schema-pointer';
+import { ConsoleLogger, type Logger } from '@inversifyjs/logger';
 import {
   type OpenApi3Dot1Object,
   type OpenApi3Dot1OperationObject,
@@ -59,11 +60,18 @@ type MetadataTuple = [
 ];
 
 export class SwaggerUiProvider {
+  readonly #logger: Logger | undefined;
   readonly #options: SwaggerUiProviderOptions;
 
   #provided: boolean;
 
   constructor(options: SwaggerUiProviderOptions) {
+    this.#logger =
+      options.logger === true
+        ? new ConsoleLogger()
+        : options.logger === false
+          ? undefined
+          : (options.logger ?? new ConsoleLogger());
     this.#options = options;
     this.#provided = false;
   }
@@ -237,13 +245,18 @@ export class SwaggerUiProvider {
       );
 
     if (operationObject !== undefined) {
-      const path: string | undefined = tryBuildOperationFromPath(
-        buildNormalizedPath(
-          `${controllerMetadata.path}/${methodMetadata.path}`,
-        ),
+      const normalizedPath: string = buildNormalizedPath(
+        `${controllerMetadata.path}/${methodMetadata.path}`,
       );
 
-      if (path !== undefined) {
+      const path: string | undefined =
+        tryBuildOperationFromPath(normalizedPath);
+
+      if (path === undefined) {
+        this.#logger?.warn(
+          `Skipping metadata for path ${normalizedPath}. Path contains wildcard character which is not supported in OpenAPI specification`,
+        );
+      } else {
         const openApi3Dot1PathItemObject: OpenApi3Dot1PathItemObject =
           this.#buildOrGetPathItemObject(pathToPathItemObjectMap, path);
 

--- a/packages/framework/http/libraries/open-api/src/openApi/services/v3Dot2/SwaggerUiProvider.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/services/v3Dot2/SwaggerUiProvider.ts
@@ -7,6 +7,7 @@ import {
   RequestMethodType,
 } from '@inversifyjs/http-core';
 import { escapeJsonPointerFragments } from '@inversifyjs/json-schema-pointer';
+import { ConsoleLogger, type Logger } from '@inversifyjs/logger';
 import {
   type OpenApi3Dot2Object,
   type OpenApi3Dot2OperationObject,
@@ -59,11 +60,18 @@ type MetadataTuple = [
 ];
 
 export class SwaggerUiProvider {
+  readonly #logger: Logger | undefined;
   readonly #options: SwaggerUiProviderOptions;
 
   #provided: boolean;
 
   constructor(options: SwaggerUiProviderOptions) {
+    this.#logger =
+      options.logger === true
+        ? new ConsoleLogger()
+        : options.logger === false
+          ? undefined
+          : (options.logger ?? new ConsoleLogger());
     this.#options = options;
     this.#provided = false;
   }
@@ -237,13 +245,18 @@ export class SwaggerUiProvider {
       );
 
     if (operationObject !== undefined) {
-      const path: string | undefined = tryBuildOperationFromPath(
-        buildNormalizedPath(
-          `${controllerMetadata.path}/${methodMetadata.path}`,
-        ),
+      const normalizedPath: string = buildNormalizedPath(
+        `${controllerMetadata.path}/${methodMetadata.path}`,
       );
 
-      if (path !== undefined) {
+      const path: string | undefined =
+        tryBuildOperationFromPath(normalizedPath);
+
+      if (path === undefined) {
+        this.#logger?.warn(
+          `Skipping metadata for path ${normalizedPath}. Path contains wildcard character which is not supported in OpenAPI specification`,
+        );
+      } else {
         const openApi3Dot2PathItemObject: OpenApi3Dot2PathItemObject =
           this.#buildOrGetPathItemObject(pathToPathItemObjectMap, path);
 

--- a/packages/framework/http/libraries/open-api/src/openApi/services/v3Dot2/SwaggerUiProvider.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/services/v3Dot2/SwaggerUiProvider.ts
@@ -21,6 +21,7 @@ import { mergeOpenApiPathItemObjectIntoOpenApiPaths } from '../../../metadata/ac
 import { type ControllerOpenApiMetadata } from '../../../metadata/models/v3Dot2/ControllerOpenApiMetadata.js';
 import { controllerOpenApiMetadataReflectKey } from '../../../reflectMetadata/data/v3Dot2/controllerOpenApiMetadataReflectKey.js';
 import { mergeOpenApiTypeSchema } from '../../actions/v3Dot2/mergeOpenApiTypeSchema.js';
+import { tryBuildOperationFromPath } from '../../calculations/buildOperationFromPath.js';
 import { buildSwaggerUiController } from '../../calculations/buildSwaggerUiController.js';
 import { type BaseSwaggerUiController } from '../../controllers/BaseSwagggerUiController.js';
 import { type SwaggerUiProviderOptions } from '../../models/v3Dot2/SwaggerUiProviderOptions.js';
@@ -236,29 +237,34 @@ export class SwaggerUiProvider {
       );
 
     if (operationObject !== undefined) {
-      const path: string = buildNormalizedPath(
-        `${controllerMetadata.path}/${methodMetadata.path}`,
+      const path: string | undefined = tryBuildOperationFromPath(
+        buildNormalizedPath(
+          `${controllerMetadata.path}/${methodMetadata.path}`,
+        ),
       );
 
-      const openApi3Dot2PathItemObject: OpenApi3Dot2PathItemObject =
-        this.#buildOrGetPathItemObject(pathToPathItemObjectMap, path);
+      if (path !== undefined) {
+        const openApi3Dot2PathItemObject: OpenApi3Dot2PathItemObject =
+          this.#buildOrGetPathItemObject(pathToPathItemObjectMap, path);
 
-      if (controllerOpenApiMetadata.servers !== undefined) {
-        openApi3Dot2PathItemObject.servers = [
-          ...controllerOpenApiMetadata.servers,
-        ];
+        if (controllerOpenApiMetadata.servers !== undefined) {
+          openApi3Dot2PathItemObject.servers = [
+            ...controllerOpenApiMetadata.servers,
+          ];
+        }
+
+        if (controllerOpenApiMetadata.summary !== undefined) {
+          openApi3Dot2PathItemObject.summary =
+            controllerOpenApiMetadata.summary;
+        }
+
+        this.#setPathItemObjectOperations(
+          openApi3Dot2PathItemObject,
+          methodMetadata.requestMethodType,
+          operationObject,
+          path,
+        );
       }
-
-      if (controllerOpenApiMetadata.summary !== undefined) {
-        openApi3Dot2PathItemObject.summary = controllerOpenApiMetadata.summary;
-      }
-
-      this.#setPathItemObjectOperations(
-        openApi3Dot2PathItemObject,
-        methodMetadata.requestMethodType,
-        operationObject,
-        path,
-      );
     }
   }
 

--- a/packages/framework/http/libraries/open-api/src/openApi/services/v3Dot2/SwaggerUiProvider.ts
+++ b/packages/framework/http/libraries/open-api/src/openApi/services/v3Dot2/SwaggerUiProvider.ts
@@ -7,7 +7,7 @@ import {
   RequestMethodType,
 } from '@inversifyjs/http-core';
 import { escapeJsonPointerFragments } from '@inversifyjs/json-schema-pointer';
-import { ConsoleLogger, type Logger } from '@inversifyjs/logger';
+import { type Logger } from '@inversifyjs/logger';
 import {
   type OpenApi3Dot2Object,
   type OpenApi3Dot2OperationObject,
@@ -24,6 +24,7 @@ import { controllerOpenApiMetadataReflectKey } from '../../../reflectMetadata/da
 import { mergeOpenApiTypeSchema } from '../../actions/v3Dot2/mergeOpenApiTypeSchema.js';
 import { tryBuildOperationFromPath } from '../../calculations/buildOperationFromPath.js';
 import { buildSwaggerUiController } from '../../calculations/buildSwaggerUiController.js';
+import { resolveLogger } from '../../calculations/resolveLogger.js';
 import { type BaseSwaggerUiController } from '../../controllers/BaseSwagggerUiController.js';
 import { type SwaggerUiProviderOptions } from '../../models/v3Dot2/SwaggerUiProviderOptions.js';
 
@@ -66,12 +67,7 @@ export class SwaggerUiProvider {
   #provided: boolean;
 
   constructor(options: SwaggerUiProviderOptions) {
-    this.#logger =
-      options.logger === true
-        ? new ConsoleLogger()
-        : options.logger === false
-          ? undefined
-          : (options.logger ?? new ConsoleLogger());
+    this.#logger = resolveLogger(options.logger);
     this.#options = options;
     this.#provided = false;
   }
@@ -254,7 +250,7 @@ export class SwaggerUiProvider {
 
       if (path === undefined) {
         this.#logger?.warn(
-          `Skipping metadata for path ${normalizedPath}. Path contains wildcard character which is not supported in OpenAPI specification`,
+          `Skipping metadata for path ${normalizedPath}. The framework-level wildcard segment (*) has no equivalent in OpenAPI path templates, therefore metadata is skipped`,
         );
       } else {
         const openApi3Dot2PathItemObject: OpenApi3Dot2PathItemObject =

--- a/packages/framework/validation/libraries/openapi/src/index.ts
+++ b/packages/framework/validation/libraries/openapi/src/index.ts
@@ -1,2 +1,3 @@
 export { ValidatedBody } from './metadata/decorators/ValidatedBody.js';
 export { ValidatedHeaders } from './metadata/decorators/ValidatedHeaders.js';
+export { ValidatedParams } from './metadata/decorators/ValidatedParams.js';

--- a/packages/framework/validation/libraries/openapi/src/metadata/decorators/ValidatedParams.ts
+++ b/packages/framework/validation/libraries/openapi/src/metadata/decorators/ValidatedParams.ts
@@ -1,0 +1,54 @@
+import {
+  createCustomParameterDecorator,
+  type CustomParameterDecoratorHandlerOptions,
+} from '@inversifyjs/http-core';
+import {
+  InversifyValidationError,
+  InversifyValidationErrorKind,
+} from '@inversifyjs/validation-common';
+
+import { getPath } from '../../validation/calculations/getPath.js';
+import { type ParamValidationInputParam } from '../../validation/models/ParamValidationInputParam.js';
+import { validatedInputParamParamType } from '../../validation/models/validatedInputParamTypes.js';
+import { setValidateMetadata } from '../actions/setValidateMetadata.js';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function ValidatedParams(): ParameterDecorator {
+  return (
+    target: object,
+    key: string | symbol | undefined,
+    index: number,
+  ): void => {
+    setValidateMetadata(target, key, index);
+    createCustomParameterDecorator(
+      async (
+        request: unknown,
+        _response: unknown,
+        options: CustomParameterDecoratorHandlerOptions<unknown, unknown>,
+      ): Promise<ParamValidationInputParam> => {
+        const method: string = options.getMethod(request).toLowerCase();
+        const url: string = options.getUrl(request);
+
+        const params: unknown = options.getParams(request);
+
+        if (
+          typeof params !== 'object' ||
+          params === null ||
+          Array.isArray(params)
+        ) {
+          throw new InversifyValidationError(
+            InversifyValidationErrorKind.unknown,
+            `${method.toUpperCase()} ${url}: Expected params to be a non array object`,
+          );
+        }
+
+        return {
+          method,
+          params: params as Record<string, string | string[]>,
+          path: getPath(url),
+          type: validatedInputParamParamType,
+        };
+      },
+    )(target, key, index);
+  };
+}

--- a/packages/framework/validation/libraries/openapi/src/router/calculations/buildRouterNode.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/calculations/buildRouterNode.spec.ts
@@ -1,0 +1,163 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { type RouterNode } from '../models/RouterNode.js';
+import { wildcardKey } from '../models/wildcardKey.js';
+import { buildRouterNode } from './buildRouterNode.js';
+
+describe(buildRouterNode, () => {
+  describe('having an empty paths array', () => {
+    describe('when called', () => {
+      let result: RouterNode;
+
+      beforeAll(() => {
+        result = buildRouterNode([]);
+      });
+
+      it('should return a node with no children and no path', () => {
+        expect(result).toStrictEqual({
+          children: undefined,
+          path: undefined,
+        });
+      });
+    });
+  });
+
+  describe('having a single static path', () => {
+    describe('when called', () => {
+      let result: RouterNode;
+
+      beforeAll(() => {
+        result = buildRouterNode(['/users']);
+      });
+
+      it('should build a tree for the path', () => {
+        const usersNode: RouterNode | undefined =
+          result.children?.['']?.children?.['users'];
+
+        expect(usersNode).toBeDefined();
+        expect(usersNode?.path).toBe('/users');
+      });
+    });
+  });
+
+  describe('having a path with a param', () => {
+    describe('when called', () => {
+      let result: RouterNode;
+
+      beforeAll(() => {
+        result = buildRouterNode(['/users/{userId}']);
+      });
+
+      it('should build a tree with a wildcard node for the param', () => {
+        const wildcardNode: RouterNode | undefined =
+          result.children?.['']?.children?.['users']?.children?.[wildcardKey];
+
+        expect(wildcardNode).toBeDefined();
+        expect(wildcardNode?.path).toBe('/users/{userId}');
+      });
+    });
+  });
+
+  describe('having multiple paths with shared prefix', () => {
+    describe('when called', () => {
+      let result: RouterNode;
+
+      beforeAll(() => {
+        result = buildRouterNode(['/users', '/users/{userId}']);
+      });
+
+      it('should build a tree with shared prefix nodes', () => {
+        const usersNode: RouterNode | undefined =
+          result.children?.['']?.children?.['users'];
+
+        expect(usersNode).toBeDefined();
+        expect(usersNode?.path).toBe('/users');
+
+        const wildcardNode: RouterNode | undefined =
+          usersNode?.children?.[wildcardKey];
+
+        expect(wildcardNode).toBeDefined();
+        expect(wildcardNode?.path).toBe('/users/{userId}');
+      });
+    });
+  });
+
+  describe('having paths where first registered route takes priority on conflict', () => {
+    describe('when called with /users/{userId} before /users/{id}', () => {
+      let result: RouterNode;
+
+      beforeAll(() => {
+        result = buildRouterNode(['/users/{userId}', '/users/{id}']);
+      });
+
+      it('should use the first registered path for the wildcard node', () => {
+        const wildcardNode: RouterNode | undefined =
+          result.children?.['']?.children?.['users']?.children?.[wildcardKey];
+
+        expect(wildcardNode).toBeDefined();
+        expect(wildcardNode?.path).toBe('/users/{userId}');
+      });
+    });
+  });
+
+  describe('having a complex nested path', () => {
+    describe('when called', () => {
+      let result: RouterNode;
+
+      beforeAll(() => {
+        result = buildRouterNode(['/users/{userId}/posts/{postId}']);
+      });
+
+      it('should build a deeply nested tree', () => {
+        const postsWildcardNode: RouterNode | undefined =
+          result.children?.['']?.children?.['users']?.children?.[wildcardKey]
+            ?.children?.['posts']?.children?.[wildcardKey];
+
+        expect(postsWildcardNode).toBeDefined();
+        expect(postsWildcardNode?.path).toBe('/users/{userId}/posts/{postId}');
+      });
+    });
+  });
+
+  describe('having a param path registered before a static path that competes', () => {
+    describe('when called with /users/{userId} and /users/me', () => {
+      let result: RouterNode;
+
+      beforeAll(() => {
+        result = buildRouterNode(['/users/{userId}', '/users/me']);
+      });
+
+      it('should have both static and wildcard children with first registered winning', () => {
+        const usersNode: RouterNode | undefined =
+          result.children?.['']?.children?.['users'];
+
+        expect(usersNode).toBeDefined();
+        expect(usersNode?.children?.['me']?.path).toBe('/users/{userId}');
+        expect(usersNode?.children?.[wildcardKey]?.path).toBe(
+          '/users/{userId}',
+        );
+      });
+    });
+  });
+
+  describe('having a static path registered before a param path that competes', () => {
+    describe('when called with /users/me and /users/{userId}', () => {
+      let result: RouterNode;
+
+      beforeAll(() => {
+        result = buildRouterNode(['/users/me', '/users/{userId}']);
+      });
+
+      it('should have both static and wildcard children with first registered winning', () => {
+        const usersNode: RouterNode | undefined =
+          result.children?.['']?.children?.['users'];
+
+        expect(usersNode).toBeDefined();
+        expect(usersNode?.children?.['me']?.path).toBe('/users/me');
+        expect(usersNode?.children?.[wildcardKey]?.path).toBe(
+          '/users/{userId}',
+        );
+      });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/router/calculations/buildRouterNode.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/calculations/buildRouterNode.spec.ts
@@ -1,7 +1,12 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 
+import { trieLookup } from '../../trie/calculations/trieLookup.js';
 import { type RouterNode } from '../models/RouterNode.js';
-import { wildcardKey } from '../models/wildcardKey.js';
+import { RouterNodeMatchKind } from '../models/RouterNodeMatchKind.js';
+import {
+  type RouterNodeParamMatch,
+  type RouterNodeParamMatchRoute,
+} from '../models/RouterNodeParamMatch.js';
 import { buildRouterNode } from './buildRouterNode.js';
 
 describe(buildRouterNode, () => {
@@ -13,11 +18,11 @@ describe(buildRouterNode, () => {
         result = buildRouterNode([]);
       });
 
-      it('should return a node with no children and no path', () => {
-        expect(result).toStrictEqual({
-          children: undefined,
-          path: undefined,
-        });
+      it('should return an empty router node', () => {
+        expect(result.match).toBeUndefined();
+        expect(result.nextLiterals.children.size).toBe(0);
+        expect(result.nextLiterals.value).toBeUndefined();
+        expect(result.nextParam).toBeUndefined();
       });
     });
   });
@@ -30,17 +35,30 @@ describe(buildRouterNode, () => {
         result = buildRouterNode(['/users']);
       });
 
-      it('should build a tree for the path', () => {
+      it('should build a literal match at the terminal node', () => {
+        const leadingEmpty: RouterNode | undefined = trieLookup(
+          result.nextLiterals,
+          '',
+          0,
+          0,
+        );
         const usersNode: RouterNode | undefined =
-          result.children?.['']?.children?.['users'];
+          leadingEmpty !== undefined
+            ? trieLookup(leadingEmpty.nextLiterals, 'users', 0, 5)
+            : undefined;
 
         expect(usersNode).toBeDefined();
-        expect(usersNode?.path).toBe('/users');
+        expect(usersNode?.match).toStrictEqual({
+          kind: RouterNodeMatchKind.literal,
+          route: '/users',
+        });
+        expect(usersNode?.nextLiterals.children.size).toBe(0);
+        expect(usersNode?.nextParam).toBeUndefined();
       });
     });
   });
 
-  describe('having a path with a param', () => {
+  describe('having a single path with a param', () => {
     describe('when called', () => {
       let result: RouterNode;
 
@@ -48,59 +66,158 @@ describe(buildRouterNode, () => {
         result = buildRouterNode(['/users/{userId}']);
       });
 
-      it('should build a tree with a wildcard node for the param', () => {
-        const wildcardNode: RouterNode | undefined =
-          result.children?.['']?.children?.['users']?.children?.[wildcardKey];
+      it('should build a param match under a nextParam node', () => {
+        const leadingEmpty: RouterNode | undefined = trieLookup(
+          result.nextLiterals,
+          '',
+          0,
+          0,
+        );
+        const usersNode: RouterNode | undefined =
+          leadingEmpty !== undefined
+            ? trieLookup(leadingEmpty.nextLiterals, 'users', 0, 5)
+            : undefined;
+        const paramNode: RouterNode | undefined = usersNode?.nextParam;
 
-        expect(wildcardNode).toBeDefined();
-        expect(wildcardNode?.path).toBe('/users/{userId}');
+        expect(paramNode).toBeDefined();
+        expect(paramNode?.match?.kind).toBe(RouterNodeMatchKind.param);
+
+        const paramMatch: RouterNodeParamMatch =
+          paramNode?.match as RouterNodeParamMatch;
+
+        expect(paramMatch.routes).toHaveLength(1);
+        expect(paramMatch.routes[0]?.route).toBe('/users/{userId}');
+        expect(paramMatch.routes[0]?.constraints).toHaveLength(1);
       });
     });
   });
 
-  describe('having multiple paths with shared prefix', () => {
+  describe('having multiple sibling static paths', () => {
     describe('when called', () => {
       let result: RouterNode;
 
       beforeAll(() => {
-        result = buildRouterNode(['/users', '/users/{userId}']);
+        result = buildRouterNode(['/users', '/posts']);
       });
 
-      it('should build a tree with shared prefix nodes', () => {
+      it('should build literal nodes for each path', () => {
+        const leadingEmpty: RouterNode | undefined = trieLookup(
+          result.nextLiterals,
+          '',
+          0,
+          0,
+        );
+
         const usersNode: RouterNode | undefined =
-          result.children?.['']?.children?.['users'];
+          leadingEmpty !== undefined
+            ? trieLookup(leadingEmpty.nextLiterals, 'users', 0, 5)
+            : undefined;
+        const postsNode: RouterNode | undefined =
+          leadingEmpty !== undefined
+            ? trieLookup(leadingEmpty.nextLiterals, 'posts', 0, 5)
+            : undefined;
 
-        expect(usersNode).toBeDefined();
-        expect(usersNode?.path).toBe('/users');
-
-        const wildcardNode: RouterNode | undefined =
-          usersNode?.children?.[wildcardKey];
-
-        expect(wildcardNode).toBeDefined();
-        expect(wildcardNode?.path).toBe('/users/{userId}');
+        expect(usersNode?.match).toStrictEqual({
+          kind: RouterNodeMatchKind.literal,
+          route: '/users',
+        });
+        expect(postsNode?.match).toStrictEqual({
+          kind: RouterNodeMatchKind.literal,
+          route: '/posts',
+        });
       });
     });
   });
 
-  describe('having paths where first registered route takes priority on conflict', () => {
-    describe('when called with /users/{userId} before /users/{id}', () => {
+  describe('having a shared prefix with a literal and a param branch', () => {
+    describe('when called', () => {
       let result: RouterNode;
 
       beforeAll(() => {
-        result = buildRouterNode(['/users/{userId}', '/users/{id}']);
+        result = buildRouterNode(['/users/me', '/users/{userId}']);
       });
 
-      it('should use the first registered path for the wildcard node', () => {
-        const wildcardNode: RouterNode | undefined =
-          result.children?.['']?.children?.['users']?.children?.[wildcardKey];
+      it('should expose both the literal child and the nextParam child', () => {
+        const leadingEmpty: RouterNode | undefined = trieLookup(
+          result.nextLiterals,
+          '',
+          0,
+          0,
+        );
+        const usersNode: RouterNode | undefined =
+          leadingEmpty !== undefined
+            ? trieLookup(leadingEmpty.nextLiterals, 'users', 0, 5)
+            : undefined;
 
-        expect(wildcardNode).toBeDefined();
-        expect(wildcardNode?.path).toBe('/users/{userId}');
+        const meNode: RouterNode | undefined =
+          usersNode !== undefined
+            ? trieLookup(usersNode.nextLiterals, 'me', 0, 2)
+            : undefined;
+
+        expect(meNode?.match).toStrictEqual({
+          kind: RouterNodeMatchKind.literal,
+          route: '/users/me',
+        });
+
+        const paramNode: RouterNode | undefined = usersNode?.nextParam;
+
+        expect(paramNode?.match?.kind).toBe(RouterNodeMatchKind.param);
+
+        const paramMatch: RouterNodeParamMatch =
+          paramNode?.match as RouterNodeParamMatch;
+
+        expect(paramMatch.routes[0]?.route).toBe('/users/{userId}');
       });
     });
   });
 
-  describe('having a complex nested path', () => {
+  describe('having a literal sibling that also matches the param regex', () => {
+    describe('when called', () => {
+      let result: RouterNode;
+
+      beforeAll(() => {
+        result = buildRouterNode(['/users/admin/settings', '/users/{userId}']);
+      });
+
+      it('should set the param match as a fallback on the literal branch', () => {
+        const leadingEmpty: RouterNode | undefined = trieLookup(
+          result.nextLiterals,
+          '',
+          0,
+          0,
+        );
+        const usersNode: RouterNode | undefined =
+          leadingEmpty !== undefined
+            ? trieLookup(leadingEmpty.nextLiterals, 'users', 0, 5)
+            : undefined;
+        const adminNode: RouterNode | undefined =
+          usersNode !== undefined
+            ? trieLookup(usersNode.nextLiterals, 'admin', 0, 5)
+            : undefined;
+
+        // `/users/admin` is not itself a registered route, but it should
+        // match `/users/{userId}` — so the admin node needs a param match.
+        expect(adminNode?.match?.kind).toBe(RouterNodeMatchKind.param);
+
+        const adminMatch: RouterNodeParamMatch =
+          adminNode?.match as RouterNodeParamMatch;
+
+        expect(adminMatch.routes[0]?.route).toBe('/users/{userId}');
+
+        const settingsNode: RouterNode | undefined =
+          adminNode !== undefined
+            ? trieLookup(adminNode.nextLiterals, 'settings', 0, 8)
+            : undefined;
+
+        expect(settingsNode?.match).toStrictEqual({
+          kind: RouterNodeMatchKind.literal,
+          route: '/users/admin/settings',
+        });
+      });
+    });
+  });
+
+  describe('having a deeply nested path with multiple params', () => {
     describe('when called', () => {
       let result: RouterNode;
 
@@ -108,55 +225,129 @@ describe(buildRouterNode, () => {
         result = buildRouterNode(['/users/{userId}/posts/{postId}']);
       });
 
-      it('should build a deeply nested tree', () => {
-        const postsWildcardNode: RouterNode | undefined =
-          result.children?.['']?.children?.['users']?.children?.[wildcardKey]
-            ?.children?.['posts']?.children?.[wildcardKey];
+      it('should build the expected nextParam chain', () => {
+        const leadingEmpty: RouterNode | undefined = trieLookup(
+          result.nextLiterals,
+          '',
+          0,
+          0,
+        );
+        const usersNode: RouterNode | undefined =
+          leadingEmpty !== undefined
+            ? trieLookup(leadingEmpty.nextLiterals, 'users', 0, 5)
+            : undefined;
+        const userIdNode: RouterNode | undefined = usersNode?.nextParam;
+        const postsNode: RouterNode | undefined =
+          userIdNode !== undefined
+            ? trieLookup(userIdNode.nextLiterals, 'posts', 0, 5)
+            : undefined;
+        const postIdNode: RouterNode | undefined = postsNode?.nextParam;
 
-        expect(postsWildcardNode).toBeDefined();
-        expect(postsWildcardNode?.path).toBe('/users/{userId}/posts/{postId}');
+        expect(postIdNode?.match?.kind).toBe(RouterNodeMatchKind.param);
+
+        const [route]: RouterNodeParamMatchRoute[] = (
+          postIdNode?.match as RouterNodeParamMatch
+        ).routes;
+
+        expect(route?.route).toBe('/users/{userId}/posts/{postId}');
+        expect(route?.constraints).toHaveLength(2);
       });
     });
   });
 
-  describe('having a param path registered before a static path that competes', () => {
-    describe('when called with /users/{userId} and /users/me', () => {
+  describe('having a segment with more than one param', () => {
+    describe('when called', () => {
       let result: RouterNode;
 
       beforeAll(() => {
-        result = buildRouterNode(['/users/{userId}', '/users/me']);
+        result = buildRouterNode(['/files/{name}.{ext}']);
       });
 
-      it('should prioritize the static route while keeping wildcard matching', () => {
-        const usersNode: RouterNode | undefined =
-          result.children?.['']?.children?.['users'];
+      it('should attach a param route with a single constraint at the param segment', () => {
+        const leadingEmpty: RouterNode | undefined = trieLookup(
+          result.nextLiterals,
+          '',
+          0,
+          0,
+        );
+        const filesNode: RouterNode | undefined =
+          leadingEmpty !== undefined
+            ? trieLookup(leadingEmpty.nextLiterals, 'files', 0, 5)
+            : undefined;
+        const paramNode: RouterNode | undefined = filesNode?.nextParam;
 
-        expect(usersNode).toBeDefined();
-        expect(usersNode?.children?.['me']?.path).toBe('/users/me');
-        expect(usersNode?.children?.[wildcardKey]?.path).toBe(
-          '/users/{userId}',
+        expect(paramNode?.match?.kind).toBe(RouterNodeMatchKind.param);
+
+        const paramMatch: RouterNodeParamMatch =
+          paramNode?.match as RouterNodeParamMatch;
+        const [route]: RouterNodeParamMatchRoute[] = paramMatch.routes;
+
+        expect(route?.route).toBe('/files/{name}.{ext}');
+        expect(route?.constraints).toHaveLength(1);
+      });
+    });
+  });
+
+  describe('having two param paths that converge at the same node', () => {
+    describe('when called with /files/{name} and /files/{name}.{ext}', () => {
+      let result: RouterNode;
+
+      beforeAll(() => {
+        result = buildRouterNode(['/files/{name}', '/files/{name}.{ext}']);
+      });
+
+      it('should aggregate both routes on the same param match', () => {
+        const leadingEmpty: RouterNode | undefined = trieLookup(
+          result.nextLiterals,
+          '',
+          0,
+          0,
+        );
+        const filesNode: RouterNode | undefined =
+          leadingEmpty !== undefined
+            ? trieLookup(leadingEmpty.nextLiterals, 'files', 0, 5)
+            : undefined;
+        const paramNode: RouterNode | undefined = filesNode?.nextParam;
+
+        expect(paramNode?.match?.kind).toBe(RouterNodeMatchKind.param);
+
+        const paramMatch: RouterNodeParamMatch =
+          paramNode?.match as RouterNodeParamMatch;
+        const routes: readonly string[] = paramMatch.routes.map(
+          ({ route }: RouterNodeParamMatchRoute) => route,
+        );
+
+        expect(routes).toStrictEqual(
+          expect.arrayContaining(['/files/{name}', '/files/{name}.{ext}']),
         );
       });
     });
   });
 
-  describe('having a static path registered before a param path that competes', () => {
-    describe('when called with /users/me and /users/{userId}', () => {
+  describe('having the same path registered twice', () => {
+    describe('when called', () => {
       let result: RouterNode;
 
       beforeAll(() => {
-        result = buildRouterNode(['/users/me', '/users/{userId}']);
+        result = buildRouterNode(['/users', '/users']);
       });
 
-      it('should prioritize the static route while keeping wildcard matching', () => {
-        const usersNode: RouterNode | undefined =
-          result.children?.['']?.children?.['users'];
-
-        expect(usersNode).toBeDefined();
-        expect(usersNode?.children?.['me']?.path).toBe('/users/me');
-        expect(usersNode?.children?.[wildcardKey]?.path).toBe(
-          '/users/{userId}',
+      it('should keep a single literal match', () => {
+        const leadingEmpty: RouterNode | undefined = trieLookup(
+          result.nextLiterals,
+          '',
+          0,
+          0,
         );
+        const usersNode: RouterNode | undefined =
+          leadingEmpty !== undefined
+            ? trieLookup(leadingEmpty.nextLiterals, 'users', 0, 5)
+            : undefined;
+
+        expect(usersNode?.match).toStrictEqual({
+          kind: RouterNodeMatchKind.literal,
+          route: '/users',
+        });
       });
     });
   });

--- a/packages/framework/validation/libraries/openapi/src/router/calculations/buildRouterNode.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/calculations/buildRouterNode.spec.ts
@@ -127,12 +127,12 @@ describe(buildRouterNode, () => {
         result = buildRouterNode(['/users/{userId}', '/users/me']);
       });
 
-      it('should have both static and wildcard children with first registered winning', () => {
+      it('should prioritize the static route while keeping wildcard matching', () => {
         const usersNode: RouterNode | undefined =
           result.children?.['']?.children?.['users'];
 
         expect(usersNode).toBeDefined();
-        expect(usersNode?.children?.['me']?.path).toBe('/users/{userId}');
+        expect(usersNode?.children?.['me']?.path).toBe('/users/me');
         expect(usersNode?.children?.[wildcardKey]?.path).toBe(
           '/users/{userId}',
         );
@@ -148,7 +148,7 @@ describe(buildRouterNode, () => {
         result = buildRouterNode(['/users/me', '/users/{userId}']);
       });
 
-      it('should have both static and wildcard children with first registered winning', () => {
+      it('should prioritize the static route while keeping wildcard matching', () => {
         const usersNode: RouterNode | undefined =
           result.children?.['']?.children?.['users'];
 

--- a/packages/framework/validation/libraries/openapi/src/router/calculations/buildRouterNode.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/calculations/buildRouterNode.spec.ts
@@ -288,6 +288,42 @@ describe(buildRouterNode, () => {
     });
   });
 
+  describe('having a path where the segment literal suffix contains a special regex character', () => {
+    describe('when called', () => {
+      let result: RouterNode;
+
+      beforeAll(() => {
+        result = buildRouterNode(['/{param}+']);
+      });
+
+      it('should build a param route whose constraint matches a value ending with a literal "+" but not without it', () => {
+        const leadingEmpty: RouterNode | undefined = trieLookup(
+          result.nextLiterals,
+          '',
+          0,
+          0,
+        );
+        const paramNode: RouterNode | undefined = leadingEmpty?.nextParam;
+
+        expect(paramNode?.match?.kind).toBe(RouterNodeMatchKind.param);
+
+        const paramMatch: RouterNodeParamMatch =
+          paramNode?.match as RouterNodeParamMatch;
+        const [route]: RouterNodeParamMatchRoute[] = paramMatch.routes;
+
+        expect(route?.constraints).toHaveLength(1);
+
+        const constraintEntry: [number, RegExp] = (
+          route?.constraints as [number, RegExp][]
+        )[0] as [number, RegExp];
+        const constraint: RegExp = constraintEntry[1];
+
+        expect(constraint.test('abc+')).toBe(true);
+        expect(constraint.test('abc')).toBe(false);
+      });
+    });
+  });
+
   describe('having two param paths that converge at the same node', () => {
     describe('when called with /files/{name} and /files/{name}.{ext}', () => {
       let result: RouterNode;

--- a/packages/framework/validation/libraries/openapi/src/router/calculations/buildRouterNode.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/calculations/buildRouterNode.ts
@@ -1,50 +1,139 @@
+import { trieInsert } from '../../trie/actions/trieInsert.js';
+import { createTrieNode } from '../../trie/calculations/createTrieNode.js';
+import { trieIterateEntries } from '../../trie/calculations/trieIterateEntries.js';
+import { trieLookup } from '../../trie/calculations/trieLookup.js';
 import { type RouterNode } from '../models/RouterNode.js';
-import { wildcardKey } from '../models/wildcardKey.js';
-import { isPathParam } from './isPathParam.js';
+import { RouterNodeMatchKind } from '../models/RouterNodeMatchKind.js';
+import { sortOpenApiPathTemplates } from './sortOpenApiPathTemplates.js';
+
+function extractConstraints(
+  pathSegments: (string | RegExp)[],
+): [number, RegExp][] {
+  return pathSegments
+    .map(
+      (segment: string | RegExp, index: number): [number, string | RegExp] => [
+        index,
+        segment,
+      ],
+    )
+    .filter(
+      (
+        indexAndPathSegment: [number, string | RegExp],
+      ): indexAndPathSegment is [number, RegExp] =>
+        indexAndPathSegment[1] instanceof RegExp,
+    );
+}
+
+function maybeSetAuxiliaryNodeMatch(
+  node: RouterNode,
+  path: string,
+  pathSegmentsOrConstraints: (string | RegExp)[],
+): void {
+  const constraints: [number, RegExp][] = extractConstraints(
+    pathSegmentsOrConstraints,
+  );
+
+  if (node.match === undefined) {
+    if (constraints.length === 0) {
+      node.match = {
+        kind: RouterNodeMatchKind.literal,
+        route: path,
+      };
+    } else {
+      node.match = {
+        kind: RouterNodeMatchKind.param,
+        routes: [
+          {
+            constraints,
+            route: path,
+          },
+        ],
+      };
+    }
+  } else {
+    if (
+      node.match.kind === RouterNodeMatchKind.param &&
+      constraints.length > 0
+    ) {
+      node.match.routes.push({
+        constraints,
+        route: path,
+      });
+    }
+  }
+}
 
 function populateAuxiliaryNode(
   node: RouterNode,
   path: string,
-  pathSegments: (string | symbol)[],
+  pathSegmentsOrConstraints: (string | RegExp)[],
   index: number,
 ): void {
-  const segment: string | symbol | undefined = pathSegments[index];
+  const segment: string | RegExp | undefined = pathSegmentsOrConstraints[index];
 
   if (segment === undefined) {
-    if (node.path === undefined) {
-      node.path = path;
+    maybeSetAuxiliaryNodeMatch(node, path, pathSegmentsOrConstraints);
+    return;
+  }
+
+  if (typeof segment === 'string') {
+    let childNode: RouterNode | undefined = trieLookup(
+      node.nextLiterals,
+      segment,
+      0,
+      segment.length,
+    );
+
+    if (childNode === undefined) {
+      childNode = {
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
+      };
+
+      trieInsert(node.nextLiterals, segment, childNode);
     }
+
+    populateAuxiliaryNode(
+      childNode,
+      path,
+      pathSegmentsOrConstraints,
+      index + 1,
+    );
 
     return;
   }
 
-  if (node.children === undefined) {
-    node.children = {};
-  }
+  // Segment is a RegExp, so we need to populate the nextParam node
 
-  if (node.children[segment] === undefined) {
-    node.children[segment] = {
-      children: undefined,
-      path: undefined,
+  if (node.nextParam === undefined) {
+    node.nextParam = {
+      match: undefined,
+      nextLiterals: createTrieNode(),
+      nextParam: undefined,
     };
   }
 
-  populateAuxiliaryNode(node.children[segment], path, pathSegments, index + 1);
+  populateAuxiliaryNode(
+    node.nextParam,
+    path,
+    pathSegmentsOrConstraints,
+    index + 1,
+  );
 }
 
 function populateRouterNode(
   routerAndAuxiliaryNodePairList: [RouterNode, RouterNode][],
-  path: string,
-  pathSegments: (string | symbol)[],
+  pathSegmentsOrConstraints: (string | RegExp)[],
   index: number,
 ): void {
-  const segment: string | symbol | undefined = pathSegments[index];
+  const segment: string | RegExp | undefined = pathSegmentsOrConstraints[index];
 
   if (segment === undefined) {
     // We reach the end of the path segments, so we can populate the router nodes
-    for (const [node] of routerAndAuxiliaryNodePairList) {
-      if (node.path === undefined) {
-        node.path = path;
+    for (const [routerNode, auxiliaryNode] of routerAndAuxiliaryNodePairList) {
+      if (routerNode.match === undefined) {
+        routerNode.match = auxiliaryNode.match;
       }
     }
 
@@ -56,133 +145,150 @@ function populateRouterNode(
   const nextRouterAndAuxiliaryNodePairList: [RouterNode, RouterNode][] = [];
 
   for (const [routerNode, auxiliaryNode] of routerAndAuxiliaryNodePairList) {
-    let nextSegmentProperties: (string | symbol)[];
-
-    if (segment === wildcardKey) {
-      nextSegmentProperties =
-        auxiliaryNode.children === undefined
-          ? []
-          : Reflect.ownKeys(auxiliaryNode.children).filter(
-              (key: string | symbol) => key !== wildcardKey,
-            );
-      nextSegmentProperties.push(wildcardKey);
-    } else {
-      nextSegmentProperties = [segment];
-    }
-
-    for (const nextSegmentProperty of nextSegmentProperties) {
-      const nextAuxiliaryNode: RouterNode | undefined =
-        auxiliaryNode.children?.[nextSegmentProperty];
+    if (typeof segment === 'string') {
+      const nextAuxiliaryNode: RouterNode | undefined = trieLookup(
+        auxiliaryNode.nextLiterals,
+        segment,
+        0,
+        segment.length,
+      );
 
       if (nextAuxiliaryNode !== undefined) {
-        if (routerNode.children === undefined) {
-          routerNode.children = {};
+        let nextRouterNode: RouterNode | undefined = trieLookup(
+          routerNode.nextLiterals,
+          segment,
+          0,
+          segment.length,
+        );
+
+        if (nextRouterNode === undefined) {
+          nextRouterNode = {
+            match: undefined,
+            nextLiterals: createTrieNode(),
+            nextParam: undefined,
+          };
+
+          trieInsert(routerNode.nextLiterals, segment, nextRouterNode);
         }
 
-        if (routerNode.children[nextSegmentProperty] === undefined) {
-          routerNode.children[nextSegmentProperty] = {
-            children: undefined,
-            path: undefined,
+        nextRouterAndAuxiliaryNodePairList.push([
+          nextRouterNode,
+          nextAuxiliaryNode,
+        ]);
+      }
+    } else {
+      // First, let's create the nextParam node if it does not exists in the auxiliary node
+
+      if (auxiliaryNode.nextParam !== undefined) {
+        if (routerNode.nextParam === undefined) {
+          routerNode.nextParam = {
+            match: undefined,
+            nextLiterals: createTrieNode(),
+            nextParam: undefined,
           };
         }
 
         nextRouterAndAuxiliaryNodePairList.push([
-          routerNode.children[nextSegmentProperty],
-          nextAuxiliaryNode,
+          routerNode.nextParam,
+          auxiliaryNode.nextParam,
         ]);
+
+        /*
+         * Now, we need to populate literal nodes for all the next literals of the
+         * auxiliary node that matches the current segment pattern
+         */
+
+        for (const [nextAuxiliaryLiteral] of trieIterateEntries(
+          auxiliaryNode.nextLiterals,
+        )) {
+          if (segment.test(nextAuxiliaryLiteral)) {
+            let nextRouterNode: RouterNode | undefined = trieLookup(
+              routerNode.nextLiterals,
+              nextAuxiliaryLiteral,
+              0,
+              nextAuxiliaryLiteral.length,
+            );
+
+            if (nextRouterNode === undefined) {
+              nextRouterNode = {
+                match: undefined,
+                nextLiterals: createTrieNode(),
+                nextParam: undefined,
+              };
+
+              trieInsert(
+                routerNode.nextLiterals,
+                nextAuxiliaryLiteral,
+                nextRouterNode,
+              );
+            }
+
+            nextRouterAndAuxiliaryNodePairList.push([
+              nextRouterNode,
+              auxiliaryNode.nextParam,
+            ]);
+          }
+        }
       }
     }
   }
 
   populateRouterNode(
     nextRouterAndAuxiliaryNodePairList,
-    path,
-    pathSegments,
+    pathSegmentsOrConstraints,
     index + 1,
   );
 }
 
-/**
- * Sorts path segments to keep path priority as stated in OpenAPI 3.X specifications.
- * @param firstSegments First segments
- * @param secondSegments Second segments
- * @returns Numeric value indicating the order of the segments for sorting purposes.
- */
-function sortPathSegments(
-  firstSegments: (string | symbol)[],
-  secondSegments: (string | symbol)[],
-): number {
-  const minLength: number = Math.min(
-    firstSegments.length,
-    secondSegments.length,
-  );
+const PARAM_SEGMENT_REGEXP: RegExp = /\{[^{]+\}/g;
 
-  for (let index: number = 0; index < minLength; ++index) {
-    const firstSegment: string | symbol = firstSegments[index] as
-      | string
-      | symbol;
-    const secondSegment: string | symbol = secondSegments[index] as
-      | string
-      | symbol;
-
-    if (typeof firstSegment === 'string') {
-      if (typeof secondSegment === 'string') {
-        if (firstSegment < secondSegment) {
-          return -1;
-        } else if (firstSegment > secondSegment) {
-          return 1;
-        }
-      } else {
-        return -1;
-      }
-    } else {
-      if (typeof secondSegment === 'string') {
-        return 1;
-      }
-    }
+function pathSegmentToSegmentOrConstraint(segment: string): string | RegExp {
+  if (PARAM_SEGMENT_REGEXP.test(segment)) {
+    return new RegExp(segment.replaceAll(PARAM_SEGMENT_REGEXP, '.+'));
   }
 
-  return firstSegments.length - secondSegments.length;
+  return segment;
 }
 
 export function buildRouterNode(paths: string[]): RouterNode {
-  const pathAndSegmentsList: [string, (string | symbol)[]][] = paths.map(
-    (path: string) => [
+  const pathAndSegmentsOrConstraints: [string, (string | RegExp)[]][] =
+    paths.map((path: string) => [
       path,
-      path
-        .split('/')
-        .map((segment: string) =>
-          isPathParam(segment) ? wildcardKey : segment,
-        ),
-    ],
-  );
+      path.split('/').map(pathSegmentToSegmentOrConstraint),
+    ]);
 
-  pathAndSegmentsList.sort(
+  pathAndSegmentsOrConstraints.sort(
     (
-      [, firstSegments]: [string, (string | symbol)[]],
-      [, secondSegments]: [string, (string | symbol)[]],
-    ) => sortPathSegments(firstSegments, secondSegments),
+      [firstPath]: [string, (string | RegExp)[]],
+      [secondPath]: [string, (string | RegExp)[]],
+    ) => sortOpenApiPathTemplates(firstPath, secondPath),
   );
 
   // Useful data structure to efficiently build the router tree, but not ideal for runtime usage
   const auxiliaryNode: RouterNode = {
-    children: undefined,
-    path: undefined,
+    match: undefined,
+    nextLiterals: createTrieNode(),
+    nextParam: undefined,
   };
 
   // Populate the auxiliary node with all paths
-  for (const [path, pathSegments] of pathAndSegmentsList) {
-    populateAuxiliaryNode(auxiliaryNode, path, pathSegments, 0);
+  for (const [path, pathSegmentOrConstraint] of pathAndSegmentsOrConstraints) {
+    populateAuxiliaryNode(auxiliaryNode, path, pathSegmentOrConstraint, 0);
   }
 
   // Create the final router node with the assistance of the auxiliary node
   const routerNode: RouterNode = {
-    children: undefined,
-    path: undefined,
+    match: undefined,
+    nextLiterals: createTrieNode(),
+    nextParam: undefined,
   };
 
-  for (const [path, pathSegments] of pathAndSegmentsList) {
-    populateRouterNode([[routerNode, auxiliaryNode]], path, pathSegments, 0);
+  for (const [, pathSegmentsOrConstraints] of pathAndSegmentsOrConstraints) {
+    populateRouterNode(
+      [[routerNode, auxiliaryNode]],
+      pathSegmentsOrConstraints,
+      0,
+    );
   }
 
   return routerNode;

--- a/packages/framework/validation/libraries/openapi/src/router/calculations/buildRouterNode.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/calculations/buildRouterNode.ts
@@ -1,0 +1,141 @@
+import { type RouterNode } from '../models/RouterNode.js';
+import { wildcardKey } from '../models/wildcardKey.js';
+import { isPathParam } from './isPathParam.js';
+
+function populateAuxiliaryNode(
+  node: RouterNode,
+  path: string,
+  pathSegments: string[],
+  index: number,
+): void {
+  const segment: string | undefined = pathSegments[index];
+
+  if (segment === undefined) {
+    if (node.path === undefined) {
+      node.path = path;
+    }
+
+    return;
+  }
+
+  if (node.children === undefined) {
+    node.children = {};
+  }
+
+  const nextSegmentProperty: string | symbol = isPathParam(segment)
+    ? wildcardKey
+    : segment;
+
+  if (node.children[nextSegmentProperty] === undefined) {
+    node.children[nextSegmentProperty] = {
+      children: undefined,
+      path: undefined,
+    };
+  }
+
+  populateAuxiliaryNode(
+    node.children[nextSegmentProperty],
+    path,
+    pathSegments,
+    index + 1,
+  );
+}
+
+function populateRouterNode(
+  routerAndAuxiliaryNodePairList: [RouterNode, RouterNode][],
+  path: string,
+  pathSegments: string[],
+  index: number,
+): void {
+  const segment: string | undefined = pathSegments[index];
+
+  if (segment === undefined) {
+    // We reach the end of the path segments, so we can populate the router nodes
+    for (const [node] of routerAndAuxiliaryNodePairList) {
+      if (node.path === undefined) {
+        node.path = path;
+      }
+    }
+
+    return;
+  }
+
+  // We need to expand the router nodes with the current segment and then continue with the next segment
+
+  const nextRouterAndAuxiliaryNodePairList: [RouterNode, RouterNode][] = [];
+
+  for (const [routerNode, auxiliaryNode] of routerAndAuxiliaryNodePairList) {
+    let nextSegmentProperties: (string | symbol)[];
+
+    if (isPathParam(segment)) {
+      nextSegmentProperties =
+        auxiliaryNode.children === undefined
+          ? []
+          : Reflect.ownKeys(auxiliaryNode.children).filter(
+              (key: string | symbol) => key !== wildcardKey,
+            );
+      nextSegmentProperties.push(wildcardKey);
+    } else {
+      nextSegmentProperties = [segment];
+    }
+
+    for (const nextSegmentProperty of nextSegmentProperties) {
+      const nextAuxiliaryNode: RouterNode | undefined =
+        auxiliaryNode.children?.[nextSegmentProperty];
+
+      if (nextAuxiliaryNode !== undefined) {
+        if (routerNode.children === undefined) {
+          routerNode.children = {};
+        }
+
+        if (routerNode.children[nextSegmentProperty] === undefined) {
+          routerNode.children[nextSegmentProperty] = {
+            children: undefined,
+            path: undefined,
+          };
+        }
+
+        nextRouterAndAuxiliaryNodePairList.push([
+          routerNode.children[nextSegmentProperty],
+          nextAuxiliaryNode,
+        ]);
+      }
+    }
+  }
+
+  populateRouterNode(
+    nextRouterAndAuxiliaryNodePairList,
+    path,
+    pathSegments,
+    index + 1,
+  );
+}
+
+export function buildRouterNode(paths: string[]): RouterNode {
+  const pathAndSegmentsList: [string, string[]][] = paths.map(
+    (path: string) => [path, path.split('/')],
+  );
+
+  // Useful data structure to efficiently build the router tree, but not ideal for runtime usage
+  const auxiliaryNode: RouterNode = {
+    children: undefined,
+    path: undefined,
+  };
+
+  // Populate the auxiliary node with all paths
+  for (const [path, pathSegments] of pathAndSegmentsList) {
+    populateAuxiliaryNode(auxiliaryNode, path, pathSegments, 0);
+  }
+
+  // Create the final router node with the assistance of the auxiliary node
+  const routerNode: RouterNode = {
+    children: undefined,
+    path: undefined,
+  };
+
+  for (const [path, pathSegments] of pathAndSegmentsList) {
+    populateRouterNode([[routerNode, auxiliaryNode]], path, pathSegments, 0);
+  }
+
+  return routerNode;
+}

--- a/packages/framework/validation/libraries/openapi/src/router/calculations/buildRouterNode.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/calculations/buildRouterNode.ts
@@ -5,10 +5,10 @@ import { isPathParam } from './isPathParam.js';
 function populateAuxiliaryNode(
   node: RouterNode,
   path: string,
-  pathSegments: string[],
+  pathSegments: (string | symbol)[],
   index: number,
 ): void {
-  const segment: string | undefined = pathSegments[index];
+  const segment: string | symbol | undefined = pathSegments[index];
 
   if (segment === undefined) {
     if (node.path === undefined) {
@@ -22,32 +22,23 @@ function populateAuxiliaryNode(
     node.children = {};
   }
 
-  const nextSegmentProperty: string | symbol = isPathParam(segment)
-    ? wildcardKey
-    : segment;
-
-  if (node.children[nextSegmentProperty] === undefined) {
-    node.children[nextSegmentProperty] = {
+  if (node.children[segment] === undefined) {
+    node.children[segment] = {
       children: undefined,
       path: undefined,
     };
   }
 
-  populateAuxiliaryNode(
-    node.children[nextSegmentProperty],
-    path,
-    pathSegments,
-    index + 1,
-  );
+  populateAuxiliaryNode(node.children[segment], path, pathSegments, index + 1);
 }
 
 function populateRouterNode(
   routerAndAuxiliaryNodePairList: [RouterNode, RouterNode][],
   path: string,
-  pathSegments: string[],
+  pathSegments: (string | symbol)[],
   index: number,
 ): void {
-  const segment: string | undefined = pathSegments[index];
+  const segment: string | symbol | undefined = pathSegments[index];
 
   if (segment === undefined) {
     // We reach the end of the path segments, so we can populate the router nodes
@@ -67,7 +58,7 @@ function populateRouterNode(
   for (const [routerNode, auxiliaryNode] of routerAndAuxiliaryNodePairList) {
     let nextSegmentProperties: (string | symbol)[];
 
-    if (isPathParam(segment)) {
+    if (segment === wildcardKey) {
       nextSegmentProperties =
         auxiliaryNode.children === undefined
           ? []
@@ -111,9 +102,66 @@ function populateRouterNode(
   );
 }
 
+/**
+ * Sorts path segments to keep path priority as stated in OpenAPI 3.X specifications.
+ * @param firstSegments First segments
+ * @param secondSegments Second segments
+ * @returns Numeric value indicating the order of the segments for sorting purposes.
+ */
+function sortPathSegments(
+  firstSegments: (string | symbol)[],
+  secondSegments: (string | symbol)[],
+): number {
+  const minLength: number = Math.min(
+    firstSegments.length,
+    secondSegments.length,
+  );
+
+  for (let index: number = 0; index < minLength; ++index) {
+    const firstSegment: string | symbol = firstSegments[index] as
+      | string
+      | symbol;
+    const secondSegment: string | symbol = secondSegments[index] as
+      | string
+      | symbol;
+
+    if (typeof firstSegment === 'string') {
+      if (typeof secondSegment === 'string') {
+        if (firstSegment < secondSegment) {
+          return -1;
+        } else if (firstSegment > secondSegment) {
+          return 1;
+        }
+      } else {
+        return -1;
+      }
+    } else {
+      if (typeof secondSegment === 'string') {
+        return 1;
+      }
+    }
+  }
+
+  return firstSegments.length - secondSegments.length;
+}
+
 export function buildRouterNode(paths: string[]): RouterNode {
-  const pathAndSegmentsList: [string, string[]][] = paths.map(
-    (path: string) => [path, path.split('/')],
+  const pathAndSegmentsList: [string, (string | symbol)[]][] = paths.map(
+    (path: string) => [
+      path,
+      path
+        .split('/')
+        .map((segment: string) =>
+          isPathParam(segment) ? wildcardKey : segment,
+        ),
+    ],
+  );
+
+  pathAndSegmentsList.sort(
+    (
+      [, firstSegments]: [string, (string | symbol)[]],
+      [, secondSegments]: [string, (string | symbol)[]],
+    ) => sortPathSegments(firstSegments, secondSegments),
   );
 
   // Useful data structure to efficiently build the router tree, but not ideal for runtime usage

--- a/packages/framework/validation/libraries/openapi/src/router/calculations/buildRouterNode.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/calculations/buildRouterNode.ts
@@ -240,21 +240,32 @@ function populateRouterNode(
   );
 }
 
-const PARAM_SEGMENT_REGEXP: RegExp = /\{[^{]+\}/g;
+const PARAM_SEGMENT_REGEXP: RegExp = /\{[^{}]+\}/;
+
+function escapeRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
 function pathSegmentToSegmentOrConstraint(segment: string): string | RegExp {
-  if (PARAM_SEGMENT_REGEXP.test(segment)) {
-    return new RegExp(segment.replaceAll(PARAM_SEGMENT_REGEXP, '.+'));
+  if (!segment.includes('{')) {
+    return segment;
   }
 
-  return segment;
+  const pattern: string = segment
+    .split(PARAM_SEGMENT_REGEXP)
+    .map(escapeRegExp)
+    .join('.+');
+
+  return new RegExp(`^${pattern}$`);
 }
 
 export function buildRouterNode(paths: string[]): RouterNode {
   const pathAndSegmentsOrConstraints: [string, (string | RegExp)[]][] =
     paths.map((path: string) => [
       path,
-      path.split('/').map(pathSegmentToSegmentOrConstraint),
+      (path === '/' ? [''] : path.split('/')).map(
+        pathSegmentToSegmentOrConstraint,
+      ),
     ]);
 
   pathAndSegmentsOrConstraints.sort(

--- a/packages/framework/validation/libraries/openapi/src/router/calculations/findRoute.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/calculations/findRoute.spec.ts
@@ -1,0 +1,239 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { type RouterNode } from '../models/RouterNode.js';
+import { wildcardKey } from '../models/wildcardKey.js';
+import { findRoute } from './findRoute.js';
+
+describe(findRoute, () => {
+  describe('having a simple static tree', () => {
+    let rootNode: RouterNode;
+
+    beforeAll(() => {
+      rootNode = {
+        children: {
+          '': {
+            children: {
+              users: {
+                children: undefined,
+                path: '/users',
+              },
+            },
+            path: undefined,
+          },
+        },
+        path: undefined,
+      };
+    });
+
+    describe('when called with a matching path', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = findRoute(rootNode, '/users');
+      });
+
+      it('should return the matched path', () => {
+        expect(result).toBe('/users');
+      });
+    });
+
+    describe('when called with a non-matching path', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = findRoute(rootNode, '/posts');
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a tree with wildcard nodes', () => {
+    let rootNode: RouterNode;
+
+    beforeAll(() => {
+      rootNode = {
+        children: {
+          '': {
+            children: {
+              users: {
+                children: {
+                  [wildcardKey]: {
+                    children: undefined,
+                    path: '/users/{userId}',
+                  },
+                },
+                path: '/users',
+              },
+            },
+            path: undefined,
+          },
+        },
+        path: undefined,
+      };
+    });
+
+    describe('when called with a path that matches the wildcard', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = findRoute(rootNode, '/users/123');
+      });
+
+      it('should return the wildcard path', () => {
+        expect(result).toBe('/users/{userId}');
+      });
+    });
+
+    describe('when called with a path that matches the static node', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = findRoute(rootNode, '/users');
+      });
+
+      it('should return the static path', () => {
+        expect(result).toBe('/users');
+      });
+    });
+  });
+
+  describe('having a tree with static and wildcard at same level', () => {
+    let rootNode: RouterNode;
+
+    beforeAll(() => {
+      rootNode = {
+        children: {
+          '': {
+            children: {
+              users: {
+                children: {
+                  me: {
+                    children: undefined,
+                    path: '/users/me',
+                  },
+                  [wildcardKey]: {
+                    children: undefined,
+                    path: '/users/{userId}',
+                  },
+                },
+                path: undefined,
+              },
+            },
+            path: undefined,
+          },
+        },
+        path: undefined,
+      };
+    });
+
+    describe('when called with /users/me', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = findRoute(rootNode, '/users/me');
+      });
+
+      it('should prefer the static match over the wildcard', () => {
+        expect(result).toBe('/users/me');
+      });
+    });
+
+    describe('when called with /users/456', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = findRoute(rootNode, '/users/456');
+      });
+
+      it('should fall back to the wildcard match', () => {
+        expect(result).toBe('/users/{userId}');
+      });
+    });
+  });
+
+  describe('having a node with no children', () => {
+    let rootNode: RouterNode;
+
+    beforeAll(() => {
+      rootNode = {
+        children: undefined,
+        path: undefined,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = findRoute(rootNode, '/anything');
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a deeply nested path with params', () => {
+    let rootNode: RouterNode;
+
+    beforeAll(() => {
+      rootNode = {
+        children: {
+          '': {
+            children: {
+              users: {
+                children: {
+                  [wildcardKey]: {
+                    children: {
+                      posts: {
+                        children: {
+                          [wildcardKey]: {
+                            children: undefined,
+                            path: '/users/{userId}/posts/{postId}',
+                          },
+                        },
+                        path: undefined,
+                      },
+                    },
+                    path: undefined,
+                  },
+                },
+                path: undefined,
+              },
+            },
+            path: undefined,
+          },
+        },
+        path: undefined,
+      };
+    });
+
+    describe('when called with a full matching path', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = findRoute(rootNode, '/users/abc/posts/xyz');
+      });
+
+      it('should return the nested path', () => {
+        expect(result).toBe('/users/{userId}/posts/{postId}');
+      });
+    });
+
+    describe('when called with a partial path', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = findRoute(rootNode, '/users/abc/posts');
+      });
+
+      it('should return undefined since partial path has no path', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/router/calculations/findRoute.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/calculations/findRoute.spec.ts
@@ -1,7 +1,9 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 
+import { trieInsert } from '../../trie/actions/trieInsert.js';
+import { createTrieNode } from '../../trie/calculations/createTrieNode.js';
 import { type RouterNode } from '../models/RouterNode.js';
-import { wildcardKey } from '../models/wildcardKey.js';
+import { RouterNodeMatchKind } from '../models/RouterNodeMatchKind.js';
 import { findRoute } from './findRoute.js';
 
 describe(findRoute, () => {
@@ -9,24 +11,29 @@ describe(findRoute, () => {
     let rootNode: RouterNode;
 
     beforeAll(() => {
-      rootNode = {
-        children: {
-          '': {
-            children: {
-              users: {
-                children: undefined,
-                path: '/users',
-              },
-            },
-            path: undefined,
-          },
-        },
-        path: undefined,
+      const usersNode: RouterNode = {
+        match: { kind: RouterNodeMatchKind.literal, route: '/users' },
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
       };
+
+      const emptySegmentNode: RouterNode = {
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
+      };
+      trieInsert(emptySegmentNode.nextLiterals, 'users', usersNode);
+
+      rootNode = {
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
+      };
+      trieInsert(rootNode.nextLiterals, '', emptySegmentNode);
     });
 
     describe('when called with a matching path', () => {
-      let result: unknown;
+      let result: string | undefined;
 
       beforeAll(() => {
         result = findRoute(rootNode, '/users');
@@ -38,7 +45,7 @@ describe(findRoute, () => {
     });
 
     describe('when called with a non-matching path', () => {
-      let result: unknown;
+      let result: string | undefined;
 
       beforeAll(() => {
         result = findRoute(rootNode, '/posts');
@@ -48,124 +55,398 @@ describe(findRoute, () => {
         expect(result).toBeUndefined();
       });
     });
+
+    describe('when called with a prefix-only path', () => {
+      let result: string | undefined;
+
+      beforeAll(() => {
+        result = findRoute(rootNode, '/use');
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when called with a path longer than the tree', () => {
+      let result: string | undefined;
+
+      beforeAll(() => {
+        result = findRoute(rootNode, '/users/extra');
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
   });
 
-  describe('having a tree with wildcard nodes', () => {
+  describe('having a tree with a param node', () => {
     let rootNode: RouterNode;
 
     beforeAll(() => {
-      rootNode = {
-        children: {
-          '': {
-            children: {
-              users: {
-                children: {
-                  [wildcardKey]: {
-                    children: undefined,
-                    path: '/users/{userId}',
-                  },
-                },
-                path: '/users',
-              },
-            },
-            path: undefined,
-          },
+      const userIdParamNode: RouterNode = {
+        match: {
+          kind: RouterNodeMatchKind.param,
+          routes: [{ constraints: [[2, /.+/]], route: '/users/{userId}' }],
         },
-        path: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
       };
+
+      const usersNode: RouterNode = {
+        match: { kind: RouterNodeMatchKind.literal, route: '/users' },
+        nextLiterals: createTrieNode(),
+        nextParam: userIdParamNode,
+      };
+
+      const emptySegmentNode: RouterNode = {
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
+      };
+      trieInsert(emptySegmentNode.nextLiterals, 'users', usersNode);
+
+      rootNode = {
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
+      };
+      trieInsert(rootNode.nextLiterals, '', emptySegmentNode);
     });
 
-    describe('when called with a path that matches the wildcard', () => {
-      let result: unknown;
+    describe('when called with a path that matches the param', () => {
+      let result: string | undefined;
 
       beforeAll(() => {
         result = findRoute(rootNode, '/users/123');
       });
 
-      it('should return the wildcard path', () => {
+      it('should return the param route', () => {
         expect(result).toBe('/users/{userId}');
       });
     });
 
-    describe('when called with a path that matches the static node', () => {
-      let result: unknown;
+    describe('when called with the literal path', () => {
+      let result: string | undefined;
 
       beforeAll(() => {
         result = findRoute(rootNode, '/users');
       });
 
-      it('should return the static path', () => {
+      it('should return the literal route', () => {
         expect(result).toBe('/users');
       });
     });
   });
 
-  describe('having a tree with static and wildcard at same level', () => {
+  describe('having literal and param at the same level', () => {
     let rootNode: RouterNode;
 
     beforeAll(() => {
-      rootNode = {
-        children: {
-          '': {
-            children: {
-              users: {
-                children: {
-                  me: {
-                    children: undefined,
-                    path: '/users/me',
-                  },
-                  [wildcardKey]: {
-                    children: undefined,
-                    path: '/users/{userId}',
-                  },
-                },
-                path: undefined,
-              },
-            },
-            path: undefined,
-          },
+      const userIdParamNode: RouterNode = {
+        match: {
+          kind: RouterNodeMatchKind.param,
+          routes: [{ constraints: [[2, /.+/]], route: '/users/{userId}' }],
         },
-        path: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
       };
+
+      const meNode: RouterNode = {
+        match: { kind: RouterNodeMatchKind.literal, route: '/users/me' },
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
+      };
+
+      const usersNode: RouterNode = {
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: userIdParamNode,
+      };
+      trieInsert(usersNode.nextLiterals, 'me', meNode);
+
+      const emptySegmentNode: RouterNode = {
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
+      };
+      trieInsert(emptySegmentNode.nextLiterals, 'users', usersNode);
+
+      rootNode = {
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
+      };
+      trieInsert(rootNode.nextLiterals, '', emptySegmentNode);
     });
 
     describe('when called with /users/me', () => {
-      let result: unknown;
+      let result: string | undefined;
 
       beforeAll(() => {
         result = findRoute(rootNode, '/users/me');
       });
 
-      it('should prefer the static match over the wildcard', () => {
+      it('should prefer the literal match over the param', () => {
         expect(result).toBe('/users/me');
       });
     });
 
     describe('when called with /users/456', () => {
-      let result: unknown;
+      let result: string | undefined;
 
       beforeAll(() => {
         result = findRoute(rootNode, '/users/456');
       });
 
-      it('should fall back to the wildcard match', () => {
+      it('should fall back to the param match', () => {
         expect(result).toBe('/users/{userId}');
       });
     });
   });
 
-  describe('having a node with no children', () => {
+  describe('having a param route with a rejecting constraint', () => {
+    let rootNode: RouterNode;
+
+    beforeAll(() => {
+      const idParamNode: RouterNode = {
+        match: {
+          kind: RouterNodeMatchKind.param,
+          routes: [{ constraints: [[2, /^\d+$/]], route: '/items/{id}' }],
+        },
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
+      };
+
+      const itemsNode: RouterNode = {
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: idParamNode,
+      };
+
+      const emptySegmentNode: RouterNode = {
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
+      };
+      trieInsert(emptySegmentNode.nextLiterals, 'items', itemsNode);
+
+      rootNode = {
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
+      };
+      trieInsert(rootNode.nextLiterals, '', emptySegmentNode);
+    });
+
+    describe('when called with a segment that satisfies the constraint', () => {
+      let result: string | undefined;
+
+      beforeAll(() => {
+        result = findRoute(rootNode, '/items/42');
+      });
+
+      it('should return the route', () => {
+        expect(result).toBe('/items/{id}');
+      });
+    });
+
+    describe('when called with a segment that fails the constraint', () => {
+      let result: string | undefined;
+
+      beforeAll(() => {
+        result = findRoute(rootNode, '/items/abc');
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having multiple param routes at the same node', () => {
+    let rootNode: RouterNode;
+
+    beforeAll(() => {
+      const nameParamNode: RouterNode = {
+        match: {
+          kind: RouterNodeMatchKind.param,
+          routes: [
+            {
+              constraints: [[2, /^.+\..+$/]],
+              route: '/files/{name}.{ext}',
+            },
+            { constraints: [[2, /^.+$/]], route: '/files/{name}' },
+          ],
+        },
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
+      };
+
+      const filesNode: RouterNode = {
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: nameParamNode,
+      };
+
+      const emptySegmentNode: RouterNode = {
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
+      };
+      trieInsert(emptySegmentNode.nextLiterals, 'files', filesNode);
+
+      rootNode = {
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
+      };
+      trieInsert(rootNode.nextLiterals, '', emptySegmentNode);
+    });
+
+    describe('when the first route constraint matches', () => {
+      let result: string | undefined;
+
+      beforeAll(() => {
+        result = findRoute(rootNode, '/files/report.pdf');
+      });
+
+      it('should return the first matching route', () => {
+        expect(result).toBe('/files/{name}.{ext}');
+      });
+    });
+
+    describe('when only the second route constraint matches', () => {
+      let result: string | undefined;
+
+      beforeAll(() => {
+        result = findRoute(rootNode, '/files/report');
+      });
+
+      it('should return the second matching route', () => {
+        expect(result).toBe('/files/{name}');
+      });
+    });
+  });
+
+  describe('having a deeply nested path with multiple params', () => {
+    let rootNode: RouterNode;
+
+    beforeAll(() => {
+      const postIdParamNode: RouterNode = {
+        match: {
+          kind: RouterNodeMatchKind.param,
+          routes: [
+            {
+              constraints: [
+                [2, /^\d+$/],
+                [4, /^\d+$/],
+              ],
+              route: '/users/{userId}/posts/{postId}',
+            },
+          ],
+        },
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
+      };
+
+      const postsNode: RouterNode = {
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: postIdParamNode,
+      };
+
+      const userIdParamNode: RouterNode = {
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
+      };
+      trieInsert(userIdParamNode.nextLiterals, 'posts', postsNode);
+
+      const usersNode: RouterNode = {
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: userIdParamNode,
+      };
+
+      const emptySegmentNode: RouterNode = {
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
+      };
+      trieInsert(emptySegmentNode.nextLiterals, 'users', usersNode);
+
+      rootNode = {
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
+      };
+      trieInsert(rootNode.nextLiterals, '', emptySegmentNode);
+    });
+
+    describe('when all params satisfy their constraints', () => {
+      let result: string | undefined;
+
+      beforeAll(() => {
+        result = findRoute(rootNode, '/users/1/posts/2');
+      });
+
+      it('should return the nested route', () => {
+        expect(result).toBe('/users/{userId}/posts/{postId}');
+      });
+    });
+
+    describe('when the last param does not satisfy its constraint', () => {
+      let result: string | undefined;
+
+      beforeAll(() => {
+        result = findRoute(rootNode, '/users/1/posts/xyz');
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when the first param does not satisfy its constraint', () => {
+      let result: string | undefined;
+
+      beforeAll(() => {
+        result = findRoute(rootNode, '/users/abc/posts/2');
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when called with a partial path', () => {
+      let result: string | undefined;
+
+      beforeAll(() => {
+        result = findRoute(rootNode, '/users/1/posts');
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having an empty node', () => {
     let rootNode: RouterNode;
 
     beforeAll(() => {
       rootNode = {
-        children: undefined,
-        path: undefined,
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
       };
     });
 
     describe('when called', () => {
-      let result: unknown;
+      let result: string | undefined;
 
       beforeAll(() => {
         result = findRoute(rootNode, '/anything');
@@ -177,61 +458,39 @@ describe(findRoute, () => {
     });
   });
 
-  describe('having a deeply nested path with params', () => {
+  describe('having a node whose match is undefined at the terminal segment', () => {
     let rootNode: RouterNode;
 
     beforeAll(() => {
-      rootNode = {
-        children: {
-          '': {
-            children: {
-              users: {
-                children: {
-                  [wildcardKey]: {
-                    children: {
-                      posts: {
-                        children: {
-                          [wildcardKey]: {
-                            children: undefined,
-                            path: '/users/{userId}/posts/{postId}',
-                          },
-                        },
-                        path: undefined,
-                      },
-                    },
-                    path: undefined,
-                  },
-                },
-                path: undefined,
-              },
-            },
-            path: undefined,
-          },
-        },
-        path: undefined,
+      const usersNode: RouterNode = {
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
       };
+
+      const emptySegmentNode: RouterNode = {
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
+      };
+      trieInsert(emptySegmentNode.nextLiterals, 'users', usersNode);
+
+      rootNode = {
+        match: undefined,
+        nextLiterals: createTrieNode(),
+        nextParam: undefined,
+      };
+      trieInsert(rootNode.nextLiterals, '', emptySegmentNode);
     });
 
-    describe('when called with a full matching path', () => {
-      let result: unknown;
+    describe('when called', () => {
+      let result: string | undefined;
 
       beforeAll(() => {
-        result = findRoute(rootNode, '/users/abc/posts/xyz');
+        result = findRoute(rootNode, '/users');
       });
 
-      it('should return the nested path', () => {
-        expect(result).toBe('/users/{userId}/posts/{postId}');
-      });
-    });
-
-    describe('when called with a partial path', () => {
-      let result: unknown;
-
-      beforeAll(() => {
-        result = findRoute(rootNode, '/users/abc/posts');
-      });
-
-      it('should return undefined since partial path has no path', () => {
+      it('should return undefined', () => {
         expect(result).toBeUndefined();
       });
     });

--- a/packages/framework/validation/libraries/openapi/src/router/calculations/findRoute.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/calculations/findRoute.ts
@@ -1,23 +1,61 @@
+import { trieLookup } from '../../trie/calculations/trieLookup.js';
 import { type RouterNode } from '../models/RouterNode.js';
-import { wildcardKey } from '../models/wildcardKey.js';
+import { RouterNodeMatchKind } from '../models/RouterNodeMatchKind.js';
+import { type RouterNodeParamMatchRoute } from '../models/RouterNodeParamMatch.js';
 
 export function findRoute(node: RouterNode, path: string): string | undefined {
-  const segments: string[] = path.split('/');
+  const segmentBounds: [number, number][] = [];
 
   let currentNode: RouterNode | undefined = node;
+  let segmentStart: number = 0;
 
-  for (const segment of segments) {
-    if (currentNode.children === undefined) {
-      return undefined;
+  while (segmentStart < path.length) {
+    let segmentEnd: number = path.indexOf('/', segmentStart);
+
+    if (segmentEnd === -1) {
+      segmentEnd = path.length;
     }
 
-    currentNode =
-      currentNode.children[segment] ?? currentNode.children[wildcardKey];
+    segmentBounds.push([segmentStart, segmentEnd]);
+
+    /*
+     * We could probably optimize this further with a compressed trie, but the
+     * current character-level trie already provides O(segment_length) lookup
+     * with zero intermediate allocations.
+     */
+    const nextLiteral: RouterNode | undefined = trieLookup(
+      currentNode.nextLiterals,
+      path,
+      segmentStart,
+      segmentEnd,
+    );
+
+    currentNode = nextLiteral ?? currentNode.nextParam;
 
     if (currentNode === undefined) {
       return undefined;
     }
+
+    segmentStart = segmentEnd + 1;
   }
 
-  return currentNode.path;
+  if (currentNode.match === undefined) {
+    return undefined;
+  }
+
+  if (currentNode.match.kind === RouterNodeMatchKind.literal) {
+    return currentNode.match.route;
+  }
+
+  return currentNode.match.routes.find(
+    ({ constraints }: RouterNodeParamMatchRoute): boolean =>
+      constraints.every(([index, constraint]: [number, RegExp]): boolean => {
+        const [start, end]: [number, number] = segmentBounds[index] as [
+          number,
+          number,
+        ];
+
+        return constraint.test(path.slice(start, end));
+      }),
+  )?.route;
 }

--- a/packages/framework/validation/libraries/openapi/src/router/calculations/findRoute.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/calculations/findRoute.ts
@@ -1,0 +1,23 @@
+import { type RouterNode } from '../models/RouterNode.js';
+import { wildcardKey } from '../models/wildcardKey.js';
+
+export function findRoute(node: RouterNode, path: string): string | undefined {
+  const segments: string[] = path.split('/');
+
+  let currentNode: RouterNode | undefined = node;
+
+  for (const segment of segments) {
+    if (currentNode.children === undefined) {
+      return undefined;
+    }
+
+    currentNode =
+      currentNode.children[segment] ?? currentNode.children[wildcardKey];
+
+    if (currentNode === undefined) {
+      return undefined;
+    }
+  }
+
+  return currentNode.path;
+}

--- a/packages/framework/validation/libraries/openapi/src/router/calculations/isPathParam.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/calculations/isPathParam.spec.ts
@@ -1,0 +1,61 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { isPathParam } from './isPathParam.js';
+
+describe(isPathParam, () => {
+  describe('having a segment that is a path param', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = isPathParam('{userId}');
+      });
+
+      it('should return true', () => {
+        expect(result).toBe(true);
+      });
+    });
+  });
+
+  describe('having a segment that is not a path param', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = isPathParam('users');
+      });
+
+      it('should return false', () => {
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('having a segment that starts with { but does not end with }', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = isPathParam('{userId');
+      });
+
+      it('should return false', () => {
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('having an empty segment', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = isPathParam('');
+      });
+
+      it('should return false', () => {
+        expect(result).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/router/calculations/isPathParam.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/calculations/isPathParam.ts
@@ -1,0 +1,3 @@
+export function isPathParam(segment: string): boolean {
+  return segment.startsWith('{') && segment.endsWith('}');
+}

--- a/packages/framework/validation/libraries/openapi/src/router/calculations/sortOpenApiPathTemplates.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/calculations/sortOpenApiPathTemplates.spec.ts
@@ -167,4 +167,18 @@ describe(sortOpenApiPathTemplates, () => {
       });
     });
   });
+
+  describe('having a templated path and a concrete sibling sharing the same literal prefix', () => {
+    describe('when called', () => {
+      let result: number;
+
+      beforeAll(() => {
+        result = sortOpenApiPathTemplates('/users/{id}', '/users/~me');
+      });
+
+      it('should return a positive number placing the concrete path first', () => {
+        expect(result).toBeGreaterThan(0);
+      });
+    });
+  });
 });

--- a/packages/framework/validation/libraries/openapi/src/router/calculations/sortOpenApiPathTemplates.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/calculations/sortOpenApiPathTemplates.spec.ts
@@ -1,0 +1,170 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { sortOpenApiPathTemplates } from './sortOpenApiPathTemplates.js';
+
+describe(sortOpenApiPathTemplates, () => {
+  describe('having two identical paths', () => {
+    describe('when called', () => {
+      let result: number;
+
+      beforeAll(() => {
+        result = sortOpenApiPathTemplates('/users', '/users');
+      });
+
+      it('should return 0', () => {
+        expect(result).toBe(0);
+      });
+    });
+  });
+
+  describe('having two paths with no params, first alphabetically less than second', () => {
+    describe('when called', () => {
+      let result: number;
+
+      beforeAll(() => {
+        result = sortOpenApiPathTemplates('/posts', '/users');
+      });
+
+      it('should return a negative number', () => {
+        expect(result).toBeLessThan(0);
+      });
+    });
+  });
+
+  describe('having two paths with no params, first alphabetically greater than second', () => {
+    describe('when called', () => {
+      let result: number;
+
+      beforeAll(() => {
+        result = sortOpenApiPathTemplates('/users', '/posts');
+      });
+
+      it('should return a positive number', () => {
+        expect(result).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe('having two paths with a param, literal slice before param is less in first', () => {
+    describe('when called', () => {
+      let result: number;
+
+      beforeAll(() => {
+        result = sortOpenApiPathTemplates('/api/v1/{id}', '/api/v2/{id}');
+      });
+
+      it('should return a negative number', () => {
+        expect(result).toBeLessThan(0);
+      });
+    });
+  });
+
+  describe('having two paths with a param, literal slice before param is greater in first', () => {
+    describe('when called', () => {
+      let result: number;
+
+      beforeAll(() => {
+        result = sortOpenApiPathTemplates('/api/v2/{id}', '/api/v1/{id}');
+      });
+
+      it('should return a positive number', () => {
+        expect(result).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe('having two paths with a param at the same position and equal literal slices before the param', () => {
+    describe('when called', () => {
+      let result: number;
+
+      beforeAll(() => {
+        result = sortOpenApiPathTemplates('/users/{id}', '/users/{name}');
+      });
+
+      it('should fall back to full string comparison and return a negative number', () => {
+        expect(result).toBeLessThan(0);
+      });
+    });
+  });
+
+  describe('having first path with a param and second path without any param', () => {
+    describe('when called', () => {
+      let result: number;
+
+      beforeAll(() => {
+        result = sortOpenApiPathTemplates('/users/{id}', '/users');
+      });
+
+      it('should return a positive number placing the param-less path first', () => {
+        expect(result).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe('having first path without a param and second path with a param', () => {
+    describe('when called', () => {
+      let result: number;
+
+      beforeAll(() => {
+        result = sortOpenApiPathTemplates('/users', '/users/{id}');
+      });
+
+      it('should return a negative number placing the param-less path first', () => {
+        expect(result).toBeLessThan(0);
+      });
+    });
+  });
+
+  describe('having two paths with multiple params and different literal sections between params', () => {
+    describe('when called', () => {
+      let result: number;
+
+      beforeAll(() => {
+        result = sortOpenApiPathTemplates(
+          '/api/v1/{userId}/posts/{postId}',
+          '/api/v2/{userId}/posts/{postId}',
+        );
+      });
+
+      it('should return a negative number based on the first differing literal section', () => {
+        expect(result).toBeLessThan(0);
+      });
+    });
+  });
+
+  describe('having two paths with multiple params and equal literal sections between params', () => {
+    describe('when called', () => {
+      let result: number;
+
+      beforeAll(() => {
+        result = sortOpenApiPathTemplates(
+          '/users/{userId}/posts/{postId}',
+          '/users/{userId}/posts/{commentId}',
+        );
+      });
+
+      it('should fall back to full string comparison', () => {
+        expect(result).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe('having two paths with params at different positions', () => {
+    describe('when called', () => {
+      let result: number;
+
+      beforeAll(() => {
+        result = sortOpenApiPathTemplates('/a/{x}/c', '/a/b/{y}');
+      });
+
+      it('should compare the literal slice before the first param', () => {
+        // firstPathParamStartIndex = 3 ('{' in '/a/{x}/c')
+        // secondPathParamStartIndex = 5 ('{' in '/a/b/{y}')
+        // firstSlice = '/a/{x}/c'.slice(0, 3) = '/a/'
+        // secondSlice = '/a/b/{y}'.slice(0, 5) = '/a/b/'
+        // '/a/' < '/a/b/' → return -1 (negative)
+        expect(result).toBeLessThan(0);
+      });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/router/calculations/sortOpenApiPathTemplates.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/calculations/sortOpenApiPathTemplates.ts
@@ -1,0 +1,69 @@
+/**
+ * Sorts path segments to keep path priority as stated in OpenAPI 3.X specifications.
+ * @param firstPathTemplate First path template
+ * @param secondPathTemplate Second path template
+ * @returns Numeric value indicating the order of the paths for sorting purposes.
+ */
+export function sortOpenApiPathTemplates(
+  firstPathTemplate: string,
+  secondPathTemplate: string,
+): number {
+  let currentFirstPathIndex: number = 0;
+  let currentSecondPathIndex: number = 0;
+
+  let firstPathParamStartIndex: number = firstPathTemplate.indexOf('{');
+  let secondPathParamStartIndex: number = secondPathTemplate.indexOf('{');
+
+  while (firstPathParamStartIndex !== -1 && secondPathParamStartIndex !== -1) {
+    if (firstPathParamStartIndex === -1) {
+      return -1;
+    }
+
+    if (secondPathParamStartIndex === -1) {
+      return 1;
+    }
+
+    // Compare slices
+    const firstPathSlice: string = firstPathTemplate.slice(
+      currentFirstPathIndex,
+      firstPathParamStartIndex,
+    );
+    const secondPathSlice: string = secondPathTemplate.slice(
+      currentSecondPathIndex,
+      secondPathParamStartIndex,
+    );
+
+    if (firstPathSlice < secondPathSlice) {
+      return -1;
+    }
+
+    if (firstPathSlice > secondPathSlice) {
+      return 1;
+    }
+
+    // Move the indices to the next slice
+    currentFirstPathIndex =
+      firstPathTemplate.indexOf('}', firstPathParamStartIndex + 1) + 1;
+    currentSecondPathIndex =
+      secondPathTemplate.indexOf('}', secondPathParamStartIndex + 1) + 1;
+
+    firstPathParamStartIndex = firstPathTemplate.indexOf(
+      '{',
+      currentFirstPathIndex,
+    );
+    secondPathParamStartIndex = secondPathTemplate.indexOf(
+      '{',
+      currentSecondPathIndex,
+    );
+  }
+
+  if (firstPathTemplate < secondPathTemplate) {
+    return -1;
+  }
+
+  if (firstPathTemplate > secondPathTemplate) {
+    return 1;
+  }
+
+  return 0;
+}

--- a/packages/framework/validation/libraries/openapi/src/router/calculations/sortOpenApiPathTemplates.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/calculations/sortOpenApiPathTemplates.ts
@@ -57,6 +57,36 @@ export function sortOpenApiPathTemplates(
     );
   }
 
+  if (firstPathParamStartIndex !== -1) {
+    const firstLiteralSlice: string = firstPathTemplate.slice(
+      currentFirstPathIndex,
+      firstPathParamStartIndex,
+    );
+    const secondLiteralSlice: string = secondPathTemplate.slice(
+      currentSecondPathIndex,
+      currentSecondPathIndex + firstLiteralSlice.length,
+    );
+
+    if (firstLiteralSlice === secondLiteralSlice) {
+      return 1;
+    }
+  }
+
+  if (secondPathParamStartIndex !== -1) {
+    const secondLiteralSlice: string = secondPathTemplate.slice(
+      currentSecondPathIndex,
+      secondPathParamStartIndex,
+    );
+    const firstLiteralSlice: string = firstPathTemplate.slice(
+      currentFirstPathIndex,
+      currentFirstPathIndex + secondLiteralSlice.length,
+    );
+
+    if (secondLiteralSlice === firstLiteralSlice) {
+      return -1;
+    }
+  }
+
   if (firstPathTemplate < secondPathTemplate) {
     return -1;
   }

--- a/packages/framework/validation/libraries/openapi/src/router/models/BaseRouterNodeMatch.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/models/BaseRouterNodeMatch.ts
@@ -1,0 +1,5 @@
+import { type RouterNodeMatchKind } from './RouterNodeMatchKind.js';
+
+export interface BaseRouterNodeMatch<TKind extends RouterNodeMatchKind> {
+  readonly kind: TKind;
+}

--- a/packages/framework/validation/libraries/openapi/src/router/models/RouterNode.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/models/RouterNode.ts
@@ -40,7 +40,7 @@
  * 6. If all segments are processed and a node with a path is found, the
  *    path is matched.
  *
- * Further optimizations can be made to avoid unnecesary string slice
+ * Further optimizations can be made to avoid unnecessary string slice
  * operations, but so far it is good enough for our use case.
  */
 export interface RouterNode {

--- a/packages/framework/validation/libraries/openapi/src/router/models/RouterNode.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/models/RouterNode.ts
@@ -1,49 +1,13 @@
+import { type TrieNode } from '../../trie/models/TrieNode.js';
+import { type RouterNodeMatch } from './RouterNodeMatch.js';
+
 /**
- * RouterNode represents a node in the path tree used for OpenAPI
- * path matching. Each node can have children nodes corresponding to
- * the next segment in the path, and it may also store the full path
- * if it represents a complete path in the OpenAPI specification.
- *
- * Children nodes are stored in a record where the key is either a
- * path segment or a wildcard symbol (for path parameters). The value
- * is another RouterNode representing the next level in the path
- * hierarchy.
- *
- * This way, we can efficiently match incoming request paths against
- * the OpenAPI paths, including handling path parameters.
- *
- * For example, for the OpenAPI paths:
- * - /users/{userId}
- * - /users/{userId}/posts
- * - /users/{userId}/posts/{postId}
- *
- * The pathfinder tree would have a root node with a child for "users",
- * which in turn has a child for the wildcard key (representing
- * "{userId}"), which then has a child for "posts", and so on.
- *
- * Given a request path like "/users/123/posts/456", we can traverse the
- * tree by matching "users" to the first child, then matching "123" to
- * the wildcard key, then matching "posts" to the next child, and
- * finally matching "456" to the wildcard key at the end.
- *
- * Basically, the traverse algorithm is as follows:
- *
- * 1. Start at the root node with the full path segments.
- * 2. For each segment in the path, check if there is a matching child
- *    node.
- * 3. If a matching child node is found, move to that node and continue
- *    with the next segment.
- * 4. If no matching child node is found, check for a wildcard child node
- *    and move to it if available.
- * 5. Repeat steps 2-4 until all segments are processed or no matching
- *    node is found.
- * 6. If all segments are processed and a node with a path is found, the
- *    path is matched.
- *
- * Further optimizations can be made to avoid unnecessary string slice
- * operations, but so far it is good enough for our use case.
+ * Represents a node in the router tree.
+ * A param can now include multiple param based routes with different constraints,
+ * supporting routes with multiple parameters at the same segment.
  */
 export interface RouterNode {
-  children: Record<string | symbol, RouterNode> | undefined;
-  path: string | undefined;
+  match: RouterNodeMatch | undefined;
+  nextLiterals: TrieNode<RouterNode>;
+  nextParam: RouterNode | undefined;
 }

--- a/packages/framework/validation/libraries/openapi/src/router/models/RouterNode.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/models/RouterNode.ts
@@ -1,0 +1,49 @@
+/**
+ * RouterNode represents a node in the path tree used for OpenAPI
+ * path matching. Each node can have children nodes corresponding to
+ * the next segment in the path, and it may also store the full path
+ * if it represents a complete path in the OpenAPI specification.
+ *
+ * Children nodes are stored in a record where the key is either a
+ * path segment or a wildcard symbol (for path parameters). The value
+ * is another RouterNode representing the next level in the path
+ * hierarchy.
+ *
+ * This way, we can efficiently match incoming request paths against
+ * the OpenAPI paths, including handling path parameters.
+ *
+ * For example, for the OpenAPI paths:
+ * - /users/{userId}
+ * - /users/{userId}/posts
+ * - /users/{userId}/posts/{postId}
+ *
+ * The pathfinder tree would have a root node with a child for "users",
+ * which in turn has a child for the wildcard key (representing
+ * "{userId}"), which then has a child for "posts", and so on.
+ *
+ * Given a request path like "/users/123/posts/456", we can traverse the
+ * tree by matching "users" to the first child, then matching "123" to
+ * the wildcard key, then matching "posts" to the next child, and
+ * finally matching "456" to the wildcard key at the end.
+ *
+ * Basically, the traverse algorithm is as follows:
+ *
+ * 1. Start at the root node with the full path segments.
+ * 2. For each segment in the path, check if there is a matching child
+ *    node.
+ * 3. If a matching child node is found, move to that node and continue
+ *    with the next segment.
+ * 4. If no matching child node is found, check for a wildcard child node
+ *    and move to it if available.
+ * 5. Repeat steps 2-4 until all segments are processed or no matching
+ *    node is found.
+ * 6. If all segments are processed and a node with a path is found, the
+ *    path is matched.
+ *
+ * Further optimizations can be made to avoid unnecesary string slice
+ * operations, but so far it is good enough for our use case.
+ */
+export interface RouterNode {
+  children: Record<string | symbol, RouterNode> | undefined;
+  path: string | undefined;
+}

--- a/packages/framework/validation/libraries/openapi/src/router/models/RouterNodeLiteralMatch.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/models/RouterNodeLiteralMatch.ts
@@ -1,0 +1,6 @@
+import { type BaseRouterNodeMatch } from './BaseRouterNodeMatch.js';
+import { type RouterNodeMatchKind } from './RouterNodeMatchKind.js';
+
+export interface RouterNodeLiteralMatch extends BaseRouterNodeMatch<RouterNodeMatchKind.literal> {
+  readonly route: string;
+}

--- a/packages/framework/validation/libraries/openapi/src/router/models/RouterNodeMatch.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/models/RouterNodeMatch.ts
@@ -1,0 +1,4 @@
+import { type RouterNodeLiteralMatch } from './RouterNodeLiteralMatch.js';
+import { type RouterNodeParamMatch } from './RouterNodeParamMatch.js';
+
+export type RouterNodeMatch = RouterNodeLiteralMatch | RouterNodeParamMatch;

--- a/packages/framework/validation/libraries/openapi/src/router/models/RouterNodeMatchKind.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/models/RouterNodeMatchKind.ts
@@ -1,0 +1,4 @@
+export enum RouterNodeMatchKind {
+  literal = 0,
+  param = 1,
+}

--- a/packages/framework/validation/libraries/openapi/src/router/models/RouterNodeParamMatch.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/models/RouterNodeParamMatch.ts
@@ -1,0 +1,11 @@
+import { type BaseRouterNodeMatch } from './BaseRouterNodeMatch.js';
+import { type RouterNodeMatchKind } from './RouterNodeMatchKind.js';
+
+export interface RouterNodeParamMatch extends BaseRouterNodeMatch<RouterNodeMatchKind.param> {
+  readonly routes: RouterNodeParamMatchRoute[];
+}
+
+export interface RouterNodeParamMatchRoute {
+  readonly constraints: [number, RegExp][];
+  readonly route: string;
+}

--- a/packages/framework/validation/libraries/openapi/src/router/models/wildcardKey.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/models/wildcardKey.ts
@@ -1,1 +1,0 @@
-export const wildcardKey: symbol = Symbol.for('*');

--- a/packages/framework/validation/libraries/openapi/src/router/models/wildcardKey.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/models/wildcardKey.ts
@@ -1,0 +1,1 @@
+export const wildcardKey: symbol = Symbol.for('*');

--- a/packages/framework/validation/libraries/openapi/src/router/services/BaseOpenApiRouter.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/services/BaseOpenApiRouter.spec.ts
@@ -18,8 +18,12 @@ describe(BaseOpenApiRouter, () => {
 
     beforeAll(() => {
       routerNodeFixture = {
-        children: undefined,
-        path: undefined,
+        match: undefined,
+        nextLiterals: {
+          children: new Map(),
+          value: undefined,
+        },
+        nextParam: undefined,
       };
 
       vitest.mocked(buildRouterNode).mockReturnValue(routerNodeFixture);
@@ -38,7 +42,7 @@ describe(BaseOpenApiRouter, () => {
         }));
       });
 
-      it('should call buildRouterNode once', () => {
+      it('should call buildRouterNode()', () => {
         expect(buildRouterNode).toHaveBeenCalledExactlyOnceWith([
           '/users',
           '/users/{userId}',
@@ -59,7 +63,7 @@ describe(BaseOpenApiRouter, () => {
             vitest.clearAllMocks();
           });
 
-          it('should call findRoute with the router node and path', () => {
+          it('should call findRoute()', () => {
             expect(findRoute).toHaveBeenCalledExactlyOnceWith(
               routerNodeFixture,
               '/users/123',
@@ -95,7 +99,7 @@ describe(BaseOpenApiRouter, () => {
         }));
       });
 
-      it('should call buildRouterNode for each method', () => {
+      it('should call buildRouterNode()', () => {
         expect(buildRouterNode).toHaveBeenCalledTimes(2);
       });
     });

--- a/packages/framework/validation/libraries/openapi/src/router/services/BaseOpenApiRouter.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/services/BaseOpenApiRouter.spec.ts
@@ -1,0 +1,103 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+vitest.mock(import('../calculations/buildRouterNode.js'));
+vitest.mock(import('../calculations/findRoute.js'));
+
+import { buildRouterNode } from '../calculations/buildRouterNode.js';
+import { findRoute } from '../calculations/findRoute.js';
+import { type RouterNode } from '../models/RouterNode.js';
+import { BaseOpenApiRouter } from './BaseOpenApiRouter.js';
+
+describe(BaseOpenApiRouter, () => {
+  afterAll(() => {
+    vitest.restoreAllMocks();
+  });
+
+  describe('when constructed', () => {
+    let routerNodeFixture: RouterNode;
+
+    beforeAll(() => {
+      routerNodeFixture = {
+        children: undefined,
+        path: undefined,
+      };
+
+      vitest.mocked(buildRouterNode).mockReturnValue(routerNodeFixture);
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    describe('having a single method with routes', () => {
+      let router: BaseOpenApiRouter<unknown>;
+
+      beforeAll(() => {
+        router = new BaseOpenApiRouter(Symbol(), () => ({
+          get: ['/users', '/users/{userId}'],
+        }));
+      });
+
+      it('should call buildRouterNode once', () => {
+        expect(buildRouterNode).toHaveBeenCalledExactlyOnceWith([
+          '/users',
+          '/users/{userId}',
+        ]);
+      });
+
+      describe('.findRoute', () => {
+        describe('when called with a known method', () => {
+          let result: unknown;
+
+          beforeAll(() => {
+            vitest.mocked(findRoute).mockReturnValueOnce('/users/{userId}');
+
+            result = router.findRoute('get', '/users/123');
+          });
+
+          afterAll(() => {
+            vitest.clearAllMocks();
+          });
+
+          it('should call findRoute with the router node and path', () => {
+            expect(findRoute).toHaveBeenCalledExactlyOnceWith(
+              routerNodeFixture,
+              '/users/123',
+            );
+          });
+
+          it('should return the matched route', () => {
+            expect(result).toBe('/users/{userId}');
+          });
+        });
+
+        describe('when called with an unknown method', () => {
+          let result: unknown;
+
+          beforeAll(() => {
+            result = router.findRoute('post', '/users');
+          });
+
+          it('should return undefined', () => {
+            expect(result).toBeUndefined();
+          });
+        });
+      });
+    });
+
+    describe('having multiple methods with routes', () => {
+      beforeAll(() => {
+        vitest.mocked(buildRouterNode).mockClear();
+
+        new BaseOpenApiRouter(Symbol(), () => ({
+          get: ['/users'],
+          post: ['/users'],
+        }));
+      });
+
+      it('should call buildRouterNode for each method', () => {
+        expect(buildRouterNode).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/router/services/BaseOpenApiRouter.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/services/BaseOpenApiRouter.ts
@@ -1,0 +1,45 @@
+import { buildRouterNode } from '../calculations/buildRouterNode.js';
+import { findRoute } from '../calculations/findRoute.js';
+import { type RouterNode } from '../models/RouterNode.js';
+import { type OpenApiRouter } from './OpenApiRouter.js';
+
+export class BaseOpenApiRouter<TOpenApiObject> implements OpenApiRouter {
+  protected readonly _openApiObject: TOpenApiObject;
+
+  readonly #methodToRouterNodeObject: Record<string, RouterNode>;
+
+  constructor(
+    openApiObject: TOpenApiObject,
+    extractMethodToRoutesObject: (
+      openApiObject: TOpenApiObject,
+    ) => Record<string, string[]>,
+  ) {
+    this._openApiObject = openApiObject;
+
+    const methodToRoutesObject: Record<string, string[]> =
+      extractMethodToRoutesObject(openApiObject);
+
+    this.#methodToRouterNodeObject = {};
+
+    this.#populateMethodToRouterNodeObject(methodToRoutesObject);
+  }
+
+  public findRoute(method: string, path: string): string | undefined {
+    const routerNode: RouterNode | undefined =
+      this.#methodToRouterNodeObject[method];
+
+    if (routerNode === undefined) {
+      return undefined;
+    }
+
+    return findRoute(routerNode, path);
+  }
+
+  #populateMethodToRouterNodeObject(
+    methodToRoutesObject: Record<string, string[]>,
+  ): void {
+    for (const [method, routes] of Object.entries(methodToRoutesObject)) {
+      this.#methodToRouterNodeObject[method] = buildRouterNode(routes);
+    }
+  }
+}

--- a/packages/framework/validation/libraries/openapi/src/router/services/OpenApiRouter.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/services/OpenApiRouter.ts
@@ -1,0 +1,3 @@
+export interface OpenApiRouter {
+  findRoute(method: string, path: string): string | undefined;
+}

--- a/packages/framework/validation/libraries/openapi/src/router/services/v3Dot1/OpenApi3Dot1Router.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/services/v3Dot1/OpenApi3Dot1Router.spec.ts
@@ -1,0 +1,153 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { type OpenApi3Dot1Object } from '@inversifyjs/open-api-types/v3Dot1';
+
+import { OpenApi3Dot1Router } from './OpenApi3Dot1Router.js';
+
+describe(OpenApi3Dot1Router, () => {
+  describe('having an OpenAPI object with paths', () => {
+    let router: OpenApi3Dot1Router;
+
+    beforeAll(() => {
+      const openApiObject: OpenApi3Dot1Object = {
+        info: { title: 'Test', version: '1.0.0' },
+        openapi: '3.1.0',
+        paths: {
+          '/users': {
+            get: { responses: {} },
+            post: { responses: {} },
+          },
+          '/users/{userId}': {
+            get: { responses: {} },
+          },
+        },
+      };
+
+      router = new OpenApi3Dot1Router(openApiObject);
+    });
+
+    describe('.findRoute', () => {
+      describe('when called with a static path that matches', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = router.findRoute('get', '/users');
+        });
+
+        it('should return the matched path', () => {
+          expect(result).toBe('/users');
+        });
+      });
+
+      describe('when called with a parameterized path', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = router.findRoute('get', '/users/123');
+        });
+
+        it('should return the parameterized route', () => {
+          expect(result).toBe('/users/{userId}');
+        });
+      });
+
+      describe('when called with a method that has no routes', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = router.findRoute('delete', '/users');
+        });
+
+        it('should return undefined', () => {
+          expect(result).toBeUndefined();
+        });
+      });
+
+      describe('when called with a path that has no match', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = router.findRoute('get', '/posts');
+        });
+
+        it('should return undefined', () => {
+          expect(result).toBeUndefined();
+        });
+      });
+    });
+  });
+
+  describe('having an OpenAPI object with no paths', () => {
+    let router: OpenApi3Dot1Router;
+
+    beforeAll(() => {
+      const openApiObject: OpenApi3Dot1Object = {
+        info: { title: 'Test', version: '1.0.0' },
+        openapi: '3.1.0',
+      };
+
+      router = new OpenApi3Dot1Router(openApiObject);
+    });
+
+    describe('.findRoute', () => {
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = router.findRoute('get', '/users');
+        });
+
+        it('should return undefined', () => {
+          expect(result).toBeUndefined();
+        });
+      });
+    });
+  });
+
+  describe('having an OpenAPI object with static and param paths that conflict', () => {
+    let router: OpenApi3Dot1Router;
+
+    beforeAll(() => {
+      const openApiObject: OpenApi3Dot1Object = {
+        info: { title: 'Test', version: '1.0.0' },
+        openapi: '3.1.0',
+        paths: {
+          '/users/{userId}': {
+            get: { responses: {} },
+          },
+          '/users/me': {
+            get: { responses: {} },
+          },
+        },
+      };
+
+      router = new OpenApi3Dot1Router(openApiObject);
+    });
+
+    describe('.findRoute', () => {
+      describe('when called with /users/me', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = router.findRoute('get', '/users/me');
+        });
+
+        it('should return first registered route', () => {
+          expect(result).toBe('/users/{userId}');
+        });
+      });
+
+      describe('when called with /users/456', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = router.findRoute('get', '/users/456');
+        });
+
+        it('should match the parameterized route', () => {
+          expect(result).toBe('/users/{userId}');
+        });
+      });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/router/services/v3Dot1/OpenApi3Dot1Router.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/services/v3Dot1/OpenApi3Dot1Router.spec.ts
@@ -132,8 +132,8 @@ describe(OpenApi3Dot1Router, () => {
           result = router.findRoute('get', '/users/me');
         });
 
-        it('should return first registered route', () => {
-          expect(result).toBe('/users/{userId}');
+        it('should return the concrete route', () => {
+          expect(result).toBe('/users/me');
         });
       });
 

--- a/packages/framework/validation/libraries/openapi/src/router/services/v3Dot1/OpenApi3Dot1Router.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/services/v3Dot1/OpenApi3Dot1Router.ts
@@ -1,0 +1,39 @@
+import {
+  type OpenApi3Dot1Object,
+  type OpenApi3Dot1PathsObject,
+} from '@inversifyjs/open-api-types/v3Dot1';
+
+import { isOpenApiMethod } from '../../../validation/calculations/v3Dot1/isOpenApiMethod.js';
+import { BaseOpenApiRouter } from '../BaseOpenApiRouter.js';
+
+export class OpenApi3Dot1Router extends BaseOpenApiRouter<OpenApi3Dot1Object> {
+  constructor(openApiObject: OpenApi3Dot1Object) {
+    super(
+      openApiObject,
+      (openApiObject: OpenApi3Dot1Object): Record<string, string[]> => {
+        const methodToRoutesObject: Record<string, string[]> = {};
+
+        const pathItemsObject: OpenApi3Dot1PathsObject | undefined =
+          openApiObject.paths;
+
+        if (pathItemsObject !== undefined) {
+          for (const [path, pathItemObject] of Object.entries(
+            pathItemsObject,
+          )) {
+            for (const method of Object.keys(pathItemObject)) {
+              if (isOpenApiMethod(method)) {
+                if (methodToRoutesObject[method] === undefined) {
+                  methodToRoutesObject[method] = [];
+                }
+
+                methodToRoutesObject[method].push(path);
+              }
+            }
+          }
+        }
+
+        return methodToRoutesObject;
+      },
+    );
+  }
+}

--- a/packages/framework/validation/libraries/openapi/src/router/services/v3Dot2/OpenApi3Dot2Router.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/services/v3Dot2/OpenApi3Dot2Router.spec.ts
@@ -1,0 +1,153 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { type OpenApi3Dot2Object } from '@inversifyjs/open-api-types/v3Dot2';
+
+import { OpenApi3Dot2Router } from './OpenApi3Dot2Router.js';
+
+describe(OpenApi3Dot2Router, () => {
+  describe('having an OpenAPI object with paths', () => {
+    let router: OpenApi3Dot2Router;
+
+    beforeAll(() => {
+      const openApiObject: OpenApi3Dot2Object = {
+        info: { title: 'Test', version: '1.0.0' },
+        openapi: '3.2.0',
+        paths: {
+          '/users': {
+            get: { responses: {} },
+            post: { responses: {} },
+          },
+          '/users/{userId}': {
+            get: { responses: {} },
+          },
+        },
+      };
+
+      router = new OpenApi3Dot2Router(openApiObject);
+    });
+
+    describe('.findRoute', () => {
+      describe('when called with a static path that matches', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = router.findRoute('get', '/users');
+        });
+
+        it('should return the matched path', () => {
+          expect(result).toBe('/users');
+        });
+      });
+
+      describe('when called with a parameterized path', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = router.findRoute('get', '/users/123');
+        });
+
+        it('should return the parameterized route', () => {
+          expect(result).toBe('/users/{userId}');
+        });
+      });
+
+      describe('when called with a method that has no routes', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = router.findRoute('delete', '/users');
+        });
+
+        it('should return undefined', () => {
+          expect(result).toBeUndefined();
+        });
+      });
+
+      describe('when called with a path that has no match', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = router.findRoute('get', '/posts');
+        });
+
+        it('should return undefined', () => {
+          expect(result).toBeUndefined();
+        });
+      });
+    });
+  });
+
+  describe('having an OpenAPI object with no paths', () => {
+    let router: OpenApi3Dot2Router;
+
+    beforeAll(() => {
+      const openApiObject: OpenApi3Dot2Object = {
+        info: { title: 'Test', version: '1.0.0' },
+        openapi: '3.2.0',
+      };
+
+      router = new OpenApi3Dot2Router(openApiObject);
+    });
+
+    describe('.findRoute', () => {
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = router.findRoute('get', '/users');
+        });
+
+        it('should return undefined', () => {
+          expect(result).toBeUndefined();
+        });
+      });
+    });
+  });
+
+  describe('having an OpenAPI object with static and param paths that conflict', () => {
+    let router: OpenApi3Dot2Router;
+
+    beforeAll(() => {
+      const openApiObject: OpenApi3Dot2Object = {
+        info: { title: 'Test', version: '1.0.0' },
+        openapi: '3.2.0',
+        paths: {
+          '/users/{userId}': {
+            get: { responses: {} },
+          },
+          '/users/me': {
+            get: { responses: {} },
+          },
+        },
+      };
+
+      router = new OpenApi3Dot2Router(openApiObject);
+    });
+
+    describe('.findRoute', () => {
+      describe('when called with /users/me', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = router.findRoute('get', '/users/me');
+        });
+
+        it('should return first registered route', () => {
+          expect(result).toBe('/users/{userId}');
+        });
+      });
+
+      describe('when called with /users/456', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = router.findRoute('get', '/users/456');
+        });
+
+        it('should match the parameterized route', () => {
+          expect(result).toBe('/users/{userId}');
+        });
+      });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/router/services/v3Dot2/OpenApi3Dot2Router.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/services/v3Dot2/OpenApi3Dot2Router.spec.ts
@@ -132,8 +132,8 @@ describe(OpenApi3Dot2Router, () => {
           result = router.findRoute('get', '/users/me');
         });
 
-        it('should return first registered route', () => {
-          expect(result).toBe('/users/{userId}');
+        it('should return the concrete route', () => {
+          expect(result).toBe('/users/me');
         });
       });
 

--- a/packages/framework/validation/libraries/openapi/src/router/services/v3Dot2/OpenApi3Dot2Router.ts
+++ b/packages/framework/validation/libraries/openapi/src/router/services/v3Dot2/OpenApi3Dot2Router.ts
@@ -1,0 +1,39 @@
+import {
+  type OpenApi3Dot2Object,
+  type OpenApi3Dot2PathsObject,
+} from '@inversifyjs/open-api-types/v3Dot2';
+
+import { isOpenApiMethod } from '../../../validation/calculations/v3Dot2/isOpenApiMethod.js';
+import { BaseOpenApiRouter } from '../BaseOpenApiRouter.js';
+
+export class OpenApi3Dot2Router extends BaseOpenApiRouter<OpenApi3Dot2Object> {
+  constructor(openApiObject: OpenApi3Dot2Object) {
+    super(
+      openApiObject,
+      (openApiObject: OpenApi3Dot2Object): Record<string, string[]> => {
+        const methodToRoutesObject: Record<string, string[]> = {};
+
+        const pathItemsObject: OpenApi3Dot2PathsObject | undefined =
+          openApiObject.paths;
+
+        if (pathItemsObject !== undefined) {
+          for (const [path, pathItemObject] of Object.entries(
+            pathItemsObject,
+          )) {
+            for (const method of Object.keys(pathItemObject)) {
+              if (isOpenApiMethod(method)) {
+                if (methodToRoutesObject[method] === undefined) {
+                  methodToRoutesObject[method] = [];
+                }
+
+                methodToRoutesObject[method].push(path);
+              }
+            }
+          }
+        }
+
+        return methodToRoutesObject;
+      },
+    );
+  }
+}

--- a/packages/framework/validation/libraries/openapi/src/trie/actions/trieInsert.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/trie/actions/trieInsert.spec.ts
@@ -1,0 +1,157 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { createTrieNode } from '../calculations/createTrieNode.js';
+import { type TrieNode } from '../models/TrieNode.js';
+import { trieInsert } from './trieInsert.js';
+
+describe(trieInsert, () => {
+  describe('having an empty trie', () => {
+    describe('when called with a single-character key', () => {
+      let root: TrieNode<string>;
+
+      beforeAll(() => {
+        root = createTrieNode();
+        trieInsert(root, 'a', 'value-a');
+      });
+
+      it('should create a child node for the character', () => {
+        expect(root.children.get('a'.charCodeAt(0))).toBeDefined();
+      });
+
+      it('should set the value on the terminal node', () => {
+        expect(root.children.get('a'.charCodeAt(0))?.value).toBe('value-a');
+      });
+
+      it('should not set a value on the root', () => {
+        expect(root.value).toBeUndefined();
+      });
+    });
+
+    describe('when called with a multi-character key', () => {
+      let root: TrieNode<string>;
+
+      beforeAll(() => {
+        root = createTrieNode();
+        trieInsert(root, 'foo', 'bar');
+      });
+
+      it('should chain intermediate nodes for each character', () => {
+        const fNode: TrieNode<string> | undefined = root.children.get(
+          'f'.charCodeAt(0),
+        );
+        const foNode: TrieNode<string> | undefined = fNode?.children.get(
+          'o'.charCodeAt(0),
+        );
+        const fooNode: TrieNode<string> | undefined = foNode?.children.get(
+          'o'.charCodeAt(0),
+        );
+
+        expect(fooNode).toBeDefined();
+        expect(fooNode?.value).toBe('bar');
+      });
+
+      it('should leave intermediate nodes without values', () => {
+        const fNode: TrieNode<string> | undefined = root.children.get(
+          'f'.charCodeAt(0),
+        );
+        const foNode: TrieNode<string> | undefined = fNode?.children.get(
+          'o'.charCodeAt(0),
+        );
+
+        expect(fNode?.value).toBeUndefined();
+        expect(foNode?.value).toBeUndefined();
+      });
+    });
+
+    describe('when called with an empty key', () => {
+      let root: TrieNode<string>;
+
+      beforeAll(() => {
+        root = createTrieNode();
+        trieInsert(root, '', 'root-value');
+      });
+
+      it('should set the value on the root node', () => {
+        expect(root.value).toBe('root-value');
+      });
+    });
+  });
+
+  describe('having a trie with an existing key', () => {
+    describe('when called with the same key and a new value', () => {
+      let root: TrieNode<string>;
+
+      beforeAll(() => {
+        root = createTrieNode();
+        trieInsert(root, 'key', 'first');
+        trieInsert(root, 'key', 'second');
+      });
+
+      it('should overwrite the existing value', () => {
+        const kNode: TrieNode<string> | undefined = root.children.get(
+          'k'.charCodeAt(0),
+        );
+        const keNode: TrieNode<string> | undefined = kNode?.children.get(
+          'e'.charCodeAt(0),
+        );
+        const keyNode: TrieNode<string> | undefined = keNode?.children.get(
+          'y'.charCodeAt(0),
+        );
+
+        expect(keyNode?.value).toBe('second');
+      });
+    });
+  });
+
+  describe('having a trie with a shared prefix', () => {
+    describe('when called with two keys sharing a prefix', () => {
+      let root: TrieNode<string>;
+
+      beforeAll(() => {
+        root = createTrieNode();
+        trieInsert(root, 'foo', 'foo-value');
+        trieInsert(root, 'foo/bar', 'foobar-value');
+      });
+
+      it('should preserve the first key value', () => {
+        const fNode: TrieNode<string> | undefined = root.children.get(
+          'f'.charCodeAt(0),
+        );
+        const foNode: TrieNode<string> | undefined = fNode?.children.get(
+          'o'.charCodeAt(0),
+        );
+        const fooNode: TrieNode<string> | undefined = foNode?.children.get(
+          'o'.charCodeAt(0),
+        );
+
+        expect(fooNode?.value).toBe('foo-value');
+      });
+
+      it('should set the second key value on its terminal node', () => {
+        const fNode: TrieNode<string> | undefined = root.children.get(
+          'f'.charCodeAt(0),
+        );
+        const foNode: TrieNode<string> | undefined = fNode?.children.get(
+          'o'.charCodeAt(0),
+        );
+        const fooNode: TrieNode<string> | undefined = foNode?.children.get(
+          'o'.charCodeAt(0),
+        );
+        const slashNode: TrieNode<string> | undefined = fooNode?.children.get(
+          '/'.charCodeAt(0),
+        );
+        const bNode: TrieNode<string> | undefined = slashNode?.children.get(
+          'b'.charCodeAt(0),
+        );
+        const baNode: TrieNode<string> | undefined = bNode?.children.get(
+          'a'.charCodeAt(0),
+        );
+        const barNode: TrieNode<string> | undefined = baNode?.children.get(
+          'r'.charCodeAt(0),
+        );
+
+        expect(barNode?.value).toBe('foobar-value');
+      });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/trie/actions/trieInsert.ts
+++ b/packages/framework/validation/libraries/openapi/src/trie/actions/trieInsert.ts
@@ -1,0 +1,24 @@
+import { createTrieNode } from '../calculations/createTrieNode.js';
+import { type TrieNode } from '../models/TrieNode.js';
+
+/**
+ * Inserts a key-value pair into the trie rooted at `node`.
+ * Overwrites any existing value at that key.
+ */
+export function trieInsert<T>(node: TrieNode<T>, key: string, value: T): void {
+  let current: TrieNode<T> = node;
+
+  for (let i: number = 0; i < key.length; i++) {
+    const charCode: number = key.charCodeAt(i);
+    let child: TrieNode<T> | undefined = current.children.get(charCode);
+
+    if (child === undefined) {
+      child = createTrieNode<T>();
+      current.children.set(charCode, child);
+    }
+
+    current = child;
+  }
+
+  current.value = value;
+}

--- a/packages/framework/validation/libraries/openapi/src/trie/calculations/createTrieNode.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/trie/calculations/createTrieNode.spec.ts
@@ -1,0 +1,23 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { type TrieNode } from '../models/TrieNode.js';
+import { createTrieNode } from './createTrieNode.js';
+
+describe(createTrieNode, () => {
+  describe('when called', () => {
+    let result: TrieNode<unknown>;
+
+    beforeAll(() => {
+      result = createTrieNode();
+    });
+
+    it('should return a node with an empty children map', () => {
+      expect(result.children).toBeInstanceOf(Map);
+      expect(result.children.size).toBe(0);
+    });
+
+    it('should return a node with an undefined value', () => {
+      expect(result.value).toBeUndefined();
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/trie/calculations/createTrieNode.ts
+++ b/packages/framework/validation/libraries/openapi/src/trie/calculations/createTrieNode.ts
@@ -1,0 +1,8 @@
+import { type TrieNode } from '../models/TrieNode.js';
+
+export function createTrieNode<T>(): TrieNode<T> {
+  return {
+    children: new Map(),
+    value: undefined,
+  };
+}

--- a/packages/framework/validation/libraries/openapi/src/trie/calculations/trieIterateEntries.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/trie/calculations/trieIterateEntries.spec.ts
@@ -1,0 +1,106 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { trieInsert } from '../actions/trieInsert.js';
+import { type TrieNode } from '../models/TrieNode.js';
+import { createTrieNode } from './createTrieNode.js';
+import { trieIterateEntries } from './trieIterateEntries.js';
+
+describe(trieIterateEntries, () => {
+  describe('having an empty trie', () => {
+    describe('when called', () => {
+      let result: [string, string][];
+
+      beforeAll(() => {
+        result = [...trieIterateEntries<string>(createTrieNode())];
+      });
+
+      it('should yield no entries', () => {
+        expect(result).toStrictEqual([]);
+      });
+    });
+  });
+
+  describe('having a trie with a single entry', () => {
+    describe('when called', () => {
+      let result: [string, string][];
+
+      beforeAll(() => {
+        const root: TrieNode<string> = createTrieNode<string>();
+        trieInsert(root, 'foo', 'foo-value');
+
+        result = [...trieIterateEntries(root)];
+      });
+
+      it('should yield the single entry', () => {
+        expect(result).toStrictEqual([['foo', 'foo-value']]);
+      });
+    });
+  });
+
+  describe('having a trie with multiple entries', () => {
+    describe('when called', () => {
+      let result: [string, string][];
+
+      beforeAll(() => {
+        const root: TrieNode<string> = createTrieNode<string>();
+        trieInsert(root, 'a', 'value-a');
+        trieInsert(root, 'b', 'value-b');
+        trieInsert(root, 'ab', 'value-ab');
+
+        result = [...trieIterateEntries(root)];
+      });
+
+      it('should yield all entries', () => {
+        expect(result).toHaveLength(3);
+        expect(result).toStrictEqual(
+          expect.arrayContaining([
+            ['a', 'value-a'],
+            ['b', 'value-b'],
+            ['ab', 'value-ab'],
+          ]),
+        );
+      });
+    });
+  });
+
+  describe('having a trie with an empty-string entry', () => {
+    describe('when called', () => {
+      let result: [string, string][];
+
+      beforeAll(() => {
+        const root: TrieNode<string> = createTrieNode<string>();
+        trieInsert(root, '', 'root-value');
+        trieInsert(root, 'x', 'x-value');
+
+        result = [...trieIterateEntries(root)];
+      });
+
+      it('should yield the empty-string entry and the other entry', () => {
+        expect(result).toHaveLength(2);
+        expect(result).toStrictEqual(
+          expect.arrayContaining([
+            ['', 'root-value'],
+            ['x', 'x-value'],
+          ]),
+        );
+      });
+    });
+  });
+
+  describe('having a trie with a custom prefix argument', () => {
+    describe('when called with a non-empty prefix', () => {
+      let result: [string, string][];
+
+      beforeAll(() => {
+        const root: TrieNode<string> = createTrieNode<string>();
+        trieInsert(root, 'bar', 'bar-value');
+
+        result = [...trieIterateEntries(root, 'foo/')];
+      });
+
+      it('should prepend the prefix to every yielded key', () => {
+        expect(result).toStrictEqual([['foo/bar', 'bar-value']]);
+      });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/trie/calculations/trieIterateEntries.ts
+++ b/packages/framework/validation/libraries/openapi/src/trie/calculations/trieIterateEntries.ts
@@ -1,0 +1,18 @@
+import { type TrieNode } from '../models/TrieNode.js';
+
+/**
+ * Yields all [key, value] pairs stored in the trie rooted at `node`.
+ * Intended for build-time iteration; not performance-critical.
+ */
+export function* trieIterateEntries<T>(
+  node: TrieNode<T>,
+  prefix: string = '',
+): Generator<[string, T]> {
+  if (node.value !== undefined) {
+    yield [prefix, node.value];
+  }
+
+  for (const [charCode, child] of node.children) {
+    yield* trieIterateEntries(child, prefix + String.fromCharCode(charCode));
+  }
+}

--- a/packages/framework/validation/libraries/openapi/src/trie/calculations/trieLookup.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/trie/calculations/trieLookup.spec.ts
@@ -1,0 +1,160 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { trieInsert } from '../actions/trieInsert.js';
+import { createTrieNode } from './createTrieNode.js';
+import { trieLookup } from './trieLookup.js';
+
+describe(trieLookup, () => {
+  describe('having an empty trie', () => {
+    describe('when called with any range', () => {
+      let result: string | undefined;
+
+      beforeAll(() => {
+        result = trieLookup(createTrieNode<string>(), 'anything', 0, 8);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a trie with a single entry', () => {
+    let root: ReturnType<typeof createTrieNode<string>>;
+
+    beforeAll(() => {
+      root = createTrieNode<string>();
+      trieInsert(root, 'users', 'users-value');
+    });
+
+    describe('when called with a matching full-string range', () => {
+      let result: string | undefined;
+
+      beforeAll(() => {
+        result = trieLookup(root, 'users', 0, 5);
+      });
+
+      it('should return the stored value', () => {
+        expect(result).toBe('users-value');
+      });
+    });
+
+    describe('when called with a matching sub-range inside a longer string', () => {
+      let result: string | undefined;
+
+      beforeAll(() => {
+        result = trieLookup(root, '/users/123', 1, 6);
+      });
+
+      it('should return the stored value', () => {
+        expect(result).toBe('users-value');
+      });
+    });
+
+    describe('when called with a non-matching key', () => {
+      let result: string | undefined;
+
+      beforeAll(() => {
+        result = trieLookup(root, 'posts', 0, 5);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when called with a range that is only a prefix of a stored key', () => {
+      let result: string | undefined;
+
+      beforeAll(() => {
+        // 'use' is a prefix of 'users' but not a stored key
+        result = trieLookup(root, 'users', 0, 3);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when called with a range longer than the stored key', () => {
+      let result: string | undefined;
+
+      beforeAll(() => {
+        // 'usersx' is longer than 'users'
+        result = trieLookup(root, 'usersx', 0, 6);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a trie with multiple entries sharing a prefix', () => {
+    let root: ReturnType<typeof createTrieNode<string>>;
+
+    beforeAll(() => {
+      root = createTrieNode<string>();
+      trieInsert(root, 'users', 'users-value');
+      trieInsert(root, 'posts', 'posts-value');
+      trieInsert(root, 'users/me', 'users-me-value');
+    });
+
+    describe('when called with the first key', () => {
+      let result: string | undefined;
+
+      beforeAll(() => {
+        result = trieLookup(root, 'users', 0, 5);
+      });
+
+      it('should return the first value', () => {
+        expect(result).toBe('users-value');
+      });
+    });
+
+    describe('when called with the second key', () => {
+      let result: string | undefined;
+
+      beforeAll(() => {
+        result = trieLookup(root, 'posts', 0, 5);
+      });
+
+      it('should return the second value', () => {
+        expect(result).toBe('posts-value');
+      });
+    });
+
+    describe('when called with the third key', () => {
+      let result: string | undefined;
+
+      beforeAll(() => {
+        result = trieLookup(root, 'users/me', 0, 8);
+      });
+
+      it('should return the third value', () => {
+        expect(result).toBe('users-me-value');
+      });
+    });
+  });
+
+  describe('having a trie with an empty-string entry', () => {
+    let root: ReturnType<typeof createTrieNode<string>>;
+
+    beforeAll(() => {
+      root = createTrieNode<string>();
+      trieInsert(root, '', 'empty-value');
+    });
+
+    describe('when called with a zero-length range', () => {
+      let result: string | undefined;
+
+      beforeAll(() => {
+        result = trieLookup(root, 'anything', 0, 0);
+      });
+
+      it('should return the value stored at the empty key', () => {
+        expect(result).toBe('empty-value');
+      });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/trie/calculations/trieLookup.ts
+++ b/packages/framework/validation/libraries/openapi/src/trie/calculations/trieLookup.ts
@@ -1,0 +1,29 @@
+import { type TrieNode } from '../models/TrieNode.js';
+
+/**
+ * Looks up a value in the trie by matching `str` from index `start` (inclusive)
+ * to `end` (exclusive). Uses character codes internally to avoid string allocation
+ * during traversal, keeping the hot path GC-friendly.
+ */
+export function trieLookup<T>(
+  node: TrieNode<T>,
+  str: string,
+  start: number,
+  end: number,
+): T | undefined {
+  let current: TrieNode<T> = node;
+
+  for (let i: number = start; i < end; i++) {
+    const child: TrieNode<T> | undefined = current.children.get(
+      str.charCodeAt(i),
+    );
+
+    if (child === undefined) {
+      return undefined;
+    }
+
+    current = child;
+  }
+
+  return current.value;
+}

--- a/packages/framework/validation/libraries/openapi/src/trie/models/TrieNode.ts
+++ b/packages/framework/validation/libraries/openapi/src/trie/models/TrieNode.ts
@@ -1,0 +1,8 @@
+/**
+ * Represents a node in a trie data structure.
+ * Children are indexed by character codes for O(1) lookup without string allocation.
+ */
+export interface TrieNode<T> {
+  children: Map<number, TrieNode<T>>;
+  value: T | undefined;
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/buildCompositeValidationHandler.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/buildCompositeValidationHandler.spec.ts
@@ -10,9 +10,9 @@ import {
 
 import type Ajv from 'ajv';
 
+import { type OpenApiValidationContext } from '../models/OpenApiValidationContext.js';
 import { type ValidationInputParam } from '../models/ValidatedDecoratorResult.js';
 import { type ValidationHandler } from '../models/ValidationHandler.js';
-import { type OpenApiResolver } from '../services/OpenApiResolver.js';
 import { buildCompositeValidationHandler } from './buildCompositeValidationHandler.js';
 
 describe(buildCompositeValidationHandler, () => {
@@ -30,7 +30,7 @@ describe(buildCompositeValidationHandler, () => {
         result = buildCompositeValidationHandler({})(
           Symbol() as unknown as Ajv,
           Symbol(),
-          Symbol() as unknown as OpenApiResolver,
+          Symbol() as unknown as OpenApiValidationContext,
           inputParam,
           vitest.fn(),
         );
@@ -56,7 +56,7 @@ describe(buildCompositeValidationHandler, () => {
         result = buildCompositeValidationHandler({})(
           Symbol() as unknown as Ajv,
           Symbol(),
-          Symbol() as unknown as OpenApiResolver,
+          Symbol() as unknown as OpenApiValidationContext,
           inputParam,
           vitest.fn(),
         );
@@ -82,7 +82,7 @@ describe(buildCompositeValidationHandler, () => {
         result = buildCompositeValidationHandler({})(
           Symbol() as unknown as Ajv,
           Symbol(),
-          Symbol() as unknown as OpenApiResolver,
+          Symbol() as unknown as OpenApiValidationContext,
           inputParam,
           vitest.fn(),
         );
@@ -109,7 +109,7 @@ describe(buildCompositeValidationHandler, () => {
     let getEntryMock: Mock;
     let inputParam: unknown;
     let openApiObjectFixture: unknown;
-    let openApiResolverFixture: OpenApiResolver;
+    let openApiValidationContextFixture: OpenApiValidationContext;
 
     beforeAll(() => {
       discriminatorValueFixture = Symbol();
@@ -121,7 +121,8 @@ describe(buildCompositeValidationHandler, () => {
         type: discriminatorValueFixture,
       };
       openApiObjectFixture = Symbol();
-      openApiResolverFixture = Symbol() as unknown as OpenApiResolver;
+      openApiValidationContextFixture =
+        Symbol() as unknown as OpenApiValidationContext;
     });
 
     describe('when called', () => {
@@ -139,7 +140,7 @@ describe(buildCompositeValidationHandler, () => {
         })(
           ajvFixture,
           openApiObjectFixture,
-          openApiResolverFixture,
+          openApiValidationContextFixture,
           inputParam,
           getEntryMock,
         );
@@ -153,7 +154,7 @@ describe(buildCompositeValidationHandler, () => {
         expect(handlerMock).toHaveBeenCalledExactlyOnceWith(
           ajvFixture,
           openApiObjectFixture,
-          openApiResolverFixture,
+          openApiValidationContextFixture,
           inputParam,
           getEntryMock,
         );

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/buildCompositeValidationHandler.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/buildCompositeValidationHandler.ts
@@ -1,16 +1,18 @@
 import type Ajv from 'ajv';
 
+import { type OpenApiValidationContext } from '../models/OpenApiValidationContext.js';
 import { type ValidationInputParam } from '../models/ValidatedDecoratorResult.js';
 import {
   type validatedInputParamBodyType,
   type validatedInputParamHeaderType,
+  type validatedInputParamParamType,
 } from '../models/validatedInputParamTypes.js';
 import { type ValidationHandler } from '../models/ValidationHandler.js';
-import { type OpenApiResolver } from '../services/OpenApiResolver.js';
 
 type ValidatedInputParamType =
   | typeof validatedInputParamBodyType
-  | typeof validatedInputParamHeaderType;
+  | typeof validatedInputParamHeaderType
+  | typeof validatedInputParamParamType;
 
 export function buildCompositeValidationHandler<
   TOpenApiObject,
@@ -25,7 +27,7 @@ export function buildCompositeValidationHandler<
   return (
     ajv: Ajv,
     openApiObject: TOpenApiObject,
-    openApiResolver: OpenApiResolver,
+    validationContext: OpenApiValidationContext,
     inputParam: unknown,
     getEntry: (path: string, method: string) => TValidationCacheEntry,
   ): unknown => {
@@ -57,7 +59,7 @@ export function buildCompositeValidationHandler<
     return handler(
       ajv,
       openApiObject,
-      openApiResolver,
+      validationContext,
       inputParam as ValidationInputParam,
       getEntry,
     );

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/buildNonArrayParamParse.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/buildNonArrayParamParse.spec.ts
@@ -1,0 +1,133 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+vitest.mock(import('./maybeCoerceStringOrStringArrayToNonNullableBoolean.js'));
+vitest.mock(import('./maybeCoerceStringOrStringArrayToNonNullableNumber.js'));
+vitest.mock(import('./maybeCoerceStringOrStringArrayToNull.js'));
+vitest.mock(import('./maybeCoerceStringOrStringArrayToNullableBoolean.js'));
+vitest.mock(import('./maybeCoerceStringOrStringArrayToNullableNumber.js'));
+
+import { InversifyValidationError } from '@inversifyjs/validation-common';
+
+import { buildNonArrayParamParse } from './buildNonArrayParamParse.js';
+import { maybeCoerceStringOrStringArrayToNonNullableBoolean } from './maybeCoerceStringOrStringArrayToNonNullableBoolean.js';
+import { maybeCoerceStringOrStringArrayToNonNullableNumber } from './maybeCoerceStringOrStringArrayToNonNullableNumber.js';
+import { maybeCoerceStringOrStringArrayToNull } from './maybeCoerceStringOrStringArrayToNull.js';
+import { maybeCoerceStringOrStringArrayToNullableBoolean } from './maybeCoerceStringOrStringArrayToNullableBoolean.js';
+import { maybeCoerceStringOrStringArrayToNullableNumber } from './maybeCoerceStringOrStringArrayToNullableNumber.js';
+
+describe(buildNonArrayParamParse, () => {
+  afterAll(() => {
+    vitest.restoreAllMocks();
+  });
+
+  describe.each<[string, boolean, string, () => unknown]>([
+    [
+      'type is "boolean" and isNullable is false',
+      false,
+      'boolean',
+      () => maybeCoerceStringOrStringArrayToNonNullableBoolean,
+    ],
+    [
+      'type is "boolean" and isNullable is true',
+      true,
+      'boolean',
+      () => maybeCoerceStringOrStringArrayToNullableBoolean,
+    ],
+    [
+      'type is "integer" and isNullable is false',
+      false,
+      'integer',
+      () => maybeCoerceStringOrStringArrayToNonNullableNumber,
+    ],
+    [
+      'type is "integer" and isNullable is true',
+      true,
+      'integer',
+      () => maybeCoerceStringOrStringArrayToNullableNumber,
+    ],
+    [
+      'type is "number" and isNullable is false',
+      false,
+      'number',
+      () => maybeCoerceStringOrStringArrayToNonNullableNumber,
+    ],
+    [
+      'type is "number" and isNullable is true',
+      true,
+      'number',
+      () => maybeCoerceStringOrStringArrayToNullableNumber,
+    ],
+    [
+      'type is "null"',
+      false,
+      'null',
+      () => maybeCoerceStringOrStringArrayToNull,
+    ],
+  ])(
+    'having %s',
+    (
+      _: string,
+      isNullable: boolean,
+      type: string,
+      expectedFn: () => unknown,
+    ) => {
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = buildNonArrayParamParse(
+            isNullable,
+            'test-ref',
+            type as Parameters<typeof buildNonArrayParamParse>[2],
+          );
+        });
+
+        it('should return the expected parse function', () => {
+          expect(result).toBe(expectedFn());
+        });
+      });
+    },
+  );
+
+  describe('having type is "string"', () => {
+    describe('when called', () => {
+      let result: (value: string | string[] | undefined) => unknown;
+
+      beforeAll(() => {
+        result = buildNonArrayParamParse(false, 'test-ref', 'string');
+      });
+
+      it('should return a function that returns the value as-is', () => {
+        expect(result('hello')).toBe('hello');
+      });
+    });
+  });
+
+  describe('having an unsupported type', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        try {
+          buildNonArrayParamParse(
+            false,
+            'test-ref',
+            'object' as Parameters<typeof buildNonArrayParamParse>[2],
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      it('should throw an InversifyValidationError', () => {
+        expect(result).toBeInstanceOf(InversifyValidationError);
+      });
+
+      it('should throw with an unsupported type message', () => {
+        expect((result as InversifyValidationError).message).toBe(
+          'Unsupported param parameter "test-ref" type: "object"',
+        );
+      });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/buildNonArrayParamParse.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/buildNonArrayParamParse.ts
@@ -1,0 +1,42 @@
+import { type JsonSchemaType } from '@inversifyjs/json-schema-types/2020-12';
+import {
+  InversifyValidationError,
+  InversifyValidationErrorKind,
+} from '@inversifyjs/validation-common';
+
+import { maybeCoerceStringOrStringArrayToNonNullableBoolean } from './maybeCoerceStringOrStringArrayToNonNullableBoolean.js';
+import { maybeCoerceStringOrStringArrayToNonNullableNumber } from './maybeCoerceStringOrStringArrayToNonNullableNumber.js';
+import { maybeCoerceStringOrStringArrayToNull } from './maybeCoerceStringOrStringArrayToNull.js';
+import { maybeCoerceStringOrStringArrayToNullableBoolean } from './maybeCoerceStringOrStringArrayToNullableBoolean.js';
+import { maybeCoerceStringOrStringArrayToNullableNumber } from './maybeCoerceStringOrStringArrayToNullableNumber.js';
+
+export function buildNonArrayParamParse(
+  isNullable: boolean,
+  schemaRef: string,
+  type: JsonSchemaType,
+): (value: string | string[] | undefined) => unknown {
+  switch (type) {
+    case 'boolean':
+      if (isNullable) {
+        return maybeCoerceStringOrStringArrayToNullableBoolean;
+      } else {
+        return maybeCoerceStringOrStringArrayToNonNullableBoolean;
+      }
+    case 'integer':
+    case 'number':
+      if (isNullable) {
+        return maybeCoerceStringOrStringArrayToNullableNumber;
+      } else {
+        return maybeCoerceStringOrStringArrayToNonNullableNumber;
+      }
+    case 'null':
+      return maybeCoerceStringOrStringArrayToNull;
+    case 'string':
+      return (value: string | string[] | undefined): unknown => value;
+    default:
+      throw new InversifyValidationError(
+        InversifyValidationErrorKind.invalidConfiguration,
+        `Unsupported param parameter "${schemaRef}" type: "${type}"`,
+      );
+  }
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/buildParamParse.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/buildParamParse.spec.ts
@@ -1,0 +1,139 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+vitest.mock(import('./buildNonArrayParamParse.js'));
+vitest.mock(import('./inferSchemaTypeOrThrow.js'));
+
+import { type JsonSchemaType } from '@inversifyjs/json-schema-types/2020-12';
+
+import { type OpenApiResolver } from '../services/OpenApiResolver.js';
+import { buildNonArrayParamParse } from './buildNonArrayParamParse.js';
+import { buildParamParse } from './buildParamParse.js';
+import { inferSchemaTypeOrThrow } from './inferSchemaTypeOrThrow.js';
+
+describe(buildParamParse, () => {
+  afterAll(() => {
+    vitest.restoreAllMocks();
+  });
+
+  describe('having a non-array schema type', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let parseMockFixture: (value: string | string[] | undefined) => unknown;
+
+    beforeAll(() => {
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+
+      parseMockFixture = vitest.fn();
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest.mocked(inferSchemaTypeOrThrow).mockReturnValueOnce({
+          isNullable: false,
+          type: 'string' as JsonSchemaType,
+        });
+
+        vitest
+          .mocked(buildNonArrayParamParse)
+          .mockReturnValueOnce(parseMockFixture);
+
+        result = buildParamParse(
+          openApiResolverFixture,
+          { type: 'string' },
+          '#/test/schema',
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call inferSchemaTypeOrThrow', () => {
+        expect(inferSchemaTypeOrThrow).toHaveBeenCalledExactlyOnceWith(
+          openApiResolverFixture,
+          { type: 'string' },
+          '#/test/schema',
+        );
+      });
+
+      it('should call buildNonArrayParamParse', () => {
+        expect(buildNonArrayParamParse).toHaveBeenCalledExactlyOnceWith(
+          false,
+          '#/test/schema',
+          'string',
+        );
+      });
+
+      it('should return the expected parse function', () => {
+        expect(result).toBe(parseMockFixture);
+      });
+    });
+  });
+
+  describe('having an array schema type', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let parseMockFixture: (value: string | string[] | undefined) => unknown;
+
+    beforeAll(() => {
+      openApiResolverFixture = {
+        deepResolveReference: vitest
+          .fn()
+          .mockReturnValueOnce({ type: 'integer' }),
+        resolveReference: vitest.fn(),
+      };
+
+      parseMockFixture = vitest.fn();
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest
+          .mocked(inferSchemaTypeOrThrow)
+          .mockReturnValueOnce({
+            isNullable: false,
+            type: 'array' as JsonSchemaType,
+          })
+          .mockReturnValueOnce({
+            isNullable: true,
+            type: 'integer' as JsonSchemaType,
+          });
+
+        vitest
+          .mocked(buildNonArrayParamParse)
+          .mockReturnValueOnce(parseMockFixture);
+
+        result = buildParamParse(
+          openApiResolverFixture,
+          { items: { type: 'integer' }, type: 'array' },
+          '#/test/schema',
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call inferSchemaTypeOrThrow twice', () => {
+        expect(inferSchemaTypeOrThrow).toHaveBeenCalledTimes(2);
+      });
+
+      it('should call buildNonArrayParamParse with items type', () => {
+        expect(buildNonArrayParamParse).toHaveBeenCalledExactlyOnceWith(
+          true,
+          '#/test/schema/items',
+          'integer',
+        );
+      });
+
+      it('should return the expected parse function', () => {
+        expect(result).toBe(parseMockFixture);
+      });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/buildParamParse.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/buildParamParse.ts
@@ -1,0 +1,54 @@
+import { type JsonValue } from '@inversifyjs/json-schema-types';
+import {
+  type JsonSchema,
+  type JsonSchemaType,
+} from '@inversifyjs/json-schema-types/2020-12';
+
+import { type OpenApiResolver } from '../services/OpenApiResolver.js';
+import { buildNonArrayParamParse } from './buildNonArrayParamParse.js';
+import { inferSchemaTypeOrThrow } from './inferSchemaTypeOrThrow.js';
+
+export function buildParamParse(
+  openApiResolver: OpenApiResolver,
+  schema: JsonSchema | undefined,
+  schemaRef: string,
+): (value: string | string[] | undefined) => unknown {
+  const {
+    isNullable,
+    type,
+  }: {
+    isNullable: boolean;
+    type: JsonSchemaType;
+  } = inferSchemaTypeOrThrow(openApiResolver, schema, schemaRef);
+
+  let parse: (value: string | string[] | undefined) => unknown;
+
+  switch (type) {
+    case 'array':
+      {
+        const itemsSchemaRef: string = `${schemaRef}/items`;
+
+        const schema: JsonValue | undefined =
+          openApiResolver.deepResolveReference(itemsSchemaRef);
+
+        const {
+          isNullable,
+          type,
+        }: {
+          isNullable: boolean;
+          type: JsonSchemaType;
+        } = inferSchemaTypeOrThrow(
+          openApiResolver,
+          schema as JsonSchema | undefined,
+          itemsSchemaRef,
+        );
+
+        parse = buildNonArrayParamParse(isNullable, itemsSchemaRef, type);
+      }
+      break;
+    default:
+      parse = buildNonArrayParamParse(isNullable, schemaRef, type);
+  }
+
+  return parse;
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/inferSchemaTypeOrThrow.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/inferSchemaTypeOrThrow.ts
@@ -31,7 +31,7 @@ export function inferSchemaTypeOrThrow(
   ) {
     throw new InversifyValidationError(
       InversifyValidationErrorKind.invalidConfiguration,
-      `Unable to determine header parameter "${schemaRef}" type: expected exactly 1 type but found "${[...typesSet].join(', ')}"`,
+      `Unable to determine parameter "${schemaRef}" type: expected exactly 1 type but found "${[...typesSet].join(', ')}"`,
     );
   }
 

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getParamParameterObjects.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getParamParameterObjects.spec.ts
@@ -1,0 +1,376 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+vitest.mock(import('@inversifyjs/json-schema-pointer'));
+vitest.mock(import('./getOperationObject.js'));
+vitest.mock(import('./getPathItemObject.js'));
+
+import { escapeJsonPointerFragments } from '@inversifyjs/json-schema-pointer';
+import {
+  type OpenApi3Dot1Object,
+  type OpenApi3Dot1OperationObject,
+  type OpenApi3Dot1ParameterObject,
+  type OpenApi3Dot1PathItemObject,
+  type OpenApi3Dot1ReferenceObject,
+} from '@inversifyjs/open-api-types/v3Dot1';
+
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
+import { getOperationObject } from './getOperationObject.js';
+import {
+  getParamParameterObjects,
+  type ParamParameterEntry,
+} from './getParamParameterObjects.js';
+import { getPathItemObject } from './getPathItemObject.js';
+
+describe(getParamParameterObjects, () => {
+  let openApiObjectFixture: OpenApi3Dot1Object;
+  let pathFixture: string;
+  let methodFixture: string;
+
+  beforeAll(() => {
+    openApiObjectFixture = Symbol() as unknown as OpenApi3Dot1Object;
+    pathFixture = '/users/{userId}';
+    methodFixture = 'get';
+
+    vitest
+      .mocked(escapeJsonPointerFragments)
+      .mockImplementation((...fragments: string[]) => fragments.join('/'));
+  });
+
+  afterAll(() => {
+    vitest.clearAllMocks();
+  });
+
+  describe('when called, and operation has path parameters only', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let result: Map<string, ParamParameterEntry>;
+
+    beforeAll(() => {
+      const parameterFixture: OpenApi3Dot1ParameterObject = {
+        in: 'path',
+        name: 'userId',
+        required: true,
+        schema: { type: 'string' },
+      };
+
+      const operationFixture: OpenApi3Dot1OperationObject = {
+        parameters: [parameterFixture],
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot1PathItemObject = {
+        get: operationFixture,
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getParamParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should return a map with the path parameter', () => {
+      expect(result.size).toBe(1);
+      expect(result.has('userId')).toBe(true);
+    });
+
+    it('should return entry with correct pointer prefix', () => {
+      const entry: ParamParameterEntry = result.get(
+        'userId',
+      ) as ParamParameterEntry;
+
+      expect(entry.pointerPrefix).toBe(
+        `paths/${pathFixture}/${methodFixture}/parameters/0`,
+      );
+    });
+  });
+
+  describe('when called, and path item has path parameters only', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let result: Map<string, ParamParameterEntry>;
+
+    beforeAll(() => {
+      const parameterFixture: OpenApi3Dot1ParameterObject = {
+        in: 'path',
+        name: 'userId',
+        required: true,
+        schema: { type: 'string' },
+      };
+
+      const operationFixture: OpenApi3Dot1OperationObject = {
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot1PathItemObject = {
+        get: operationFixture,
+        parameters: [parameterFixture],
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getParamParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should return a map with the path parameter', () => {
+      expect(result.size).toBe(1);
+      expect(result.has('userId')).toBe(true);
+    });
+
+    it('should return entry with path-item pointer prefix', () => {
+      const entry: ParamParameterEntry = result.get(
+        'userId',
+      ) as ParamParameterEntry;
+
+      expect(entry.pointerPrefix).toBe(`paths/${pathFixture}/parameters/0`);
+    });
+  });
+
+  describe('when called, and operation overrides path-item parameter', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let result: Map<string, ParamParameterEntry>;
+
+    beforeAll(() => {
+      const pathItemParamFixture: OpenApi3Dot1ParameterObject = {
+        in: 'path',
+        name: 'userId',
+        schema: { type: 'string' },
+      };
+
+      const operationParamFixture: OpenApi3Dot1ParameterObject = {
+        in: 'path',
+        name: 'userId',
+        schema: { format: 'uuid', type: 'string' },
+      };
+
+      const operationFixture: OpenApi3Dot1OperationObject = {
+        parameters: [operationParamFixture],
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot1PathItemObject = {
+        get: operationFixture,
+        parameters: [pathItemParamFixture],
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getParamParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should return only one entry (operation overrides)', () => {
+      expect(result.size).toBe(1);
+    });
+
+    it('should use the operation-level parameter', () => {
+      const entry: ParamParameterEntry = result.get(
+        'userId',
+      ) as ParamParameterEntry;
+
+      expect(entry.parameter.schema).toStrictEqual({
+        format: 'uuid',
+        type: 'string',
+      });
+    });
+
+    it('should have operation pointer prefix', () => {
+      const entry: ParamParameterEntry = result.get(
+        'userId',
+      ) as ParamParameterEntry;
+
+      expect(entry.pointerPrefix).toBe(
+        `paths/${pathFixture}/${methodFixture}/parameters/0`,
+      );
+    });
+  });
+
+  describe('when called, and parameter is a $ref reference', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let result: Map<string, ParamParameterEntry>;
+
+    beforeAll(() => {
+      const refFixture: OpenApi3Dot1ReferenceObject = {
+        $ref: '#/components/parameters/UserIdParam',
+      };
+
+      const resolvedParamFixture: OpenApi3Dot1ParameterObject = {
+        in: 'path',
+        name: 'userId',
+        required: true,
+        schema: { type: 'string' },
+      };
+
+      const operationFixture: OpenApi3Dot1OperationObject = {
+        parameters: [refFixture],
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot1PathItemObject = {
+        get: operationFixture,
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest
+          .fn()
+          .mockReturnValueOnce(resolvedParamFixture),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getParamParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should resolve the $ref and return the path parameter', () => {
+      expect(result.size).toBe(1);
+      expect(result.has('userId')).toBe(true);
+    });
+
+    it('should call deepResolveReference', () => {
+      expect(
+        openApiResolverFixture.deepResolveReference,
+      ).toHaveBeenCalledExactlyOnceWith('#/components/parameters/UserIdParam');
+    });
+  });
+
+  describe('when called, and no parameters exist', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let result: Map<string, ParamParameterEntry>;
+
+    beforeAll(() => {
+      const operationFixture: OpenApi3Dot1OperationObject = {
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot1PathItemObject = {
+        get: operationFixture,
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getParamParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should return empty map', () => {
+      expect(result.size).toBe(0);
+    });
+  });
+
+  describe('when called, and parameters include non-path params', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let result: Map<string, ParamParameterEntry>;
+
+    beforeAll(() => {
+      const pathParam: OpenApi3Dot1ParameterObject = {
+        in: 'path',
+        name: 'userId',
+        schema: { type: 'string' },
+      };
+
+      const queryParam: OpenApi3Dot1ParameterObject = {
+        in: 'query',
+        name: 'page',
+        schema: { type: 'integer' },
+      };
+
+      const operationFixture: OpenApi3Dot1OperationObject = {
+        parameters: [pathParam, queryParam],
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot1PathItemObject = {
+        get: operationFixture,
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getParamParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should return only path parameters', () => {
+      expect(result.size).toBe(1);
+      expect(result.has('userId')).toBe(true);
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getParamParameterObjects.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getParamParameterObjects.ts
@@ -1,0 +1,88 @@
+import { escapeJsonPointerFragments } from '@inversifyjs/json-schema-pointer';
+import {
+  type OpenApi3Dot1Object,
+  type OpenApi3Dot1OperationObject,
+  type OpenApi3Dot1ParameterObject,
+  type OpenApi3Dot1PathItemObject,
+  type OpenApi3Dot1ReferenceObject,
+} from '@inversifyjs/open-api-types/v3Dot1';
+
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
+import { getOperationObject } from './getOperationObject.js';
+import { getPathItemObject } from './getPathItemObject.js';
+
+export interface ParamParameterEntry {
+  parameter: OpenApi3Dot1ParameterObject;
+  pointerPrefix: string;
+}
+
+function isReferenceObject(
+  param: OpenApi3Dot1ParameterObject | OpenApi3Dot1ReferenceObject,
+): param is OpenApi3Dot1ReferenceObject {
+  return '$ref' in param;
+}
+
+export function getParamParameterObjects(
+  openApiObject: OpenApi3Dot1Object,
+  openApiResolver: OpenApiResolver,
+  method: string,
+  path: string,
+): Map<string, ParamParameterEntry> {
+  const pathItemObject: OpenApi3Dot1PathItemObject = getPathItemObject(
+    openApiObject,
+    path,
+  );
+  const operationObject: OpenApi3Dot1OperationObject = getOperationObject(
+    openApiObject,
+    method,
+    path,
+  );
+
+  const result: Map<string, ParamParameterEntry> = new Map();
+
+  if (pathItemObject.parameters !== undefined) {
+    for (let i: number = 0; i < pathItemObject.parameters.length; i++) {
+      const raw: OpenApi3Dot1ParameterObject | OpenApi3Dot1ReferenceObject =
+        pathItemObject.parameters[i] as
+          | OpenApi3Dot1ParameterObject
+          | OpenApi3Dot1ReferenceObject;
+
+      const param: OpenApi3Dot1ParameterObject = isReferenceObject(raw)
+        ? (openApiResolver.deepResolveReference(
+            raw.$ref,
+          ) as unknown as OpenApi3Dot1ParameterObject)
+        : raw;
+
+      if (param.in === 'path') {
+        result.set(param.name, {
+          parameter: param,
+          pointerPrefix: `paths/${escapeJsonPointerFragments(path)}/parameters/${String(i)}`,
+        });
+      }
+    }
+  }
+
+  if (operationObject.parameters !== undefined) {
+    for (let i: number = 0; i < operationObject.parameters.length; i++) {
+      const raw: OpenApi3Dot1ParameterObject | OpenApi3Dot1ReferenceObject =
+        operationObject.parameters[i] as
+          | OpenApi3Dot1ParameterObject
+          | OpenApi3Dot1ReferenceObject;
+
+      const param: OpenApi3Dot1ParameterObject = isReferenceObject(raw)
+        ? (openApiResolver.deepResolveReference(
+            raw.$ref,
+          ) as unknown as OpenApi3Dot1ParameterObject)
+        : raw;
+
+      if (param.in === 'path') {
+        result.set(param.name, {
+          parameter: param,
+          pointerPrefix: `paths/${escapeJsonPointerFragments(path)}/${method}/parameters/${String(i)}`,
+        });
+      }
+    }
+  }
+
+  return result;
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getRequestBodyObject.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getRequestBodyObject.spec.ts
@@ -9,26 +9,21 @@ import {
   InversifyValidationErrorKind,
 } from '@inversifyjs/validation-common';
 
-import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
 import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
 import { getRequestBodyObject } from './getRequestBodyObject.js';
 
 describe(getRequestBodyObject, () => {
   let openApiResolverMock: OpenApiResolver;
-  let inputParamFixture: BodyValidationInputParam<unknown>;
+  let methodFixture: string;
+  let routeFixture: string;
 
   beforeAll(() => {
     openApiResolverMock = {
       deepResolveReference: vitest.fn(),
       resolveReference: vitest.fn(),
     };
-    inputParamFixture = {
-      body: { name: 'test' },
-      contentType: 'application/json',
-      method: 'post',
-      path: '/users',
-      type: Symbol() as unknown as BodyValidationInputParam<unknown>['type'],
-    };
+    methodFixture = 'post';
+    routeFixture = '/users';
   });
 
   describe('having an operationObject with no requestBody', () => {
@@ -48,7 +43,8 @@ describe(getRequestBodyObject, () => {
           getRequestBodyObject(
             openApiResolverMock,
             operationObjectFixture,
-            inputParamFixture,
+            methodFixture,
+            routeFixture,
           );
         } catch (error: unknown) {
           result = error;
@@ -58,7 +54,7 @@ describe(getRequestBodyObject, () => {
       it('should throw an InversifyValidationError', () => {
         const expectedErrorProperties: Partial<InversifyValidationError> = {
           kind: InversifyValidationErrorKind.validationFailed,
-          message: `No requestBody found for method ${inputParamFixture.method} for path ${inputParamFixture.path}`,
+          message: `No requestBody found for ${methodFixture.toUpperCase()} ${routeFixture}`,
         };
 
         expect(result).toBeInstanceOf(InversifyValidationError);
@@ -90,7 +86,8 @@ describe(getRequestBodyObject, () => {
         result = getRequestBodyObject(
           openApiResolverMock,
           operationObjectFixture,
-          inputParamFixture,
+          methodFixture,
+          routeFixture,
         );
       });
 
@@ -126,7 +123,8 @@ describe(getRequestBodyObject, () => {
           getRequestBodyObject(
             openApiResolverMock,
             operationObjectFixture,
-            inputParamFixture,
+            methodFixture,
+            routeFixture,
           );
         } catch (error: unknown) {
           result = error;
@@ -146,7 +144,7 @@ describe(getRequestBodyObject, () => {
       it('should throw an InversifyValidationError', () => {
         const expectedErrorProperties: Partial<InversifyValidationError> = {
           kind: InversifyValidationErrorKind.validationFailed,
-          message: `Could not resolve $ref pointer ${refFixture}`,
+          message: `Could not resolve $ref pointer ${refFixture} for ${methodFixture.toUpperCase()} ${routeFixture}`,
         };
 
         expect(result).toBeInstanceOf(InversifyValidationError);
@@ -181,7 +179,8 @@ describe(getRequestBodyObject, () => {
           getRequestBodyObject(
             openApiResolverMock,
             operationObjectFixture,
-            inputParamFixture,
+            methodFixture,
+            routeFixture,
           );
         } catch (error: unknown) {
           result = error;
@@ -201,7 +200,7 @@ describe(getRequestBodyObject, () => {
       it('should throw an InversifyValidationError', () => {
         const expectedErrorProperties: Partial<InversifyValidationError> = {
           kind: InversifyValidationErrorKind.validationFailed,
-          message: `Resolved $ref pointer ${refFixture} is not a valid object`,
+          message: `Resolved $ref pointer ${refFixture} is not a valid request body object for ${methodFixture.toUpperCase()} ${routeFixture}`,
         };
 
         expect(result).toBeInstanceOf(InversifyValidationError);
@@ -236,7 +235,8 @@ describe(getRequestBodyObject, () => {
           getRequestBodyObject(
             openApiResolverMock,
             operationObjectFixture,
-            inputParamFixture,
+            methodFixture,
+            routeFixture,
           );
         } catch (error: unknown) {
           result = error;
@@ -256,7 +256,7 @@ describe(getRequestBodyObject, () => {
       it('should throw an InversifyValidationError', () => {
         const expectedErrorProperties: Partial<InversifyValidationError> = {
           kind: InversifyValidationErrorKind.validationFailed,
-          message: `Resolved $ref pointer ${refFixture} is not a valid object`,
+          message: `Resolved $ref pointer ${refFixture} is not a valid request body object for ${methodFixture.toUpperCase()} ${routeFixture}`,
         };
 
         expect(result).toBeInstanceOf(InversifyValidationError);
@@ -300,7 +300,8 @@ describe(getRequestBodyObject, () => {
         result = getRequestBodyObject(
           openApiResolverMock,
           operationObjectFixture,
-          inputParamFixture,
+          methodFixture,
+          routeFixture,
         );
       });
 

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getRequestBodyObject.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getRequestBodyObject.ts
@@ -12,13 +12,13 @@ import {
   InversifyValidationErrorKind,
 } from '@inversifyjs/validation-common';
 
-import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
 import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
 
 export function getRequestBodyObject(
   openApiResolver: OpenApiResolver,
   operationObject: OpenApi3Dot1OperationObject,
-  inputParam: BodyValidationInputParam<unknown>,
+  method: string,
+  route: string,
 ): OpenApi3Dot1RequestBodyObject {
   const requestBodyObject:
     | OpenApi3Dot1RequestBodyObject
@@ -28,7 +28,7 @@ export function getRequestBodyObject(
   if (requestBodyObject === undefined) {
     throw new InversifyValidationError(
       InversifyValidationErrorKind.validationFailed,
-      `No requestBody found for method ${inputParam.method} for path ${inputParam.path}`,
+      `No requestBody found for ${method.toUpperCase()} ${route}`,
     );
   }
 
@@ -46,7 +46,7 @@ export function getRequestBodyObject(
     if (resolvedRef === undefined) {
       throw new InversifyValidationError(
         InversifyValidationErrorKind.validationFailed,
-        `Could not resolve $ref pointer ${ref}`,
+        `Could not resolve $ref pointer ${ref} for ${method.toUpperCase()} ${route}`,
       );
     }
 
@@ -57,7 +57,7 @@ export function getRequestBodyObject(
     ) {
       throw new InversifyValidationError(
         InversifyValidationErrorKind.validationFailed,
-        `Resolved $ref pointer ${ref} is not a valid object`,
+        `Resolved $ref pointer ${ref} is not a valid request body object for ${method.toUpperCase()} ${route}`,
       );
     }
 

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleBodyValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleBodyValidation.spec.ts
@@ -26,7 +26,9 @@ import {
 import type Ajv from 'ajv';
 import { type ValidateFunction } from 'ajv';
 
+import { type OpenApiRouter } from '../../../router/services/OpenApiRouter.js';
 import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
+import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { SCHEMA_ID } from '../../models/v3Dot1/schemaId.js';
 import { type ValidationCacheEntry } from '../../models/v3Dot1/ValidationCacheEntry.js';
 import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
@@ -36,11 +38,20 @@ import { handleBodyValidation } from './handleBodyValidation.js';
 
 describe(handleBodyValidation, () => {
   let openApiObjectFixture: OpenApi3Dot1Object;
+  let validationContextFixture: OpenApiValidationContext;
   let openApiResolverFixture: OpenApiResolver;
+  let openApiRouterMock: OpenApiRouter;
 
   beforeAll(() => {
     openApiObjectFixture = Symbol() as unknown as OpenApi3Dot1Object;
     openApiResolverFixture = Symbol() as unknown as OpenApiResolver;
+    openApiRouterMock = {
+      findRoute: vitest.fn(),
+    };
+    validationContextFixture = {
+      resolver: openApiResolverFixture,
+      router: openApiRouterMock,
+    };
   });
 
   describe('having an inputParam with contentType', () => {
@@ -94,6 +105,7 @@ describe(handleBodyValidation, () => {
         validationCacheEntryFixture = {
           body: undefined,
           headers: undefined,
+          params: undefined,
         };
 
         getEntryMock = vitest
@@ -110,11 +122,15 @@ describe(handleBodyValidation, () => {
           .mocked(escapeJsonPointerFragments)
           .mockReturnValueOnce(escapedPointerFixture);
 
+        vitest
+          .mocked(openApiRouterMock.findRoute)
+          .mockReturnValueOnce(pathFixture);
+
         try {
           handleBodyValidation(
             ajvMock,
             openApiObjectFixture,
-            openApiResolverFixture,
+            validationContextFixture,
             inputParamFixture,
             getEntryMock,
           );
@@ -146,7 +162,8 @@ describe(handleBodyValidation, () => {
         expect(getRequestBodyObject).toHaveBeenCalledExactlyOnceWith(
           openApiResolverFixture,
           operationObjectFixture,
-          inputParamFixture,
+          methodFixture,
+          pathFixture,
         );
       });
 
@@ -200,6 +217,7 @@ describe(handleBodyValidation, () => {
         validationCacheEntryFixture = {
           body: undefined,
           headers: undefined,
+          params: undefined,
         };
 
         getEntryMock = vitest
@@ -216,10 +234,14 @@ describe(handleBodyValidation, () => {
           .mocked(escapeJsonPointerFragments)
           .mockReturnValueOnce(escapedPointerFixture);
 
+        vitest
+          .mocked(openApiRouterMock.findRoute)
+          .mockReturnValueOnce(pathFixture);
+
         result = handleBodyValidation(
           ajvMock,
           openApiObjectFixture,
-          openApiResolverFixture,
+          validationContextFixture,
           inputParamFixture,
           getEntryMock,
         );
@@ -248,7 +270,8 @@ describe(handleBodyValidation, () => {
         expect(getRequestBodyObject).toHaveBeenCalledExactlyOnceWith(
           openApiResolverFixture,
           operationObjectFixture,
-          inputParamFixture,
+          methodFixture,
+          pathFixture,
         );
       });
 
@@ -289,6 +312,7 @@ describe(handleBodyValidation, () => {
         validationCacheEntryFixture = {
           body: undefined,
           headers: undefined,
+          params: undefined,
         };
 
         getEntryMock = vitest
@@ -305,11 +329,15 @@ describe(handleBodyValidation, () => {
           .mocked(escapeJsonPointerFragments)
           .mockReturnValueOnce(escapedPointerFixture);
 
+        vitest
+          .mocked(openApiRouterMock.findRoute)
+          .mockReturnValueOnce(pathFixture);
+
         try {
           handleBodyValidation(
             ajvMock,
             openApiObjectFixture,
-            openApiResolverFixture,
+            validationContextFixture,
             inputParamFixture,
             getEntryMock,
           );
@@ -388,6 +416,7 @@ describe(handleBodyValidation, () => {
         validationCacheEntryFixture = {
           body: undefined,
           headers: undefined,
+          params: undefined,
         };
 
         getEntryMock = vitest
@@ -404,10 +433,14 @@ describe(handleBodyValidation, () => {
           .mocked(escapeJsonPointerFragments)
           .mockReturnValueOnce(escapedPointerFixture);
 
+        vitest
+          .mocked(openApiRouterMock.findRoute)
+          .mockReturnValueOnce(pathFixture);
+
         result = handleBodyValidation(
           ajvMock,
           openApiObjectFixture,
-          openApiResolverFixture,
+          validationContextFixture,
           inputParamFixture,
           getEntryMock,
         );
@@ -488,6 +521,7 @@ describe(handleBodyValidation, () => {
         validationCacheEntryFixture = {
           body: undefined,
           headers: undefined,
+          params: undefined,
         };
 
         getEntryMock = vitest
@@ -504,10 +538,14 @@ describe(handleBodyValidation, () => {
           .mocked(escapeJsonPointerFragments)
           .mockReturnValueOnce(escapedPointerFixture);
 
+        vitest
+          .mocked(openApiRouterMock.findRoute)
+          .mockReturnValueOnce(pathFixture);
+
         result = handleBodyValidation(
           ajvMock,
           openApiObjectFixture,
-          openApiResolverFixture,
+          validationContextFixture,
           inputParamFixture,
           getEntryMock,
         );

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleBodyValidation.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleBodyValidation.ts
@@ -12,6 +12,7 @@ import type Ajv from 'ajv';
 import { type ErrorObject, type ValidateFunction } from 'ajv';
 
 import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
+import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { SCHEMA_ID } from '../../models/v3Dot1/schemaId.js';
 import {
   type ValidationCacheEntry,
@@ -25,16 +26,17 @@ function getValidationCacheEntryBody(
   ajv: Ajv,
   openApiObject: OpenApi3Dot1Object,
   openApiResolver: OpenApiResolver,
-  inputParam: BodyValidationInputParam<unknown>,
+  method: string,
+  route: string,
 ): ValidationCacheEntryBody {
   const operationObject: OpenApi3Dot1OperationObject = getOperationObject(
     openApiObject,
-    inputParam.method,
-    inputParam.path,
+    method,
+    route,
   );
 
   const openApi3Dot1RequestBodyObject: OpenApi3Dot1RequestBodyObject =
-    getRequestBodyObject(openApiResolver, operationObject, inputParam);
+    getRequestBodyObject(openApiResolver, operationObject, method, route);
 
   const required: boolean = openApi3Dot1RequestBodyObject.required ?? false;
 
@@ -48,8 +50,8 @@ function getValidationCacheEntryBody(
   for (const contentType of contentTypes) {
     const schemaPointer: string = `${SCHEMA_ID}#/${escapeJsonPointerFragments(
       'paths',
-      inputParam.path,
-      inputParam.method,
+      route,
+      method,
       'requestBody',
       'content',
       contentType,
@@ -86,6 +88,7 @@ function getValidationCacheEntryBody(
 function handleRequiredBodyValidation(
   validationCacheEntryBody: ValidationCacheEntryBody,
   inputParam: BodyValidationInputParam<unknown>,
+  route: string,
 ): unknown {
   const validate: ValidateFunction | undefined =
     validationCacheEntryBody.contentToValidateMap.get(inputParam.contentType);
@@ -93,7 +96,7 @@ function handleRequiredBodyValidation(
   if (validate === undefined) {
     throw new InversifyValidationError(
       InversifyValidationErrorKind.validationFailed,
-      `Unable to find schema for operation: ${inputParam.method.toUpperCase()} ${inputParam.path} with content type: ${inputParam.contentType ?? '-'}`,
+      `Unable to find schema for operation: ${inputParam.method.toUpperCase()} ${route} with content type: ${inputParam.contentType ?? '-'}`,
     );
   }
 
@@ -117,12 +120,24 @@ function handleRequiredBodyValidation(
 export function handleBodyValidation(
   ajv: Ajv,
   openApiObject: OpenApi3Dot1Object,
-  openApiResolver: OpenApiResolver,
+  validationContext: OpenApiValidationContext,
   inputParam: BodyValidationInputParam<unknown>,
   getEntry: (path: string, method: string) => ValidationCacheEntry,
 ): unknown {
-  const validationCacheEntry: ValidationCacheEntry = getEntry(
+  const route: string | undefined = validationContext.router.findRoute(
+    inputParam.method,
     inputParam.path,
+  );
+
+  if (route === undefined) {
+    throw new InversifyValidationError(
+      InversifyValidationErrorKind.validationFailed,
+      `Unable to find route for operation: ${inputParam.method.toUpperCase()} ${inputParam.path}`,
+    );
+  }
+
+  const validationCacheEntry: ValidationCacheEntry = getEntry(
+    route,
     inputParam.method,
   );
 
@@ -130,18 +145,27 @@ export function handleBodyValidation(
     validationCacheEntry.body = getValidationCacheEntryBody(
       ajv,
       openApiObject,
-      openApiResolver,
-      inputParam,
+      validationContext.resolver,
+      inputParam.method,
+      route,
     );
   }
 
   if (validationCacheEntry.body.required) {
-    return handleRequiredBodyValidation(validationCacheEntry.body, inputParam);
+    return handleRequiredBodyValidation(
+      validationCacheEntry.body,
+      inputParam,
+      route,
+    );
   }
 
   if (inputParam.body === undefined || inputParam.body === '') {
     return undefined;
   }
 
-  return handleRequiredBodyValidation(validationCacheEntry.body, inputParam);
+  return handleRequiredBodyValidation(
+    validationCacheEntry.body,
+    inputParam,
+    route,
+  );
 }

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleHeaderValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleHeaderValidation.spec.ts
@@ -20,7 +20,9 @@ import {
 import type Ajv from 'ajv';
 import { type ValidateFunction } from 'ajv';
 
+import { type OpenApiRouter } from '../../../router/services/OpenApiRouter.js';
 import { type HeaderValidationInputParam } from '../../models/HeaderValidationInputParam.js';
+import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { type ValidationCacheEntry } from '../../models/v3Dot1/ValidationCacheEntry.js';
 import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
 import { buildHeaderParse } from '../buildHeaderParse.js';
@@ -32,11 +34,20 @@ import { handleHeaderValidation } from './handleHeaderValidation.js';
 
 describe(handleHeaderValidation, () => {
   let openApiObjectFixture: OpenApi3Dot1Object;
+  let validationContextFixture: OpenApiValidationContext;
   let openApiResolverFixture: OpenApiResolver;
+  let openApiRouterMock: OpenApiRouter;
 
   beforeAll(() => {
     openApiObjectFixture = Symbol() as unknown as OpenApi3Dot1Object;
     openApiResolverFixture = Symbol() as unknown as OpenApiResolver;
+    openApiRouterMock = {
+      findRoute: vitest.fn(),
+    };
+    validationContextFixture = {
+      resolver: openApiResolverFixture,
+      router: openApiRouterMock,
+    };
   });
 
   afterAll(() => {
@@ -82,6 +93,7 @@ describe(handleHeaderValidation, () => {
       const validationCacheEntry: ValidationCacheEntry = {
         body: undefined,
         headers: undefined,
+        params: undefined,
       };
 
       const getEntryMock: Mock<
@@ -95,10 +107,14 @@ describe(handleHeaderValidation, () => {
         type: Symbol() as unknown as HeaderValidationInputParam['type'],
       };
 
+      vitest
+        .mocked(openApiRouterMock.findRoute)
+        .mockReturnValueOnce(inputParam.path);
+
       result = handleHeaderValidation(
         ajvMock,
         openApiObjectFixture,
-        openApiResolverFixture,
+        validationContextFixture,
         inputParam,
         getEntryMock,
       );
@@ -152,6 +168,7 @@ describe(handleHeaderValidation, () => {
       const validationCacheEntry: ValidationCacheEntry = {
         body: undefined,
         headers: undefined,
+        params: undefined,
       };
 
       const getEntryMock: Mock<
@@ -166,10 +183,14 @@ describe(handleHeaderValidation, () => {
       };
 
       try {
+        vitest
+          .mocked(openApiRouterMock.findRoute)
+          .mockReturnValueOnce(inputParam.path);
+
         handleHeaderValidation(
           ajvMock,
           openApiObjectFixture,
-          openApiResolverFixture,
+          validationContextFixture,
           inputParam,
           getEntryMock,
         );
@@ -231,6 +252,7 @@ describe(handleHeaderValidation, () => {
       const validationCacheEntry: ValidationCacheEntry = {
         body: undefined,
         headers: undefined,
+        params: undefined,
       };
 
       const getEntryMock: Mock<
@@ -244,10 +266,14 @@ describe(handleHeaderValidation, () => {
         type: Symbol() as unknown as HeaderValidationInputParam['type'],
       };
 
+      vitest
+        .mocked(openApiRouterMock.findRoute)
+        .mockReturnValueOnce(inputParam.path);
+
       result = handleHeaderValidation(
         ajvMock,
         openApiObjectFixture,
-        openApiResolverFixture,
+        validationContextFixture,
         inputParam,
         getEntryMock,
       );
@@ -312,6 +338,7 @@ describe(handleHeaderValidation, () => {
       const validationCacheEntry: ValidationCacheEntry = {
         body: undefined,
         headers: undefined,
+        params: undefined,
       };
 
       const getEntryMock: Mock<
@@ -326,10 +353,14 @@ describe(handleHeaderValidation, () => {
       };
 
       try {
+        vitest
+          .mocked(openApiRouterMock.findRoute)
+          .mockReturnValueOnce(inputParam.path);
+
         handleHeaderValidation(
           ajvMock,
           openApiObjectFixture,
-          openApiResolverFixture,
+          validationContextFixture,
           inputParam,
           getEntryMock,
         );
@@ -381,6 +412,7 @@ describe(handleHeaderValidation, () => {
             },
           ],
         ]),
+        params: undefined,
       };
 
       const getEntryMock: Mock<
@@ -394,10 +426,14 @@ describe(handleHeaderValidation, () => {
         type: Symbol() as unknown as HeaderValidationInputParam['type'],
       };
 
+      vitest
+        .mocked(openApiRouterMock.findRoute)
+        .mockReturnValueOnce(inputParam.path);
+
       result = handleHeaderValidation(
         ajvMock,
         openApiObjectFixture,
-        openApiResolverFixture,
+        validationContextFixture,
         inputParam,
         getEntryMock,
       );

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleHeaderValidation.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleHeaderValidation.ts
@@ -7,6 +7,7 @@ import type Ajv from 'ajv';
 import { type ErrorObject, type ValidateFunction } from 'ajv';
 
 import { type HeaderValidationInputParam } from '../../models/HeaderValidationInputParam.js';
+import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { SCHEMA_ID } from '../../models/v3Dot1/schemaId.js';
 import {
   type ValidationCacheEntry,
@@ -23,18 +24,14 @@ function getHeaderParameterEntryMap(
   ajv: Ajv,
   openApiObject: OpenApi3Dot1Object,
   openApiResolver: OpenApiResolver,
-  inputParam: HeaderValidationInputParam,
+  method: string,
+  route: string,
 ): Map<string, ValidationCacheEntryHeader> {
   const headerParameterEntryMap: Map<string, ValidationCacheEntryHeader> =
     new Map();
 
   const headerParams: Map<string, HeaderParameterEntry> =
-    getHeaderParameterObjects(
-      openApiObject,
-      openApiResolver,
-      inputParam.method,
-      inputParam.path,
-    );
+    getHeaderParameterObjects(openApiObject, openApiResolver, method, route);
 
   for (const [headerName, headerParam] of headerParams) {
     const parse: (value: string | string[] | undefined) => unknown =
@@ -69,12 +66,24 @@ function getHeaderParameterEntryMap(
 export function handleHeaderValidation(
   ajv: Ajv,
   openApiObject: OpenApi3Dot1Object,
-  openApiResolver: OpenApiResolver,
+  validationContext: OpenApiValidationContext,
   inputParam: HeaderValidationInputParam,
   getEntry: (path: string, method: string) => ValidationCacheEntry,
 ): unknown {
-  const validationCacheEntry: ValidationCacheEntry = getEntry(
+  const route: string | undefined = validationContext.router.findRoute(
+    inputParam.method,
     inputParam.path,
+  );
+
+  if (route === undefined) {
+    throw new InversifyValidationError(
+      InversifyValidationErrorKind.validationFailed,
+      `Unable to find route for operation: ${inputParam.method.toUpperCase()} ${inputParam.path}`,
+    );
+  }
+
+  const validationCacheEntry: ValidationCacheEntry = getEntry(
+    route,
     inputParam.method,
   );
 
@@ -82,8 +91,9 @@ export function handleHeaderValidation(
     validationCacheEntry.headers = getHeaderParameterEntryMap(
       ajv,
       openApiObject,
-      openApiResolver,
-      inputParam,
+      validationContext.resolver,
+      inputParam.method,
+      route,
     );
   }
 

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleParamValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleParamValidation.spec.ts
@@ -1,0 +1,383 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  type Mock,
+  type Mocked,
+  vitest,
+} from 'vitest';
+
+vitest.mock(import('../buildParamParse.js'));
+vitest.mock(import('./getParamParameterObjects.js'));
+
+import { type OpenApi3Dot1Object } from '@inversifyjs/open-api-types/v3Dot1';
+import {
+  InversifyValidationError,
+  InversifyValidationErrorKind,
+} from '@inversifyjs/validation-common';
+import type Ajv from 'ajv';
+import { type ValidateFunction } from 'ajv';
+
+import { type OpenApiRouter } from '../../../router/services/OpenApiRouter.js';
+import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
+import { type ParamValidationInputParam } from '../../models/ParamValidationInputParam.js';
+import { type ValidationCacheEntry } from '../../models/v3Dot1/ValidationCacheEntry.js';
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
+import { buildParamParse } from '../buildParamParse.js';
+import {
+  getParamParameterObjects,
+  type ParamParameterEntry,
+} from './getParamParameterObjects.js';
+import { handleParamValidation } from './handleParamValidation.js';
+
+describe(handleParamValidation, () => {
+  let openApiObjectFixture: OpenApi3Dot1Object;
+  let validationContextFixture: OpenApiValidationContext;
+  let openApiResolverFixture: OpenApiResolver;
+  let openApiRouterMock: OpenApiRouter;
+
+  beforeAll(() => {
+    openApiObjectFixture = Symbol() as unknown as OpenApi3Dot1Object;
+    openApiResolverFixture = Symbol() as unknown as OpenApiResolver;
+    openApiRouterMock = {
+      findRoute: vitest.fn(),
+    };
+    validationContextFixture = {
+      resolver: openApiResolverFixture,
+      router: openApiRouterMock,
+    };
+  });
+
+  afterAll(() => {
+    vitest.restoreAllMocks();
+  });
+
+  describe('when called, and params are valid with string type', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      const paramParamMap: Map<string, ParamParameterEntry> = new Map([
+        [
+          'userId',
+          {
+            parameter: {
+              in: 'path',
+              name: 'userId',
+              required: true,
+              schema: { type: 'string' },
+            },
+            pointerPrefix: 'paths/~1users~1{userId}/get/parameters/0',
+          },
+        ],
+      ]);
+
+      vitest
+        .mocked(getParamParameterObjects)
+        .mockReturnValueOnce(paramParamMap);
+
+      const parseMock: Mock = vitest.fn().mockReturnValueOnce('abc-123');
+
+      vitest.mocked(buildParamParse).mockReturnValueOnce(parseMock);
+
+      const validateMock: ValidateFunction = Object.assign(
+        vitest.fn().mockReturnValueOnce(true),
+        { errors: null, schema: {} },
+      ) as unknown as ValidateFunction;
+
+      const ajvMock: Mocked<Ajv> = {
+        getSchema: vitest.fn().mockReturnValueOnce(validateMock),
+      } as Partial<Mocked<Ajv>> as Mocked<Ajv>;
+
+      const validationCacheEntry: ValidationCacheEntry = {
+        body: undefined,
+        headers: undefined,
+        params: undefined,
+      };
+
+      const getEntryMock: Mock<
+        (path: string, method: string) => ValidationCacheEntry
+      > = vitest.fn().mockReturnValueOnce(validationCacheEntry);
+
+      const inputParam: ParamValidationInputParam = {
+        method: 'get',
+        params: { userId: 'abc-123' },
+        path: '/users/{userId}',
+        type: Symbol() as unknown as ParamValidationInputParam['type'],
+      };
+
+      vitest
+        .mocked(openApiRouterMock.findRoute)
+        .mockReturnValueOnce(inputParam.path);
+
+      result = handleParamValidation(
+        ajvMock,
+        openApiObjectFixture,
+        validationContextFixture,
+        inputParam,
+        getEntryMock,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should return validated params record', () => {
+      expect(result).toStrictEqual({ userId: 'abc-123' });
+    });
+  });
+
+  describe('when called, and required param is missing', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      const paramParamMap: Map<string, ParamParameterEntry> = new Map([
+        [
+          'userId',
+          {
+            parameter: {
+              in: 'path',
+              name: 'userId',
+              required: true,
+              schema: { type: 'string' },
+            },
+            pointerPrefix: 'paths/~1users~1{userId}/get/parameters/0',
+          },
+        ],
+      ]);
+
+      vitest
+        .mocked(getParamParameterObjects)
+        .mockReturnValueOnce(paramParamMap);
+
+      const parseMock: Mock = vitest.fn();
+
+      vitest.mocked(buildParamParse).mockReturnValueOnce(parseMock);
+
+      const validateMock: ValidateFunction = Object.assign(vitest.fn(), {
+        errors: null,
+        schema: {},
+      }) as unknown as ValidateFunction;
+
+      const ajvMock: Mocked<Ajv> = {
+        getSchema: vitest.fn().mockReturnValueOnce(validateMock),
+      } as Partial<Mocked<Ajv>> as Mocked<Ajv>;
+
+      const validationCacheEntry: ValidationCacheEntry = {
+        body: undefined,
+        headers: undefined,
+        params: undefined,
+      };
+
+      const getEntryMock: Mock<
+        (path: string, method: string) => ValidationCacheEntry
+      > = vitest.fn().mockReturnValueOnce(validationCacheEntry);
+
+      const inputParam: ParamValidationInputParam = {
+        method: 'get',
+        params: {},
+        path: '/users/{userId}',
+        type: Symbol() as unknown as ParamValidationInputParam['type'],
+      };
+
+      try {
+        vitest
+          .mocked(openApiRouterMock.findRoute)
+          .mockReturnValueOnce(inputParam.path);
+
+        handleParamValidation(
+          ajvMock,
+          openApiObjectFixture,
+          validationContextFixture,
+          inputParam,
+          getEntryMock,
+        );
+      } catch (error: unknown) {
+        result = error;
+      }
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should throw an InversifyValidationError', () => {
+      const expectedErrorProperties: Partial<InversifyValidationError> = {
+        kind: InversifyValidationErrorKind.validationFailed,
+        message: 'Missing required param: userId',
+      };
+
+      expect(result).toBeInstanceOf(InversifyValidationError);
+      expect(result).toMatchObject(expectedErrorProperties);
+    });
+  });
+
+  describe('when called, and validation fails', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      const paramParamMap: Map<string, ParamParameterEntry> = new Map([
+        [
+          'userId',
+          {
+            parameter: {
+              in: 'path',
+              name: 'userId',
+              required: true,
+              schema: { minimum: 1, type: 'integer' },
+            },
+            pointerPrefix: 'paths/~1users~1{userId}/get/parameters/0',
+          },
+        ],
+      ]);
+
+      vitest
+        .mocked(getParamParameterObjects)
+        .mockReturnValueOnce(paramParamMap);
+
+      const parseMock: Mock = vitest.fn().mockReturnValueOnce('not-valid');
+
+      vitest.mocked(buildParamParse).mockReturnValueOnce(parseMock);
+
+      const validateMock: ValidateFunction = Object.assign(
+        vitest.fn().mockReturnValueOnce(false),
+        {
+          errors: [
+            {
+              instancePath: '',
+              keyword: 'type',
+              message: 'must be integer',
+              params: {},
+              schemaPath: '#/type',
+            },
+          ],
+          schema: {},
+        },
+      ) as unknown as ValidateFunction;
+
+      const ajvMock: Mocked<Ajv> = {
+        getSchema: vitest.fn().mockReturnValueOnce(validateMock),
+      } as Partial<Mocked<Ajv>> as Mocked<Ajv>;
+
+      const validationCacheEntry: ValidationCacheEntry = {
+        body: undefined,
+        headers: undefined,
+        params: undefined,
+      };
+
+      const getEntryMock: Mock<
+        (path: string, method: string) => ValidationCacheEntry
+      > = vitest.fn().mockReturnValueOnce(validationCacheEntry);
+
+      const inputParam: ParamValidationInputParam = {
+        method: 'get',
+        params: { userId: 'not-valid' },
+        path: '/users/{userId}',
+        type: Symbol() as unknown as ParamValidationInputParam['type'],
+      };
+
+      try {
+        vitest
+          .mocked(openApiRouterMock.findRoute)
+          .mockReturnValueOnce(inputParam.path);
+
+        handleParamValidation(
+          ajvMock,
+          openApiObjectFixture,
+          validationContextFixture,
+          inputParam,
+          getEntryMock,
+        );
+      } catch (error: unknown) {
+        result = error;
+      }
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should throw an InversifyValidationError', () => {
+      const expectedErrorProperties: Partial<InversifyValidationError> = {
+        kind: InversifyValidationErrorKind.validationFailed,
+        message: expect.stringContaining('userId'),
+      };
+
+      expect(result).toBeInstanceOf(InversifyValidationError);
+      expect(result).toMatchObject(expectedErrorProperties);
+    });
+  });
+
+  describe('when called, and cached params are reused', () => {
+    let result: unknown;
+    let ajvMock: Mocked<Ajv>;
+
+    beforeAll(() => {
+      const parseMock: Mock = vitest.fn().mockReturnValueOnce('test');
+
+      const validateMock: ValidateFunction = Object.assign(
+        vitest.fn().mockReturnValueOnce(true),
+        { errors: null, schema: {} },
+      ) as unknown as ValidateFunction;
+
+      ajvMock = {
+        getSchema: vitest.fn(),
+      } as Partial<Mocked<Ajv>> as Mocked<Ajv>;
+
+      const validationCacheEntry: ValidationCacheEntry = {
+        body: undefined,
+        headers: undefined,
+        params: new Map([
+          [
+            'userId',
+            {
+              parse: parseMock,
+              validate: validateMock,
+            },
+          ],
+        ]),
+      };
+
+      const getEntryMock: Mock<
+        (path: string, method: string) => ValidationCacheEntry
+      > = vitest.fn().mockReturnValueOnce(validationCacheEntry);
+
+      const inputParam: ParamValidationInputParam = {
+        method: 'get',
+        params: { userId: 'test' },
+        path: '/users/{userId}',
+        type: Symbol() as unknown as ParamValidationInputParam['type'],
+      };
+
+      vitest
+        .mocked(openApiRouterMock.findRoute)
+        .mockReturnValueOnce(inputParam.path);
+
+      result = handleParamValidation(
+        ajvMock,
+        openApiObjectFixture,
+        validationContextFixture,
+        inputParam,
+        getEntryMock,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should not call ajv.getSchema()', () => {
+      expect(ajvMock.getSchema).not.toHaveBeenCalled();
+    });
+
+    it('should not call getParamParameterObjects()', () => {
+      expect(getParamParameterObjects).not.toHaveBeenCalled();
+    });
+
+    it('should return validated params', () => {
+      expect(result).toStrictEqual({ userId: 'test' });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleParamValidation.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleParamValidation.ts
@@ -1,0 +1,152 @@
+import { type OpenApi3Dot1Object } from '@inversifyjs/open-api-types/v3Dot1';
+import {
+  InversifyValidationError,
+  InversifyValidationErrorKind,
+} from '@inversifyjs/validation-common';
+import type Ajv from 'ajv';
+import { type ErrorObject, type ValidateFunction } from 'ajv';
+
+import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
+import { type ParamValidationInputParam } from '../../models/ParamValidationInputParam.js';
+import { SCHEMA_ID } from '../../models/v3Dot1/schemaId.js';
+import {
+  type ValidationCacheEntry,
+  type ValidationCacheEntryParam,
+} from '../../models/v3Dot1/ValidationCacheEntry.js';
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
+import { buildParamParse } from '../buildParamParse.js';
+import {
+  getParamParameterObjects,
+  type ParamParameterEntry,
+} from './getParamParameterObjects.js';
+
+function getParamParameterEntryMap(
+  ajv: Ajv,
+  openApiObject: OpenApi3Dot1Object,
+  openApiResolver: OpenApiResolver,
+  method: string,
+  route: string,
+): Map<string, ValidationCacheEntryParam> {
+  const paramParameterEntryMap: Map<string, ValidationCacheEntryParam> =
+    new Map();
+
+  const paramParams: Map<string, ParamParameterEntry> =
+    getParamParameterObjects(openApiObject, openApiResolver, method, route);
+
+  for (const [paramName, paramParam] of paramParams) {
+    const parse: (value: string | string[] | undefined) => unknown =
+      buildParamParse(
+        openApiResolver,
+        paramParam.parameter.schema,
+        `${SCHEMA_ID}#/${paramParam.pointerPrefix}/schema`,
+      );
+
+    const ajvSchemaPointer: string = `${SCHEMA_ID}#/${paramParam.pointerPrefix}/schema`;
+
+    const validate: ValidateFunction | undefined =
+      ajv.getSchema(ajvSchemaPointer);
+
+    if (validate === undefined) {
+      throw new InversifyValidationError(
+        InversifyValidationErrorKind.validationFailed,
+        `Unable to find schema for pointer: ${ajvSchemaPointer}`,
+      );
+    }
+
+    paramParameterEntryMap.set(paramName, {
+      parse,
+      validate: validate,
+    });
+  }
+
+  return paramParameterEntryMap;
+}
+
+export function handleParamValidation(
+  ajv: Ajv,
+  openApiObject: OpenApi3Dot1Object,
+  validationContext: OpenApiValidationContext,
+  inputParam: ParamValidationInputParam,
+  getEntry: (path: string, method: string) => ValidationCacheEntry,
+): unknown {
+  const route: string | undefined = validationContext.router.findRoute(
+    inputParam.method,
+    inputParam.path,
+  );
+
+  if (route === undefined) {
+    throw new InversifyValidationError(
+      InversifyValidationErrorKind.validationFailed,
+      `Unable to find route for operation: ${inputParam.method.toUpperCase()} ${inputParam.path}`,
+    );
+  }
+
+  const validationCacheEntry: ValidationCacheEntry = getEntry(
+    route,
+    inputParam.method,
+  );
+
+  if (validationCacheEntry.params === undefined) {
+    validationCacheEntry.params = getParamParameterEntryMap(
+      ajv,
+      openApiObject,
+      validationContext.resolver,
+      inputParam.method,
+      route,
+    );
+  }
+
+  const computedParams: Record<string, unknown> = {
+    ...inputParam.params,
+  };
+
+  let valid: boolean = true;
+  const paramToErrorObject: Record<string, ErrorObject[]> = {};
+
+  for (const [
+    paramName,
+    validationCacheEntryParam,
+  ] of validationCacheEntry.params) {
+    if (!(paramName in inputParam.params)) {
+      throw new InversifyValidationError(
+        InversifyValidationErrorKind.validationFailed,
+        `Missing required param: ${paramName}`,
+      );
+    }
+
+    const paramValue: string | string[] | undefined =
+      inputParam.params[paramName];
+
+    computedParams[paramName] = validationCacheEntryParam.parse(paramValue);
+
+    const isValidParam: boolean = validationCacheEntryParam.validate(
+      computedParams[paramName],
+    );
+
+    if (!isValidParam) {
+      valid = false;
+
+      paramToErrorObject[paramName] = [
+        ...(validationCacheEntryParam.validate.errors ?? []),
+      ];
+    }
+  }
+
+  if (!valid) {
+    throw new InversifyValidationError(
+      InversifyValidationErrorKind.validationFailed,
+      Object.entries(paramToErrorObject)
+        .map(([paramName, errors]: [string, ErrorObject[]]): string =>
+          errors
+            .map(
+              (error: ErrorObject): string =>
+                `[param: ${paramName}, schemaPath: ${error.schemaPath}, instancePath: ${error.instancePath}]: "${error.message ?? '-'}"`,
+            )
+            .join('\n'),
+        )
+        .join('\n'),
+    );
+  }
+
+  return computedParams;
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getParamParameterObjects.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getParamParameterObjects.spec.ts
@@ -1,0 +1,376 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+vitest.mock(import('@inversifyjs/json-schema-pointer'));
+vitest.mock(import('./getOperationObject.js'));
+vitest.mock(import('./getPathItemObject.js'));
+
+import { escapeJsonPointerFragments } from '@inversifyjs/json-schema-pointer';
+import {
+  type OpenApi3Dot2Object,
+  type OpenApi3Dot2OperationObject,
+  type OpenApi3Dot2ParameterObject,
+  type OpenApi3Dot2PathItemObject,
+  type OpenApi3Dot2ReferenceObject,
+} from '@inversifyjs/open-api-types/v3Dot2';
+
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
+import { getOperationObject } from './getOperationObject.js';
+import {
+  getParamParameterObjects,
+  type ParamParameterEntry,
+} from './getParamParameterObjects.js';
+import { getPathItemObject } from './getPathItemObject.js';
+
+describe(getParamParameterObjects, () => {
+  let openApiObjectFixture: OpenApi3Dot2Object;
+  let pathFixture: string;
+  let methodFixture: string;
+
+  beforeAll(() => {
+    openApiObjectFixture = Symbol() as unknown as OpenApi3Dot2Object;
+    pathFixture = '/users/{userId}';
+    methodFixture = 'get';
+
+    vitest
+      .mocked(escapeJsonPointerFragments)
+      .mockImplementation((...fragments: string[]) => fragments.join('/'));
+  });
+
+  afterAll(() => {
+    vitest.clearAllMocks();
+  });
+
+  describe('when called, and operation has path parameters only', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let result: Map<string, ParamParameterEntry>;
+
+    beforeAll(() => {
+      const parameterFixture: OpenApi3Dot2ParameterObject = {
+        in: 'path',
+        name: 'userId',
+        required: true,
+        schema: { type: 'string' },
+      };
+
+      const operationFixture: OpenApi3Dot2OperationObject = {
+        parameters: [parameterFixture],
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot2PathItemObject = {
+        get: operationFixture,
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getParamParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should return a map with the path parameter', () => {
+      expect(result.size).toBe(1);
+      expect(result.has('userId')).toBe(true);
+    });
+
+    it('should return entry with correct pointer prefix', () => {
+      const entry: ParamParameterEntry = result.get(
+        'userId',
+      ) as ParamParameterEntry;
+
+      expect(entry.pointerPrefix).toBe(
+        `paths/${pathFixture}/${methodFixture}/parameters/0`,
+      );
+    });
+  });
+
+  describe('when called, and path item has path parameters only', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let result: Map<string, ParamParameterEntry>;
+
+    beforeAll(() => {
+      const parameterFixture: OpenApi3Dot2ParameterObject = {
+        in: 'path',
+        name: 'userId',
+        required: true,
+        schema: { type: 'string' },
+      };
+
+      const operationFixture: OpenApi3Dot2OperationObject = {
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot2PathItemObject = {
+        get: operationFixture,
+        parameters: [parameterFixture],
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getParamParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should return a map with the path parameter', () => {
+      expect(result.size).toBe(1);
+      expect(result.has('userId')).toBe(true);
+    });
+
+    it('should return entry with path-item pointer prefix', () => {
+      const entry: ParamParameterEntry = result.get(
+        'userId',
+      ) as ParamParameterEntry;
+
+      expect(entry.pointerPrefix).toBe(`paths/${pathFixture}/parameters/0`);
+    });
+  });
+
+  describe('when called, and operation overrides path-item parameter', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let result: Map<string, ParamParameterEntry>;
+
+    beforeAll(() => {
+      const pathItemParamFixture: OpenApi3Dot2ParameterObject = {
+        in: 'path',
+        name: 'userId',
+        schema: { type: 'string' },
+      };
+
+      const operationParamFixture: OpenApi3Dot2ParameterObject = {
+        in: 'path',
+        name: 'userId',
+        schema: { format: 'uuid', type: 'string' },
+      };
+
+      const operationFixture: OpenApi3Dot2OperationObject = {
+        parameters: [operationParamFixture],
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot2PathItemObject = {
+        get: operationFixture,
+        parameters: [pathItemParamFixture],
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getParamParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should return only one entry (operation overrides)', () => {
+      expect(result.size).toBe(1);
+    });
+
+    it('should use the operation-level parameter', () => {
+      const entry: ParamParameterEntry = result.get(
+        'userId',
+      ) as ParamParameterEntry;
+
+      expect(entry.parameter.schema).toStrictEqual({
+        format: 'uuid',
+        type: 'string',
+      });
+    });
+
+    it('should have operation pointer prefix', () => {
+      const entry: ParamParameterEntry = result.get(
+        'userId',
+      ) as ParamParameterEntry;
+
+      expect(entry.pointerPrefix).toBe(
+        `paths/${pathFixture}/${methodFixture}/parameters/0`,
+      );
+    });
+  });
+
+  describe('when called, and parameter is a $ref reference', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let result: Map<string, ParamParameterEntry>;
+
+    beforeAll(() => {
+      const refFixture: OpenApi3Dot2ReferenceObject = {
+        $ref: '#/components/parameters/UserIdParam',
+      };
+
+      const resolvedParamFixture: OpenApi3Dot2ParameterObject = {
+        in: 'path',
+        name: 'userId',
+        required: true,
+        schema: { type: 'string' },
+      };
+
+      const operationFixture: OpenApi3Dot2OperationObject = {
+        parameters: [refFixture],
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot2PathItemObject = {
+        get: operationFixture,
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest
+          .fn()
+          .mockReturnValueOnce(resolvedParamFixture),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getParamParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should resolve the $ref and return the path parameter', () => {
+      expect(result.size).toBe(1);
+      expect(result.has('userId')).toBe(true);
+    });
+
+    it('should call deepResolveReference', () => {
+      expect(
+        openApiResolverFixture.deepResolveReference,
+      ).toHaveBeenCalledExactlyOnceWith('#/components/parameters/UserIdParam');
+    });
+  });
+
+  describe('when called, and no parameters exist', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let result: Map<string, ParamParameterEntry>;
+
+    beforeAll(() => {
+      const operationFixture: OpenApi3Dot2OperationObject = {
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot2PathItemObject = {
+        get: operationFixture,
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getParamParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should return empty map', () => {
+      expect(result.size).toBe(0);
+    });
+  });
+
+  describe('when called, and parameters include non-path params', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let result: Map<string, ParamParameterEntry>;
+
+    beforeAll(() => {
+      const pathParam: OpenApi3Dot2ParameterObject = {
+        in: 'path',
+        name: 'userId',
+        schema: { type: 'string' },
+      };
+
+      const queryParam: OpenApi3Dot2ParameterObject = {
+        in: 'query',
+        name: 'page',
+        schema: { type: 'integer' },
+      };
+
+      const operationFixture: OpenApi3Dot2OperationObject = {
+        parameters: [pathParam, queryParam],
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot2PathItemObject = {
+        get: operationFixture,
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getParamParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should return only path parameters', () => {
+      expect(result.size).toBe(1);
+      expect(result.has('userId')).toBe(true);
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getParamParameterObjects.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getParamParameterObjects.ts
@@ -1,0 +1,88 @@
+import { escapeJsonPointerFragments } from '@inversifyjs/json-schema-pointer';
+import {
+  type OpenApi3Dot2Object,
+  type OpenApi3Dot2OperationObject,
+  type OpenApi3Dot2ParameterObject,
+  type OpenApi3Dot2PathItemObject,
+  type OpenApi3Dot2ReferenceObject,
+} from '@inversifyjs/open-api-types/v3Dot2';
+
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
+import { getOperationObject } from './getOperationObject.js';
+import { getPathItemObject } from './getPathItemObject.js';
+
+export interface ParamParameterEntry {
+  parameter: OpenApi3Dot2ParameterObject;
+  pointerPrefix: string;
+}
+
+function isReferenceObject(
+  param: OpenApi3Dot2ParameterObject | OpenApi3Dot2ReferenceObject,
+): param is OpenApi3Dot2ReferenceObject {
+  return '$ref' in param;
+}
+
+export function getParamParameterObjects(
+  openApiObject: OpenApi3Dot2Object,
+  openApiResolver: OpenApiResolver,
+  method: string,
+  path: string,
+): Map<string, ParamParameterEntry> {
+  const pathItemObject: OpenApi3Dot2PathItemObject = getPathItemObject(
+    openApiObject,
+    path,
+  );
+  const operationObject: OpenApi3Dot2OperationObject = getOperationObject(
+    openApiObject,
+    method,
+    path,
+  );
+
+  const result: Map<string, ParamParameterEntry> = new Map();
+
+  if (pathItemObject.parameters !== undefined) {
+    for (let i: number = 0; i < pathItemObject.parameters.length; i++) {
+      const raw: OpenApi3Dot2ParameterObject | OpenApi3Dot2ReferenceObject =
+        pathItemObject.parameters[i] as
+          | OpenApi3Dot2ParameterObject
+          | OpenApi3Dot2ReferenceObject;
+
+      const param: OpenApi3Dot2ParameterObject = isReferenceObject(raw)
+        ? (openApiResolver.deepResolveReference(
+            raw.$ref,
+          ) as unknown as OpenApi3Dot2ParameterObject)
+        : raw;
+
+      if (param.in === 'path') {
+        result.set(param.name, {
+          parameter: param,
+          pointerPrefix: `paths/${escapeJsonPointerFragments(path)}/parameters/${String(i)}`,
+        });
+      }
+    }
+  }
+
+  if (operationObject.parameters !== undefined) {
+    for (let i: number = 0; i < operationObject.parameters.length; i++) {
+      const raw: OpenApi3Dot2ParameterObject | OpenApi3Dot2ReferenceObject =
+        operationObject.parameters[i] as
+          | OpenApi3Dot2ParameterObject
+          | OpenApi3Dot2ReferenceObject;
+
+      const param: OpenApi3Dot2ParameterObject = isReferenceObject(raw)
+        ? (openApiResolver.deepResolveReference(
+            raw.$ref,
+          ) as unknown as OpenApi3Dot2ParameterObject)
+        : raw;
+
+      if (param.in === 'path') {
+        result.set(param.name, {
+          parameter: param,
+          pointerPrefix: `paths/${escapeJsonPointerFragments(path)}/${method}/parameters/${String(i)}`,
+        });
+      }
+    }
+  }
+
+  return result;
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getRequestBodyObject.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getRequestBodyObject.spec.ts
@@ -9,26 +9,21 @@ import {
   InversifyValidationErrorKind,
 } from '@inversifyjs/validation-common';
 
-import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
 import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
 import { getRequestBodyObject } from './getRequestBodyObject.js';
 
 describe(getRequestBodyObject, () => {
   let openApiResolverMock: OpenApiResolver;
-  let inputParamFixture: BodyValidationInputParam<unknown>;
+  let methodFixture: string;
+  let routeFixture: string;
 
   beforeAll(() => {
     openApiResolverMock = {
       deepResolveReference: vitest.fn(),
       resolveReference: vitest.fn(),
     };
-    inputParamFixture = {
-      body: { name: 'test' },
-      contentType: 'application/json',
-      method: 'post',
-      path: '/users',
-      type: Symbol() as unknown as BodyValidationInputParam<unknown>['type'],
-    };
+    methodFixture = 'post';
+    routeFixture = '/users';
   });
 
   describe('having an operationObject with no requestBody', () => {
@@ -48,7 +43,8 @@ describe(getRequestBodyObject, () => {
           getRequestBodyObject(
             openApiResolverMock,
             operationObjectFixture,
-            inputParamFixture,
+            methodFixture,
+            routeFixture,
           );
         } catch (error: unknown) {
           result = error;
@@ -58,7 +54,7 @@ describe(getRequestBodyObject, () => {
       it('should throw an InversifyValidationError', () => {
         const expectedErrorProperties: Partial<InversifyValidationError> = {
           kind: InversifyValidationErrorKind.validationFailed,
-          message: `No requestBody found for method ${inputParamFixture.method} for path ${inputParamFixture.path}`,
+          message: `No requestBody found for ${methodFixture.toUpperCase()} ${routeFixture}`,
         };
 
         expect(result).toBeInstanceOf(InversifyValidationError);
@@ -90,7 +86,8 @@ describe(getRequestBodyObject, () => {
         result = getRequestBodyObject(
           openApiResolverMock,
           operationObjectFixture,
-          inputParamFixture,
+          methodFixture,
+          routeFixture,
         );
       });
 
@@ -126,7 +123,8 @@ describe(getRequestBodyObject, () => {
           getRequestBodyObject(
             openApiResolverMock,
             operationObjectFixture,
-            inputParamFixture,
+            methodFixture,
+            routeFixture,
           );
         } catch (error: unknown) {
           result = error;
@@ -146,7 +144,7 @@ describe(getRequestBodyObject, () => {
       it('should throw an InversifyValidationError', () => {
         const expectedErrorProperties: Partial<InversifyValidationError> = {
           kind: InversifyValidationErrorKind.validationFailed,
-          message: `Could not resolve $ref pointer ${refFixture}`,
+          message: `Could not resolve $ref pointer ${refFixture} for ${methodFixture.toUpperCase()} ${routeFixture}`,
         };
 
         expect(result).toBeInstanceOf(InversifyValidationError);
@@ -181,7 +179,8 @@ describe(getRequestBodyObject, () => {
           getRequestBodyObject(
             openApiResolverMock,
             operationObjectFixture,
-            inputParamFixture,
+            methodFixture,
+            routeFixture,
           );
         } catch (error: unknown) {
           result = error;
@@ -201,7 +200,7 @@ describe(getRequestBodyObject, () => {
       it('should throw an InversifyValidationError', () => {
         const expectedErrorProperties: Partial<InversifyValidationError> = {
           kind: InversifyValidationErrorKind.validationFailed,
-          message: `Resolved $ref pointer ${refFixture} is not a valid object`,
+          message: `Resolved $ref pointer ${refFixture} is not a valid request body object for ${methodFixture.toUpperCase()} ${routeFixture}`,
         };
 
         expect(result).toBeInstanceOf(InversifyValidationError);
@@ -236,7 +235,8 @@ describe(getRequestBodyObject, () => {
           getRequestBodyObject(
             openApiResolverMock,
             operationObjectFixture,
-            inputParamFixture,
+            methodFixture,
+            routeFixture,
           );
         } catch (error: unknown) {
           result = error;
@@ -256,7 +256,7 @@ describe(getRequestBodyObject, () => {
       it('should throw an InversifyValidationError', () => {
         const expectedErrorProperties: Partial<InversifyValidationError> = {
           kind: InversifyValidationErrorKind.validationFailed,
-          message: `Resolved $ref pointer ${refFixture} is not a valid object`,
+          message: `Resolved $ref pointer ${refFixture} is not a valid request body object for ${methodFixture.toUpperCase()} ${routeFixture}`,
         };
 
         expect(result).toBeInstanceOf(InversifyValidationError);
@@ -300,7 +300,8 @@ describe(getRequestBodyObject, () => {
         result = getRequestBodyObject(
           openApiResolverMock,
           operationObjectFixture,
-          inputParamFixture,
+          methodFixture,
+          routeFixture,
         );
       });
 

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getRequestBodyObject.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getRequestBodyObject.ts
@@ -12,13 +12,13 @@ import {
   InversifyValidationErrorKind,
 } from '@inversifyjs/validation-common';
 
-import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
 import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
 
 export function getRequestBodyObject(
   openApiResolver: OpenApiResolver,
   operationObject: OpenApi3Dot2OperationObject,
-  inputParam: BodyValidationInputParam<unknown>,
+  method: string,
+  route: string,
 ): OpenApi3Dot2RequestBodyObject {
   const requestBodyObject:
     | OpenApi3Dot2RequestBodyObject
@@ -28,7 +28,7 @@ export function getRequestBodyObject(
   if (requestBodyObject === undefined) {
     throw new InversifyValidationError(
       InversifyValidationErrorKind.validationFailed,
-      `No requestBody found for method ${inputParam.method} for path ${inputParam.path}`,
+      `No requestBody found for ${method.toUpperCase()} ${route}`,
     );
   }
 
@@ -46,7 +46,7 @@ export function getRequestBodyObject(
     if (resolvedRef === undefined) {
       throw new InversifyValidationError(
         InversifyValidationErrorKind.validationFailed,
-        `Could not resolve $ref pointer ${ref}`,
+        `Could not resolve $ref pointer ${ref} for ${method.toUpperCase()} ${route}`,
       );
     }
 
@@ -57,7 +57,7 @@ export function getRequestBodyObject(
     ) {
       throw new InversifyValidationError(
         InversifyValidationErrorKind.validationFailed,
-        `Resolved $ref pointer ${ref} is not a valid object`,
+        `Resolved $ref pointer ${ref} is not a valid request body object for ${method.toUpperCase()} ${route}`,
       );
     }
 

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleBodyValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleBodyValidation.spec.ts
@@ -26,7 +26,9 @@ import {
 import type Ajv from 'ajv';
 import { type ValidateFunction } from 'ajv';
 
+import { type OpenApiRouter } from '../../../router/services/OpenApiRouter.js';
 import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
+import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { SCHEMA_ID } from '../../models/v3Dot2/schemaId.js';
 import { type ValidationCacheEntry } from '../../models/v3Dot2/ValidationCacheEntry.js';
 import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
@@ -36,11 +38,20 @@ import { handleBodyValidation } from './handleBodyValidation.js';
 
 describe(handleBodyValidation, () => {
   let openApiObjectFixture: OpenApi3Dot2Object;
+  let validationContextFixture: OpenApiValidationContext;
   let openApiResolverFixture: OpenApiResolver;
+  let openApiRouterMock: OpenApiRouter;
 
   beforeAll(() => {
     openApiObjectFixture = Symbol() as unknown as OpenApi3Dot2Object;
     openApiResolverFixture = Symbol() as unknown as OpenApiResolver;
+    openApiRouterMock = {
+      findRoute: vitest.fn(),
+    };
+    validationContextFixture = {
+      resolver: openApiResolverFixture,
+      router: openApiRouterMock,
+    };
   });
 
   describe('having an inputParam with contentType', () => {
@@ -94,6 +105,7 @@ describe(handleBodyValidation, () => {
         validationCacheEntryFixture = {
           body: undefined,
           headers: undefined,
+          params: undefined,
         };
 
         getEntryMock = vitest
@@ -110,11 +122,15 @@ describe(handleBodyValidation, () => {
           .mocked(escapeJsonPointerFragments)
           .mockReturnValueOnce(escapedPointerFixture);
 
+        vitest
+          .mocked(openApiRouterMock.findRoute)
+          .mockReturnValueOnce(pathFixture);
+
         try {
           handleBodyValidation(
             ajvMock,
             openApiObjectFixture,
-            openApiResolverFixture,
+            validationContextFixture,
             inputParamFixture,
             getEntryMock,
           );
@@ -146,7 +162,8 @@ describe(handleBodyValidation, () => {
         expect(getRequestBodyObject).toHaveBeenCalledExactlyOnceWith(
           openApiResolverFixture,
           operationObjectFixture,
-          inputParamFixture,
+          methodFixture,
+          pathFixture,
         );
       });
 
@@ -200,6 +217,7 @@ describe(handleBodyValidation, () => {
         validationCacheEntryFixture = {
           body: undefined,
           headers: undefined,
+          params: undefined,
         };
 
         getEntryMock = vitest
@@ -216,10 +234,14 @@ describe(handleBodyValidation, () => {
           .mocked(escapeJsonPointerFragments)
           .mockReturnValueOnce(escapedPointerFixture);
 
+        vitest
+          .mocked(openApiRouterMock.findRoute)
+          .mockReturnValueOnce(pathFixture);
+
         result = handleBodyValidation(
           ajvMock,
           openApiObjectFixture,
-          openApiResolverFixture,
+          validationContextFixture,
           inputParamFixture,
           getEntryMock,
         );
@@ -248,7 +270,8 @@ describe(handleBodyValidation, () => {
         expect(getRequestBodyObject).toHaveBeenCalledExactlyOnceWith(
           openApiResolverFixture,
           operationObjectFixture,
-          inputParamFixture,
+          methodFixture,
+          pathFixture,
         );
       });
 
@@ -289,6 +312,7 @@ describe(handleBodyValidation, () => {
         validationCacheEntryFixture = {
           body: undefined,
           headers: undefined,
+          params: undefined,
         };
 
         getEntryMock = vitest
@@ -305,11 +329,15 @@ describe(handleBodyValidation, () => {
           .mocked(escapeJsonPointerFragments)
           .mockReturnValueOnce(escapedPointerFixture);
 
+        vitest
+          .mocked(openApiRouterMock.findRoute)
+          .mockReturnValueOnce(pathFixture);
+
         try {
           handleBodyValidation(
             ajvMock,
             openApiObjectFixture,
-            openApiResolverFixture,
+            validationContextFixture,
             inputParamFixture,
             getEntryMock,
           );
@@ -388,6 +416,7 @@ describe(handleBodyValidation, () => {
         validationCacheEntryFixture = {
           body: undefined,
           headers: undefined,
+          params: undefined,
         };
 
         getEntryMock = vitest
@@ -404,10 +433,14 @@ describe(handleBodyValidation, () => {
           .mocked(escapeJsonPointerFragments)
           .mockReturnValueOnce(escapedPointerFixture);
 
+        vitest
+          .mocked(openApiRouterMock.findRoute)
+          .mockReturnValueOnce(pathFixture);
+
         result = handleBodyValidation(
           ajvMock,
           openApiObjectFixture,
-          openApiResolverFixture,
+          validationContextFixture,
           inputParamFixture,
           getEntryMock,
         );
@@ -488,6 +521,7 @@ describe(handleBodyValidation, () => {
         validationCacheEntryFixture = {
           body: undefined,
           headers: undefined,
+          params: undefined,
         };
 
         getEntryMock = vitest
@@ -504,10 +538,14 @@ describe(handleBodyValidation, () => {
           .mocked(escapeJsonPointerFragments)
           .mockReturnValueOnce(escapedPointerFixture);
 
+        vitest
+          .mocked(openApiRouterMock.findRoute)
+          .mockReturnValueOnce(pathFixture);
+
         result = handleBodyValidation(
           ajvMock,
           openApiObjectFixture,
-          openApiResolverFixture,
+          validationContextFixture,
           inputParamFixture,
           getEntryMock,
         );

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleBodyValidation.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleBodyValidation.ts
@@ -12,6 +12,7 @@ import type Ajv from 'ajv';
 import { type ErrorObject, type ValidateFunction } from 'ajv';
 
 import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
+import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { SCHEMA_ID } from '../../models/v3Dot2/schemaId.js';
 import {
   type ValidationCacheEntry,
@@ -25,16 +26,17 @@ function getValidationCacheEntryBody(
   ajv: Ajv,
   openApiObject: OpenApi3Dot2Object,
   openApiResolver: OpenApiResolver,
-  inputParam: BodyValidationInputParam<unknown>,
+  method: string,
+  route: string,
 ): ValidationCacheEntryBody {
   const operationObject: OpenApi3Dot2OperationObject = getOperationObject(
     openApiObject,
-    inputParam.method,
-    inputParam.path,
+    method,
+    route,
   );
 
   const openApi3Dot2RequestBodyObject: OpenApi3Dot2RequestBodyObject =
-    getRequestBodyObject(openApiResolver, operationObject, inputParam);
+    getRequestBodyObject(openApiResolver, operationObject, method, route);
 
   const required: boolean = openApi3Dot2RequestBodyObject.required ?? false;
 
@@ -48,8 +50,8 @@ function getValidationCacheEntryBody(
   for (const contentType of contentTypes) {
     const schemaPointer: string = `${SCHEMA_ID}#/${escapeJsonPointerFragments(
       'paths',
-      inputParam.path,
-      inputParam.method,
+      route,
+      method,
       'requestBody',
       'content',
       contentType,
@@ -86,6 +88,7 @@ function getValidationCacheEntryBody(
 function handleRequiredBodyValidation(
   validationCacheEntryBody: ValidationCacheEntryBody,
   inputParam: BodyValidationInputParam<unknown>,
+  route: string,
 ): unknown {
   const validate: ValidateFunction | undefined =
     validationCacheEntryBody.contentToValidateMap.get(inputParam.contentType);
@@ -93,7 +96,7 @@ function handleRequiredBodyValidation(
   if (validate === undefined) {
     throw new InversifyValidationError(
       InversifyValidationErrorKind.validationFailed,
-      `Unable to find schema for operation: ${inputParam.method.toUpperCase()} ${inputParam.path} with content type: ${inputParam.contentType ?? '-'}`,
+      `Unable to find schema for operation: ${inputParam.method.toUpperCase()} ${route} with content type: ${inputParam.contentType ?? '-'}`,
     );
   }
 
@@ -117,12 +120,24 @@ function handleRequiredBodyValidation(
 export function handleBodyValidation(
   ajv: Ajv,
   openApiObject: OpenApi3Dot2Object,
-  openApiResolver: OpenApiResolver,
+  validationContext: OpenApiValidationContext,
   inputParam: BodyValidationInputParam<unknown>,
   getEntry: (path: string, method: string) => ValidationCacheEntry,
 ): unknown {
-  const validationCacheEntry: ValidationCacheEntry = getEntry(
+  const route: string | undefined = validationContext.router.findRoute(
+    inputParam.method,
     inputParam.path,
+  );
+
+  if (route === undefined) {
+    throw new InversifyValidationError(
+      InversifyValidationErrorKind.validationFailed,
+      `Unable to find route for operation: ${inputParam.method.toUpperCase()} ${inputParam.path}`,
+    );
+  }
+
+  const validationCacheEntry: ValidationCacheEntry = getEntry(
+    route,
     inputParam.method,
   );
 
@@ -130,18 +145,27 @@ export function handleBodyValidation(
     validationCacheEntry.body = getValidationCacheEntryBody(
       ajv,
       openApiObject,
-      openApiResolver,
-      inputParam,
+      validationContext.resolver,
+      inputParam.method,
+      route,
     );
   }
 
   if (validationCacheEntry.body.required) {
-    return handleRequiredBodyValidation(validationCacheEntry.body, inputParam);
+    return handleRequiredBodyValidation(
+      validationCacheEntry.body,
+      inputParam,
+      route,
+    );
   }
 
   if (inputParam.body === undefined || inputParam.body === '') {
     return undefined;
   }
 
-  return handleRequiredBodyValidation(validationCacheEntry.body, inputParam);
+  return handleRequiredBodyValidation(
+    validationCacheEntry.body,
+    inputParam,
+    route,
+  );
 }

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleHeaderValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleHeaderValidation.spec.ts
@@ -20,7 +20,9 @@ import {
 import type Ajv from 'ajv';
 import { type ValidateFunction } from 'ajv';
 
+import { type OpenApiRouter } from '../../../router/services/OpenApiRouter.js';
 import { type HeaderValidationInputParam } from '../../models/HeaderValidationInputParam.js';
+import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { type ValidationCacheEntry } from '../../models/v3Dot2/ValidationCacheEntry.js';
 import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
 import { buildHeaderParse } from '../buildHeaderParse.js';
@@ -32,11 +34,20 @@ import { handleHeaderValidation } from './handleHeaderValidation.js';
 
 describe(handleHeaderValidation, () => {
   let openApiObjectFixture: OpenApi3Dot2Object;
+  let validationContextFixture: OpenApiValidationContext;
   let openApiResolverFixture: OpenApiResolver;
+  let openApiRouterMock: OpenApiRouter;
 
   beforeAll(() => {
     openApiObjectFixture = Symbol() as unknown as OpenApi3Dot2Object;
     openApiResolverFixture = Symbol() as unknown as OpenApiResolver;
+    openApiRouterMock = {
+      findRoute: vitest.fn(),
+    };
+    validationContextFixture = {
+      resolver: openApiResolverFixture,
+      router: openApiRouterMock,
+    };
   });
 
   afterAll(() => {
@@ -82,6 +93,7 @@ describe(handleHeaderValidation, () => {
       const validationCacheEntry: ValidationCacheEntry = {
         body: undefined,
         headers: undefined,
+        params: undefined,
       };
 
       const getEntryMock: Mock<
@@ -95,10 +107,14 @@ describe(handleHeaderValidation, () => {
         type: Symbol() as unknown as HeaderValidationInputParam['type'],
       };
 
+      vitest
+        .mocked(openApiRouterMock.findRoute)
+        .mockReturnValueOnce(inputParam.path);
+
       result = handleHeaderValidation(
         ajvMock,
         openApiObjectFixture,
-        openApiResolverFixture,
+        validationContextFixture,
         inputParam,
         getEntryMock,
       );
@@ -152,6 +168,7 @@ describe(handleHeaderValidation, () => {
       const validationCacheEntry: ValidationCacheEntry = {
         body: undefined,
         headers: undefined,
+        params: undefined,
       };
 
       const getEntryMock: Mock<
@@ -165,11 +182,15 @@ describe(handleHeaderValidation, () => {
         type: Symbol() as unknown as HeaderValidationInputParam['type'],
       };
 
+      vitest
+        .mocked(openApiRouterMock.findRoute)
+        .mockReturnValueOnce(inputParam.path);
+
       try {
         handleHeaderValidation(
           ajvMock,
           openApiObjectFixture,
-          openApiResolverFixture,
+          validationContextFixture,
           inputParam,
           getEntryMock,
         );
@@ -231,6 +252,7 @@ describe(handleHeaderValidation, () => {
       const validationCacheEntry: ValidationCacheEntry = {
         body: undefined,
         headers: undefined,
+        params: undefined,
       };
 
       const getEntryMock: Mock<
@@ -244,10 +266,14 @@ describe(handleHeaderValidation, () => {
         type: Symbol() as unknown as HeaderValidationInputParam['type'],
       };
 
+      vitest
+        .mocked(openApiRouterMock.findRoute)
+        .mockReturnValueOnce(inputParam.path);
+
       result = handleHeaderValidation(
         ajvMock,
         openApiObjectFixture,
-        openApiResolverFixture,
+        validationContextFixture,
         inputParam,
         getEntryMock,
       );
@@ -312,6 +338,7 @@ describe(handleHeaderValidation, () => {
       const validationCacheEntry: ValidationCacheEntry = {
         body: undefined,
         headers: undefined,
+        params: undefined,
       };
 
       const getEntryMock: Mock<
@@ -325,11 +352,15 @@ describe(handleHeaderValidation, () => {
         type: Symbol() as unknown as HeaderValidationInputParam['type'],
       };
 
+      vitest
+        .mocked(openApiRouterMock.findRoute)
+        .mockReturnValueOnce(inputParam.path);
+
       try {
         handleHeaderValidation(
           ajvMock,
           openApiObjectFixture,
-          openApiResolverFixture,
+          validationContextFixture,
           inputParam,
           getEntryMock,
         );
@@ -381,6 +412,7 @@ describe(handleHeaderValidation, () => {
             },
           ],
         ]),
+        params: undefined,
       };
 
       const getEntryMock: Mock<
@@ -394,10 +426,14 @@ describe(handleHeaderValidation, () => {
         type: Symbol() as unknown as HeaderValidationInputParam['type'],
       };
 
+      vitest
+        .mocked(openApiRouterMock.findRoute)
+        .mockReturnValueOnce(inputParam.path);
+
       result = handleHeaderValidation(
         ajvMock,
         openApiObjectFixture,
-        openApiResolverFixture,
+        validationContextFixture,
         inputParam,
         getEntryMock,
       );

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleHeaderValidation.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleHeaderValidation.ts
@@ -7,6 +7,7 @@ import type Ajv from 'ajv';
 import { type ErrorObject, type ValidateFunction } from 'ajv';
 
 import { type HeaderValidationInputParam } from '../../models/HeaderValidationInputParam.js';
+import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { SCHEMA_ID } from '../../models/v3Dot2/schemaId.js';
 import {
   type ValidationCacheEntry,
@@ -23,18 +24,14 @@ function getHeaderParameterEntryMap(
   ajv: Ajv,
   openApiObject: OpenApi3Dot2Object,
   openApiResolver: OpenApiResolver,
-  inputParam: HeaderValidationInputParam,
+  method: string,
+  route: string,
 ): Map<string, ValidationCacheEntryHeader> {
   const headerParameterEntryMap: Map<string, ValidationCacheEntryHeader> =
     new Map();
 
   const headerParams: Map<string, HeaderParameterEntry> =
-    getHeaderParameterObjects(
-      openApiObject,
-      openApiResolver,
-      inputParam.method,
-      inputParam.path,
-    );
+    getHeaderParameterObjects(openApiObject, openApiResolver, method, route);
 
   for (const [headerName, headerParam] of headerParams) {
     const parse: (value: string | string[] | undefined) => unknown =
@@ -69,12 +66,24 @@ function getHeaderParameterEntryMap(
 export function handleHeaderValidation(
   ajv: Ajv,
   openApiObject: OpenApi3Dot2Object,
-  openApiResolver: OpenApiResolver,
+  validationContext: OpenApiValidationContext,
   inputParam: HeaderValidationInputParam,
   getEntry: (path: string, method: string) => ValidationCacheEntry,
 ): unknown {
-  const validationCacheEntry: ValidationCacheEntry = getEntry(
+  const route: string | undefined = validationContext.router.findRoute(
+    inputParam.method,
     inputParam.path,
+  );
+
+  if (route === undefined) {
+    throw new InversifyValidationError(
+      InversifyValidationErrorKind.validationFailed,
+      `Unable to find route for operation: ${inputParam.method.toUpperCase()} ${inputParam.path}`,
+    );
+  }
+
+  const validationCacheEntry: ValidationCacheEntry = getEntry(
+    route,
     inputParam.method,
   );
 
@@ -82,8 +91,9 @@ export function handleHeaderValidation(
     validationCacheEntry.headers = getHeaderParameterEntryMap(
       ajv,
       openApiObject,
-      openApiResolver,
-      inputParam,
+      validationContext.resolver,
+      inputParam.method,
+      route,
     );
   }
 

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleParamValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleParamValidation.spec.ts
@@ -1,0 +1,383 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  type Mock,
+  type Mocked,
+  vitest,
+} from 'vitest';
+
+vitest.mock(import('../buildParamParse.js'));
+vitest.mock(import('./getParamParameterObjects.js'));
+
+import { type OpenApi3Dot2Object } from '@inversifyjs/open-api-types/v3Dot2';
+import {
+  InversifyValidationError,
+  InversifyValidationErrorKind,
+} from '@inversifyjs/validation-common';
+import type Ajv from 'ajv';
+import { type ValidateFunction } from 'ajv';
+
+import { type OpenApiRouter } from '../../../router/services/OpenApiRouter.js';
+import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
+import { type ParamValidationInputParam } from '../../models/ParamValidationInputParam.js';
+import { type ValidationCacheEntry } from '../../models/v3Dot2/ValidationCacheEntry.js';
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
+import { buildParamParse } from '../buildParamParse.js';
+import {
+  getParamParameterObjects,
+  type ParamParameterEntry,
+} from './getParamParameterObjects.js';
+import { handleParamValidation } from './handleParamValidation.js';
+
+describe(handleParamValidation, () => {
+  let openApiObjectFixture: OpenApi3Dot2Object;
+  let validationContextFixture: OpenApiValidationContext;
+  let openApiResolverFixture: OpenApiResolver;
+  let openApiRouterMock: OpenApiRouter;
+
+  beforeAll(() => {
+    openApiObjectFixture = Symbol() as unknown as OpenApi3Dot2Object;
+    openApiResolverFixture = Symbol() as unknown as OpenApiResolver;
+    openApiRouterMock = {
+      findRoute: vitest.fn(),
+    };
+    validationContextFixture = {
+      resolver: openApiResolverFixture,
+      router: openApiRouterMock,
+    };
+  });
+
+  afterAll(() => {
+    vitest.restoreAllMocks();
+  });
+
+  describe('when called, and params are valid with string type', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      const paramParamMap: Map<string, ParamParameterEntry> = new Map([
+        [
+          'userId',
+          {
+            parameter: {
+              in: 'path',
+              name: 'userId',
+              required: true,
+              schema: { type: 'string' },
+            },
+            pointerPrefix: 'paths/~1users~1{userId}/get/parameters/0',
+          },
+        ],
+      ]);
+
+      vitest
+        .mocked(getParamParameterObjects)
+        .mockReturnValueOnce(paramParamMap);
+
+      const parseMock: Mock = vitest.fn().mockReturnValueOnce('abc-123');
+
+      vitest.mocked(buildParamParse).mockReturnValueOnce(parseMock);
+
+      const validateMock: ValidateFunction = Object.assign(
+        vitest.fn().mockReturnValueOnce(true),
+        { errors: null, schema: {} },
+      ) as unknown as ValidateFunction;
+
+      const ajvMock: Mocked<Ajv> = {
+        getSchema: vitest.fn().mockReturnValueOnce(validateMock),
+      } as Partial<Mocked<Ajv>> as Mocked<Ajv>;
+
+      const validationCacheEntry: ValidationCacheEntry = {
+        body: undefined,
+        headers: undefined,
+        params: undefined,
+      };
+
+      const getEntryMock: Mock<
+        (path: string, method: string) => ValidationCacheEntry
+      > = vitest.fn().mockReturnValueOnce(validationCacheEntry);
+
+      const inputParam: ParamValidationInputParam = {
+        method: 'get',
+        params: { userId: 'abc-123' },
+        path: '/users/{userId}',
+        type: Symbol() as unknown as ParamValidationInputParam['type'],
+      };
+
+      vitest
+        .mocked(openApiRouterMock.findRoute)
+        .mockReturnValueOnce(inputParam.path);
+
+      result = handleParamValidation(
+        ajvMock,
+        openApiObjectFixture,
+        validationContextFixture,
+        inputParam,
+        getEntryMock,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should return validated params record', () => {
+      expect(result).toStrictEqual({ userId: 'abc-123' });
+    });
+  });
+
+  describe('when called, and required param is missing', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      const paramParamMap: Map<string, ParamParameterEntry> = new Map([
+        [
+          'userId',
+          {
+            parameter: {
+              in: 'path',
+              name: 'userId',
+              required: true,
+              schema: { type: 'string' },
+            },
+            pointerPrefix: 'paths/~1users~1{userId}/get/parameters/0',
+          },
+        ],
+      ]);
+
+      vitest
+        .mocked(getParamParameterObjects)
+        .mockReturnValueOnce(paramParamMap);
+
+      const parseMock: Mock = vitest.fn();
+
+      vitest.mocked(buildParamParse).mockReturnValueOnce(parseMock);
+
+      const validateMock: ValidateFunction = Object.assign(vitest.fn(), {
+        errors: null,
+        schema: {},
+      }) as unknown as ValidateFunction;
+
+      const ajvMock: Mocked<Ajv> = {
+        getSchema: vitest.fn().mockReturnValueOnce(validateMock),
+      } as Partial<Mocked<Ajv>> as Mocked<Ajv>;
+
+      const validationCacheEntry: ValidationCacheEntry = {
+        body: undefined,
+        headers: undefined,
+        params: undefined,
+      };
+
+      const getEntryMock: Mock<
+        (path: string, method: string) => ValidationCacheEntry
+      > = vitest.fn().mockReturnValueOnce(validationCacheEntry);
+
+      const inputParam: ParamValidationInputParam = {
+        method: 'get',
+        params: {},
+        path: '/users/{userId}',
+        type: Symbol() as unknown as ParamValidationInputParam['type'],
+      };
+
+      vitest
+        .mocked(openApiRouterMock.findRoute)
+        .mockReturnValueOnce(inputParam.path);
+
+      try {
+        handleParamValidation(
+          ajvMock,
+          openApiObjectFixture,
+          validationContextFixture,
+          inputParam,
+          getEntryMock,
+        );
+      } catch (error: unknown) {
+        result = error;
+      }
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should throw an InversifyValidationError', () => {
+      const expectedErrorProperties: Partial<InversifyValidationError> = {
+        kind: InversifyValidationErrorKind.validationFailed,
+        message: 'Missing required param: userId',
+      };
+
+      expect(result).toBeInstanceOf(InversifyValidationError);
+      expect(result).toMatchObject(expectedErrorProperties);
+    });
+  });
+
+  describe('when called, and validation fails', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      const paramParamMap: Map<string, ParamParameterEntry> = new Map([
+        [
+          'userId',
+          {
+            parameter: {
+              in: 'path',
+              name: 'userId',
+              required: true,
+              schema: { minimum: 1, type: 'integer' },
+            },
+            pointerPrefix: 'paths/~1users~1{userId}/get/parameters/0',
+          },
+        ],
+      ]);
+
+      vitest
+        .mocked(getParamParameterObjects)
+        .mockReturnValueOnce(paramParamMap);
+
+      const parseMock: Mock = vitest.fn().mockReturnValueOnce('not-valid');
+
+      vitest.mocked(buildParamParse).mockReturnValueOnce(parseMock);
+
+      const validateMock: ValidateFunction = Object.assign(
+        vitest.fn().mockReturnValueOnce(false),
+        {
+          errors: [
+            {
+              instancePath: '',
+              keyword: 'type',
+              message: 'must be integer',
+              params: {},
+              schemaPath: '#/type',
+            },
+          ],
+          schema: {},
+        },
+      ) as unknown as ValidateFunction;
+
+      const ajvMock: Mocked<Ajv> = {
+        getSchema: vitest.fn().mockReturnValueOnce(validateMock),
+      } as Partial<Mocked<Ajv>> as Mocked<Ajv>;
+
+      const validationCacheEntry: ValidationCacheEntry = {
+        body: undefined,
+        headers: undefined,
+        params: undefined,
+      };
+
+      const getEntryMock: Mock<
+        (path: string, method: string) => ValidationCacheEntry
+      > = vitest.fn().mockReturnValueOnce(validationCacheEntry);
+
+      const inputParam: ParamValidationInputParam = {
+        method: 'get',
+        params: { userId: 'not-valid' },
+        path: '/users/{userId}',
+        type: Symbol() as unknown as ParamValidationInputParam['type'],
+      };
+
+      vitest
+        .mocked(openApiRouterMock.findRoute)
+        .mockReturnValueOnce(inputParam.path);
+
+      try {
+        handleParamValidation(
+          ajvMock,
+          openApiObjectFixture,
+          validationContextFixture,
+          inputParam,
+          getEntryMock,
+        );
+      } catch (error: unknown) {
+        result = error;
+      }
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should throw an InversifyValidationError', () => {
+      const expectedErrorProperties: Partial<InversifyValidationError> = {
+        kind: InversifyValidationErrorKind.validationFailed,
+        message: expect.stringContaining('userId'),
+      };
+
+      expect(result).toBeInstanceOf(InversifyValidationError);
+      expect(result).toMatchObject(expectedErrorProperties);
+    });
+  });
+
+  describe('when called, and cached params are reused', () => {
+    let result: unknown;
+    let ajvMock: Mocked<Ajv>;
+
+    beforeAll(() => {
+      const parseMock: Mock = vitest.fn().mockReturnValueOnce('test');
+
+      const validateMock: ValidateFunction = Object.assign(
+        vitest.fn().mockReturnValueOnce(true),
+        { errors: null, schema: {} },
+      ) as unknown as ValidateFunction;
+
+      ajvMock = {
+        getSchema: vitest.fn(),
+      } as Partial<Mocked<Ajv>> as Mocked<Ajv>;
+
+      const validationCacheEntry: ValidationCacheEntry = {
+        body: undefined,
+        headers: undefined,
+        params: new Map([
+          [
+            'userId',
+            {
+              parse: parseMock,
+              validate: validateMock,
+            },
+          ],
+        ]),
+      };
+
+      const getEntryMock: Mock<
+        (path: string, method: string) => ValidationCacheEntry
+      > = vitest.fn().mockReturnValueOnce(validationCacheEntry);
+
+      const inputParam: ParamValidationInputParam = {
+        method: 'get',
+        params: { userId: 'test' },
+        path: '/users/{userId}',
+        type: Symbol() as unknown as ParamValidationInputParam['type'],
+      };
+
+      vitest
+        .mocked(openApiRouterMock.findRoute)
+        .mockReturnValueOnce(inputParam.path);
+
+      result = handleParamValidation(
+        ajvMock,
+        openApiObjectFixture,
+        validationContextFixture,
+        inputParam,
+        getEntryMock,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should not call ajv.getSchema()', () => {
+      expect(ajvMock.getSchema).not.toHaveBeenCalled();
+    });
+
+    it('should not call getParamParameterObjects()', () => {
+      expect(getParamParameterObjects).not.toHaveBeenCalled();
+    });
+
+    it('should return validated params', () => {
+      expect(result).toStrictEqual({ userId: 'test' });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleParamValidation.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleParamValidation.ts
@@ -1,0 +1,152 @@
+import { type OpenApi3Dot2Object } from '@inversifyjs/open-api-types/v3Dot2';
+import {
+  InversifyValidationError,
+  InversifyValidationErrorKind,
+} from '@inversifyjs/validation-common';
+import type Ajv from 'ajv';
+import { type ErrorObject, type ValidateFunction } from 'ajv';
+
+import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
+import { type ParamValidationInputParam } from '../../models/ParamValidationInputParam.js';
+import { SCHEMA_ID } from '../../models/v3Dot2/schemaId.js';
+import {
+  type ValidationCacheEntry,
+  type ValidationCacheEntryParam,
+} from '../../models/v3Dot2/ValidationCacheEntry.js';
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
+import { buildParamParse } from '../buildParamParse.js';
+import {
+  getParamParameterObjects,
+  type ParamParameterEntry,
+} from './getParamParameterObjects.js';
+
+function getParamParameterEntryMap(
+  ajv: Ajv,
+  openApiObject: OpenApi3Dot2Object,
+  openApiResolver: OpenApiResolver,
+  method: string,
+  route: string,
+): Map<string, ValidationCacheEntryParam> {
+  const paramParameterEntryMap: Map<string, ValidationCacheEntryParam> =
+    new Map();
+
+  const paramParams: Map<string, ParamParameterEntry> =
+    getParamParameterObjects(openApiObject, openApiResolver, method, route);
+
+  for (const [paramName, paramParam] of paramParams) {
+    const parse: (value: string | string[] | undefined) => unknown =
+      buildParamParse(
+        openApiResolver,
+        paramParam.parameter.schema,
+        `${SCHEMA_ID}#/${paramParam.pointerPrefix}/schema`,
+      );
+
+    const ajvSchemaPointer: string = `${SCHEMA_ID}#/${paramParam.pointerPrefix}/schema`;
+
+    const validate: ValidateFunction | undefined =
+      ajv.getSchema(ajvSchemaPointer);
+
+    if (validate === undefined) {
+      throw new InversifyValidationError(
+        InversifyValidationErrorKind.validationFailed,
+        `Unable to find schema for pointer: ${ajvSchemaPointer}`,
+      );
+    }
+
+    paramParameterEntryMap.set(paramName, {
+      parse,
+      validate: validate,
+    });
+  }
+
+  return paramParameterEntryMap;
+}
+
+export function handleParamValidation(
+  ajv: Ajv,
+  openApiObject: OpenApi3Dot2Object,
+  validationContext: OpenApiValidationContext,
+  inputParam: ParamValidationInputParam,
+  getEntry: (path: string, method: string) => ValidationCacheEntry,
+): unknown {
+  const route: string | undefined = validationContext.router.findRoute(
+    inputParam.method,
+    inputParam.path,
+  );
+
+  if (route === undefined) {
+    throw new InversifyValidationError(
+      InversifyValidationErrorKind.validationFailed,
+      `Unable to find route for operation: ${inputParam.method.toUpperCase()} ${inputParam.path}`,
+    );
+  }
+
+  const validationCacheEntry: ValidationCacheEntry = getEntry(
+    route,
+    inputParam.method,
+  );
+
+  if (validationCacheEntry.params === undefined) {
+    validationCacheEntry.params = getParamParameterEntryMap(
+      ajv,
+      openApiObject,
+      validationContext.resolver,
+      inputParam.method,
+      route,
+    );
+  }
+
+  const computedParams: Record<string, unknown> = {
+    ...inputParam.params,
+  };
+
+  let valid: boolean = true;
+  const paramToErrorObject: Record<string, ErrorObject[]> = {};
+
+  for (const [
+    paramName,
+    validationCacheEntryParam,
+  ] of validationCacheEntry.params) {
+    if (!(paramName in inputParam.params)) {
+      throw new InversifyValidationError(
+        InversifyValidationErrorKind.validationFailed,
+        `Missing required param: ${paramName}`,
+      );
+    }
+
+    const paramValue: string | string[] | undefined =
+      inputParam.params[paramName];
+
+    computedParams[paramName] = validationCacheEntryParam.parse(paramValue);
+
+    const isValidParam: boolean = validationCacheEntryParam.validate(
+      computedParams[paramName],
+    );
+
+    if (!isValidParam) {
+      valid = false;
+
+      paramToErrorObject[paramName] = [
+        ...(validationCacheEntryParam.validate.errors ?? []),
+      ];
+    }
+  }
+
+  if (!valid) {
+    throw new InversifyValidationError(
+      InversifyValidationErrorKind.validationFailed,
+      Object.entries(paramToErrorObject)
+        .map(([paramName, errors]: [string, ErrorObject[]]): string =>
+          errors
+            .map(
+              (error: ErrorObject): string =>
+                `[param: ${paramName}, schemaPath: ${error.schemaPath}, instancePath: ${error.instancePath}]: "${error.message ?? '-'}"`,
+            )
+            .join('\n'),
+        )
+        .join('\n'),
+    );
+  }
+
+  return computedParams;
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/models/OpenApiValidationContext.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/models/OpenApiValidationContext.ts
@@ -1,0 +1,7 @@
+import { type OpenApiRouter } from '../../router/services/OpenApiRouter.js';
+import { type OpenApiResolver } from '../services/OpenApiResolver.js';
+
+export interface OpenApiValidationContext {
+  resolver: OpenApiResolver;
+  router: OpenApiRouter;
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/models/ParamValidationInputParam.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/models/ParamValidationInputParam.ts
@@ -1,0 +1,8 @@
+import { type validatedInputParamParamType } from './validatedInputParamTypes.js';
+
+export interface ParamValidationInputParam {
+  params: Record<string, string | string[]>;
+  method: string;
+  path: string;
+  type: typeof validatedInputParamParamType;
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/models/ValidatedDecoratorResult.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/models/ValidatedDecoratorResult.ts
@@ -1,6 +1,8 @@
 import { type BodyValidationInputParam } from './BodyValidationInputParam.js';
 import { type HeaderValidationInputParam } from './HeaderValidationInputParam.js';
+import { type ParamValidationInputParam } from './ParamValidationInputParam.js';
 
 export type ValidationInputParam =
   | BodyValidationInputParam<unknown>
-  | HeaderValidationInputParam;
+  | HeaderValidationInputParam
+  | ParamValidationInputParam;

--- a/packages/framework/validation/libraries/openapi/src/validation/models/ValidationHandler.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/models/ValidationHandler.ts
@@ -1,6 +1,6 @@
 import type Ajv from 'ajv';
 
-import { type OpenApiResolver } from '../services/OpenApiResolver.js';
+import { type OpenApiValidationContext } from './OpenApiValidationContext.js';
 import { type ValidationInputParam } from './ValidatedDecoratorResult.js';
 
 export type ValidationHandler<
@@ -10,7 +10,7 @@ export type ValidationHandler<
 > = (
   ajv: Ajv,
   openApiObject: TOpenApiObject,
-  openApiResolver: OpenApiResolver,
+  validationContext: OpenApiValidationContext,
   inputParam: TValidatedDecoratorResult,
   getEntry: (path: string, method: string) => TValidationCacheEntry,
 ) => unknown;

--- a/packages/framework/validation/libraries/openapi/src/validation/models/v3Dot1/ValidationCacheEntry.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/models/v3Dot1/ValidationCacheEntry.ts
@@ -11,7 +11,13 @@ export interface ValidationCacheEntryHeader {
   validate: ValidateFunction;
 }
 
+export interface ValidationCacheEntryParam {
+  parse: (value: string | string[] | undefined) => unknown;
+  validate: ValidateFunction;
+}
+
 export interface ValidationCacheEntry {
   body: ValidationCacheEntryBody | undefined;
   headers: Map<string, ValidationCacheEntryHeader> | undefined;
+  params: Map<string, ValidationCacheEntryParam> | undefined;
 }

--- a/packages/framework/validation/libraries/openapi/src/validation/models/v3Dot2/ValidationCacheEntry.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/models/v3Dot2/ValidationCacheEntry.ts
@@ -11,7 +11,13 @@ export interface ValidationCacheEntryHeader {
   validate: ValidateFunction;
 }
 
+export interface ValidationCacheEntryParam {
+  parse: (value: string | string[] | undefined) => unknown;
+  validate: ValidateFunction;
+}
+
 export interface ValidationCacheEntry {
   body: ValidationCacheEntryBody | undefined;
   headers: Map<string, ValidationCacheEntryHeader> | undefined;
+  params: Map<string, ValidationCacheEntryParam> | undefined;
 }

--- a/packages/framework/validation/libraries/openapi/src/validation/models/validatedInputParamTypes.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/models/validatedInputParamTypes.ts
@@ -5,3 +5,7 @@ export const validatedInputParamBodyType: unique symbol = Symbol.for(
 export const validatedInputParamHeaderType: unique symbol = Symbol.for(
   '@inversifyjs/open-api-validation/validatedInputParamHeaderType',
 );
+
+export const validatedInputParamParamType: unique symbol = Symbol.for(
+  '@inversifyjs/open-api-validation/validatedInputParamParamType',
+);

--- a/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot1/OpenApiValidationPipe.int.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot1/OpenApiValidationPipe.int.spec.ts
@@ -34,6 +34,7 @@ import { Container, type Newable } from 'inversify';
 
 import { ValidatedBody } from '../../../metadata/decorators/ValidatedBody.js';
 import { ValidatedHeaders } from '../../../metadata/decorators/ValidatedHeaders.js';
+import { ValidatedParams } from '../../../metadata/decorators/ValidatedParams.js';
 import { OpenApiValidationPipe } from './OpenApiValidationPipe.js';
 
 interface Server {
@@ -812,6 +813,98 @@ describe(OpenApiValidationPipe, () => {
             expect(response.status).toBe(400);
             await expect(response.json()).resolves.toStrictEqual({
               message: expect.stringContaining('x-page-size'),
+            });
+          });
+        });
+      });
+
+      describe('having an OpenApiValidationPipe (v3.1) in an HTTP server with validated params', () => {
+        @Controller('/users')
+        class UserController {
+          @OasParameter({
+            in: 'path',
+            name: 'userId',
+            required: true,
+            schema: { format: 'uuid', type: 'string' },
+          })
+          @Get('/:userId')
+          public async getUser(
+            @ValidatedParams() _params: Record<string, unknown>,
+          ): Promise<{ ok: boolean }> {
+            return { ok: true };
+          }
+        }
+
+        let server: Server;
+
+        beforeAll(async () => {
+          const container: Container = new Container();
+
+          container.bind(ValidationErrorFilter).toSelf().inSingletonScope();
+          container.bind(UserController).toSelf().inSingletonScope();
+
+          const openApiObject: OpenApi3Dot1Object = {
+            info: { title: 'Test API', version: '1.0.0' },
+            openapi: '3.1.0',
+          };
+
+          const swaggerProvider: SwaggerUiProvider = new SwaggerUiProvider({
+            api: {
+              openApiObject,
+              path: '/docs',
+            },
+          });
+
+          swaggerProvider.provide(container);
+
+          server = await buildServer(
+            container,
+            [ValidationErrorFilter],
+            [new OpenApiValidationPipe(swaggerProvider.openApiObject)],
+          );
+        });
+
+        afterAll(async () => {
+          await server.shutdown();
+        });
+
+        describe('when a GET /users/:userId request is made with a valid uuid param', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/users/550e8400-e29b-41d4-a716-446655440000`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(200);
+            expect(response.headers.get('content-type')).toStrictEqual(
+              expect.stringContaining('application/json'),
+            );
+            await expect(response.json()).resolves.toStrictEqual({ ok: true });
+          });
+        });
+
+        describe('when a GET /users/:userId request is made with an invalid uuid param', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/users/not-a-uuid`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(400);
+            await expect(response.json()).resolves.toStrictEqual({
+              message: expect.stringContaining('userId'),
             });
           });
         });

--- a/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot1/OpenApiValidationPipe.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot1/OpenApiValidationPipe.ts
@@ -9,23 +9,26 @@ import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 
 import { openApiValidationMetadataReflectKey } from '../../../metadata/models/openApiValidationMetadataReflectKey.js';
+import { OpenApi3Dot1Router } from '../../../router/services/v3Dot1/OpenApi3Dot1Router.js';
 import { buildCompositeValidationHandler } from '../../calculations/buildCompositeValidationHandler.js';
 import { handleBodyValidation } from '../../calculations/v3Dot1/handleBodyValidation.js';
 import { handleHeaderValidation } from '../../calculations/v3Dot1/handleHeaderValidation.js';
+import { handleParamValidation } from '../../calculations/v3Dot1/handleParamValidation.js';
+import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { SCHEMA_ID } from '../../models/v3Dot1/schemaId.js';
 import { type ValidationCacheEntry } from '../../models/v3Dot1/ValidationCacheEntry.js';
 import {
   validatedInputParamBodyType,
   validatedInputParamHeaderType,
+  validatedInputParamParamType,
 } from '../../models/validatedInputParamTypes.js';
-import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
 import { DefaultOpenApiResolver } from '../../services/v3Dot1/DefaultOpenApiResolver.js';
 import { ValidationCache } from '../../services/v3Dot1/ValidationCache.js';
 
 const handler: (
   ajv: Ajv,
   openApiObject: OpenApi3Dot1Object,
-  openApiResolver: OpenApiResolver,
+  validationContext: OpenApiValidationContext,
   inputParam: unknown,
   getEntry: (path: string, method: string) => ValidationCacheEntry,
 ) => unknown = buildCompositeValidationHandler<
@@ -34,18 +37,22 @@ const handler: (
 >({
   [validatedInputParamBodyType]: handleBodyValidation,
   [validatedInputParamHeaderType]: handleHeaderValidation,
+  [validatedInputParamParamType]: handleParamValidation,
 });
 
 export class OpenApiValidationPipe implements Pipe {
   readonly #openApiObject: OpenApi3Dot1Object;
-  readonly #openApiResolver: OpenApiResolver;
   readonly #validationCache: ValidationCache;
+  readonly #validationContext: OpenApiValidationContext;
 
   #ajv: Ajv | undefined;
 
   constructor(openApiObject: OpenApi3Dot1Object) {
     this.#openApiObject = openApiObject;
-    this.#openApiResolver = new DefaultOpenApiResolver(openApiObject);
+    this.#validationContext = {
+      resolver: new DefaultOpenApiResolver(openApiObject),
+      router: new OpenApi3Dot1Router(openApiObject),
+    };
     this.#validationCache = new ValidationCache();
     this.#ajv = undefined;
   }
@@ -90,7 +97,7 @@ export class OpenApiValidationPipe implements Pipe {
     return handler(
       ajv,
       this.#openApiObject,
-      this.#openApiResolver,
+      this.#validationContext,
       input,
       this.#validationCache.getOrCreate.bind(this.#validationCache),
     );

--- a/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot2/OpenApiValidationPipe.int.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot2/OpenApiValidationPipe.int.spec.ts
@@ -34,6 +34,7 @@ import { Container, type Newable } from 'inversify';
 
 import { ValidatedBody } from '../../../metadata/decorators/ValidatedBody.js';
 import { ValidatedHeaders } from '../../../metadata/decorators/ValidatedHeaders.js';
+import { ValidatedParams } from '../../../metadata/decorators/ValidatedParams.js';
 import { OpenApiValidationPipe } from './OpenApiValidationPipe.js';
 
 interface Server {
@@ -812,6 +813,98 @@ describe(OpenApiValidationPipe, () => {
             expect(response.status).toBe(400);
             await expect(response.json()).resolves.toStrictEqual({
               message: expect.stringContaining('x-page-size'),
+            });
+          });
+        });
+      });
+
+      describe('having an OpenApiValidationPipe (v3.2) in an HTTP server with validated params', () => {
+        @Controller('/users')
+        class UserController {
+          @OasParameter({
+            in: 'path',
+            name: 'userId',
+            required: true,
+            schema: { format: 'uuid', type: 'string' },
+          })
+          @Get('/:userId')
+          public async getUser(
+            @ValidatedParams() _params: Record<string, unknown>,
+          ): Promise<{ ok: boolean }> {
+            return { ok: true };
+          }
+        }
+
+        let server: Server;
+
+        beforeAll(async () => {
+          const container: Container = new Container();
+
+          container.bind(ValidationErrorFilter).toSelf().inSingletonScope();
+          container.bind(UserController).toSelf().inSingletonScope();
+
+          const openApiObject: OpenApi3Dot2Object = {
+            info: { title: 'Test API', version: '1.0.0' },
+            openapi: '3.2.0',
+          };
+
+          const swaggerProvider: SwaggerUiProvider = new SwaggerUiProvider({
+            api: {
+              openApiObject,
+              path: '/docs',
+            },
+          });
+
+          swaggerProvider.provide(container);
+
+          server = await buildServer(
+            container,
+            [ValidationErrorFilter],
+            [new OpenApiValidationPipe(swaggerProvider.openApiObject)],
+          );
+        });
+
+        afterAll(async () => {
+          await server.shutdown();
+        });
+
+        describe('when a GET /users/:userId request is made with a valid uuid param', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/users/550e8400-e29b-41d4-a716-446655440000`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(200);
+            expect(response.headers.get('content-type')).toStrictEqual(
+              expect.stringContaining('application/json'),
+            );
+            await expect(response.json()).resolves.toStrictEqual({ ok: true });
+          });
+        });
+
+        describe('when a GET /users/:userId request is made with an invalid uuid param', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/users/not-a-uuid`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(400);
+            await expect(response.json()).resolves.toStrictEqual({
+              message: expect.stringContaining('userId'),
             });
           });
         });

--- a/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot2/OpenApiValidationPipe.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot2/OpenApiValidationPipe.ts
@@ -9,23 +9,26 @@ import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 
 import { openApiValidationMetadataReflectKey } from '../../../metadata/models/openApiValidationMetadataReflectKey.js';
+import { OpenApi3Dot2Router } from '../../../router/services/v3Dot2/OpenApi3Dot2Router.js';
 import { buildCompositeValidationHandler } from '../../calculations/buildCompositeValidationHandler.js';
 import { handleBodyValidation } from '../../calculations/v3Dot2/handleBodyValidation.js';
 import { handleHeaderValidation } from '../../calculations/v3Dot2/handleHeaderValidation.js';
+import { handleParamValidation } from '../../calculations/v3Dot2/handleParamValidation.js';
+import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { SCHEMA_ID } from '../../models/v3Dot2/schemaId.js';
 import { type ValidationCacheEntry } from '../../models/v3Dot2/ValidationCacheEntry.js';
 import {
   validatedInputParamBodyType,
   validatedInputParamHeaderType,
+  validatedInputParamParamType,
 } from '../../models/validatedInputParamTypes.js';
-import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
 import { DefaultOpenApiResolver } from '../../services/v3Dot2/DefaultOpenApiResolver.js';
 import { ValidationCache } from '../../services/v3Dot2/ValidationCache.js';
 
 const handler: (
   ajv: Ajv,
   openApiObject: OpenApi3Dot2Object,
-  openApiResolver: OpenApiResolver,
+  validationContext: OpenApiValidationContext,
   inputParam: unknown,
   getEntry: (path: string, method: string) => ValidationCacheEntry,
 ) => unknown = buildCompositeValidationHandler<
@@ -34,18 +37,22 @@ const handler: (
 >({
   [validatedInputParamBodyType]: handleBodyValidation,
   [validatedInputParamHeaderType]: handleHeaderValidation,
+  [validatedInputParamParamType]: handleParamValidation,
 });
 
 export class OpenApiValidationPipe implements Pipe {
   readonly #openApiObject: OpenApi3Dot2Object;
-  readonly #openApiResolver: OpenApiResolver;
   readonly #validationCache: ValidationCache;
+  readonly #validationContext: OpenApiValidationContext;
 
   #ajv: Ajv | undefined;
 
   constructor(openApiObject: OpenApi3Dot2Object) {
     this.#openApiObject = openApiObject;
-    this.#openApiResolver = new DefaultOpenApiResolver(openApiObject);
+    this.#validationContext = {
+      resolver: new DefaultOpenApiResolver(openApiObject),
+      router: new OpenApi3Dot2Router(openApiObject),
+    };
     this.#validationCache = new ValidationCache();
     this.#ajv = undefined;
   }
@@ -90,7 +97,7 @@ export class OpenApiValidationPipe implements Pipe {
     return handler(
       ajv,
       this.#openApiObject,
-      this.#openApiResolver,
+      this.#validationContext,
       input,
       this.#validationCache.getOrCreate.bind(this.#validationCache),
     );

--- a/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot1/ValidationCache.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot1/ValidationCache.ts
@@ -6,6 +6,7 @@ export class ValidationCache extends BaseValidationCache<ValidationCacheEntry> {
     return {
       body: undefined,
       headers: undefined,
+      params: undefined,
     };
   }
 }

--- a/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot2/ValidationCache.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot2/ValidationCache.ts
@@ -6,6 +6,7 @@ export class ValidationCache extends BaseValidationCache<ValidationCacheEntry> {
     return {
       body: undefined,
       headers: undefined,
+      params: undefined,
     };
   }
 }


### PR DESCRIPTION
### Changed
- Updated OpenApiValidationPipe to handle param related operations.
- Updated OpenApiValidationPipe to handle param operations.
- Updated SwaggerUiProvider to properly build param related operations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ValidatedParams decorator and parameter-level validation in the OpenAPI validation pipeline
  * New route-matching engine to resolve methods/paths to OpenAPI operations
  * Optional logger support for OpenAPI schema providers

* **Bug Fixes**
  * Fixed path parameter templating to be OpenAPI-compliant (`:param` → `{param}`)

* **Chores**
  * Bumped package version metadata for @inversifyjs/open-api-validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->