### PR TITLE
Purge tslib dependencies

### DIFF
--- a/.changeset/all-dragons-take.md
+++ b/.changeset/all-dragons-take.md
@@ -1,0 +1,7 @@
+---
+"@inversifyjs/http-better-auth": patch
+"@inversifyjs/http-open-api": patch
+"@inversifyjs/http-hono": patch
+---
+
+- Updated compiled files to no longer rely on tslib

--- a/.changeset/sharp-gifts-change.md
+++ b/.changeset/sharp-gifts-change.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/foundation-typescript-config": minor
+---
+
+- Updated `importHelpers` to be false

--- a/knip.ts
+++ b/knip.ts
@@ -10,7 +10,7 @@ const defaultWorkspaceProjectConfig: WorkspaceProjectConfig & {
     "src/{index,cli,main}.{js,cjs,mjs,jsx,ts,cts,mts,tsx}",
     "**/?(*.)+(spec|spec-d).[jt]s?(x)",
   ],
-  ignoreDependencies: ["ts-loader", "tslib"],
+  ignoreDependencies: [],
   project: [
     "**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}!",
     "!vitest.config.stryker.mjs",
@@ -31,15 +31,20 @@ export default {
   workspaces: {
     ".": {
       entry: [],
-      ignoreDependencies: [
-        ...defaultWorkspaceProjectConfig.ignoreDependencies,
-        "@fission-ai/openspec",
-      ],
+      ignoreDependencies: defaultWorkspaceProjectConfig.ignoreDependencies,
       project: [],
     },
     "packages/container/examples/*": defaultWorkspaceProjectConfig,
     "packages/container/libraries/*": defaultWorkspaceProjectConfig,
     "packages/container/tools/*": defaultWorkspaceProjectConfig,
+    "packages/container/tools/container-benchmarks": {
+      ...defaultWorkspaceProjectConfig,
+      ignoreDependencies: [
+        ...defaultWorkspaceProjectConfig.ignoreDependencies,
+        "ts-loader",
+        "tslib",
+      ],
+    },
     "packages/container/tools/e2e-tests": {
       entry: [
         "config/*.mjs",
@@ -50,6 +55,8 @@ export default {
       ignoreDependencies: [
         ...defaultWorkspaceProjectConfig.ignoreDependencies,
         "ts-node",
+        "ts-loader",
+        "tslib",
       ],
       project: [...defaultWorkspaceProjectConfig.project, "!config/*"],
     },
@@ -59,11 +66,9 @@ export default {
         "src/{pages,theme}/**/*.{js,ts,jsx,tsx}",
         "{blog,docs,graphql-docs,logger-docs,openapi-docs,validation-docs}/**/*.mdx",
       ],
-      ignoreDependencies: ["@docusaurus/faster"],
     },
     "packages/docs/services/inversify-site": {
       entry: ["src/{pages,theme}/**/*.{js,ts,jsx,tsx}", "{blog,docs}/**/*.mdx"],
-      ignoreDependencies: ["@docusaurus/faster", "inversify"],
       ignoreFiles: ["i18n/**"],
     },
     "packages/docs/tools/*": defaultWorkspaceProjectConfig,
@@ -111,7 +116,7 @@ export default {
         ...defaultWorkspaceProjectConfig.ignoreDependencies,
         "@inversifyjs/common",
         "@inversifyjs/container",
-        "@inversifyjs/core",
+        "ts-loader",
       ],
     },
     "packages/foundation/libraries/*": defaultWorkspaceProjectConfig,
@@ -132,7 +137,9 @@ export default {
       ],
       ignoreDependencies: [
         ...defaultWorkspaceProjectConfig.ignoreDependencies,
+        "ts-loader",
         "ts-node",
+        "tslib",
       ],
       project: [...defaultWorkspaceProjectConfig.project, "!config/*"],
     },
@@ -145,7 +152,8 @@ export default {
       ],
       ignoreDependencies: [
         ...defaultWorkspaceProjectConfig.ignoreDependencies,
-        "ts-node",
+        "ts-loader",
+        "tslib",
       ],
       project: defaultWorkspaceProjectConfig.project,
     },

--- a/packages/container/examples/plugin-example/package.json
+++ b/packages/container/examples/plugin-example/package.json
@@ -12,7 +12,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3"
   },
   "peerDependencies": {

--- a/packages/container/examples/plugin-usage-example/package.json
+++ b/packages/container/examples/plugin-usage-example/package.json
@@ -13,7 +13,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3"
   },
   "homepage": "https://inversify.io",

--- a/packages/container/libraries/binding-decorators/package.json
+++ b/packages/container/libraries/binding-decorators/package.json
@@ -18,7 +18,6 @@
     "prettier": "3.8.3",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/container/libraries/common/package.json
