### PR TITLE
Update container benchmarks with inversify 8 scenarios

### DIFF
--- a/packages/container/tools/container-benchmarks/package.json
+++ b/packages/container/tools/container-benchmarks/package.json
@@ -12,6 +12,7 @@
     "@nestjs/core": "11.1.24",
     "inversify6": "npm:inversify@6.2.2",
     "inversify7": "npm:inversify@7.11.0",
+    "inversify8": "npm:inversify@8.1.0",
     "rxjs": "7.8.2",
     "tinybench": "6.0.2",
     "tsyringe": "4.10.0"

--- a/packages/container/tools/container-benchmarks/src/bin/run.ts
+++ b/packages/container/tools/container-benchmarks/src/bin/run.ts
@@ -16,6 +16,10 @@ import { Inversify7GetComplexServiceInSingletonScope } from '../scenario/Inversi
 import { Inversify7GetComplexServiceInTransientScope } from '../scenario/Inversify7/Inversify7GetComplexServiceInTransientScope';
 import { Inversify7GetServiceInSingletonScope } from '../scenario/Inversify7/Inversify7GetServiceInSingletonScope';
 import { Inversify7GetServiceInTransientScope } from '../scenario/Inversify7/Inversify7GetServiceInTransientScope';
+import { Inversify8GetComplexServiceInSingletonScope } from '../scenario/inversify8/Inversify8GetComplexServiceInSingletonScope';
+import { Inversify8GetComplexServiceInTransientScope } from '../scenario/inversify8/Inversify8GetComplexServiceInTransientScope';
+import { Inversify8GetServiceInSingletonScope } from '../scenario/inversify8/Inversify8GetServiceInSingletonScope';
+import { Inversify8GetServiceInTransientScope } from '../scenario/inversify8/Inversify8GetServiceInTransientScope';
 import { InversifyCurrentGetComplexServiceInSingletonScope } from '../scenario/inversifyCurrent/InversifyCurrentGetComplexServiceInSingletonScope';
 import { InversifyCurrentGetComplexServiceInTransientScope } from '../scenario/inversifyCurrent/InversifyCurrentGetComplexServiceInTransientScope';
 import { InversifyCurrentGetServiceInSingletonScope } from '../scenario/inversifyCurrent/InversifyCurrentGetServiceInSingletonScope';
@@ -41,6 +45,7 @@ export async function run(): Promise<void> {
         new InversifyCurrentGetServiceInSingletonScope(),
         new Inversify6GetServiceInSingletonScope(),
         new Inversify7GetServiceInSingletonScope(),
+        new Inversify8GetServiceInSingletonScope(),
         new NestCoreGetServiceInSingletonScopeScenario(),
         new TsyringeGetServiceInSingletonScope(),
       ],
@@ -62,6 +67,7 @@ export async function run(): Promise<void> {
         new InversifyCurrentGetServiceInTransientScope(),
         new Inversify6GetServiceInTransientScope(),
         new Inversify7GetServiceInTransientScope(),
+        new Inversify8GetServiceInTransientScope(),
         new NestCoreGetServiceInTransientScopeScenario(),
         new TsyringeGetServiceInTransientScope(),
       ],
@@ -83,6 +89,7 @@ export async function run(): Promise<void> {
         new InversifyCurrentGetComplexServiceInSingletonScope(),
         new Inversify6GetComplexServiceInSingletonScope(),
         new Inversify7GetComplexServiceInSingletonScope(),
+        new Inversify8GetComplexServiceInSingletonScope(),
         new NestCoreGetComplexServiceInSingletonScopeScenario(),
         new TsyringeGetComplexServiceInSingletonScope(),
       ],
@@ -104,6 +111,7 @@ export async function run(): Promise<void> {
         new InversifyCurrentGetComplexServiceInTransientScope(),
         new Inversify6GetComplexServiceInTransientScope(),
         new Inversify7GetComplexServiceInTransientScope(),
+        new Inversify8GetComplexServiceInTransientScope(),
         new NestCoreGetComplexServiceInTransientScopeScenario(),
         new TsyringeGetComplexServiceInTransientScope(),
       ],

--- a/packages/container/tools/container-benchmarks/src/scenario/inversify8/Inversify8BaseScenario.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/inversify8/Inversify8BaseScenario.ts
@@ -1,0 +1,25 @@
+import { Scenario } from '@inversifyjs/benchmark-utils';
+import { Container } from 'inversify8';
+
+import { Platform } from '../models/Platform';
+
+export abstract class Inversify8BaseScenario implements Scenario<Platform> {
+  public readonly platform: Platform;
+
+  protected readonly _container: Container;
+
+  constructor() {
+    this._container = new Container();
+    this.platform = Platform.inversify8;
+  }
+
+  public async setUp(): Promise<void> {
+    return undefined;
+  }
+
+  public async tearDown(): Promise<void> {
+    return undefined;
+  }
+
+  public abstract execute(): Promise<void>;
+}

