### PR TITLE
Unplugin dts migration

### DIFF
--- a/packages/docs/tools/react-code-runner/package.json
+++ b/packages/docs/tools/react-code-runner/package.json
@@ -32,8 +32,8 @@
     "tslib": "2.8.1",
     "typescript": "6.0.3",
     "typescript-eslint": "8.59.3",
-    "vite": "8.0.12",
-    "vite-plugin-dts": "4.5.4",
+    "unplugin-dts": "1.0.0",
+    "vite": "8.0.11",
     "vite-plugin-lib-inject-css": "2.2.2"
   },
   "peerDependencies": {

--- a/packages/docs/tools/react-code-runner/vite.config.ts
+++ b/packages/docs/tools/react-code-runner/vite.config.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { globSync } from 'glob';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import dts from 'vite-plugin-dts';
+import dts from 'unplugin-dts/vite';
 import { libInjectCss } from 'vite-plugin-lib-inject-css';
 
 export default defineConfig({
@@ -12,7 +12,7 @@ export default defineConfig({
     react(),
     libInjectCss(),
     dts({
-      outDir: 'lib/esm',
+      outDirs: 'lib/esm',
       tsconfigPath: 'tsconfig.esm.json',
     }),
   ],

--- a/turbo.json
+++ b/turbo.json
@@ -13,7 +13,7 @@
     },
     "@inversifyjs/react-code-runner#build": {
       "dependsOn": ["^build"],
-      "inputs": ["src/**/*.{css,cts,mts,ts,tsx}"],
+      "inputs": ["src/**/*.{css,cts,mts,ts,tsx}", "vite.config.ts"],
       "outputs": ["generated/**", "lib/**"]
     },
     "@inversifyjs/code-examples#build": {


### PR DESCRIPTION
### Changed
- Updated `vitest` build config to rely on `unplugin-dts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tooling dependencies and refactored build configuration for the React code runner package.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inversify/monorepo/pull/1874)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->