+++ b/packages/container/libraries/common/package.json
@@ -14,7 +14,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/container/libraries/container/package.json
+++ b/packages/container/libraries/container/package.json
@@ -20,7 +20,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/container/libraries/core/package.json
+++ b/packages/container/libraries/core/package.json
@@ -20,7 +20,6 @@
     "prettier": "3.8.3",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/container/libraries/inversify/package.json
+++ b/packages/container/libraries/inversify/package.json
@@ -17,7 +17,6 @@
     "prettier": "3.8.3",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/container/libraries/plugin-dispose/package.json
+++ b/packages/container/libraries/plugin-dispose/package.json
@@ -20,7 +20,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/container/libraries/plugin/package.json
+++ b/packages/container/libraries/plugin/package.json
@@ -10,7 +10,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3"
   },
   "homepage": "https://inversify.io",

--- a/packages/container/libraries/strongly-typed/package.json
+++ b/packages/container/libraries/strongly-typed/package.json
@@ -12,7 +12,6 @@
     "prettier": "3.8.3",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/docs/tools/binding-decorators-code-examples/package.json
+++ b/packages/docs/tools/binding-decorators-code-examples/package.json
@@ -17,7 +17,6 @@
     "glob": "13.0.6",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/docs/tools/code-examples-devkit/package.json
+++ b/packages/docs/tools/code-examples-devkit/package.json
@@ -12,8 +12,7 @@
     "@types/node": "24.12.2",
     "eslint": "10.2.1",
     "prettier": "3.8.3",
-    "rimraf": "6.1.3",
-    "tslib": "2.8.1"
+    "rimraf": "6.1.3"
   },
   "homepage": "https://inversify.io",
   "keywords": [

--- a/packages/docs/tools/inversify-code-examples/package.json
+++ b/packages/docs/tools/inversify-code-examples/package.json
@@ -17,7 +17,6 @@
     "prettier": "3.8.3",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/docs/tools/inversify-graphql-code-examples/package.json
+++ b/packages/docs/tools/inversify-graphql-code-examples/package.json
@@ -24,7 +24,6 @@
     "mercurius": "16.9.0",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/docs/tools/inversify-http-code-examples/package.json
+++ b/packages/docs/tools/inversify-http-code-examples/package.json
@@ -35,7 +35,6 @@
     "multer": "2.1.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.66.0",
     "vitest": "4.1.5"

--- a/packages/docs/tools/inversify-http-open-api-code-examples/package.json
+++ b/packages/docs/tools/inversify-http-open-api-code-examples/package.json
@@ -20,7 +20,6 @@
     "inversify": "8.1.0",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/docs/tools/inversify-logger-code-examples/package.json
+++ b/packages/docs/tools/inversify-logger-code-examples/package.json
@@ -14,7 +14,6 @@
     "glob": "13.0.6",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/docs/tools/inversify-validation-code-examples/package.json
+++ b/packages/docs/tools/inversify-validation-code-examples/package.json
@@ -30,7 +30,6 @@
     "inversify": "8.1.0",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5",
     "zod": "4.3.6"

--- a/packages/foundation/libraries/benchmark-utils/package.json
+++ b/packages/foundation/libraries/benchmark-utils/package.json
@@ -29,7 +29,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3"
   },
   "devEngines": {

--- a/packages/foundation/libraries/prototype-utils/package.json
+++ b/packages/foundation/libraries/prototype-utils/package.json
@@ -34,7 +34,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/foundation/libraries/reflect-metadata-utils/package.json
+++ b/packages/foundation/libraries/reflect-metadata-utils/package.json
@@ -36,7 +36,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/foundation/tools/changelog-generator/package.json
+++ b/packages/foundation/tools/changelog-generator/package.json
@@ -10,7 +10,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3"
   },
   "homepage": "https://inversify.io",

--- a/packages/foundation/tools/eslint-plugin-require-extensions/package.json
+++ b/packages/foundation/tools/eslint-plugin-require-extensions/package.json
@@ -30,7 +30,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "typescript-eslint": "8.59.0",
     "vitest": "4.1.5"

--- a/packages/foundation/tools/typescript-config/tsconfig.base.json
+++ b/packages/foundation/tools/typescript-config/tsconfig.base.json
@@ -7,7 +7,7 @@
     "esModuleInterop": true,
     "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,
-    "importHelpers": true,
+    "importHelpers": false,
     "lib": ["ES2022"],
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,

