### PR TITLE
Implement ValidatedQuery

### DIFF
--- a/.changeset/curvy-moose-count.md
+++ b/.changeset/curvy-moose-count.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/http-uwebsockets": patch
+---
+
+- Bumped uwebsocket dependency.

--- a/.changeset/spicy-cycles-smell.md
+++ b/.changeset/spicy-cycles-smell.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/open-api-validation": minor
+---
+
+- Added `ValidatedQuery` decorator.

--- a/.changeset/upset-facts-kick.md
+++ b/.changeset/upset-facts-kick.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/http-hono": patch
+---
+
+- Updated `InversifyHttpHonoAdapter` to properly handle multiple query params.

--- a/.changeset/upset-facts-kick.md
+++ b/.changeset/upset-facts-kick.md
@@ -2,4 +2,4 @@
 "@inversifyjs/http-hono": patch
 ---
 
-- Updated `InversifyHttpHonoAdapter` to properly handle multiple query params.
+- Updated `InversifyHonoHttpAdapter` to properly handle multiple query params.

--- a/packages/docs/services/inversify-framework-site/validation-docs/openapi/api.mdx
+++ b/packages/docs/services/inversify-framework-site/validation-docs/openapi/api.mdx
@@ -5,6 +5,8 @@ title: API
 import apiOpenApiValidationPipeSource from '@inversifyjs/validation-code-examples/generated/examples/v1/openApiValidation/apiOpenApiValidationPipe.ts.txt';
 import apiValidateDecoratorSource from '@inversifyjs/validation-code-examples/generated/examples/v1/openApiValidation/apiValidateDecorator.ts.txt';
 import apiValidateHeadersDecoratorSource from '@inversifyjs/validation-code-examples/generated/examples/v1/openApiValidation/apiValidateHeadersDecorator.ts.txt';
+import apiValidateParamsDecoratorSource from '@inversifyjs/validation-code-examples/generated/examples/v1/openApiValidation/apiValidateParamsDecorator.ts.txt';
+import apiValidateQueryDecoratorSource from '@inversifyjs/validation-code-examples/generated/examples/v1/openApiValidation/apiValidateQueryDecorator.ts.txt';
 import CodeBlock from '@theme/CodeBlock';
 
 ## OpenApiValidationPipe
@@ -107,3 +109,49 @@ A header validation failure:
 ```
 
 Use `InversifyValidationErrorFilter` (from `@inversifyjs/http-validation`) or a custom `@CatchError(InversifyValidationError)` filter to convert these errors into HTTP 400 responses.
+
+## ValidatedParams
+
+A custom parameter decorator that extracts URL path parameters along with the HTTP method and URL, and marks the parameter for OpenAPI path parameter validation.
+
+```ts
+ValidatedParams(): ParameterDecorator
+```
+
+Apply `@ValidatedParams()` to any controller method parameter you want to validate against OpenAPI path parameters defined with `@OasParameter({ in: 'path', ... })`:
+
+```ts
+@Get('/:userId')
+public getUser(@ValidatedParams() params: Record<string, unknown>): string {
+  return `User ID: ${String(params['userId'])}`;
+}
+```
+
+`@ValidatedParams()` is built with `createCustomParameterDecorator` from `@inversifyjs/http-core`. It stores a boolean validation marker on the parameter index and provides a handler that extracts all URL path parameters, the HTTP method, and URL at runtime. The `OpenApiValidationPipe` checks for this marker and validates each path parameter individually against its OpenAPI schema, coercing string values to the expected type when needed.
+
+### Example: validate URL path parameters with OpenAPI schema
+
+<CodeBlock language="ts">{apiValidateParamsDecoratorSource}</CodeBlock>
+
+## ValidatedQuery
+
+A custom parameter decorator that extracts URL query parameters along with the HTTP method and URL, and marks the parameter for OpenAPI query parameter validation.
+
+```ts
+ValidatedQuery(): ParameterDecorator
+```
+
+Apply `@ValidatedQuery()` to any controller method parameter you want to validate against OpenAPI query parameters defined with `@OasParameter({ in: 'query', ... })`:
+
+```ts
+@Get('/')
+public getProducts(@ValidatedQuery() query: Record<string, unknown>): string {
+  return `Search: ${String(query['search'])}`;
+}
+```
+
+`@ValidatedQuery()` is built with `createCustomParameterDecorator` from `@inversifyjs/http-core`. It stores a boolean validation marker on the parameter index and provides a handler that extracts all query parameters as an object, the HTTP method, and URL at runtime. The `OpenApiValidationPipe` checks for this marker and validates each query parameter individually against its OpenAPI schema. Because query parameters arrive as strings over HTTP, the pipe uses `coerceTypes: true` on the Ajv instance and additionally pre-coerces string values to the expected type (boolean, number, null) before validation.
+
+### Example: validate query parameters with OpenAPI schema
+
+<CodeBlock language="ts">{apiValidateQueryDecoratorSource}</CodeBlock>

--- a/packages/docs/services/inversify-framework-site/validation-docs/openapi/api.mdx
+++ b/packages/docs/services/inversify-framework-site/validation-docs/openapi/api.mdx
@@ -11,7 +11,7 @@ import CodeBlock from '@theme/CodeBlock';
 
 ## OpenApiValidationPipe
 
-Validates incoming request bodies and headers against the schemas defined in your OpenAPI specification. The pipe uses Ajv for JSON Schema validation and supports format validation via `ajv-formats`.
+Validates incoming request bodies, headers, path parameters, and query parameters against the schemas defined in your OpenAPI specification. The pipe uses Ajv for JSON Schema validation and supports format validation via `ajv-formats`.
 
 ```ts
 constructor(

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/openApiValidation/apiValidateParamsDecorator.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/openApiValidation/apiValidateParamsDecorator.ts
@@ -1,0 +1,18 @@
+// Begin-example
+import { Controller, Get } from '@inversifyjs/http-core';
+import { OasParameter } from '@inversifyjs/http-open-api';
+import { ValidatedParams } from '@inversifyjs/open-api-validation';
+
+@Controller('/users')
+export class UserController {
+  @OasParameter({
+    in: 'path',
+    name: 'userId',
+    required: true,
+    schema: { format: 'uuid', type: 'string' },
+  })
+  @Get('/:userId')
+  public getUser(@ValidatedParams() params: Record<string, unknown>): string {
+    return `User ID: ${String(params['userId'])}`;
+  }
+}

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/openApiValidation/apiValidateQueryDecorator.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/openApiValidation/apiValidateQueryDecorator.ts
@@ -1,0 +1,24 @@
+// Begin-example
+import { Controller, Get } from '@inversifyjs/http-core';
+import { OasParameter } from '@inversifyjs/http-open-api';
+import { ValidatedQuery } from '@inversifyjs/open-api-validation';
+
+@Controller('/products')
+export class ProductController {
+  @OasParameter({
+    in: 'query',
+    name: 'search',
+    required: true,
+    schema: { type: 'string' },
+  })
+  @OasParameter({
+    in: 'query',
+    name: 'limit',
+    required: false,
+    schema: { minimum: 1, type: 'integer' },
+  })
+  @Get('/')
+  public getProducts(@ValidatedQuery() query: Record<string, unknown>): string {
+    return `Search: ${String(query['search'])}`;
+  }
+}

--- a/packages/framework/http/libraries/hono/src/adapter/InversifyHonoHttpAdapter.ts
+++ b/packages/framework/http/libraries/hono/src/adapter/InversifyHonoHttpAdapter.ts
@@ -158,8 +158,8 @@ export class InversifyHonoHttpAdapter extends InversifyHttpAdapter<
   protected _getQuery(request: HonoRequest, parameterName: string): unknown;
   protected _getQuery(request: HonoRequest, parameterName?: string): unknown {
     return parameterName === undefined
-      ? request.query()
-      : request.query(parameterName);
+      ? this.#parseQueriesRecord(request)
+      : this.#parseQueriesParam(request, parameterName);
   }
 
   protected _getHeaders(
@@ -388,6 +388,35 @@ export class InversifyHonoHttpAdapter extends InversifyHttpAdapter<
     const normalizedContentType: string = contentType.trim().toLowerCase();
 
     return normalizedContentType === '' ? undefined : normalizedContentType;
+  }
+
+  #parseQueriesRecord(request: HonoRequest): Record<string, string | string[]> {
+    const queries: Record<string, string | string[]> = request.queries();
+
+    for (const [key, value] of Object.entries(queries)) {
+      if ((value as string[]).length === 1) {
+        queries[key] = (value as [string])[0];
+      }
+    }
+
+    return queries;
+  }
+
+  #parseQueriesParam(
+    request: HonoRequest,
+    paramName: string,
+  ): string | string[] | undefined {
+    const query: string[] | undefined = request.queries(paramName);
+
+    if (query === undefined) {
+      return undefined;
+    }
+
+    if (query.length === 1) {
+      return query[0];
+    }
+
+    return query;
   }
 
   #parseUrlEncodedBody(

--- a/packages/framework/validation/libraries/openapi/src/index.ts
+++ b/packages/framework/validation/libraries/openapi/src/index.ts
@@ -1,3 +1,4 @@
 export { ValidatedBody } from './metadata/decorators/ValidatedBody.js';
 export { ValidatedHeaders } from './metadata/decorators/ValidatedHeaders.js';
 export { ValidatedParams } from './metadata/decorators/ValidatedParams.js';
+export { ValidatedQuery } from './metadata/decorators/ValidatedQuery.js';

