### PR TITLE
Enforce mimimum release age policy

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -59,6 +59,11 @@
   ],
   "packageRules": [
     {
+      "description": "Ignore updates to dependencies that are less than 3 days old",
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days"
+    },
+    {
       "enabled": false,
       "matchDepTypes": ["peerDependencies"],
       "matchPackageNames": ["express"],

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,6 +30,7 @@ allowBuilds:
   '@scarf/scarf': false
   lmdb: false
   msgpackr-extract: false
+minimumReleaseAge: 1440
 overrides:
   postcss: 8.5.15
 packageExtensions:
@@ -39,5 +40,4 @@ packageExtensions:
   "@docusaurus/preset-classic@*":
     peerDependencies:
       postcss: ">=8"
-minimumReleaseAgeExclude:
-  - lint-staged@17.0.6
+


### PR DESCRIPTION
### Changed
- Enforced minimum release age policy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management policies to improve release stability and quality assurance.
  * Dependencies released on npm will be held for a minimum of 3 days before being considered for automatic updates, allowing time for potential issues to be identified and resolved.
  * Consolidated release age verification settings across project configurations for consistent dependency handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->