--- a/packages/container/tools/container-benchmarks/src/scenario/inversify8/Inversify8GetComplexServiceInSingletonScope.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/inversify8/Inversify8GetComplexServiceInSingletonScope.ts
@@ -1,0 +1,184 @@
+import { injectable } from 'inversify8';
+
+import { Inversify8BaseScenario } from './Inversify8BaseScenario';
+
+@injectable()
+class FinalNode {
+  public log() {
+    return 'log!';
+  }
+}
+
+@injectable()
+class Node10 {
+  private readonly node1: FinalNode;
+  private readonly node2: FinalNode;
+
+  constructor(node1: FinalNode, node2: FinalNode) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node9 {
+  private readonly node1: Node10;
+  private readonly node2: Node10;
+
+  constructor(node1: Node10, node2: Node10) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node8 {
+  private readonly node1: Node9;
+  private readonly node2: Node9;
+
+  constructor(node1: Node9, node2: Node9) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node7 {
+  private readonly node1: Node8;
+  private readonly node2: Node8;
+
+  constructor(node1: Node8, node2: Node8) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node6 {
+  private readonly node1: Node7;
+  private readonly node2: Node7;
+
+  constructor(node1: Node7, node2: Node7) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node5 {
+  private readonly node1: Node6;
+  private readonly node2: Node6;
+
+  constructor(node1: Node6, node2: Node6) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node4 {
+  private readonly node1: Node5;
+  private readonly node2: Node5;
+
+  constructor(node1: Node5, node2: Node5) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node3 {
+  private readonly node1: Node4;
+  private readonly node2: Node4;
+
+  constructor(node1: Node4, node2: Node4) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node2 {
+  private readonly node1: Node3;
+  private readonly node2: Node3;
+
+  constructor(node1: Node3, node2: Node3) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node1 {
+  private readonly node1: Node2;
+  private readonly node2: Node2;
+
+  constructor(node1: Node2, node2: Node2) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+export class Inversify8GetComplexServiceInSingletonScope extends Inversify8BaseScenario {
+  public override async setUp(): Promise<void> {
+    this._container.bind(FinalNode).toSelf().inSingletonScope();
+    this._container.bind(Node1).toSelf().inSingletonScope();
+    this._container.bind(Node2).toSelf().inSingletonScope();
+    this._container.bind(Node3).toSelf().inSingletonScope();
+    this._container.bind(Node4).toSelf().inSingletonScope();
+    this._container.bind(Node5).toSelf().inSingletonScope();
+    this._container.bind(Node6).toSelf().inSingletonScope();
+    this._container.bind(Node7).toSelf().inSingletonScope();
+    this._container.bind(Node8).toSelf().inSingletonScope();
+    this._container.bind(Node9).toSelf().inSingletonScope();
+    this._container.bind(Node10).toSelf().inSingletonScope();
+  }
+
+  public async execute(): Promise<void> {
+    this._container.get(Node1);
+  }
+
+  public override async tearDown(): Promise<void> {
+    await this._container.unbindAllAsync();
+  }
+}

--- a/packages/container/tools/container-benchmarks/src/scenario/inversify8/Inversify8GetComplexServiceInTransientScope.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/inversify8/Inversify8GetComplexServiceInTransientScope.ts
@@ -1,0 +1,184 @@
+import { injectable } from 'inversify8';
+
+import { Inversify8BaseScenario } from './Inversify8BaseScenario';
+
+@injectable()
+class FinalNode {
+  public log() {
+    return 'log!';
+  }
+}
+
+@injectable()
+class Node10 {
+  private readonly node1: FinalNode;
+  private readonly node2: FinalNode;
+
+  constructor(node1: FinalNode, node2: FinalNode) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node9 {
+  private readonly node1: Node10;
+  private readonly node2: Node10;
+
+  constructor(node1: Node10, node2: Node10) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node8 {
+  private readonly node1: Node9;
+  private readonly node2: Node9;
+
+  constructor(node1: Node9, node2: Node9) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node7 {
+  private readonly node1: Node8;
+  private readonly node2: Node8;
+
+  constructor(node1: Node8, node2: Node8) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node6 {
+  private readonly node1: Node7;
+  private readonly node2: Node7;
+
+  constructor(node1: Node7, node2: Node7) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node5 {
+  private readonly node1: Node6;
+  private readonly node2: Node6;
+
+  constructor(node1: Node6, node2: Node6) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node4 {
+  private readonly node1: Node5;
+  private readonly node2: Node5;
+
+  constructor(node1: Node5, node2: Node5) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node3 {
+  private readonly node1: Node4;
+  private readonly node2: Node4;
+
+  constructor(node1: Node4, node2: Node4) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node2 {
+  private readonly node1: Node3;
+  private readonly node2: Node3;
+
+  constructor(node1: Node3, node2: Node3) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node1 {
+  private readonly node1: Node2;
+  private readonly node2: Node2;
+
+  constructor(node1: Node2, node2: Node2) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+export class Inversify8GetComplexServiceInTransientScope extends Inversify8BaseScenario {
+  public override async setUp(): Promise<void> {
+    this._container.bind(FinalNode).toSelf().inTransientScope();
+    this._container.bind(Node1).toSelf().inTransientScope();
+    this._container.bind(Node2).toSelf().inTransientScope();
+    this._container.bind(Node3).toSelf().inTransientScope();
+    this._container.bind(Node4).toSelf().inTransientScope();
+    this._container.bind(Node5).toSelf().inTransientScope();
+    this._container.bind(Node6).toSelf().inTransientScope();
+    this._container.bind(Node7).toSelf().inTransientScope();
+    this._container.bind(Node8).toSelf().inTransientScope();
+    this._container.bind(Node9).toSelf().inTransientScope();
+    this._container.bind(Node10).toSelf().inTransientScope();
+  }
+
+  public async execute(): Promise<void> {
+    this._container.get(Node1);
+  }
+
+  public override async tearDown(): Promise<void> {
+    await this._container.unbindAllAsync();
+  }
+}

--- a/packages/container/tools/container-benchmarks/src/scenario/inversify8/Inversify8GetServiceInSingletonScope.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/inversify8/Inversify8GetServiceInSingletonScope.ts
@@ -1,0 +1,38 @@
+import { injectable } from 'inversify8';
+
+import { Inversify8BaseScenario } from './Inversify8BaseScenario';
+
+@injectable()
+class Katana {
+  public hit() {
+    return 'cut!';
+  }
+}
+
+@injectable()
+class Samurai {
+  readonly #katana: Katana;
+
+  constructor(katana: Katana) {
+    this.#katana = katana;
+  }
+
+  public attack() {
+    return this.#katana.hit();
+  }
+}
+
+export class Inversify8GetServiceInSingletonScope extends Inversify8BaseScenario {
+  public override async setUp(): Promise<void> {
+    this._container.bind(Katana).toSelf().inSingletonScope();
+    this._container.bind(Samurai).toSelf().inSingletonScope();
+  }
+
+  public async execute(): Promise<void> {
+    this._container.get(Samurai);
+  }
+
+  public override async tearDown(): Promise<void> {
+    await this._container.unbindAllAsync();
+  }
+}

--- a/packages/container/tools/container-benchmarks/src/scenario/inversify8/Inversify8GetServiceInTransientScope.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/inversify8/Inversify8GetServiceInTransientScope.ts
@@ -1,0 +1,38 @@
+import { injectable } from 'inversify8';
+
+import { Inversify8BaseScenario } from './Inversify8BaseScenario';
+
+@injectable()
+class Katana {
+  public hit() {
+    return 'cut!';
+  }
+}
+
+@injectable()
+class Samurai {
+  readonly #katana: Katana;
+
+  constructor(katana: Katana) {
+    this.#katana = katana;
+  }
+
+  public attack() {
+    return this.#katana.hit();
+  }
+}
+
+export class Inversify8GetServiceInTransientScope extends Inversify8BaseScenario {
+  public override async setUp(): Promise<void> {
+    this._container.bind(Katana).toSelf().inTransientScope();
+    this._container.bind(Samurai).toSelf().inTransientScope();
+  }
+
+  public async execute(): Promise<void> {
+    this._container.get(Samurai);
+  }
+
+  public override async tearDown(): Promise<void> {
+    await this._container.unbindAllAsync();
+  }
+}

--- a/packages/container/tools/container-benchmarks/src/scenario/models/Platform.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/models/Platform.ts
@@ -1,6 +1,7 @@
 export enum Platform {
   inversify6 = 'inversify6',
   inversify7 = 'inversify7',
+  inversify8 = 'inversify8',
   inversifyCurrent = 'inversifyCurrent',
   nestJs = 'NestJS',
   tsyringe = 'tsyringe',


### PR DESCRIPTION
### Added
- Added `inversify@8` scenarios to container benchmarks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added Inversify 8 benchmarking support with new performance test scenarios covering service resolution in singleton and transient scopes, including both simple and complex dependency graphs for comprehensive performance analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->