--- a/packages/framework/validation/libraries/openapi/src/metadata/decorators/ValidatedQuery.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/metadata/decorators/ValidatedQuery.spec.ts
@@ -1,0 +1,295 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+vitest.mock(import('@inversifyjs/http-core'));
+vitest.mock(import('../actions/setValidateMetadata.js'));
+vitest.mock(import('../../validation/calculations/getPath.js'));
+
+import {
+  createCustomParameterDecorator,
+  type CustomParameterDecoratorHandlerOptions,
+} from '@inversifyjs/http-core';
+import {
+  InversifyValidationError,
+  InversifyValidationErrorKind,
+} from '@inversifyjs/validation-common';
+
+import { getPath } from '../../validation/calculations/getPath.js';
+import { type QueryValidationInputParam } from '../../validation/models/QueryValidationInputParam.js';
+import { validatedInputParamQueryType } from '../../validation/models/validatedInputParamTypes.js';
+import { setValidateMetadata } from '../actions/setValidateMetadata.js';
+import { ValidatedQuery } from './ValidatedQuery.js';
+
+describe(ValidatedQuery, () => {
+  describe('when called', () => {
+    let result: ParameterDecorator;
+
+    beforeAll(() => {
+      result = ValidatedQuery();
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should return a function', () => {
+      expect(result).toBeTypeOf('function');
+    });
+
+    describe('when the returned decorator is applied', () => {
+      let targetFixture: object;
+      let keyFixture: string;
+      let indexFixture: number;
+      let innerDecoratorMock: ReturnType<typeof vitest.fn>;
+
+      beforeAll(() => {
+        targetFixture = class {};
+        keyFixture = 'someMethod';
+        indexFixture = 0;
+        innerDecoratorMock = vitest.fn();
+
+        vitest
+          .mocked(createCustomParameterDecorator)
+          .mockReturnValueOnce(
+            innerDecoratorMock as unknown as ParameterDecorator,
+          );
+
+        result(targetFixture, keyFixture, indexFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call setValidateMetadata', () => {
+        expect(setValidateMetadata).toHaveBeenCalledExactlyOnceWith(
+          targetFixture,
+          keyFixture,
+          indexFixture,
+        );
+      });
+
+      it('should call createCustomParameterDecorator', () => {
+        expect(createCustomParameterDecorator).toHaveBeenCalledExactlyOnceWith(
+          expect.any(Function),
+        );
+      });
+
+      it('should apply the parameter decorator from createCustomParameterDecorator', () => {
+        expect(innerDecoratorMock).toHaveBeenCalledExactlyOnceWith(
+          targetFixture,
+          keyFixture,
+          indexFixture,
+        );
+      });
+    });
+  });
+
+  describe('handler', () => {
+    let handler: (
+      request: unknown,
+      response: unknown,
+      options: CustomParameterDecoratorHandlerOptions<unknown, unknown>,
+    ) => Promise<QueryValidationInputParam>;
+
+    beforeAll(() => {
+      vitest
+        .mocked(createCustomParameterDecorator)
+        .mockReturnValueOnce(vitest.fn());
+
+      const decorator: ParameterDecorator = ValidatedQuery();
+
+      decorator(class {}, 'method', 0);
+
+      handler = (
+        vitest.mocked(createCustomParameterDecorator).mock.calls[0] as [
+          typeof handler,
+        ]
+      )[0];
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    describe('when called, and getQuery() returns a valid object', () => {
+      let requestFixture: unknown;
+      let responseFixture: unknown;
+      let queriesFixture: Record<string, string[]>;
+      let methodFixture: string;
+      let urlFixture: string;
+      let pathFixture: string;
+      let result: unknown;
+
+      beforeAll(async () => {
+        requestFixture = Symbol();
+        responseFixture = Symbol();
+        queriesFixture = { page: ['1'], search: ['foo'] };
+        methodFixture = 'GET';
+        urlFixture = '/items?page=1&search=foo';
+        pathFixture = '/items';
+
+        vitest.mocked(getPath).mockReturnValueOnce(pathFixture);
+
+        result = await handler(requestFixture, responseFixture, {
+          getBody: vitest.fn(),
+          getCookies: vitest.fn(),
+          getHeaders: vitest.fn(),
+          getMethod: vitest.fn().mockReturnValueOnce(methodFixture),
+          getParams: vitest.fn(),
+          getQuery: vitest.fn().mockReturnValueOnce(queriesFixture),
+          getUrl: vitest.fn().mockReturnValueOnce(urlFixture),
+          setHeader: vitest.fn(),
+          setStatus: vitest.fn(),
+        });
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call getPath()', () => {
+        expect(getPath).toHaveBeenCalledExactlyOnceWith(urlFixture);
+      });
+
+      it('should return a QueryValidationInputParam', () => {
+        const expected: QueryValidationInputParam = {
+          method: methodFixture.toLowerCase(),
+          path: pathFixture,
+          queries: queriesFixture,
+          type: validatedInputParamQueryType,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+
+    describe('when called, and getQuery() returns null', () => {
+      let requestFixture: unknown;
+      let responseFixture: unknown;
+      let result: unknown;
+
+      beforeAll(async () => {
+        requestFixture = Symbol();
+        responseFixture = Symbol();
+
+        try {
+          await handler(requestFixture, responseFixture, {
+            getBody: vitest.fn(),
+            getCookies: vitest.fn(),
+            getHeaders: vitest.fn(),
+            getMethod: vitest.fn().mockReturnValueOnce('GET'),
+            getParams: vitest.fn(),
+            getQuery: vitest.fn().mockReturnValueOnce(null),
+            getUrl: vitest.fn().mockReturnValueOnce('/items'),
+            setHeader: vitest.fn(),
+            setStatus: vitest.fn(),
+          });
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should throw an InversifyValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyValidationError> = {
+          kind: InversifyValidationErrorKind.unknown,
+          message: expect.stringContaining(
+            'Expected query to be a non array object',
+          ),
+        };
+
+        expect(result).toBeInstanceOf(InversifyValidationError);
+        expect(result).toMatchObject(expectedErrorProperties);
+      });
+    });
+
+    describe('when called, and getQuery() returns an array', () => {
+      let requestFixture: unknown;
+      let responseFixture: unknown;
+      let result: unknown;
+
+      beforeAll(async () => {
+        requestFixture = Symbol();
+        responseFixture = Symbol();
+
+        try {
+          await handler(requestFixture, responseFixture, {
+            getBody: vitest.fn(),
+            getCookies: vitest.fn(),
+            getHeaders: vitest.fn(),
+            getMethod: vitest.fn().mockReturnValueOnce('POST'),
+            getParams: vitest.fn(),
+            getQuery: vitest.fn().mockReturnValueOnce(['foo', 'bar']),
+            getUrl: vitest.fn().mockReturnValueOnce('/items'),
+            setHeader: vitest.fn(),
+            setStatus: vitest.fn(),
+          });
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should throw an InversifyValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyValidationError> = {
+          kind: InversifyValidationErrorKind.unknown,
+          message: expect.stringContaining(
+            'Expected query to be a non array object',
+          ),
+        };
+
+        expect(result).toBeInstanceOf(InversifyValidationError);
+        expect(result).toMatchObject(expectedErrorProperties);
+      });
+    });
+
+    describe('when called, and getQuery() returns a string', () => {
+      let requestFixture: unknown;
+      let responseFixture: unknown;
+      let result: unknown;
+
+      beforeAll(async () => {
+        requestFixture = Symbol();
+        responseFixture = Symbol();
+
+        try {
+          await handler(requestFixture, responseFixture, {
+            getBody: vitest.fn(),
+            getCookies: vitest.fn(),
+            getHeaders: vitest.fn(),
+            getMethod: vitest.fn().mockReturnValueOnce('GET'),
+            getParams: vitest.fn(),
+            getQuery: vitest.fn().mockReturnValueOnce('not-an-object'),
+            getUrl: vitest.fn().mockReturnValueOnce('/items'),
+            setHeader: vitest.fn(),
+            setStatus: vitest.fn(),
+          });
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should throw an InversifyValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyValidationError> = {
+          kind: InversifyValidationErrorKind.unknown,
+          message: expect.stringContaining(
+            'Expected query to be a non array object',
+          ),
+        };
+
+        expect(result).toBeInstanceOf(InversifyValidationError);
+        expect(result).toMatchObject(expectedErrorProperties);
+      });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/metadata/decorators/ValidatedQuery.ts
+++ b/packages/framework/validation/libraries/openapi/src/metadata/decorators/ValidatedQuery.ts
@@ -1,0 +1,54 @@
+import {
+  createCustomParameterDecorator,
+  type CustomParameterDecoratorHandlerOptions,
+} from '@inversifyjs/http-core';
+import {
+  InversifyValidationError,
+  InversifyValidationErrorKind,
+} from '@inversifyjs/validation-common';
+
+import { getPath } from '../../validation/calculations/getPath.js';
+import { type QueryValidationInputParam } from '../../validation/models/QueryValidationInputParam.js';
+import { validatedInputParamQueryType } from '../../validation/models/validatedInputParamTypes.js';
+import { setValidateMetadata } from '../actions/setValidateMetadata.js';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function ValidatedQuery(): ParameterDecorator {
+  return (
+    target: object,
+    key: string | symbol | undefined,
+    index: number,
+  ): void => {
+    setValidateMetadata(target, key, index);
+    createCustomParameterDecorator(
+      async (
+        request: unknown,
+        _response: unknown,
+        options: CustomParameterDecoratorHandlerOptions<unknown, unknown>,
+      ): Promise<QueryValidationInputParam> => {
+        const method: string = options.getMethod(request).toLowerCase();
+        const url: string = options.getUrl(request);
+
+        const queries: unknown = options.getQuery(request);
+
+        if (
+          typeof queries !== 'object' ||
+          queries === null ||
+          Array.isArray(queries)
+        ) {
+          throw new InversifyValidationError(
+            InversifyValidationErrorKind.unknown,
+            `${method.toUpperCase()} ${url}: Expected query to be a non array object`,
+          );
+        }
+
+        return {
+          method,
+          path: getPath(url),
+          queries: queries as Record<string, unknown>,
+          type: validatedInputParamQueryType,
+        };
+      },
+    )(target, key, index);
+  };
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/buildCompositeValidationHandler.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/buildCompositeValidationHandler.spec.ts
@@ -28,10 +28,10 @@ describe(buildCompositeValidationHandler, () => {
 
       beforeAll(() => {
         result = buildCompositeValidationHandler({})(
-          Symbol() as unknown as Ajv,
           Symbol(),
           Symbol() as unknown as OpenApiValidationContext,
           inputParam,
+          vitest.fn(),
           vitest.fn(),
         );
       });
@@ -54,10 +54,10 @@ describe(buildCompositeValidationHandler, () => {
 
       beforeAll(() => {
         result = buildCompositeValidationHandler({})(
-          Symbol() as unknown as Ajv,
           Symbol(),
           Symbol() as unknown as OpenApiValidationContext,
           inputParam,
+          vitest.fn(),
           vitest.fn(),
         );
       });
@@ -80,10 +80,10 @@ describe(buildCompositeValidationHandler, () => {
 
       beforeAll(() => {
         result = buildCompositeValidationHandler({})(
-          Symbol() as unknown as Ajv,
           Symbol(),
           Symbol() as unknown as OpenApiValidationContext,
           inputParam,
+          vitest.fn(),
           vitest.fn(),
         );
       });
@@ -96,6 +96,7 @@ describe(buildCompositeValidationHandler, () => {
 
   describe('having non handler map and object input params with right discriminator', () => {
     let ajvFixture: Ajv;
+    let coerceTypesFixture: boolean;
     let discriminatorValueFixture: symbol;
     let handlerMock: Mock<
       ValidationHandler<
@@ -106,6 +107,7 @@ describe(buildCompositeValidationHandler, () => {
         unknown
       >
     >;
+    let getAjvMock: Mock<(coerceTypes: boolean) => Ajv>;
     let getEntryMock: Mock;
     let inputParam: unknown;
     let openApiObjectFixture: unknown;
@@ -113,9 +115,11 @@ describe(buildCompositeValidationHandler, () => {
 
     beforeAll(() => {
       discriminatorValueFixture = Symbol();
+      coerceTypesFixture = true;
 
       handlerMock = vitest.fn();
       ajvFixture = Symbol() as unknown as Ajv;
+      getAjvMock = vitest.fn();
       getEntryMock = vitest.fn();
       inputParam = {
         type: discriminatorValueFixture,
@@ -133,21 +137,26 @@ describe(buildCompositeValidationHandler, () => {
       beforeAll(() => {
         resultFixture = Symbol();
 
+        getAjvMock.mockReturnValueOnce(ajvFixture);
         handlerMock.mockReturnValueOnce(resultFixture);
 
         result = buildCompositeValidationHandler({
-          [discriminatorValueFixture]: handlerMock,
+          [discriminatorValueFixture]: [handlerMock, coerceTypesFixture],
         })(
-          ajvFixture,
           openApiObjectFixture,
           openApiValidationContextFixture,
           inputParam,
+          getAjvMock,
           getEntryMock,
         );
       });
 
       afterAll(() => {
         vitest.clearAllMocks();
+      });
+
+      it('should call getAjv()', () => {
+        expect(getAjvMock).toHaveBeenCalledExactlyOnceWith(coerceTypesFixture);
       });
 
       it('should call handler()', () => {

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/buildCompositeValidationHandler.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/buildCompositeValidationHandler.ts
@@ -6,29 +6,34 @@ import {
   type validatedInputParamBodyType,
   type validatedInputParamHeaderType,
   type validatedInputParamParamType,
+  type validatedInputParamQueryType,
 } from '../models/validatedInputParamTypes.js';
 import { type ValidationHandler } from '../models/ValidationHandler.js';
 
 type ValidatedInputParamType =
   | typeof validatedInputParamBodyType
   | typeof validatedInputParamHeaderType
-  | typeof validatedInputParamParamType;
+  | typeof validatedInputParamParamType
+  | typeof validatedInputParamQueryType;
 
 export function buildCompositeValidationHandler<
   TOpenApiObject,
   TValidationCacheEntry,
 >(handlers: {
-  [TKey in ValidatedInputParamType]?: ValidationHandler<
-    TOpenApiObject,
-    ValidationInputParam & { type: TKey },
-    TValidationCacheEntry
-  >;
+  [TKey in ValidatedInputParamType]?: [
+    ValidationHandler<
+      TOpenApiObject,
+      ValidationInputParam & { type: TKey },
+      TValidationCacheEntry
+    >,
+    boolean,
+  ];
 }) {
   return (
-    ajv: Ajv,
     openApiObject: TOpenApiObject,
     validationContext: OpenApiValidationContext,
     inputParam: unknown,
+    getAjv: (coerceTypes: boolean) => Ajv,
     getEntry: (path: string, method: string) => TValidationCacheEntry,
   ): unknown => {
     if (inputParam === null || typeof inputParam !== 'object') {
@@ -39,25 +44,41 @@ export function buildCompositeValidationHandler<
       inputParam as Partial<ValidationInputParam>
     ).type;
 
-    const handler:
-      | ValidationHandler<
-          TOpenApiObject,
-          ValidationInputParam,
-          TValidationCacheEntry
-        >
+    const handlerAndCoerceTypes:
+      | [
+          ValidationHandler<
+            TOpenApiObject,
+            ValidationInputParam,
+            TValidationCacheEntry
+          >,
+          boolean,
+        ]
       | undefined = handlers[discriminatorValue as ValidatedInputParamType] as
-      | ValidationHandler<
-          TOpenApiObject,
-          ValidationInputParam,
-          TValidationCacheEntry
-        >
+      | [
+          ValidationHandler<
+            TOpenApiObject,
+            ValidationInputParam,
+            TValidationCacheEntry
+          >,
+          boolean,
+        ]
       | undefined;
 
-    if (handler === undefined) {
+    if (handlerAndCoerceTypes === undefined) {
       return inputParam;
     }
+
+    const [handler, coerceTypes]: [
+      ValidationHandler<
+        TOpenApiObject,
+        ValidationInputParam,
+        TValidationCacheEntry
+      >,
+      boolean,
+    ] = handlerAndCoerceTypes;
+
     return handler(
-      ajv,
+      getAjv(coerceTypes),
       openApiObject,
       validationContext,
       inputParam as ValidationInputParam,

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/buildQueryParse.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/buildQueryParse.spec.ts
@@ -1,0 +1,292 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+vitest.mock(import('./inferSchemaTypeOrPrimitivaSchemaTypeOrThrow.js'));
+
+import { type OpenApiResolver } from '../services/OpenApiResolver.js';
+import { buildQueryParse, buildQueryParseFromType } from './buildQueryParse.js';
+import { inferSchemaTypeOrPrimitivaSchemaTypeOrThrow } from './inferSchemaTypeOrPrimitivaSchemaTypeOrThrow.js';
+
+describe(buildQueryParseFromType, () => {
+  afterAll(() => {
+    vitest.restoreAllMocks();
+  });
+
+  describe('having isNullable false and type "boolean"', () => {
+    describe('when called with a string "true"', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = buildQueryParseFromType(false, 'boolean')('true');
+      });
+
+      it('should return true', () => {
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('when called with a string "false"', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = buildQueryParseFromType(false, 'boolean')('false');
+      });
+
+      it('should return false', () => {
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('when called with a non-string value', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = buildQueryParseFromType(false, 'boolean')(42);
+      });
+
+      it('should return the value unchanged', () => {
+        expect(result).toBe(42);
+      });
+    });
+  });
+
+  describe('having isNullable true and type "boolean"', () => {
+    describe('when called with a string "true"', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = buildQueryParseFromType(true, 'boolean')('true');
+      });
+
+      it('should return true', () => {
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('when called with a non-string value', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = buildQueryParseFromType(true, 'boolean')(['true']);
+      });
+
+      it('should return the value unchanged', () => {
+        expect(result).toStrictEqual(['true']);
+      });
+    });
+  });
+
+  describe('having isNullable false and type "number"', () => {
+    describe('when called with a numeric string', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = buildQueryParseFromType(false, 'number')('3.14');
+      });
+
+      it('should return the parsed number', () => {
+        expect(result).toBe(3.14);
+      });
+    });
+
+    describe('when called with a non-numeric string', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = buildQueryParseFromType(false, 'number')('not-a-number');
+      });
+
+      it('should return the string unchanged', () => {
+        expect(result).toBe('not-a-number');
+      });
+    });
+
+    describe('when called with a non-string value', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = buildQueryParseFromType(false, 'number')([10, 20]);
+      });
+
+      it('should return the value unchanged', () => {
+        expect(result).toStrictEqual([10, 20]);
+      });
+    });
+  });
+
+  describe('having isNullable false and type "integer"', () => {
+    describe('when called with a numeric string', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = buildQueryParseFromType(false, 'integer')('42');
+      });
+
+      it('should return the parsed number', () => {
+        expect(result).toBe(42);
+      });
+    });
+  });
+
+  describe('having isNullable true and type "number"', () => {
+    describe('when called with a numeric string', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = buildQueryParseFromType(true, 'number')('5');
+      });
+
+      it('should return the parsed number', () => {
+        expect(result).toBe(5);
+      });
+    });
+  });
+
+  describe('having type "null"', () => {
+    describe('when called with an empty string', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = buildQueryParseFromType(false, 'null')('');
+      });
+
+      it('should return null', () => {
+        expect(result).toBeNull();
+      });
+    });
+
+    describe('when called with undefined', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = buildQueryParseFromType(false, 'null')(undefined);
+      });
+
+      it('should return null', () => {
+        expect(result).toBeNull();
+      });
+    });
+
+    describe('when called with a non-string value', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = buildQueryParseFromType(false, 'null')({ foo: 'bar' });
+      });
+
+      it('should return the value unchanged', () => {
+        expect(result).toStrictEqual({ foo: 'bar' });
+      });
+    });
+  });
+
+  describe('having type "string" (default)', () => {
+    describe('when called with any value', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = buildQueryParseFromType(false, 'string')('hello');
+      });
+
+      it('should return the value unchanged', () => {
+        expect(result).toBe('hello');
+      });
+    });
+
+    describe('when called with a non-string value', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = buildQueryParseFromType(false, 'string')(['a', 'b']);
+      });
+
+      it('should return the value unchanged', () => {
+        expect(result).toStrictEqual(['a', 'b']);
+      });
+    });
+  });
+});
+
+describe(buildQueryParse, () => {
+  let openApiResolverFixture: OpenApiResolver;
+
+  beforeAll(() => {
+    openApiResolverFixture = {
+      deepResolveReference: vitest.fn(),
+      resolveReference: vitest.fn(),
+    };
+  });
+
+  afterAll(() => {
+    vitest.restoreAllMocks();
+  });
+
+  describe('when called with a string schema', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      vitest
+        .mocked(inferSchemaTypeOrPrimitivaSchemaTypeOrThrow)
+        .mockReturnValueOnce({ isNullable: false, type: 'string' });
+
+      result = buildQueryParse(
+        openApiResolverFixture,
+        { type: 'string' },
+        '#/test/schema',
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call inferSchemaTypeOrPrimitivaSchemaTypeOrThrow', () => {
+      expect(
+        inferSchemaTypeOrPrimitivaSchemaTypeOrThrow,
+      ).toHaveBeenCalledExactlyOnceWith(
+        openApiResolverFixture,
+        { type: 'string' },
+        '#/test/schema',
+      );
+    });
+
+    it('should return a function', () => {
+      expect(result).toBeTypeOf('function');
+    });
+
+    it('should return a parse function that passes the value through', () => {
+      const parseFn: (value: unknown) => unknown = result as (
+        value: unknown,
+      ) => unknown;
+
+      expect(parseFn('hello')).toBe('hello');
+    });
+  });
+
+  describe('when called with a nullable integer schema', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      vitest
+        .mocked(inferSchemaTypeOrPrimitivaSchemaTypeOrThrow)
+        .mockReturnValueOnce({ isNullable: true, type: 'integer' });
+
+      result = buildQueryParse(
+        openApiResolverFixture,
+        { type: ['integer', 'null'] },
+        '#/test/schema',
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should return a parse function that coerces numeric strings', () => {
+      const parseFn: (value: unknown) => unknown = result as (
+        value: unknown,
+      ) => unknown;
+
+      expect(parseFn('10')).toBe(10);
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/buildQueryParse.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/buildQueryParse.ts
@@ -1,0 +1,69 @@
+import {
+  type JsonSchema,
+  type JsonSchemaType,
+} from '@inversifyjs/json-schema-types/2020-12';
+
+import { type OpenApiResolver } from '../services/OpenApiResolver.js';
+import { inferSchemaTypeOrPrimitivaSchemaTypeOrThrow } from './inferSchemaTypeOrPrimitivaSchemaTypeOrThrow.js';
+import { maybeCoerceStringToNonNullableBoolean } from './maybeCoerceStringToNonNullableBoolean.js';
+import { maybeCoerceStringToNonNullableNumber } from './maybeCoerceStringToNonNullableNumber.js';
+import { maybeCoerceStringToNull } from './maybeCoerceStringToNull.js';
+import { maybeCoerceStringToNullableBoolean } from './maybeCoerceStringToNullableBoolean.js';
+import { maybeCoerceStringToNullableNumber } from './maybeCoerceStringToNullableNumber.js';
+
+function passThroughIfNotString(
+  coerce: (value: string | undefined) => unknown,
+): (value: unknown) => unknown {
+  return (value: unknown): unknown => {
+    if (value === undefined || typeof value === 'string') {
+      return coerce(value);
+    }
+
+    return value;
+  };
+}
+
+export function buildQueryParseFromType(
+  isNullable: boolean,
+  type: JsonSchemaType,
+): (value: unknown) => unknown {
+  switch (type) {
+    case 'boolean':
+      if (isNullable) {
+        return passThroughIfNotString(maybeCoerceStringToNullableBoolean);
+      } else {
+        return passThroughIfNotString(maybeCoerceStringToNonNullableBoolean);
+      }
+    case 'integer':
+    case 'number':
+      if (isNullable) {
+        return passThroughIfNotString(maybeCoerceStringToNullableNumber);
+      } else {
+        return passThroughIfNotString(maybeCoerceStringToNonNullableNumber);
+      }
+    case 'null':
+      return passThroughIfNotString(maybeCoerceStringToNull);
+    default:
+      return (value: unknown): unknown => value;
+  }
+}
+
+export function buildQueryParse(
+  openApiResolver: OpenApiResolver,
+  schema: JsonSchema | undefined,
+  schemaRef: string,
+): (value: unknown) => unknown {
+  const {
+    isNullable,
+    type,
+  }: {
+    isNullable: boolean;
+    type: JsonSchemaType;
+  } = inferSchemaTypeOrPrimitivaSchemaTypeOrThrow(
+    openApiResolver,
+    schema,
+    schemaRef,
+  );
+
+  return buildQueryParseFromType(isNullable, type);
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/inferSchemaTypeOrPrimitivaSchemaTypeOrThrow.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/inferSchemaTypeOrPrimitivaSchemaTypeOrThrow.spec.ts
@@ -1,0 +1,229 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+vitest.mock(import('./inferOpenApiSchemaTypes.js'));
+
+import { type JsonSchemaType } from '@inversifyjs/json-schema-types/2020-12';
+import {
+  InversifyValidationError,
+  InversifyValidationErrorKind,
+} from '@inversifyjs/validation-common';
+
+import { type OpenApiResolver } from '../services/OpenApiResolver.js';
+import { inferOpenApiSchemaTypes } from './inferOpenApiSchemaTypes.js';
+import { inferSchemaTypeOrPrimitivaSchemaTypeOrThrow } from './inferSchemaTypeOrPrimitivaSchemaTypeOrThrow.js';
+
+describe(inferSchemaTypeOrPrimitivaSchemaTypeOrThrow, () => {
+  let openApiResolverFixture: OpenApiResolver;
+
+  beforeAll(() => {
+    openApiResolverFixture = {
+      deepResolveReference: vitest.fn(),
+      resolveReference: vitest.fn(),
+    };
+  });
+
+  afterAll(() => {
+    vitest.restoreAllMocks();
+  });
+
+  describe('having an undefined schema', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        try {
+          inferSchemaTypeOrPrimitivaSchemaTypeOrThrow(
+            openApiResolverFixture,
+            undefined,
+            '#/test/schema',
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should throw an InversifyValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyValidationError> = {
+          kind: InversifyValidationErrorKind.invalidConfiguration,
+          message: expect.stringContaining('#/test/schema'),
+        };
+
+        expect(result).toBeInstanceOf(InversifyValidationError);
+        expect(result).toMatchObject(expectedErrorProperties);
+      });
+    });
+  });
+
+  describe('having a schema that resolves to exactly one type', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest
+          .mocked(inferOpenApiSchemaTypes)
+          .mockReturnValueOnce(new Set<JsonSchemaType>(['string']));
+
+        result = inferSchemaTypeOrPrimitivaSchemaTypeOrThrow(
+          openApiResolverFixture,
+          { type: 'string' },
+          '#/test/schema',
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should return the expected result', () => {
+        expect(result).toStrictEqual({
+          isNullable: false,
+          type: 'string',
+        });
+      });
+    });
+  });
+
+  describe('having a schema that resolves to a type and null', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest
+          .mocked(inferOpenApiSchemaTypes)
+          .mockReturnValueOnce(new Set<JsonSchemaType>(['integer', 'null']));
+
+        result = inferSchemaTypeOrPrimitivaSchemaTypeOrThrow(
+          openApiResolverFixture,
+          { type: ['integer', 'null'] },
+          '#/test/schema',
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should return the expected result with isNullable true', () => {
+        expect(result).toStrictEqual({
+          isNullable: true,
+          type: 'integer',
+        });
+      });
+    });
+  });
+
+  describe('having a schema that resolves to multiple types including a single primitive', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest
+          .mocked(inferOpenApiSchemaTypes)
+          .mockReturnValueOnce(
+            new Set<JsonSchemaType>(['string', 'array', 'null']),
+          );
+
+        result = inferSchemaTypeOrPrimitivaSchemaTypeOrThrow(
+          openApiResolverFixture,
+          { anyOf: [{ type: 'string' }, { type: 'array' }, { type: 'null' }] },
+          '#/test/schema',
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should return the primitive type with isNullable true', () => {
+        expect(result).toStrictEqual({
+          isNullable: true,
+          type: 'string',
+        });
+      });
+    });
+  });
+
+  describe('having a schema that resolves to multiple non-primitive types without a single primitive', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest
+          .mocked(inferOpenApiSchemaTypes)
+          .mockReturnValueOnce(new Set<JsonSchemaType>(['array', 'object']));
+
+        try {
+          inferSchemaTypeOrPrimitivaSchemaTypeOrThrow(
+            openApiResolverFixture,
+            { anyOf: [{ type: 'array' }, { type: 'object' }] },
+            '#/test/schema',
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should throw an InversifyValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyValidationError> = {
+          kind: InversifyValidationErrorKind.invalidConfiguration,
+          message: expect.stringContaining('#/test/schema'),
+        };
+
+        expect(result).toBeInstanceOf(InversifyValidationError);
+        expect(result).toMatchObject(expectedErrorProperties);
+      });
+    });
+  });
+
+  describe('having a schema that resolves to multiple primitive types', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest
+          .mocked(inferOpenApiSchemaTypes)
+          .mockReturnValueOnce(
+            new Set<JsonSchemaType>(['string', 'integer', 'null']),
+          );
+
+        try {
+          inferSchemaTypeOrPrimitivaSchemaTypeOrThrow(
+            openApiResolverFixture,
+            {
+              anyOf: [
+                { type: 'string' },
+                { type: 'integer' },
+                { type: 'null' },
+              ],
+            },
+            '#/test/schema',
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should throw an InversifyValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyValidationError> = {
+          kind: InversifyValidationErrorKind.invalidConfiguration,
+          message: expect.stringContaining('#/test/schema'),
+        };
+
+        expect(result).toBeInstanceOf(InversifyValidationError);
+        expect(result).toMatchObject(expectedErrorProperties);
+      });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/inferSchemaTypeOrPrimitivaSchemaTypeOrThrow.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/inferSchemaTypeOrPrimitivaSchemaTypeOrThrow.ts
@@ -1,0 +1,64 @@
+import {
+  type JsonSchema,
+  type JsonSchemaType,
+} from '@inversifyjs/json-schema-types/2020-12';
+import {
+  InversifyValidationError,
+  InversifyValidationErrorKind,
+} from '@inversifyjs/validation-common';
+
+import { type OpenApiResolver } from '../services/OpenApiResolver.js';
+import { inferOpenApiSchemaTypes } from './inferOpenApiSchemaTypes.js';
+
+const TYPES_ALLOWED_IF_NULLABLE: number = 2;
+
+export function inferSchemaTypeOrPrimitivaSchemaTypeOrThrow(
+  openApiResolver: OpenApiResolver,
+  schema: JsonSchema | undefined,
+  schemaRef: string,
+): {
+  isNullable: boolean;
+  type: JsonSchemaType;
+} {
+  const typesSet: Set<JsonSchemaType> =
+    schema === undefined
+      ? new Set()
+      : inferOpenApiSchemaTypes(openApiResolver, schema);
+
+  if (
+    typesSet.size !== 1 &&
+    !(typesSet.size === TYPES_ALLOWED_IF_NULLABLE && typesSet.has('null'))
+  ) {
+    const primitiveTypes: JsonSchemaType[] = [...typesSet].filter(
+      (t: JsonSchemaType): boolean =>
+        t === 'string' || t === 'number' || t === 'integer' || t === 'boolean',
+    );
+
+    if (primitiveTypes.length !== 1) {
+      throw new InversifyValidationError(
+        InversifyValidationErrorKind.invalidConfiguration,
+        `Unable to determine parameter "${schemaRef}" type: expected exactly 1 type but found "${[...typesSet].join(', ')}"`,
+      );
+    }
+
+    const [type]: [JsonSchemaType] = primitiveTypes as [JsonSchemaType];
+
+    const isNullable: boolean = typesSet.has('null');
+
+    return {
+      isNullable,
+      type,
+    };
+  }
+
+  const isNullable: boolean = typesSet.has('null');
+
+  const type: JsonSchemaType = [...typesSet].find(
+    (t: JsonSchemaType): boolean => t !== 'null',
+  ) as JsonSchemaType;
+
+  return {
+    isNullable,
+    type,
+  };
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getQueryParameterObjects.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getQueryParameterObjects.spec.ts
@@ -1,0 +1,258 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+vitest.mock(import('@inversifyjs/json-schema-pointer'));
+vitest.mock(import('./getOperationObject.js'));
+vitest.mock(import('./getPathItemObject.js'));
+
+import { escapeJsonPointerFragments } from '@inversifyjs/json-schema-pointer';
+import {
+  type OpenApi3Dot1Object,
+  type OpenApi3Dot1OperationObject,
+  type OpenApi3Dot1ParameterObject,
+  type OpenApi3Dot1PathItemObject,
+  type OpenApi3Dot1ReferenceObject,
+} from '@inversifyjs/open-api-types/v3Dot1';
+
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
+import { getOperationObject } from './getOperationObject.js';
+import { getPathItemObject } from './getPathItemObject.js';
+import {
+  getQueryParameterObjects,
+  type QueryParameterEntry,
+} from './getQueryParameterObjects.js';
+
+describe(getQueryParameterObjects, () => {
+  let openApiObjectFixture: OpenApi3Dot1Object;
+  let pathFixture: string;
+  let methodFixture: string;
+
+  beforeAll(() => {
+    openApiObjectFixture = Symbol() as unknown as OpenApi3Dot1Object;
+    pathFixture = '/users';
+    methodFixture = 'get';
+
+    vitest
+      .mocked(escapeJsonPointerFragments)
+      .mockImplementation((...fragments: string[]) => fragments.join('/'));
+  });
+
+  afterAll(() => {
+    vitest.clearAllMocks();
+  });
+
+  describe('when called, and operation has query parameters only', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let result: Map<string, QueryParameterEntry>;
+
+    beforeAll(() => {
+      const parameterFixture: OpenApi3Dot1ParameterObject = {
+        in: 'query',
+        name: 'page',
+        required: true,
+        schema: { type: 'integer' },
+      };
+
+      const operationFixture: OpenApi3Dot1OperationObject = {
+        parameters: [parameterFixture],
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot1PathItemObject = {
+        get: operationFixture,
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getQueryParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should return a map with the query parameter', () => {
+      expect(result.size).toBe(1);
+      expect(result.has('page')).toBe(true);
+    });
+
+    it('should return entry with correct pointer prefix', () => {
+      const entry: QueryParameterEntry = result.get(
+        'page',
+      ) as QueryParameterEntry;
+
+      expect(entry.pointerPrefix).toBe(
+        `paths/${pathFixture}/${methodFixture}/parameters/0`,
+      );
+    });
+  });
+
+  describe('when called, and path item has query parameters only', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let result: Map<string, QueryParameterEntry>;
+
+    beforeAll(() => {
+      const parameterFixture: OpenApi3Dot1ParameterObject = {
+        in: 'query',
+        name: 'page',
+        schema: { type: 'integer' },
+      };
+
+      const operationFixture: OpenApi3Dot1OperationObject = {
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot1PathItemObject = {
+        get: operationFixture,
+        parameters: [parameterFixture],
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getQueryParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should return entry with path-item pointer prefix', () => {
+      const entry: QueryParameterEntry = result.get(
+        'page',
+      ) as QueryParameterEntry;
+
+      expect(entry.pointerPrefix).toBe(`paths/${pathFixture}/parameters/0`);
+    });
+  });
+
+  describe('when called, and parameter is a $ref reference', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let result: Map<string, QueryParameterEntry>;
+
+    beforeAll(() => {
+      const refFixture: OpenApi3Dot1ReferenceObject = {
+        $ref: '#/components/parameters/PageParam',
+      };
+
+      const resolvedParamFixture: OpenApi3Dot1ParameterObject = {
+        in: 'query',
+        name: 'page',
+        schema: { type: 'integer' },
+      };
+
+      const operationFixture: OpenApi3Dot1OperationObject = {
+        parameters: [refFixture],
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot1PathItemObject = {
+        get: operationFixture,
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest
+          .fn()
+          .mockReturnValueOnce(resolvedParamFixture),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getQueryParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should resolve the $ref and return the query parameter', () => {
+      expect(result.size).toBe(1);
+      expect(result.has('page')).toBe(true);
+    });
+
+    it('should call deepResolveReference', () => {
+      expect(
+        openApiResolverFixture.deepResolveReference,
+      ).toHaveBeenCalledExactlyOnceWith('#/components/parameters/PageParam');
+    });
+  });
+
+  describe('when called, and parameters include non-query params', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let result: Map<string, QueryParameterEntry>;
+
+    beforeAll(() => {
+      const pathParam: OpenApi3Dot1ParameterObject = {
+        in: 'path',
+        name: 'userId',
+        schema: { type: 'string' },
+      };
+
+      const queryParam: OpenApi3Dot1ParameterObject = {
+        in: 'query',
+        name: 'page',
+        schema: { type: 'integer' },
+      };
+
+      const operationFixture: OpenApi3Dot1OperationObject = {
+        parameters: [pathParam, queryParam],
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot1PathItemObject = {
+        get: operationFixture,
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getQueryParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should return only query parameters', () => {
+      expect(result.size).toBe(1);
+      expect(result.has('page')).toBe(true);
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getQueryParameterObjects.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getQueryParameterObjects.ts
@@ -1,0 +1,88 @@
+import { escapeJsonPointerFragments } from '@inversifyjs/json-schema-pointer';
+import {
+  type OpenApi3Dot1Object,
+  type OpenApi3Dot1OperationObject,
+  type OpenApi3Dot1ParameterObject,
+  type OpenApi3Dot1PathItemObject,
+  type OpenApi3Dot1ReferenceObject,
+} from '@inversifyjs/open-api-types/v3Dot1';
+
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
+import { getOperationObject } from './getOperationObject.js';
+import { getPathItemObject } from './getPathItemObject.js';
+
+export interface QueryParameterEntry {
+  parameter: OpenApi3Dot1ParameterObject;
+  pointerPrefix: string;
+}
+
+function isReferenceObject(
+  param: OpenApi3Dot1ParameterObject | OpenApi3Dot1ReferenceObject,
+): param is OpenApi3Dot1ReferenceObject {
+  return '$ref' in param;
+}
+
+export function getQueryParameterObjects(
+  openApiObject: OpenApi3Dot1Object,
+  openApiResolver: OpenApiResolver,
+  method: string,
+  path: string,
+): Map<string, QueryParameterEntry> {
+  const pathItemObject: OpenApi3Dot1PathItemObject = getPathItemObject(
+    openApiObject,
+    path,
+  );
+  const operationObject: OpenApi3Dot1OperationObject = getOperationObject(
+    openApiObject,
+    method,
+    path,
+  );
+
+  const result: Map<string, QueryParameterEntry> = new Map();
+
+  if (pathItemObject.parameters !== undefined) {
+    for (let i: number = 0; i < pathItemObject.parameters.length; i++) {
+      const raw: OpenApi3Dot1ParameterObject | OpenApi3Dot1ReferenceObject =
+        pathItemObject.parameters[i] as
+          | OpenApi3Dot1ParameterObject
+          | OpenApi3Dot1ReferenceObject;
+
+      const param: OpenApi3Dot1ParameterObject = isReferenceObject(raw)
+        ? (openApiResolver.deepResolveReference(
+            raw.$ref,
+          ) as unknown as OpenApi3Dot1ParameterObject)
+        : raw;
+
+      if (param.in === 'query') {
+        result.set(param.name, {
+          parameter: param,
+          pointerPrefix: `paths/${escapeJsonPointerFragments(path)}/parameters/${String(i)}`,
+        });
+      }
+    }
+  }
+
+  if (operationObject.parameters !== undefined) {
+    for (let i: number = 0; i < operationObject.parameters.length; i++) {
+      const raw: OpenApi3Dot1ParameterObject | OpenApi3Dot1ReferenceObject =
+        operationObject.parameters[i] as
+          | OpenApi3Dot1ParameterObject
+          | OpenApi3Dot1ReferenceObject;
+
+      const param: OpenApi3Dot1ParameterObject = isReferenceObject(raw)
+        ? (openApiResolver.deepResolveReference(
+            raw.$ref,
+          ) as unknown as OpenApi3Dot1ParameterObject)
+        : raw;
+
+      if (param.in === 'query') {
+        result.set(param.name, {
+          parameter: param,
+          pointerPrefix: `paths/${escapeJsonPointerFragments(path)}/${method}/parameters/${String(i)}`,
+        });
+      }
+    }
+  }
+
+  return result;
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleBodyValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleBodyValidation.spec.ts
@@ -106,6 +106,7 @@ describe(handleBodyValidation, () => {
           body: undefined,
           headers: undefined,
           params: undefined,
+          queries: undefined,
         };
 
         getEntryMock = vitest
@@ -218,6 +219,7 @@ describe(handleBodyValidation, () => {
           body: undefined,
           headers: undefined,
           params: undefined,
+          queries: undefined,
         };
 
         getEntryMock = vitest
@@ -313,6 +315,7 @@ describe(handleBodyValidation, () => {
           body: undefined,
           headers: undefined,
           params: undefined,
+          queries: undefined,
         };
 
         getEntryMock = vitest
@@ -417,6 +420,7 @@ describe(handleBodyValidation, () => {
           body: undefined,
           headers: undefined,
           params: undefined,
+          queries: undefined,
         };
 
         getEntryMock = vitest
@@ -522,6 +526,7 @@ describe(handleBodyValidation, () => {
           body: undefined,
           headers: undefined,
           params: undefined,
+          queries: undefined,
         };
 
         getEntryMock = vitest

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleHeaderValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleHeaderValidation.spec.ts
@@ -94,6 +94,7 @@ describe(handleHeaderValidation, () => {
         body: undefined,
         headers: undefined,
         params: undefined,
+        queries: undefined,
       };
 
       const getEntryMock: Mock<
@@ -169,6 +170,7 @@ describe(handleHeaderValidation, () => {
         body: undefined,
         headers: undefined,
         params: undefined,
+        queries: undefined,
       };
 
       const getEntryMock: Mock<
@@ -253,6 +255,7 @@ describe(handleHeaderValidation, () => {
         body: undefined,
         headers: undefined,
         params: undefined,
+        queries: undefined,
       };
 
       const getEntryMock: Mock<
@@ -339,6 +342,7 @@ describe(handleHeaderValidation, () => {
         body: undefined,
         headers: undefined,
         params: undefined,
+        queries: undefined,
       };
 
       const getEntryMock: Mock<
@@ -413,6 +417,7 @@ describe(handleHeaderValidation, () => {
           ],
         ]),
         params: undefined,
+        queries: undefined,
       };
 
       const getEntryMock: Mock<

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleParamValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleParamValidation.spec.ts
@@ -94,6 +94,7 @@ describe(handleParamValidation, () => {
         body: undefined,
         headers: undefined,
         params: undefined,
+        queries: undefined,
       };
 
       const getEntryMock: Mock<
@@ -169,6 +170,7 @@ describe(handleParamValidation, () => {
         body: undefined,
         headers: undefined,
         params: undefined,
+        queries: undefined,
       };
 
       const getEntryMock: Mock<
@@ -265,6 +267,7 @@ describe(handleParamValidation, () => {
         body: undefined,
         headers: undefined,
         params: undefined,
+        queries: undefined,
       };
 
       const getEntryMock: Mock<
@@ -338,6 +341,7 @@ describe(handleParamValidation, () => {
             },
           ],
         ]),
+        queries: undefined,
       };
 
       const getEntryMock: Mock<

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleQueryValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleQueryValidation.spec.ts
@@ -9,10 +9,10 @@ import {
   vitest,
 } from 'vitest';
 
-vitest.mock(import('../buildParamParse.js'));
-vitest.mock(import('./getParamParameterObjects.js'));
+vitest.mock(import('../buildQueryParse.js'));
+vitest.mock(import('./getQueryParameterObjects.js'));
 
-import { type OpenApi3Dot2Object } from '@inversifyjs/open-api-types/v3Dot2';
+import { type OpenApi3Dot1Object } from '@inversifyjs/open-api-types/v3Dot1';
 import {
   InversifyValidationError,
   InversifyValidationErrorKind,
@@ -22,24 +22,24 @@ import { type ValidateFunction } from 'ajv';
 
 import { type OpenApiRouter } from '../../../router/services/OpenApiRouter.js';
 import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
-import { type ParamValidationInputParam } from '../../models/ParamValidationInputParam.js';
-import { type ValidationCacheEntry } from '../../models/v3Dot2/ValidationCacheEntry.js';
+import { type QueryValidationInputParam } from '../../models/QueryValidationInputParam.js';
+import { type ValidationCacheEntry } from '../../models/v3Dot1/ValidationCacheEntry.js';
 import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
-import { buildParamParse } from '../buildParamParse.js';
+import { buildQueryParse } from '../buildQueryParse.js';
 import {
-  getParamParameterObjects,
-  type ParamParameterEntry,
-} from './getParamParameterObjects.js';
-import { handleParamValidation } from './handleParamValidation.js';
+  getQueryParameterObjects,
+  type QueryParameterEntry,
+} from './getQueryParameterObjects.js';
+import { handleQueryValidation } from './handleQueryValidation.js';
 
-describe(handleParamValidation, () => {
-  let openApiObjectFixture: OpenApi3Dot2Object;
+describe(handleQueryValidation, () => {
+  let openApiObjectFixture: OpenApi3Dot1Object;
   let validationContextFixture: OpenApiValidationContext;
   let openApiResolverFixture: OpenApiResolver;
   let openApiRouterMock: OpenApiRouter;
 
   beforeAll(() => {
-    openApiObjectFixture = Symbol() as unknown as OpenApi3Dot2Object;
+    openApiObjectFixture = Symbol() as unknown as OpenApi3Dot1Object;
     openApiResolverFixture = Symbol() as unknown as OpenApiResolver;
     openApiRouterMock = {
       findRoute: vitest.fn(),
@@ -54,32 +54,81 @@ describe(handleParamValidation, () => {
     vitest.restoreAllMocks();
   });
 
-  describe('when called, and params are valid with string type', () => {
+  describe('when called, and route is not found', () => {
     let result: unknown;
 
     beforeAll(() => {
-      const paramParamMap: Map<string, ParamParameterEntry> = new Map([
+      vitest.mocked(openApiRouterMock.findRoute).mockReturnValueOnce(undefined);
+
+      const ajvMock: Mocked<Ajv> = {
+        getSchema: vitest.fn(),
+      } as Partial<Mocked<Ajv>> as Mocked<Ajv>;
+
+      const getEntryMock: Mock<
+        (path: string, method: string) => ValidationCacheEntry
+      > = vitest.fn();
+
+      const inputParam: QueryValidationInputParam = {
+        method: 'get',
+        path: '/unknown',
+        queries: {},
+        type: Symbol() as unknown as QueryValidationInputParam['type'],
+      };
+
+      try {
+        handleQueryValidation(
+          ajvMock,
+          openApiObjectFixture,
+          validationContextFixture,
+          inputParam,
+          getEntryMock,
+        );
+      } catch (error: unknown) {
+        result = error;
+      }
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should throw an InversifyValidationError', () => {
+      const expectedErrorProperties: Partial<InversifyValidationError> = {
+        kind: InversifyValidationErrorKind.validationFailed,
+        message: expect.stringContaining('GET /unknown'),
+      };
+
+      expect(result).toBeInstanceOf(InversifyValidationError);
+      expect(result).toMatchObject(expectedErrorProperties);
+    });
+  });
+
+  describe('when called, and queries are valid', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      const queryParamMap: Map<string, QueryParameterEntry> = new Map([
         [
-          'userId',
+          'page',
           {
             parameter: {
-              in: 'path',
-              name: 'userId',
-              required: true,
-              schema: { type: 'string' },
+              in: 'query',
+              name: 'page',
+              required: false,
+              schema: { type: 'integer' },
             },
-            pointerPrefix: 'paths/~1users~1{userId}/get/parameters/0',
+            pointerPrefix: 'paths/~1items/get/parameters/0',
           },
         ],
       ]);
 
       vitest
-        .mocked(getParamParameterObjects)
-        .mockReturnValueOnce(paramParamMap);
+        .mocked(getQueryParameterObjects)
+        .mockReturnValueOnce(queryParamMap);
 
-      const parseMock: Mock = vitest.fn().mockReturnValueOnce('abc-123');
+      const parseMock: Mock = vitest.fn().mockReturnValueOnce(10);
 
-      vitest.mocked(buildParamParse).mockReturnValueOnce(parseMock);
+      vitest.mocked(buildQueryParse).mockReturnValueOnce(parseMock);
 
       const validateMock: ValidateFunction = Object.assign(
         vitest.fn().mockReturnValueOnce(true),
@@ -101,18 +150,18 @@ describe(handleParamValidation, () => {
         (path: string, method: string) => ValidationCacheEntry
       > = vitest.fn().mockReturnValueOnce(validationCacheEntry);
 
-      const inputParam: ParamValidationInputParam = {
+      const inputParam: QueryValidationInputParam = {
         method: 'get',
-        params: { userId: 'abc-123' },
-        path: '/users/{userId}',
-        type: Symbol() as unknown as ParamValidationInputParam['type'],
+        path: '/items',
+        queries: { page: '1' },
+        type: Symbol() as unknown as QueryValidationInputParam['type'],
       };
 
       vitest
         .mocked(openApiRouterMock.findRoute)
         .mockReturnValueOnce(inputParam.path);
 
-      result = handleParamValidation(
+      result = handleQueryValidation(
         ajvMock,
         openApiObjectFixture,
         validationContextFixture,
@@ -125,37 +174,37 @@ describe(handleParamValidation, () => {
       vitest.clearAllMocks();
     });
 
-    it('should return validated params record', () => {
-      expect(result).toStrictEqual({ userId: 'abc-123' });
+    it('should return the computed queries record', () => {
+      expect(result).toStrictEqual({ page: 10 });
     });
   });
 
-  describe('when called, and required param is missing', () => {
+  describe('when called, and required query is missing', () => {
     let result: unknown;
 
     beforeAll(() => {
-      const paramParamMap: Map<string, ParamParameterEntry> = new Map([
+      const queryParamMap: Map<string, QueryParameterEntry> = new Map([
         [
-          'userId',
+          'search',
           {
             parameter: {
-              in: 'path',
-              name: 'userId',
+              in: 'query',
+              name: 'search',
               required: true,
               schema: { type: 'string' },
             },
-            pointerPrefix: 'paths/~1users~1{userId}/get/parameters/0',
+            pointerPrefix: 'paths/~1items/get/parameters/0',
           },
         ],
       ]);
 
       vitest
-        .mocked(getParamParameterObjects)
-        .mockReturnValueOnce(paramParamMap);
+        .mocked(getQueryParameterObjects)
+        .mockReturnValueOnce(queryParamMap);
 
       const parseMock: Mock = vitest.fn();
 
-      vitest.mocked(buildParamParse).mockReturnValueOnce(parseMock);
+      vitest.mocked(buildQueryParse).mockReturnValueOnce(parseMock);
 
       const validateMock: ValidateFunction = Object.assign(vitest.fn(), {
         errors: null,
@@ -177,19 +226,19 @@ describe(handleParamValidation, () => {
         (path: string, method: string) => ValidationCacheEntry
       > = vitest.fn().mockReturnValueOnce(validationCacheEntry);
 
-      const inputParam: ParamValidationInputParam = {
+      const inputParam: QueryValidationInputParam = {
         method: 'get',
-        params: {},
-        path: '/users/{userId}',
-        type: Symbol() as unknown as ParamValidationInputParam['type'],
+        path: '/items',
+        queries: {},
+        type: Symbol() as unknown as QueryValidationInputParam['type'],
       };
 
-      vitest
-        .mocked(openApiRouterMock.findRoute)
-        .mockReturnValueOnce(inputParam.path);
-
       try {
-        handleParamValidation(
+        vitest
+          .mocked(openApiRouterMock.findRoute)
+          .mockReturnValueOnce(inputParam.path);
+
+        handleQueryValidation(
           ajvMock,
           openApiObjectFixture,
           validationContextFixture,
@@ -208,7 +257,7 @@ describe(handleParamValidation, () => {
     it('should throw an InversifyValidationError', () => {
       const expectedErrorProperties: Partial<InversifyValidationError> = {
         kind: InversifyValidationErrorKind.validationFailed,
-        message: 'Missing required param: userId',
+        message: 'Missing required query: search',
       };
 
       expect(result).toBeInstanceOf(InversifyValidationError);
@@ -216,32 +265,32 @@ describe(handleParamValidation, () => {
     });
   });
 
-  describe('when called, and validation fails', () => {
+  describe('when called, and query validation fails', () => {
     let result: unknown;
 
     beforeAll(() => {
-      const paramParamMap: Map<string, ParamParameterEntry> = new Map([
+      const queryParamMap: Map<string, QueryParameterEntry> = new Map([
         [
-          'userId',
+          'limit',
           {
             parameter: {
-              in: 'path',
-              name: 'userId',
-              required: true,
+              in: 'query',
+              name: 'limit',
+              required: false,
               schema: { minimum: 1, type: 'integer' },
             },
-            pointerPrefix: 'paths/~1users~1{userId}/get/parameters/0',
+            pointerPrefix: 'paths/~1items/get/parameters/0',
           },
         ],
       ]);
 
       vitest
-        .mocked(getParamParameterObjects)
-        .mockReturnValueOnce(paramParamMap);
+        .mocked(getQueryParameterObjects)
+        .mockReturnValueOnce(queryParamMap);
 
-      const parseMock: Mock = vitest.fn().mockReturnValueOnce('not-valid');
+      const parseMock: Mock = vitest.fn().mockReturnValueOnce('not-a-number');
 
-      vitest.mocked(buildParamParse).mockReturnValueOnce(parseMock);
+      vitest.mocked(buildQueryParse).mockReturnValueOnce(parseMock);
 
       const validateMock: ValidateFunction = Object.assign(
         vitest.fn().mockReturnValueOnce(false),
@@ -274,19 +323,19 @@ describe(handleParamValidation, () => {
         (path: string, method: string) => ValidationCacheEntry
       > = vitest.fn().mockReturnValueOnce(validationCacheEntry);
 
-      const inputParam: ParamValidationInputParam = {
+      const inputParam: QueryValidationInputParam = {
         method: 'get',
-        params: { userId: 'not-valid' },
-        path: '/users/{userId}',
-        type: Symbol() as unknown as ParamValidationInputParam['type'],
+        path: '/items',
+        queries: { limit: 'not-a-number' },
+        type: Symbol() as unknown as QueryValidationInputParam['type'],
       };
 
-      vitest
-        .mocked(openApiRouterMock.findRoute)
-        .mockReturnValueOnce(inputParam.path);
-
       try {
-        handleParamValidation(
+        vitest
+          .mocked(openApiRouterMock.findRoute)
+          .mockReturnValueOnce(inputParam.path);
+
+        handleQueryValidation(
           ajvMock,
           openApiObjectFixture,
           validationContextFixture,
@@ -305,7 +354,7 @@ describe(handleParamValidation, () => {
     it('should throw an InversifyValidationError', () => {
       const expectedErrorProperties: Partial<InversifyValidationError> = {
         kind: InversifyValidationErrorKind.validationFailed,
-        message: expect.stringContaining('userId'),
+        message: expect.stringContaining('limit'),
       };
 
       expect(result).toBeInstanceOf(InversifyValidationError);
@@ -313,12 +362,12 @@ describe(handleParamValidation, () => {
     });
   });
 
-  describe('when called, and cached params are reused', () => {
+  describe('when called, and cached queries are reused', () => {
     let result: unknown;
     let ajvMock: Mocked<Ajv>;
 
     beforeAll(() => {
-      const parseMock: Mock = vitest.fn().mockReturnValueOnce('test');
+      const parseMock: Mock = vitest.fn().mockReturnValueOnce('foo');
 
       const validateMock: ValidateFunction = Object.assign(
         vitest.fn().mockReturnValueOnce(true),
@@ -332,34 +381,35 @@ describe(handleParamValidation, () => {
       const validationCacheEntry: ValidationCacheEntry = {
         body: undefined,
         headers: undefined,
-        params: new Map([
+        params: undefined,
+        queries: new Map([
           [
-            'userId',
+            'search',
             {
               parse: parseMock,
+              required: false,
               validate: validateMock,
             },
           ],
         ]),
-        queries: undefined,
       };
 
       const getEntryMock: Mock<
         (path: string, method: string) => ValidationCacheEntry
       > = vitest.fn().mockReturnValueOnce(validationCacheEntry);
 
-      const inputParam: ParamValidationInputParam = {
+      const inputParam: QueryValidationInputParam = {
         method: 'get',
-        params: { userId: 'test' },
-        path: '/users/{userId}',
-        type: Symbol() as unknown as ParamValidationInputParam['type'],
+        path: '/items',
+        queries: { search: 'foo' },
+        type: Symbol() as unknown as QueryValidationInputParam['type'],
       };
 
       vitest
         .mocked(openApiRouterMock.findRoute)
         .mockReturnValueOnce(inputParam.path);
 
-      result = handleParamValidation(
+      result = handleQueryValidation(
         ajvMock,
         openApiObjectFixture,
         validationContextFixture,
@@ -376,12 +426,12 @@ describe(handleParamValidation, () => {
       expect(ajvMock.getSchema).not.toHaveBeenCalled();
     });
 
-    it('should not call getParamParameterObjects()', () => {
-      expect(getParamParameterObjects).not.toHaveBeenCalled();
+    it('should not call getQueryParameterObjects()', () => {
+      expect(getQueryParameterObjects).not.toHaveBeenCalled();
     });
 
-    it('should return validated params', () => {
-      expect(result).toStrictEqual({ userId: 'test' });
+    it('should return the computed queries', () => {
+      expect(result).toStrictEqual({ search: 'foo' });
     });
   });
 });

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleQueryValidation.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleQueryValidation.ts
@@ -1,0 +1,155 @@
+import { type OpenApi3Dot1Object } from '@inversifyjs/open-api-types/v3Dot1';
+import {
+  InversifyValidationError,
+  InversifyValidationErrorKind,
+} from '@inversifyjs/validation-common';
+import type Ajv from 'ajv';
+import { type ErrorObject, type ValidateFunction } from 'ajv';
+
+import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
+import { type QueryValidationInputParam } from '../../models/QueryValidationInputParam.js';
+import { SCHEMA_ID } from '../../models/v3Dot1/schemaId.js';
+import {
+  type ValidationCacheEntry,
+  type ValidationCacheEntryQuery,
+} from '../../models/v3Dot1/ValidationCacheEntry.js';
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
+import { buildQueryParse } from '../buildQueryParse.js';
+import {
+  getQueryParameterObjects,
+  type QueryParameterEntry,
+} from './getQueryParameterObjects.js';
+
+function getQueryParameterEntryMap(
+  ajv: Ajv,
+  openApiObject: OpenApi3Dot1Object,
+  openApiResolver: OpenApiResolver,
+  method: string,
+  route: string,
+): Map<string, ValidationCacheEntryQuery> {
+  const queryParameterEntryMap: Map<string, ValidationCacheEntryQuery> =
+    new Map();
+
+  const queryParams: Map<string, QueryParameterEntry> =
+    getQueryParameterObjects(openApiObject, openApiResolver, method, route);
+
+  for (const [queryName, queryParam] of queryParams) {
+    const parse: (value: unknown) => unknown = buildQueryParse(
+      openApiResolver,
+      queryParam.parameter.schema,
+      `${SCHEMA_ID}#/${queryParam.pointerPrefix}/schema`,
+    );
+
+    const ajvSchemaPointer: string = `${SCHEMA_ID}#/${queryParam.pointerPrefix}/schema`;
+
+    const validate: ValidateFunction | undefined =
+      ajv.getSchema(ajvSchemaPointer);
+
+    if (validate === undefined) {
+      throw new InversifyValidationError(
+        InversifyValidationErrorKind.validationFailed,
+        `Unable to find schema for pointer: ${ajvSchemaPointer}`,
+      );
+    }
+
+    queryParameterEntryMap.set(queryName, {
+      parse,
+      required: queryParam.parameter.required ?? false,
+      validate: validate,
+    });
+  }
+
+  return queryParameterEntryMap;
+}
+
+export function handleQueryValidation(
+  ajv: Ajv,
+  openApiObject: OpenApi3Dot1Object,
+  validationContext: OpenApiValidationContext,
+  inputParam: QueryValidationInputParam,
+  getEntry: (path: string, method: string) => ValidationCacheEntry,
+): unknown {
+  const route: string | undefined = validationContext.router.findRoute(
+    inputParam.method,
+    inputParam.path,
+  );
+
+  if (route === undefined) {
+    throw new InversifyValidationError(
+      InversifyValidationErrorKind.validationFailed,
+      `Unable to find route for operation: ${inputParam.method.toUpperCase()} ${inputParam.path}`,
+    );
+  }
+
+  const validationCacheEntry: ValidationCacheEntry = getEntry(
+    route,
+    inputParam.method,
+  );
+
+  if (validationCacheEntry.queries === undefined) {
+    validationCacheEntry.queries = getQueryParameterEntryMap(
+      ajv,
+      openApiObject,
+      validationContext.resolver,
+      inputParam.method,
+      route,
+    );
+  }
+
+  const computedQueries: Record<string, unknown> = {
+    ...inputParam.queries,
+  };
+
+  let valid: boolean = true;
+  const queryToErrorObject: Record<string, ErrorObject[]> = {};
+
+  for (const [
+    queryName,
+    validationCacheEntryQuery,
+  ] of validationCacheEntry.queries) {
+    if (!(queryName in inputParam.queries)) {
+      if (validationCacheEntryQuery.required) {
+        throw new InversifyValidationError(
+          InversifyValidationErrorKind.validationFailed,
+          `Missing required query: ${queryName}`,
+        );
+      }
+
+      continue;
+    }
+
+    const queryValue: unknown = inputParam.queries[queryName];
+
+    computedQueries[queryName] = validationCacheEntryQuery.parse(queryValue);
+
+    const isValidQuery: boolean = validationCacheEntryQuery.validate(
+      computedQueries[queryName],
+    );
+
+    if (!isValidQuery) {
+      valid = false;
+
+      queryToErrorObject[queryName] = [
+        ...(validationCacheEntryQuery.validate.errors ?? []),
+      ];
+    }
+  }
+
+  if (!valid) {
+    throw new InversifyValidationError(
+      InversifyValidationErrorKind.validationFailed,
+      Object.entries(queryToErrorObject)
+        .map(([queryName, errors]: [string, ErrorObject[]]): string =>
+          errors
+            .map(
+              (error: ErrorObject): string =>
+                `[query: ${queryName}, schemaPath: ${error.schemaPath}, instancePath: ${error.instancePath}]: "${error.message ?? '-'}"`,
+            )
+            .join('\n'),
+        )
+        .join('\n'),
+    );
+  }
+
+  return computedQueries;
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getQueryParameterObjects.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getQueryParameterObjects.spec.ts
@@ -1,0 +1,258 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+vitest.mock(import('@inversifyjs/json-schema-pointer'));
+vitest.mock(import('./getOperationObject.js'));
+vitest.mock(import('./getPathItemObject.js'));
+
+import { escapeJsonPointerFragments } from '@inversifyjs/json-schema-pointer';
+import {
+  type OpenApi3Dot2Object,
+  type OpenApi3Dot2OperationObject,
+  type OpenApi3Dot2ParameterObject,
+  type OpenApi3Dot2PathItemObject,
+  type OpenApi3Dot2ReferenceObject,
+} from '@inversifyjs/open-api-types/v3Dot2';
+
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
+import { getOperationObject } from './getOperationObject.js';
+import { getPathItemObject } from './getPathItemObject.js';
+import {
+  getQueryParameterObjects,
+  type QueryParameterEntry,
+} from './getQueryParameterObjects.js';
+
+describe(getQueryParameterObjects, () => {
+  let openApiObjectFixture: OpenApi3Dot2Object;
+  let pathFixture: string;
+  let methodFixture: string;
+
+  beforeAll(() => {
+    openApiObjectFixture = Symbol() as unknown as OpenApi3Dot2Object;
+    pathFixture = '/users';
+    methodFixture = 'get';
+
+    vitest
+      .mocked(escapeJsonPointerFragments)
+      .mockImplementation((...fragments: string[]) => fragments.join('/'));
+  });
+
+  afterAll(() => {
+    vitest.clearAllMocks();
+  });
+
+  describe('when called, and operation has query parameters only', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let result: Map<string, QueryParameterEntry>;
+
+    beforeAll(() => {
+      const parameterFixture: OpenApi3Dot2ParameterObject = {
+        in: 'query',
+        name: 'page',
+        required: true,
+        schema: { type: 'integer' },
+      };
+
+      const operationFixture: OpenApi3Dot2OperationObject = {
+        parameters: [parameterFixture],
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot2PathItemObject = {
+        get: operationFixture,
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getQueryParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should return a map with the query parameter', () => {
+      expect(result.size).toBe(1);
+      expect(result.has('page')).toBe(true);
+    });
+
+    it('should return entry with correct pointer prefix', () => {
+      const entry: QueryParameterEntry = result.get(
+        'page',
+      ) as QueryParameterEntry;
+
+      expect(entry.pointerPrefix).toBe(
+        `paths/${pathFixture}/${methodFixture}/parameters/0`,
+      );
+    });
+  });
+
+  describe('when called, and path item has query parameters only', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let result: Map<string, QueryParameterEntry>;
+
+    beforeAll(() => {
+      const parameterFixture: OpenApi3Dot2ParameterObject = {
+        in: 'query',
+        name: 'page',
+        schema: { type: 'integer' },
+      };
+
+      const operationFixture: OpenApi3Dot2OperationObject = {
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot2PathItemObject = {
+        get: operationFixture,
+        parameters: [parameterFixture],
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getQueryParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should return entry with path-item pointer prefix', () => {
+      const entry: QueryParameterEntry = result.get(
+        'page',
+      ) as QueryParameterEntry;
+
+      expect(entry.pointerPrefix).toBe(`paths/${pathFixture}/parameters/0`);
+    });
+  });
+
+  describe('when called, and parameter is a $ref reference', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let result: Map<string, QueryParameterEntry>;
+
+    beforeAll(() => {
+      const refFixture: OpenApi3Dot2ReferenceObject = {
+        $ref: '#/components/parameters/PageParam',
+      };
+
+      const resolvedParamFixture: OpenApi3Dot2ParameterObject = {
+        in: 'query',
+        name: 'page',
+        schema: { type: 'integer' },
+      };
+
+      const operationFixture: OpenApi3Dot2OperationObject = {
+        parameters: [refFixture],
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot2PathItemObject = {
+        get: operationFixture,
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest
+          .fn()
+          .mockReturnValueOnce(resolvedParamFixture),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getQueryParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should resolve the $ref and return the query parameter', () => {
+      expect(result.size).toBe(1);
+      expect(result.has('page')).toBe(true);
+    });
+
+    it('should call deepResolveReference', () => {
+      expect(
+        openApiResolverFixture.deepResolveReference,
+      ).toHaveBeenCalledExactlyOnceWith('#/components/parameters/PageParam');
+    });
+  });
+
+  describe('when called, and parameters include non-query params', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let result: Map<string, QueryParameterEntry>;
+
+    beforeAll(() => {
+      const pathParam: OpenApi3Dot2ParameterObject = {
+        in: 'path',
+        name: 'userId',
+        schema: { type: 'string' },
+      };
+
+      const queryParam: OpenApi3Dot2ParameterObject = {
+        in: 'query',
+        name: 'page',
+        schema: { type: 'integer' },
+      };
+
+      const operationFixture: OpenApi3Dot2OperationObject = {
+        parameters: [pathParam, queryParam],
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot2PathItemObject = {
+        get: operationFixture,
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getQueryParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should return only query parameters', () => {
+      expect(result.size).toBe(1);
+      expect(result.has('page')).toBe(true);
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getQueryParameterObjects.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getQueryParameterObjects.ts
@@ -1,0 +1,88 @@
+import { escapeJsonPointerFragments } from '@inversifyjs/json-schema-pointer';
+import {
+  type OpenApi3Dot2Object,
+  type OpenApi3Dot2OperationObject,
+  type OpenApi3Dot2ParameterObject,
+  type OpenApi3Dot2PathItemObject,
+  type OpenApi3Dot2ReferenceObject,
+} from '@inversifyjs/open-api-types/v3Dot2';
+
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
+import { getOperationObject } from './getOperationObject.js';
+import { getPathItemObject } from './getPathItemObject.js';
+
+export interface QueryParameterEntry {
+  parameter: OpenApi3Dot2ParameterObject;
+  pointerPrefix: string;
+}
+
+function isReferenceObject(
+  param: OpenApi3Dot2ParameterObject | OpenApi3Dot2ReferenceObject,
+): param is OpenApi3Dot2ReferenceObject {
+  return '$ref' in param;
+}
+
+export function getQueryParameterObjects(
+  openApiObject: OpenApi3Dot2Object,
+  openApiResolver: OpenApiResolver,
+  method: string,
+  path: string,
+): Map<string, QueryParameterEntry> {
+  const pathItemObject: OpenApi3Dot2PathItemObject = getPathItemObject(
+    openApiObject,
+    path,
+  );
+  const operationObject: OpenApi3Dot2OperationObject = getOperationObject(
+    openApiObject,
+    method,
+    path,
+  );
+
+  const result: Map<string, QueryParameterEntry> = new Map();
+
+  if (pathItemObject.parameters !== undefined) {
+    for (let i: number = 0; i < pathItemObject.parameters.length; i++) {
+      const raw: OpenApi3Dot2ParameterObject | OpenApi3Dot2ReferenceObject =
+        pathItemObject.parameters[i] as
+          | OpenApi3Dot2ParameterObject
+          | OpenApi3Dot2ReferenceObject;
+
+      const param: OpenApi3Dot2ParameterObject = isReferenceObject(raw)
+        ? (openApiResolver.deepResolveReference(
+            raw.$ref,
+          ) as unknown as OpenApi3Dot2ParameterObject)
+        : raw;
+
+      if (param.in === 'query') {
+        result.set(param.name, {
+          parameter: param,
+          pointerPrefix: `paths/${escapeJsonPointerFragments(path)}/parameters/${String(i)}`,
+        });
+      }
+    }
+  }
+
+  if (operationObject.parameters !== undefined) {
+    for (let i: number = 0; i < operationObject.parameters.length; i++) {
+      const raw: OpenApi3Dot2ParameterObject | OpenApi3Dot2ReferenceObject =
+        operationObject.parameters[i] as
+          | OpenApi3Dot2ParameterObject
+          | OpenApi3Dot2ReferenceObject;
+
+      const param: OpenApi3Dot2ParameterObject = isReferenceObject(raw)
+        ? (openApiResolver.deepResolveReference(
+            raw.$ref,
+          ) as unknown as OpenApi3Dot2ParameterObject)
+        : raw;
+
+      if (param.in === 'query') {
+        result.set(param.name, {
+          parameter: param,
+          pointerPrefix: `paths/${escapeJsonPointerFragments(path)}/${method}/parameters/${String(i)}`,
+        });
+      }
+    }
+  }
+
+  return result;
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleBodyValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleBodyValidation.spec.ts
@@ -106,6 +106,7 @@ describe(handleBodyValidation, () => {
           body: undefined,
           headers: undefined,
           params: undefined,
+          queries: undefined,
         };
 
         getEntryMock = vitest
@@ -218,6 +219,7 @@ describe(handleBodyValidation, () => {
           body: undefined,
           headers: undefined,
           params: undefined,
+          queries: undefined,
         };
 
         getEntryMock = vitest
@@ -313,6 +315,7 @@ describe(handleBodyValidation, () => {
           body: undefined,
           headers: undefined,
           params: undefined,
+          queries: undefined,
         };
 
         getEntryMock = vitest
@@ -417,6 +420,7 @@ describe(handleBodyValidation, () => {
           body: undefined,
           headers: undefined,
           params: undefined,
+          queries: undefined,
         };
 
         getEntryMock = vitest
@@ -522,6 +526,7 @@ describe(handleBodyValidation, () => {
           body: undefined,
           headers: undefined,
           params: undefined,
+          queries: undefined,
         };
 
         getEntryMock = vitest

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleHeaderValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleHeaderValidation.spec.ts
@@ -94,6 +94,7 @@ describe(handleHeaderValidation, () => {
         body: undefined,
         headers: undefined,
         params: undefined,
+        queries: undefined,
       };
 
       const getEntryMock: Mock<
@@ -169,6 +170,7 @@ describe(handleHeaderValidation, () => {
         body: undefined,
         headers: undefined,
         params: undefined,
+        queries: undefined,
       };
 
       const getEntryMock: Mock<
@@ -253,6 +255,7 @@ describe(handleHeaderValidation, () => {
         body: undefined,
         headers: undefined,
         params: undefined,
+        queries: undefined,
       };
 
       const getEntryMock: Mock<
@@ -339,6 +342,7 @@ describe(handleHeaderValidation, () => {
         body: undefined,
         headers: undefined,
         params: undefined,
+        queries: undefined,
       };
 
       const getEntryMock: Mock<
@@ -413,6 +417,7 @@ describe(handleHeaderValidation, () => {
           ],
         ]),
         params: undefined,
+        queries: undefined,
       };
 
       const getEntryMock: Mock<

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleQueryValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleQueryValidation.spec.ts
@@ -9,8 +9,8 @@ import {
   vitest,
 } from 'vitest';
 
-vitest.mock(import('../buildParamParse.js'));
-vitest.mock(import('./getParamParameterObjects.js'));
+vitest.mock(import('../buildQueryParse.js'));
+vitest.mock(import('./getQueryParameterObjects.js'));
 
 import { type OpenApi3Dot2Object } from '@inversifyjs/open-api-types/v3Dot2';
 import {
@@ -22,17 +22,17 @@ import { type ValidateFunction } from 'ajv';
 
 import { type OpenApiRouter } from '../../../router/services/OpenApiRouter.js';
 import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
-import { type ParamValidationInputParam } from '../../models/ParamValidationInputParam.js';
+import { type QueryValidationInputParam } from '../../models/QueryValidationInputParam.js';
 import { type ValidationCacheEntry } from '../../models/v3Dot2/ValidationCacheEntry.js';
 import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
-import { buildParamParse } from '../buildParamParse.js';
+import { buildQueryParse } from '../buildQueryParse.js';
 import {
-  getParamParameterObjects,
-  type ParamParameterEntry,
-} from './getParamParameterObjects.js';
-import { handleParamValidation } from './handleParamValidation.js';
+  getQueryParameterObjects,
+  type QueryParameterEntry,
+} from './getQueryParameterObjects.js';
+import { handleQueryValidation } from './handleQueryValidation.js';
 
-describe(handleParamValidation, () => {
+describe(handleQueryValidation, () => {
   let openApiObjectFixture: OpenApi3Dot2Object;
   let validationContextFixture: OpenApiValidationContext;
   let openApiResolverFixture: OpenApiResolver;
@@ -54,32 +54,81 @@ describe(handleParamValidation, () => {
     vitest.restoreAllMocks();
   });
 
-  describe('when called, and params are valid with string type', () => {
+  describe('when called, and route is not found', () => {
     let result: unknown;
 
     beforeAll(() => {
-      const paramParamMap: Map<string, ParamParameterEntry> = new Map([
+      vitest.mocked(openApiRouterMock.findRoute).mockReturnValueOnce(undefined);
+
+      const ajvMock: Mocked<Ajv> = {
+        getSchema: vitest.fn(),
+      } as Partial<Mocked<Ajv>> as Mocked<Ajv>;
+
+      const getEntryMock: Mock<
+        (path: string, method: string) => ValidationCacheEntry
+      > = vitest.fn();
+
+      const inputParam: QueryValidationInputParam = {
+        method: 'get',
+        path: '/unknown',
+        queries: {},
+        type: Symbol() as unknown as QueryValidationInputParam['type'],
+      };
+
+      try {
+        handleQueryValidation(
+          ajvMock,
+          openApiObjectFixture,
+          validationContextFixture,
+          inputParam,
+          getEntryMock,
+        );
+      } catch (error: unknown) {
+        result = error;
+      }
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should throw an InversifyValidationError', () => {
+      const expectedErrorProperties: Partial<InversifyValidationError> = {
+        kind: InversifyValidationErrorKind.validationFailed,
+        message: expect.stringContaining('GET /unknown'),
+      };
+
+      expect(result).toBeInstanceOf(InversifyValidationError);
+      expect(result).toMatchObject(expectedErrorProperties);
+    });
+  });
+
+  describe('when called, and queries are valid', () => {
+    let result: unknown;
+
+    beforeAll(() => {
+      const queryParamMap: Map<string, QueryParameterEntry> = new Map([
         [
-          'userId',
+          'page',
           {
             parameter: {
-              in: 'path',
-              name: 'userId',
-              required: true,
-              schema: { type: 'string' },
+              in: 'query',
+              name: 'page',
+              required: false,
+              schema: { type: 'integer' },
             },
-            pointerPrefix: 'paths/~1users~1{userId}/get/parameters/0',
+            pointerPrefix: 'paths/~1items/get/parameters/0',
           },
         ],
       ]);
 
       vitest
-        .mocked(getParamParameterObjects)
-        .mockReturnValueOnce(paramParamMap);
+        .mocked(getQueryParameterObjects)
+        .mockReturnValueOnce(queryParamMap);
 
-      const parseMock: Mock = vitest.fn().mockReturnValueOnce('abc-123');
+      const parseMock: Mock = vitest.fn().mockReturnValueOnce(10);
 
-      vitest.mocked(buildParamParse).mockReturnValueOnce(parseMock);
+      vitest.mocked(buildQueryParse).mockReturnValueOnce(parseMock);
 
       const validateMock: ValidateFunction = Object.assign(
         vitest.fn().mockReturnValueOnce(true),
@@ -101,18 +150,18 @@ describe(handleParamValidation, () => {
         (path: string, method: string) => ValidationCacheEntry
       > = vitest.fn().mockReturnValueOnce(validationCacheEntry);
 
-      const inputParam: ParamValidationInputParam = {
+      const inputParam: QueryValidationInputParam = {
         method: 'get',
-        params: { userId: 'abc-123' },
-        path: '/users/{userId}',
-        type: Symbol() as unknown as ParamValidationInputParam['type'],
+        path: '/items',
+        queries: { page: '1' },
+        type: Symbol() as unknown as QueryValidationInputParam['type'],
       };
 
       vitest
         .mocked(openApiRouterMock.findRoute)
         .mockReturnValueOnce(inputParam.path);
 
-      result = handleParamValidation(
+      result = handleQueryValidation(
         ajvMock,
         openApiObjectFixture,
         validationContextFixture,
@@ -125,37 +174,37 @@ describe(handleParamValidation, () => {
       vitest.clearAllMocks();
     });
 
-    it('should return validated params record', () => {
-      expect(result).toStrictEqual({ userId: 'abc-123' });
+    it('should return the computed queries record', () => {
+      expect(result).toStrictEqual({ page: 10 });
     });
   });
 
-  describe('when called, and required param is missing', () => {
+  describe('when called, and required query is missing', () => {
     let result: unknown;
 
     beforeAll(() => {
-      const paramParamMap: Map<string, ParamParameterEntry> = new Map([
+      const queryParamMap: Map<string, QueryParameterEntry> = new Map([
         [
-          'userId',
+          'search',
           {
             parameter: {
-              in: 'path',
-              name: 'userId',
+              in: 'query',
+              name: 'search',
               required: true,
               schema: { type: 'string' },
             },
-            pointerPrefix: 'paths/~1users~1{userId}/get/parameters/0',
+            pointerPrefix: 'paths/~1items/get/parameters/0',
           },
         ],
       ]);
 
       vitest
-        .mocked(getParamParameterObjects)
-        .mockReturnValueOnce(paramParamMap);
+        .mocked(getQueryParameterObjects)
+        .mockReturnValueOnce(queryParamMap);
 
       const parseMock: Mock = vitest.fn();
 
-      vitest.mocked(buildParamParse).mockReturnValueOnce(parseMock);
+      vitest.mocked(buildQueryParse).mockReturnValueOnce(parseMock);
 
       const validateMock: ValidateFunction = Object.assign(vitest.fn(), {
         errors: null,
@@ -177,19 +226,19 @@ describe(handleParamValidation, () => {
         (path: string, method: string) => ValidationCacheEntry
       > = vitest.fn().mockReturnValueOnce(validationCacheEntry);
 
-      const inputParam: ParamValidationInputParam = {
+      const inputParam: QueryValidationInputParam = {
         method: 'get',
-        params: {},
-        path: '/users/{userId}',
-        type: Symbol() as unknown as ParamValidationInputParam['type'],
+        path: '/items',
+        queries: {},
+        type: Symbol() as unknown as QueryValidationInputParam['type'],
       };
 
-      vitest
-        .mocked(openApiRouterMock.findRoute)
-        .mockReturnValueOnce(inputParam.path);
-
       try {
-        handleParamValidation(
+        vitest
+          .mocked(openApiRouterMock.findRoute)
+          .mockReturnValueOnce(inputParam.path);
+
+        handleQueryValidation(
           ajvMock,
           openApiObjectFixture,
           validationContextFixture,
@@ -208,7 +257,7 @@ describe(handleParamValidation, () => {
     it('should throw an InversifyValidationError', () => {
       const expectedErrorProperties: Partial<InversifyValidationError> = {
         kind: InversifyValidationErrorKind.validationFailed,
-        message: 'Missing required param: userId',
+        message: 'Missing required query: search',
       };
 
       expect(result).toBeInstanceOf(InversifyValidationError);
@@ -216,32 +265,32 @@ describe(handleParamValidation, () => {
     });
   });
 
-  describe('when called, and validation fails', () => {
+  describe('when called, and query validation fails', () => {
     let result: unknown;
 
     beforeAll(() => {
-      const paramParamMap: Map<string, ParamParameterEntry> = new Map([
+      const queryParamMap: Map<string, QueryParameterEntry> = new Map([
         [
-          'userId',
+          'limit',
           {
             parameter: {
-              in: 'path',
-              name: 'userId',
-              required: true,
+              in: 'query',
+              name: 'limit',
+              required: false,
               schema: { minimum: 1, type: 'integer' },
             },
-            pointerPrefix: 'paths/~1users~1{userId}/get/parameters/0',
+            pointerPrefix: 'paths/~1items/get/parameters/0',
           },
         ],
       ]);
 
       vitest
-        .mocked(getParamParameterObjects)
-        .mockReturnValueOnce(paramParamMap);
+        .mocked(getQueryParameterObjects)
+        .mockReturnValueOnce(queryParamMap);
 
-      const parseMock: Mock = vitest.fn().mockReturnValueOnce('not-valid');
+      const parseMock: Mock = vitest.fn().mockReturnValueOnce('not-a-number');
 
-      vitest.mocked(buildParamParse).mockReturnValueOnce(parseMock);
+      vitest.mocked(buildQueryParse).mockReturnValueOnce(parseMock);
 
       const validateMock: ValidateFunction = Object.assign(
         vitest.fn().mockReturnValueOnce(false),
@@ -274,19 +323,19 @@ describe(handleParamValidation, () => {
         (path: string, method: string) => ValidationCacheEntry
       > = vitest.fn().mockReturnValueOnce(validationCacheEntry);
 
-      const inputParam: ParamValidationInputParam = {
+      const inputParam: QueryValidationInputParam = {
         method: 'get',
-        params: { userId: 'not-valid' },
-        path: '/users/{userId}',
-        type: Symbol() as unknown as ParamValidationInputParam['type'],
+        path: '/items',
+        queries: { limit: 'not-a-number' },
+        type: Symbol() as unknown as QueryValidationInputParam['type'],
       };
 
-      vitest
-        .mocked(openApiRouterMock.findRoute)
-        .mockReturnValueOnce(inputParam.path);
-
       try {
-        handleParamValidation(
+        vitest
+          .mocked(openApiRouterMock.findRoute)
+          .mockReturnValueOnce(inputParam.path);
+
+        handleQueryValidation(
           ajvMock,
           openApiObjectFixture,
           validationContextFixture,
@@ -305,7 +354,7 @@ describe(handleParamValidation, () => {
     it('should throw an InversifyValidationError', () => {
       const expectedErrorProperties: Partial<InversifyValidationError> = {
         kind: InversifyValidationErrorKind.validationFailed,
-        message: expect.stringContaining('userId'),
+        message: expect.stringContaining('limit'),
       };
 
       expect(result).toBeInstanceOf(InversifyValidationError);
@@ -313,12 +362,12 @@ describe(handleParamValidation, () => {
     });
   });
 
-  describe('when called, and cached params are reused', () => {
+  describe('when called, and cached queries are reused', () => {
     let result: unknown;
     let ajvMock: Mocked<Ajv>;
 
     beforeAll(() => {
-      const parseMock: Mock = vitest.fn().mockReturnValueOnce('test');
+      const parseMock: Mock = vitest.fn().mockReturnValueOnce('foo');
 
       const validateMock: ValidateFunction = Object.assign(
         vitest.fn().mockReturnValueOnce(true),
@@ -332,34 +381,35 @@ describe(handleParamValidation, () => {
       const validationCacheEntry: ValidationCacheEntry = {
         body: undefined,
         headers: undefined,
-        params: new Map([
+        params: undefined,
+        queries: new Map([
           [
-            'userId',
+            'search',
             {
               parse: parseMock,
+              required: false,
               validate: validateMock,
             },
           ],
         ]),
-        queries: undefined,
       };
 
       const getEntryMock: Mock<
         (path: string, method: string) => ValidationCacheEntry
       > = vitest.fn().mockReturnValueOnce(validationCacheEntry);
 
-      const inputParam: ParamValidationInputParam = {
+      const inputParam: QueryValidationInputParam = {
         method: 'get',
-        params: { userId: 'test' },
-        path: '/users/{userId}',
-        type: Symbol() as unknown as ParamValidationInputParam['type'],
+        path: '/items',
+        queries: { search: 'foo' },
+        type: Symbol() as unknown as QueryValidationInputParam['type'],
       };
 
       vitest
         .mocked(openApiRouterMock.findRoute)
         .mockReturnValueOnce(inputParam.path);
 
-      result = handleParamValidation(
+      result = handleQueryValidation(
         ajvMock,
         openApiObjectFixture,
         validationContextFixture,
@@ -376,12 +426,12 @@ describe(handleParamValidation, () => {
       expect(ajvMock.getSchema).not.toHaveBeenCalled();
     });
 
-    it('should not call getParamParameterObjects()', () => {
-      expect(getParamParameterObjects).not.toHaveBeenCalled();
+    it('should not call getQueryParameterObjects()', () => {
+      expect(getQueryParameterObjects).not.toHaveBeenCalled();
     });
 
-    it('should return validated params', () => {
-      expect(result).toStrictEqual({ userId: 'test' });
+    it('should return the computed queries', () => {
+      expect(result).toStrictEqual({ search: 'foo' });
     });
   });
 });

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleQueryValidation.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleQueryValidation.ts
@@ -1,0 +1,155 @@
+import { type OpenApi3Dot2Object } from '@inversifyjs/open-api-types/v3Dot2';
+import {
+  InversifyValidationError,
+  InversifyValidationErrorKind,
+} from '@inversifyjs/validation-common';
+import type Ajv from 'ajv';
+import { type ErrorObject, type ValidateFunction } from 'ajv';
+
+import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
+import { type QueryValidationInputParam } from '../../models/QueryValidationInputParam.js';
+import { SCHEMA_ID } from '../../models/v3Dot2/schemaId.js';
+import {
+  type ValidationCacheEntry,
+  type ValidationCacheEntryQuery,
+} from '../../models/v3Dot2/ValidationCacheEntry.js';
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
+import { buildQueryParse } from '../buildQueryParse.js';
+import {
+  getQueryParameterObjects,
+  type QueryParameterEntry,
+} from './getQueryParameterObjects.js';
+
+function getQueryParameterEntryMap(
+  ajv: Ajv,
+  openApiObject: OpenApi3Dot2Object,
+  openApiResolver: OpenApiResolver,
+  method: string,
+  route: string,
+): Map<string, ValidationCacheEntryQuery> {
+  const queryParameterEntryMap: Map<string, ValidationCacheEntryQuery> =
+    new Map();
+
+  const queryParams: Map<string, QueryParameterEntry> =
+    getQueryParameterObjects(openApiObject, openApiResolver, method, route);
+
+  for (const [queryName, queryParam] of queryParams) {
+    const parse: (value: unknown) => unknown = buildQueryParse(
+      openApiResolver,
+      queryParam.parameter.schema,
+      `${SCHEMA_ID}#/${queryParam.pointerPrefix}/schema`,
+    );
+
+    const ajvSchemaPointer: string = `${SCHEMA_ID}#/${queryParam.pointerPrefix}/schema`;
+
+    const validate: ValidateFunction | undefined =
+      ajv.getSchema(ajvSchemaPointer);
+
+    if (validate === undefined) {
+      throw new InversifyValidationError(
+        InversifyValidationErrorKind.validationFailed,
+        `Unable to find schema for pointer: ${ajvSchemaPointer}`,
+      );
+    }
+
+    queryParameterEntryMap.set(queryName, {
+      parse,
+      required: queryParam.parameter.required ?? false,
+      validate: validate,
+    });
+  }
+
+  return queryParameterEntryMap;
+}
+
+export function handleQueryValidation(
+  ajv: Ajv,
+  openApiObject: OpenApi3Dot2Object,
+  validationContext: OpenApiValidationContext,
+  inputParam: QueryValidationInputParam,
+  getEntry: (path: string, method: string) => ValidationCacheEntry,
+): unknown {
+  const route: string | undefined = validationContext.router.findRoute(
+    inputParam.method,
+    inputParam.path,
+  );
+
+  if (route === undefined) {
+    throw new InversifyValidationError(
+      InversifyValidationErrorKind.validationFailed,
+      `Unable to find route for operation: ${inputParam.method.toUpperCase()} ${inputParam.path}`,
+    );
+  }
+
+  const validationCacheEntry: ValidationCacheEntry = getEntry(
+    route,
+    inputParam.method,
+  );
+
+  if (validationCacheEntry.queries === undefined) {
+    validationCacheEntry.queries = getQueryParameterEntryMap(
+      ajv,
+      openApiObject,
+      validationContext.resolver,
+      inputParam.method,
+      route,
+    );
+  }
+
+  const computedQueries: Record<string, unknown> = {
+    ...inputParam.queries,
+  };
+
+  let valid: boolean = true;
+  const queryToErrorObject: Record<string, ErrorObject[]> = {};
+
+  for (const [
+    queryName,
+    validationCacheEntryQuery,
+  ] of validationCacheEntry.queries) {
+    if (!(queryName in inputParam.queries)) {
+      if (validationCacheEntryQuery.required) {
+        throw new InversifyValidationError(
+          InversifyValidationErrorKind.validationFailed,
+          `Missing required query: ${queryName}`,
+        );
+      }
+
+      continue;
+    }
+
+    const queryValue: unknown = inputParam.queries[queryName];
+
+    computedQueries[queryName] = validationCacheEntryQuery.parse(queryValue);
+
+    const isValidQuery: boolean = validationCacheEntryQuery.validate(
+      computedQueries[queryName],
+    );
+
+    if (!isValidQuery) {
+      valid = false;
+
+      queryToErrorObject[queryName] = [
+        ...(validationCacheEntryQuery.validate.errors ?? []),
+      ];
+    }
+  }
+
+  if (!valid) {
+    throw new InversifyValidationError(
+      InversifyValidationErrorKind.validationFailed,
+      Object.entries(queryToErrorObject)
+        .map(([queryName, errors]: [string, ErrorObject[]]): string =>
+          errors
+            .map(
+              (error: ErrorObject): string =>
+                `[query: ${queryName}, schemaPath: ${error.schemaPath}, instancePath: ${error.instancePath}]: "${error.message ?? '-'}"`,
+            )
+            .join('\n'),
+        )
+        .join('\n'),
+    );
+  }
+
+  return computedQueries;
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/models/QueryValidationInputParam.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/models/QueryValidationInputParam.ts
@@ -1,0 +1,8 @@
+import { type validatedInputParamQueryType } from './validatedInputParamTypes.js';
+
+export interface QueryValidationInputParam {
+  queries: Record<string, unknown>;
+  method: string;
+  path: string;
+  type: typeof validatedInputParamQueryType;
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/models/ValidatedDecoratorResult.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/models/ValidatedDecoratorResult.ts
@@ -1,8 +1,10 @@
 import { type BodyValidationInputParam } from './BodyValidationInputParam.js';
 import { type HeaderValidationInputParam } from './HeaderValidationInputParam.js';
 import { type ParamValidationInputParam } from './ParamValidationInputParam.js';
+import { type QueryValidationInputParam } from './QueryValidationInputParam.js';
 
 export type ValidationInputParam =
   | BodyValidationInputParam<unknown>
   | HeaderValidationInputParam
-  | ParamValidationInputParam;
+  | ParamValidationInputParam
+  | QueryValidationInputParam;

--- a/packages/framework/validation/libraries/openapi/src/validation/models/v3Dot1/ValidationCacheEntry.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/models/v3Dot1/ValidationCacheEntry.ts
@@ -16,8 +16,15 @@ export interface ValidationCacheEntryParam {
   validate: ValidateFunction;
 }
 
+export interface ValidationCacheEntryQuery {
+  parse: (value: unknown) => unknown;
+  required: boolean;
+  validate: ValidateFunction;
+}
+
 export interface ValidationCacheEntry {
   body: ValidationCacheEntryBody | undefined;
   headers: Map<string, ValidationCacheEntryHeader> | undefined;
   params: Map<string, ValidationCacheEntryParam> | undefined;
+  queries: Map<string, ValidationCacheEntryQuery> | undefined;
 }

--- a/packages/framework/validation/libraries/openapi/src/validation/models/v3Dot2/ValidationCacheEntry.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/models/v3Dot2/ValidationCacheEntry.ts
@@ -16,8 +16,15 @@ export interface ValidationCacheEntryParam {
   validate: ValidateFunction;
 }
 
+export interface ValidationCacheEntryQuery {
+  parse: (value: unknown) => unknown;
+  required: boolean;
+  validate: ValidateFunction;
+}
+
 export interface ValidationCacheEntry {
   body: ValidationCacheEntryBody | undefined;
   headers: Map<string, ValidationCacheEntryHeader> | undefined;
   params: Map<string, ValidationCacheEntryParam> | undefined;
+  queries: Map<string, ValidationCacheEntryQuery> | undefined;
 }

--- a/packages/framework/validation/libraries/openapi/src/validation/models/validatedInputParamTypes.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/models/validatedInputParamTypes.ts
@@ -9,3 +9,7 @@ export const validatedInputParamHeaderType: unique symbol = Symbol.for(
 export const validatedInputParamParamType: unique symbol = Symbol.for(
   '@inversifyjs/open-api-validation/validatedInputParamParamType',
 );
+
+export const validatedInputParamQueryType: unique symbol = Symbol.for(
+  '@inversifyjs/open-api-validation/validatedInputParamQueryType',
+);

--- a/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot1/OpenApiValidationPipe.int.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot1/OpenApiValidationPipe.int.spec.ts
@@ -35,6 +35,7 @@ import { Container, type Newable } from 'inversify';
 import { ValidatedBody } from '../../../metadata/decorators/ValidatedBody.js';
 import { ValidatedHeaders } from '../../../metadata/decorators/ValidatedHeaders.js';
 import { ValidatedParams } from '../../../metadata/decorators/ValidatedParams.js';
+import { ValidatedQuery } from '../../../metadata/decorators/ValidatedQuery.js';
 import { OpenApiValidationPipe } from './OpenApiValidationPipe.js';
 
 interface Server {
@@ -905,6 +906,379 @@ describe(OpenApiValidationPipe, () => {
             expect(response.status).toBe(400);
             await expect(response.json()).resolves.toStrictEqual({
               message: expect.stringContaining('userId'),
+            });
+          });
+        });
+      });
+
+      describe('having an OpenApiValidationPipe (v3.1) in an HTTP server with validated query params', () => {
+        @Controller('/products')
+        class ProductController {
+          @OasParameter({
+            in: 'query',
+            name: 'search',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          })
+          @OasParameter({
+            in: 'query',
+            name: 'limit',
+            required: false,
+            schema: {
+              type: 'integer',
+            },
+          })
+          @Get()
+          public async getProducts(
+            @ValidatedQuery() _query: Record<string, unknown>,
+          ): Promise<{ ok: boolean }> {
+            return { ok: true };
+          }
+        }
+
+        let server: Server;
+
+        beforeAll(async () => {
+          const container: Container = new Container();
+
+          container.bind(ValidationErrorFilter).toSelf().inSingletonScope();
+          container.bind(ProductController).toSelf().inSingletonScope();
+
+          const openApiObject: OpenApi3Dot1Object = {
+            info: { title: 'Test API', version: '1.0.0' },
+            openapi: '3.1.0',
+          };
+
+          const swaggerProvider: SwaggerUiProvider = new SwaggerUiProvider({
+            api: {
+              openApiObject,
+              path: '/docs',
+            },
+          });
+
+          swaggerProvider.provide(container);
+
+          server = await buildServer(
+            container,
+            [ValidationErrorFilter],
+            [new OpenApiValidationPipe(swaggerProvider.openApiObject)],
+          );
+        });
+
+        afterAll(async () => {
+          await server.shutdown();
+        });
+
+        describe('when a GET /products request is made with valid query params', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/products?search=widget&limit=10`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(200);
+            expect(response.headers.get('content-type')).toStrictEqual(
+              expect.stringContaining('application/json'),
+            );
+            await expect(response.json()).resolves.toStrictEqual({ ok: true });
+          });
+        });
+
+        describe('when a GET /products request is made without the required query param', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/products`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(400);
+            await expect(response.json()).resolves.toStrictEqual({
+              message: expect.stringContaining('search'),
+            });
+          });
+        });
+
+        describe('when a GET /products request is made with an invalid integer query param', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/products?search=widget&limit=not-a-number`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(400);
+            await expect(response.json()).resolves.toStrictEqual({
+              message: expect.stringContaining('limit'),
+            });
+          });
+        });
+      });
+
+      describe('having an OpenApiValidationPipe (v3.1) in an HTTP server with an array of number query param', () => {
+        @Controller('/numbers')
+        class NumberController {
+          @OasParameter({
+            in: 'query',
+            name: 'ids',
+            required: true,
+            schema: { items: { type: 'number' }, type: 'array' },
+          })
+          @Get()
+          public async getNumbers(
+            @ValidatedQuery() _query: Record<string, unknown>,
+          ): Promise<{ ok: boolean }> {
+            return { ok: true };
+          }
+        }
+
+        let server: Server;
+
+        beforeAll(async () => {
+          const container: Container = new Container();
+
+          container.bind(ValidationErrorFilter).toSelf().inSingletonScope();
+          container.bind(NumberController).toSelf().inSingletonScope();
+
+          const openApiObject: OpenApi3Dot1Object = {
+            info: { title: 'Test API', version: '1.0.0' },
+            openapi: '3.1.0',
+          };
+
+          const swaggerProvider: SwaggerUiProvider = new SwaggerUiProvider({
+            api: {
+              openApiObject,
+              path: '/docs',
+            },
+          });
+
+          swaggerProvider.provide(container);
+
+          server = await buildServer(
+            container,
+            [ValidationErrorFilter],
+            [new OpenApiValidationPipe(swaggerProvider.openApiObject)],
+          );
+        });
+
+        afterAll(async () => {
+          await server.shutdown();
+        });
+
+        describe('when a GET /numbers request is made with a valid array of number query param', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/numbers?ids=1&ids=2&ids=3`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(200);
+            expect(response.headers.get('content-type')).toStrictEqual(
+              expect.stringContaining('application/json'),
+            );
+            await expect(response.json()).resolves.toStrictEqual({ ok: true });
+          });
+        });
+
+        describe('when a GET /numbers request is made with an invalid array of number query param', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/numbers?ids=1&ids=not-a-number&ids=3`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(400);
+            await expect(response.json()).resolves.toStrictEqual({
+              message: expect.stringContaining('ids'),
+            });
+          });
+        });
+      });
+
+      describe('having an OpenApiValidationPipe (v3.1) in an HTTP server with an array or number query params', () => {
+        @Controller('/products')
+        class ProductController {
+          @OasParameter({
+            in: 'query',
+            name: 'search',
+            required: true,
+            schema: {
+              anyOf: [
+                {
+                  type: 'string',
+                },
+                {
+                  items: { type: 'string' },
+                  type: 'array',
+                },
+              ],
+            },
+          })
+          @OasParameter({
+            in: 'query',
+            name: 'limit',
+            required: false,
+            schema: {
+              anyOf: [
+                {
+                  type: 'integer',
+                },
+                {
+                  items: { type: 'integer' },
+                  type: 'array',
+                },
+              ],
+            },
+          })
+          @Get()
+          public async getProducts(
+            @ValidatedQuery() _query: Record<string, unknown>,
+          ): Promise<{ ok: boolean }> {
+            return { ok: true };
+          }
+        }
+
+        let server: Server;
+
+        beforeAll(async () => {
+          const container: Container = new Container();
+
+          container.bind(ValidationErrorFilter).toSelf().inSingletonScope();
+          container.bind(ProductController).toSelf().inSingletonScope();
+
+          const openApiObject: OpenApi3Dot1Object = {
+            info: { title: 'Test API', version: '1.0.0' },
+            openapi: '3.1.0',
+          };
+
+          const swaggerProvider: SwaggerUiProvider = new SwaggerUiProvider({
+            api: {
+              openApiObject,
+              path: '/docs',
+            },
+          });
+
+          swaggerProvider.provide(container);
+
+          server = await buildServer(
+            container,
+            [ValidationErrorFilter],
+            [new OpenApiValidationPipe(swaggerProvider.openApiObject)],
+          );
+        });
+
+        afterAll(async () => {
+          await server.shutdown();
+        });
+
+        describe('when a GET /products request is made with valid query params', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/products?search=widget&limit=10`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(200);
+            expect(response.headers.get('content-type')).toStrictEqual(
+              expect.stringContaining('application/json'),
+            );
+            await expect(response.json()).resolves.toStrictEqual({ ok: true });
+          });
+        });
+
+        describe('when a GET /products request is made with valid array query params', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/products?search=widget&search=widget2&limit=10&limit=20`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(200);
+            expect(response.headers.get('content-type')).toStrictEqual(
+              expect.stringContaining('application/json'),
+            );
+            await expect(response.json()).resolves.toStrictEqual({ ok: true });
+          });
+        });
+
+        describe('when a GET /products request is made without the required query param', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/products`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(400);
+            await expect(response.json()).resolves.toStrictEqual({
+              message: expect.stringContaining('search'),
+            });
+          });
+        });
+
+        describe('when a GET /products request is made with an invalid integer query param', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/products?search=widget&limit=not-a-number`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(400);
+            await expect(response.json()).resolves.toStrictEqual({
+              message: expect.stringContaining('limit'),
             });
           });
         });

--- a/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot1/OpenApiValidationPipe.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot1/OpenApiValidationPipe.ts
@@ -14,6 +14,7 @@ import { buildCompositeValidationHandler } from '../../calculations/buildComposi
 import { handleBodyValidation } from '../../calculations/v3Dot1/handleBodyValidation.js';
 import { handleHeaderValidation } from '../../calculations/v3Dot1/handleHeaderValidation.js';
 import { handleParamValidation } from '../../calculations/v3Dot1/handleParamValidation.js';
+import { handleQueryValidation } from '../../calculations/v3Dot1/handleQueryValidation.js';
 import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { SCHEMA_ID } from '../../models/v3Dot1/schemaId.js';
 import { type ValidationCacheEntry } from '../../models/v3Dot1/ValidationCacheEntry.js';
@@ -21,23 +22,25 @@ import {
   validatedInputParamBodyType,
   validatedInputParamHeaderType,
   validatedInputParamParamType,
+  validatedInputParamQueryType,
 } from '../../models/validatedInputParamTypes.js';
 import { DefaultOpenApiResolver } from '../../services/v3Dot1/DefaultOpenApiResolver.js';
 import { ValidationCache } from '../../services/v3Dot1/ValidationCache.js';
 
 const handler: (
-  ajv: Ajv,
   openApiObject: OpenApi3Dot1Object,
   validationContext: OpenApiValidationContext,
   inputParam: unknown,
+  getAjv: (coerceTypes: boolean) => Ajv,
   getEntry: (path: string, method: string) => ValidationCacheEntry,
 ) => unknown = buildCompositeValidationHandler<
   OpenApi3Dot1Object,
   ValidationCacheEntry
 >({
-  [validatedInputParamBodyType]: handleBodyValidation,
-  [validatedInputParamHeaderType]: handleHeaderValidation,
-  [validatedInputParamParamType]: handleParamValidation,
+  [validatedInputParamBodyType]: [handleBodyValidation, false],
+  [validatedInputParamHeaderType]: [handleHeaderValidation, false],
+  [validatedInputParamParamType]: [handleParamValidation, false],
+  [validatedInputParamQueryType]: [handleQueryValidation, true],
 });
 
 export class OpenApiValidationPipe implements Pipe {
@@ -46,6 +49,7 @@ export class OpenApiValidationPipe implements Pipe {
   readonly #validationContext: OpenApiValidationContext;
 
   #ajv: Ajv | undefined;
+  #ajvWithCoercions: Ajv | undefined;
 
   constructor(openApiObject: OpenApi3Dot1Object) {
     this.#openApiObject = openApiObject;
@@ -55,6 +59,7 @@ export class OpenApiValidationPipe implements Pipe {
     };
     this.#validationCache = new ValidationCache();
     this.#ajv = undefined;
+    this.#ajvWithCoercions = undefined;
   }
 
   public async execute(
@@ -92,13 +97,12 @@ export class OpenApiValidationPipe implements Pipe {
       return input;
     }
 
-    const ajv: Ajv = this.#getOrInitAjv();
-
     return handler(
-      ajv,
       this.#openApiObject,
       this.#validationContext,
       input,
+      (coerceTypes: boolean) =>
+        coerceTypes ? this.#getOrInitAjvWithCoercions() : this.#getOrInitAjv(),
       this.#validationCache.getOrCreate.bind(this.#validationCache),
     );
   }
@@ -111,5 +115,19 @@ export class OpenApiValidationPipe implements Pipe {
     }
 
     return this.#ajv;
+  }
+
+  #getOrInitAjvWithCoercions(): Ajv {
+    if (this.#ajvWithCoercions === undefined) {
+      this.#ajvWithCoercions = new Ajv({
+        allErrors: true,
+        coerceTypes: true,
+        strict: false,
+      });
+      addFormats(this.#ajvWithCoercions);
+      this.#ajvWithCoercions.addSchema(this.#openApiObject, SCHEMA_ID);
+    }
+
+    return this.#ajvWithCoercions;
   }
 }

--- a/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot2/OpenApiValidationPipe.int.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot2/OpenApiValidationPipe.int.spec.ts
@@ -35,6 +35,7 @@ import { Container, type Newable } from 'inversify';
 import { ValidatedBody } from '../../../metadata/decorators/ValidatedBody.js';
 import { ValidatedHeaders } from '../../../metadata/decorators/ValidatedHeaders.js';
 import { ValidatedParams } from '../../../metadata/decorators/ValidatedParams.js';
+import { ValidatedQuery } from '../../../metadata/decorators/ValidatedQuery.js';
 import { OpenApiValidationPipe } from './OpenApiValidationPipe.js';
 
 interface Server {
@@ -905,6 +906,379 @@ describe(OpenApiValidationPipe, () => {
             expect(response.status).toBe(400);
             await expect(response.json()).resolves.toStrictEqual({
               message: expect.stringContaining('userId'),
+            });
+          });
+        });
+      });
+
+      describe('having an OpenApiValidationPipe (v3.2) in an HTTP server with validated query params', () => {
+        @Controller('/products')
+        class ProductController {
+          @OasParameter({
+            in: 'query',
+            name: 'search',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          })
+          @OasParameter({
+            in: 'query',
+            name: 'limit',
+            required: false,
+            schema: {
+              type: 'integer',
+            },
+          })
+          @Get()
+          public async getProducts(
+            @ValidatedQuery() _query: Record<string, unknown>,
+          ): Promise<{ ok: boolean }> {
+            return { ok: true };
+          }
+        }
+
+        let server: Server;
+
+        beforeAll(async () => {
+          const container: Container = new Container();
+
+          container.bind(ValidationErrorFilter).toSelf().inSingletonScope();
+          container.bind(ProductController).toSelf().inSingletonScope();
+
+          const openApiObject: OpenApi3Dot2Object = {
+            info: { title: 'Test API', version: '1.0.0' },
+            openapi: '3.2.0',
+          };
+
+          const swaggerProvider: SwaggerUiProvider = new SwaggerUiProvider({
+            api: {
+              openApiObject,
+              path: '/docs',
+            },
+          });
+
+          swaggerProvider.provide(container);
+
+          server = await buildServer(
+            container,
+            [ValidationErrorFilter],
+            [new OpenApiValidationPipe(swaggerProvider.openApiObject)],
+          );
+        });
+
+        afterAll(async () => {
+          await server.shutdown();
+        });
+
+        describe('when a GET /products request is made with valid query params', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/products?search=widget&limit=10`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(200);
+            expect(response.headers.get('content-type')).toStrictEqual(
+              expect.stringContaining('application/json'),
+            );
+            await expect(response.json()).resolves.toStrictEqual({ ok: true });
+          });
+        });
+
+        describe('when a GET /products request is made without the required query param', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/products`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(400);
+            await expect(response.json()).resolves.toStrictEqual({
+              message: expect.stringContaining('search'),
+            });
+          });
+        });
+
+        describe('when a GET /products request is made with an invalid integer query param', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/products?search=widget&limit=not-a-number`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(400);
+            await expect(response.json()).resolves.toStrictEqual({
+              message: expect.stringContaining('limit'),
+            });
+          });
+        });
+      });
+
+      describe('having an OpenApiValidationPipe (v3.2) in an HTTP server with an array of number query param', () => {
+        @Controller('/numbers')
+        class NumberController {
+          @OasParameter({
+            in: 'query',
+            name: 'ids',
+            required: true,
+            schema: { items: { type: 'number' }, type: 'array' },
+          })
+          @Get()
+          public async getNumbers(
+            @ValidatedQuery() _query: Record<string, unknown>,
+          ): Promise<{ ok: boolean }> {
+            return { ok: true };
+          }
+        }
+
+        let server: Server;
+
+        beforeAll(async () => {
+          const container: Container = new Container();
+
+          container.bind(ValidationErrorFilter).toSelf().inSingletonScope();
+          container.bind(NumberController).toSelf().inSingletonScope();
+
+          const openApiObject: OpenApi3Dot2Object = {
+            info: { title: 'Test API', version: '1.0.0' },
+            openapi: '3.2.0',
+          };
+
+          const swaggerProvider: SwaggerUiProvider = new SwaggerUiProvider({
+            api: {
+              openApiObject,
+              path: '/docs',
+            },
+          });
+
+          swaggerProvider.provide(container);
+
+          server = await buildServer(
+            container,
+            [ValidationErrorFilter],
+            [new OpenApiValidationPipe(swaggerProvider.openApiObject)],
+          );
+        });
+
+        afterAll(async () => {
+          await server.shutdown();
+        });
+
+        describe('when a GET /numbers request is made with a valid array of number query param', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/numbers?ids=1&ids=2&ids=3`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(200);
+            expect(response.headers.get('content-type')).toStrictEqual(
+              expect.stringContaining('application/json'),
+            );
+            await expect(response.json()).resolves.toStrictEqual({ ok: true });
+          });
+        });
+
+        describe('when a GET /numbers request is made with an invalid array of number query param', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/numbers?ids=1&ids=not-a-number&ids=3`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(400);
+            await expect(response.json()).resolves.toStrictEqual({
+              message: expect.stringContaining('ids'),
+            });
+          });
+        });
+      });
+
+      describe('having an OpenApiValidationPipe (v3.2) in an HTTP server with an array or number query params', () => {
+        @Controller('/products')
+        class ProductController {
+          @OasParameter({
+            in: 'query',
+            name: 'search',
+            required: true,
+            schema: {
+              anyOf: [
+                {
+                  type: 'string',
+                },
+                {
+                  items: { type: 'string' },
+                  type: 'array',
+                },
+              ],
+            },
+          })
+          @OasParameter({
+            in: 'query',
+            name: 'limit',
+            required: false,
+            schema: {
+              anyOf: [
+                {
+                  type: 'integer',
+                },
+                {
+                  items: { type: 'integer' },
+                  type: 'array',
+                },
+              ],
+            },
+          })
+          @Get()
+          public async getProducts(
+            @ValidatedQuery() _query: Record<string, unknown>,
+          ): Promise<{ ok: boolean }> {
+            return { ok: true };
+          }
+        }
+
+        let server: Server;
+
+        beforeAll(async () => {
+          const container: Container = new Container();
+
+          container.bind(ValidationErrorFilter).toSelf().inSingletonScope();
+          container.bind(ProductController).toSelf().inSingletonScope();
+
+          const openApiObject: OpenApi3Dot2Object = {
+            info: { title: 'Test API', version: '1.0.0' },
+            openapi: '3.2.0',
+          };
+
+          const swaggerProvider: SwaggerUiProvider = new SwaggerUiProvider({
+            api: {
+              openApiObject,
+              path: '/docs',
+            },
+          });
+
+          swaggerProvider.provide(container);
+
+          server = await buildServer(
+            container,
+            [ValidationErrorFilter],
+            [new OpenApiValidationPipe(swaggerProvider.openApiObject)],
+          );
+        });
+
+        afterAll(async () => {
+          await server.shutdown();
+        });
+
+        describe('when a GET /products request is made with valid query params', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/products?search=widget&limit=10`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(200);
+            expect(response.headers.get('content-type')).toStrictEqual(
+              expect.stringContaining('application/json'),
+            );
+            await expect(response.json()).resolves.toStrictEqual({ ok: true });
+          });
+        });
+
+        describe('when a GET /products request is made with valid array query params', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/products?search=widget&search=widget2&limit=10&limit=20`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(200);
+            expect(response.headers.get('content-type')).toStrictEqual(
+              expect.stringContaining('application/json'),
+            );
+            await expect(response.json()).resolves.toStrictEqual({ ok: true });
+          });
+        });
+
+        describe('when a GET /products request is made without the required query param', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/products`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(400);
+            await expect(response.json()).resolves.toStrictEqual({
+              message: expect.stringContaining('search'),
+            });
+          });
+        });
+
+        describe('when a GET /products request is made with an invalid integer query param', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/products?search=widget&limit=not-a-number`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(400);
+            await expect(response.json()).resolves.toStrictEqual({
+              message: expect.stringContaining('limit'),
             });
           });
         });

--- a/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot2/OpenApiValidationPipe.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot2/OpenApiValidationPipe.ts
@@ -14,6 +14,7 @@ import { buildCompositeValidationHandler } from '../../calculations/buildComposi
 import { handleBodyValidation } from '../../calculations/v3Dot2/handleBodyValidation.js';
 import { handleHeaderValidation } from '../../calculations/v3Dot2/handleHeaderValidation.js';
 import { handleParamValidation } from '../../calculations/v3Dot2/handleParamValidation.js';
+import { handleQueryValidation } from '../../calculations/v3Dot2/handleQueryValidation.js';
 import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { SCHEMA_ID } from '../../models/v3Dot2/schemaId.js';
 import { type ValidationCacheEntry } from '../../models/v3Dot2/ValidationCacheEntry.js';
@@ -21,23 +22,25 @@ import {
   validatedInputParamBodyType,
   validatedInputParamHeaderType,
   validatedInputParamParamType,
+  validatedInputParamQueryType,
 } from '../../models/validatedInputParamTypes.js';
 import { DefaultOpenApiResolver } from '../../services/v3Dot2/DefaultOpenApiResolver.js';
 import { ValidationCache } from '../../services/v3Dot2/ValidationCache.js';
 
 const handler: (
-  ajv: Ajv,
   openApiObject: OpenApi3Dot2Object,
   validationContext: OpenApiValidationContext,
   inputParam: unknown,
+  getAjv: (coerceTypes: boolean) => Ajv,
   getEntry: (path: string, method: string) => ValidationCacheEntry,
 ) => unknown = buildCompositeValidationHandler<
   OpenApi3Dot2Object,
   ValidationCacheEntry
 >({
-  [validatedInputParamBodyType]: handleBodyValidation,
-  [validatedInputParamHeaderType]: handleHeaderValidation,
-  [validatedInputParamParamType]: handleParamValidation,
+  [validatedInputParamBodyType]: [handleBodyValidation, false],
+  [validatedInputParamHeaderType]: [handleHeaderValidation, false],
+  [validatedInputParamParamType]: [handleParamValidation, false],
+  [validatedInputParamQueryType]: [handleQueryValidation, true],
 });
 
 export class OpenApiValidationPipe implements Pipe {
@@ -46,6 +49,7 @@ export class OpenApiValidationPipe implements Pipe {
   readonly #validationContext: OpenApiValidationContext;
 
   #ajv: Ajv | undefined;
+  #ajvWithCoercions: Ajv | undefined;
 
   constructor(openApiObject: OpenApi3Dot2Object) {
     this.#openApiObject = openApiObject;
@@ -55,6 +59,7 @@ export class OpenApiValidationPipe implements Pipe {
     };
     this.#validationCache = new ValidationCache();
     this.#ajv = undefined;
+    this.#ajvWithCoercions = undefined;
   }
 
   public async execute(
@@ -92,13 +97,12 @@ export class OpenApiValidationPipe implements Pipe {
       return input;
     }
 
-    const ajv: Ajv = this.#getOrInitAjv();
-
     return handler(
-      ajv,
       this.#openApiObject,
       this.#validationContext,
       input,
+      (coerceTypes: boolean) =>
+        coerceTypes ? this.#getOrInitAjvWithCoercions() : this.#getOrInitAjv(),
       this.#validationCache.getOrCreate.bind(this.#validationCache),
     );
   }
@@ -111,5 +115,19 @@ export class OpenApiValidationPipe implements Pipe {
     }
 
     return this.#ajv;
+  }
+
+  #getOrInitAjvWithCoercions(): Ajv {
+    if (this.#ajvWithCoercions === undefined) {
+      this.#ajvWithCoercions = new Ajv({
+        allErrors: true,
+        coerceTypes: true,
+        strict: false,
+      });
+      addFormats(this.#ajvWithCoercions);
+      this.#ajvWithCoercions.addSchema(this.#openApiObject, SCHEMA_ID);
+    }
+
+    return this.#ajvWithCoercions;
   }
 }

--- a/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot1/ValidationCache.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot1/ValidationCache.ts
@@ -7,6 +7,7 @@ export class ValidationCache extends BaseValidationCache<ValidationCacheEntry> {
       body: undefined,
       headers: undefined,
       params: undefined,
+      queries: undefined,
     };
   }
 }

--- a/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot2/ValidationCache.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot2/ValidationCache.ts
@@ -7,6 +7,7 @@ export class ValidationCache extends BaseValidationCache<ValidationCacheEntry> {
       body: undefined,
       headers: undefined,
       params: undefined,
+      queries: undefined,
     };
   }
 }


### PR DESCRIPTION
### Added
- Added `ValidatedQuery` decorator.

### Changed
- Update `OpenApiValidationPipe` to handle query parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ValidatedQuery` decorator to validate incoming query parameters against OpenAPI schemas with automatic type coercion.
  * Added `ValidatedParams` decorator to validate URL path parameters against OpenAPI schemas.
  * Enhanced multi-value query parameter support in HTTP adapters.

* **Bug Fixes**
  * Fixed Hono adapter to correctly handle multiple query parameters.

* **Documentation**
  * Added comprehensive guides and code examples for query and path parameter validation decorators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->