### PR TITLE
Quarantine turbo

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -60,7 +60,7 @@
     {
       "description": "Quarantine packages with current known issues",
       "enabled": false,
-      "matchPackageNames": []
+      "matchPackageNames": ["turbo"]
     },
     {
       "description": "Regenerate OpenSpec instruction files after @fission-ai/openspec is bumped",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "knip": "6.12.1",
     "lint-staged": "17.0.3",
     "sponsorkit": "17.1.0",
-    "turbo": "2.9.12"
+    "turbo": "2.9.11"
   },
   "homepage": "https://inversify.io",
   "keywords": [],


### PR DESCRIPTION
### Changed
- Reverted `turbo` dependency to `2.9.11` and put it in quarantine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Downgraded Turbo dependency to version 2.9.11
  * Configured Renovate to exclude Turbo from automatic dependency updates

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inversify/monorepo/pull/1865)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->