--- a/packages/framework/core/package.json
+++ b/packages/framework/core/package.json
@@ -17,7 +17,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/framework/http/libraries/better-auth/package.json
+++ b/packages/framework/http/libraries/better-auth/package.json
@@ -29,7 +29,6 @@
     "hono": "4.12.15",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.66.0",
     "vitest": "4.1.5"

--- a/packages/framework/http/libraries/core/package.json
+++ b/packages/framework/http/libraries/core/package.json
@@ -20,7 +20,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/framework/http/libraries/express-v4/package.json
+++ b/packages/framework/http/libraries/express-v4/package.json
@@ -20,7 +20,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/framework/http/libraries/express/package.json
+++ b/packages/framework/http/libraries/express/package.json
@@ -20,7 +20,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/framework/http/libraries/fastify/package.json
+++ b/packages/framework/http/libraries/fastify/package.json
@@ -20,7 +20,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/framework/http/libraries/hono/package.json
+++ b/packages/framework/http/libraries/hono/package.json
@@ -18,7 +18,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/framework/http/libraries/open-api/package.json
+++ b/packages/framework/http/libraries/open-api/package.json
@@ -37,7 +37,6 @@
     "hono": "4.12.15",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/framework/http/libraries/sse/package.json
+++ b/packages/framework/http/libraries/sse/package.json
@@ -31,7 +31,6 @@
     "inversify": "8.1.0",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.66.0",
     "vitest": "4.1.5"

--- a/packages/framework/http/libraries/uwebsockets/package.json
+++ b/packages/framework/http/libraries/uwebsockets/package.json
@@ -19,7 +19,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/framework/http/libraries/validation/package.json
+++ b/packages/framework/http/libraries/validation/package.json
@@ -19,7 +19,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/framework/http/tools/http-openapi-example/package.json
+++ b/packages/framework/http/tools/http-openapi-example/package.json
@@ -20,7 +20,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3"
   },
   "devEngines": {

--- a/packages/framework/validation/libraries/ajv/package.json
+++ b/packages/framework/validation/libraries/ajv/package.json
@@ -24,7 +24,6 @@
     "inversify": "8.1.0",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/framework/validation/libraries/class-validator/package.json
+++ b/packages/framework/validation/libraries/class-validator/package.json
@@ -23,7 +23,6 @@
     "inversify": "8.1.0",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/framework/validation/libraries/common/package.json
+++ b/packages/framework/validation/libraries/common/package.json
@@ -9,7 +9,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3"
   },
   "devEngines": {

--- a/packages/framework/validation/libraries/openapi/package.json
+++ b/packages/framework/validation/libraries/openapi/package.json
@@ -38,7 +38,6 @@
     "inversify": "8.1.0",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/framework/validation/libraries/standard-schema/package.json
+++ b/packages/framework/validation/libraries/standard-schema/package.json
@@ -24,7 +24,6 @@
     "inversify": "8.1.0",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5",
     "zod": "^4.3.6"

--- a/packages/json-schema/libraries/json-schema-pointer/package.json
+++ b/packages/json-schema/libraries/json-schema-pointer/package.json
@@ -15,7 +15,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/json-schema/libraries/json-schema-types/package.json
+++ b/packages/json-schema/libraries/json-schema-types/package.json
@@ -9,7 +9,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3"
   },
   "homepage": "https://inversify.io",

--- a/packages/json-schema/libraries/json-schema-utils/package.json
+++ b/packages/json-schema/libraries/json-schema-utils/package.json
@@ -18,7 +18,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -15,7 +15,6 @@
     "logform": "^2.7.0",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/packages/open-api/libraries/open-api-types/package.json
+++ b/packages/open-api/libraries/open-api-types/package.json
@@ -10,7 +10,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3"
   },
   "homepage": "https://inversify.io",

--- a/packages/open-api/libraries/open-api-utils/package.json
+++ b/packages/open-api/libraries/open-api-utils/package.json
@@ -18,7 +18,6 @@
     "eslint": "10.2.1",
     "prettier": "3.8.3",
     "rimraf": "6.1.3",
-    "tslib": "2.8.1",
     "typescript": "6.0.3",
     "vitest": "4.1.5"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,6 @@ ignoredBuiltDependencies:
 
 onlyBuiltDependencies:
   - '@apollo/protobufjs'
-  - '@fission-ai/openspec'
   - '@nestjs/core'
   - '@prisma/engines'
   - '@swc/core'


### PR DESCRIPTION
### Changed
- Remove unused `tslib` dependencies.
- Update libs to no longer rely on `tslib`.
- Update `knip` config accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed TypeScript helper library dependency from compiled output across all packages for improved build efficiency.
  * Updated TypeScript compiler configuration to inline helper functions instead of importing them, reducing external dependencies in built code.
  * Updated workspace and build configuration files to reflect dependency changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->