### PR TITLE
Update non cache service node with build service node options

### DIFF
--- a/.changeset/perky-eagles-cross.md
+++ b/.changeset/perky-eagles-cross.md
@@ -1,5 +1,6 @@
 ---
 "@inversifyjs/core": major
+"@inversifyjs/container": major
 ---
 
 - Removed `NonCachedServiceNodeContext.chainedBindings` in favor of `buildServiceNodeOptions`.

--- a/.changeset/perky-eagles-cross.md
+++ b/.changeset/perky-eagles-cross.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": major
+---
+
+- Removed `NonCachedServiceNodeContext.chainedBindings` in favor of `buildServiceNodeOptions`.

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,7 @@
 /pnpm-lock.yaml
 /yarn.lock
 
+/.pnpm-store
+
 ### Sponsorkit cache
 assets/.cache.json

--- a/packages/container/libraries/core/src/common/calculations/buildBuildServiceNodeOptionsFromPlanParamsConstraints.spec.ts
+++ b/packages/container/libraries/core/src/common/calculations/buildBuildServiceNodeOptionsFromPlanParamsConstraints.spec.ts
@@ -1,0 +1,246 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { type ServiceIdentifier } from '@inversifyjs/common';
+
+import { type MetadataTag } from '../../metadata/models/MetadataTag.js';
+import { type BuildServiceNodeOptions } from '../../planning/models/BuildServiceNodeOptions.js';
+import { type MultipleBindingPlanParamsConstraint } from '../../planning/models/MultipleBindingPlanParamsConstraint.js';
+import { type SingleBindingPlanParamsConstraint } from '../../planning/models/SingleBindingPlanParamsConstraint.js';
+import { buildBuildServiceNodeOptionsFromPlanParamsConstraints } from './buildBuildServiceNodeOptionsFromPlanParamsConstraints.js';
+
+describe(buildBuildServiceNodeOptionsFromPlanParamsConstraints, () => {
+  describe('having SingleBindingPlanParamsConstraint without tag', () => {
+    let constraintsFixture: SingleBindingPlanParamsConstraint;
+
+    beforeAll(() => {
+      constraintsFixture = {
+        isMultiple: false,
+        serviceIdentifier: Symbol(),
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result =
+          buildBuildServiceNodeOptionsFromPlanParamsConstraints(
+            constraintsFixture,
+          );
+      });
+
+      it('should return BuildSingleBindingServiceNodeOptions', () => {
+        const expected: BuildServiceNodeOptions = {
+          isMultiple: false,
+          name: undefined,
+          optional: false,
+          serviceIdentifier: constraintsFixture.serviceIdentifier,
+          tags: new Map(),
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having SingleBindingPlanParamsConstraint with tag', () => {
+    let constraintsFixture: SingleBindingPlanParamsConstraint;
+    let tagKeyFixture: MetadataTag;
+    let tagValueFixture: unknown;
+
+    beforeAll(() => {
+      tagKeyFixture = 'testTag';
+      tagValueFixture = Symbol();
+
+      constraintsFixture = {
+        isMultiple: false,
+        serviceIdentifier: Symbol(),
+        tag: {
+          key: tagKeyFixture,
+          value: tagValueFixture,
+        },
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result =
+          buildBuildServiceNodeOptionsFromPlanParamsConstraints(
+            constraintsFixture,
+          );
+      });
+
+      it('should return BuildSingleBindingServiceNodeOptions with tag', () => {
+        const expected: BuildServiceNodeOptions = {
+          isMultiple: false,
+          name: undefined,
+          optional: false,
+          serviceIdentifier: constraintsFixture.serviceIdentifier,
+          tags: new Map([[tagKeyFixture, tagValueFixture]]),
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having SingleBindingPlanParamsConstraint with name and isOptional', () => {
+    let constraintsFixture: SingleBindingPlanParamsConstraint;
+
+    beforeAll(() => {
+      constraintsFixture = {
+        isMultiple: false,
+        isOptional: true,
+        name: 'testName',
+        serviceIdentifier: Symbol(),
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result =
+          buildBuildServiceNodeOptionsFromPlanParamsConstraints(
+            constraintsFixture,
+          );
+      });
+
+      it('should return BuildSingleBindingServiceNodeOptions with name and optional true', () => {
+        const expected: BuildServiceNodeOptions = {
+          isMultiple: false,
+          name: 'testName',
+          optional: true,
+          serviceIdentifier: constraintsFixture.serviceIdentifier,
+          tags: new Map(),
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having MultipleBindingPlanParamsConstraint without tag', () => {
+    let constraintsFixture: MultipleBindingPlanParamsConstraint;
+
+    beforeAll(() => {
+      constraintsFixture = {
+        chained: true,
+        isMultiple: true,
+        serviceIdentifier: Symbol(),
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result =
+          buildBuildServiceNodeOptionsFromPlanParamsConstraints(
+            constraintsFixture,
+          );
+      });
+
+      it('should return BuildMultipleBindingServiceNodeOptions', () => {
+        const expected: BuildServiceNodeOptions = {
+          chained: true,
+          isMultiple: true,
+          name: undefined,
+          optional: false,
+          serviceIdentifier: constraintsFixture.serviceIdentifier,
+          tags: new Map(),
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having MultipleBindingPlanParamsConstraint with tag', () => {
+    let constraintsFixture: MultipleBindingPlanParamsConstraint;
+    let tagKeyFixture: MetadataTag;
+    let tagValueFixture: unknown;
+
+    beforeAll(() => {
+      tagKeyFixture = 'multiTag';
+      tagValueFixture = Symbol();
+
+      constraintsFixture = {
+        chained: false,
+        isMultiple: true,
+        serviceIdentifier: Symbol(),
+        tag: {
+          key: tagKeyFixture,
+          value: tagValueFixture,
+        },
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result =
+          buildBuildServiceNodeOptionsFromPlanParamsConstraints(
+            constraintsFixture,
+          );
+      });
+
+      it('should return BuildMultipleBindingServiceNodeOptions with tag', () => {
+        const expected: BuildServiceNodeOptions = {
+          chained: false,
+          isMultiple: true,
+          name: undefined,
+          optional: false,
+          serviceIdentifier: constraintsFixture.serviceIdentifier,
+          tags: new Map([[tagKeyFixture, tagValueFixture]]),
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having MultipleBindingPlanParamsConstraint with name and isOptional', () => {
+    let constraintsFixture: MultipleBindingPlanParamsConstraint;
+    let serviceIdentifierFixture: ServiceIdentifier;
+
+    beforeAll(() => {
+      serviceIdentifierFixture = Symbol();
+
+      constraintsFixture = {
+        chained: false,
+        isMultiple: true,
+        isOptional: true,
+        name: 'multiName',
+        serviceIdentifier: serviceIdentifierFixture,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result =
+          buildBuildServiceNodeOptionsFromPlanParamsConstraints(
+            constraintsFixture,
+          );
+      });
+
+      it('should return BuildMultipleBindingServiceNodeOptions with name and optional true', () => {
+        const expected: BuildServiceNodeOptions = {
+          chained: false,
+          isMultiple: true,
+          name: 'multiName',
+          optional: true,
+          serviceIdentifier: serviceIdentifierFixture,
+          tags: new Map(),
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/common/calculations/buildBuildServiceNodeOptionsFromPlanParamsConstraints.ts
+++ b/packages/container/libraries/core/src/common/calculations/buildBuildServiceNodeOptionsFromPlanParamsConstraints.ts
@@ -1,0 +1,32 @@
+import { type MetadataTag } from '../../metadata/models/MetadataTag.js';
+import { type BuildServiceNodeOptions } from '../../planning/models/BuildServiceNodeOptions.js';
+import { type PlanParamsConstraint } from '../../planning/models/PlanParamsConstraint.js';
+
+export function buildBuildServiceNodeOptionsFromPlanParamsConstraints(
+  constraints: PlanParamsConstraint,
+): BuildServiceNodeOptions {
+  const tags: Map<MetadataTag, unknown> = new Map();
+
+  if (constraints.tag !== undefined) {
+    tags.set(constraints.tag.key, constraints.tag.value);
+  }
+
+  if (constraints.isMultiple) {
+    return {
+      chained: constraints.chained,
+      isMultiple: constraints.isMultiple,
+      name: constraints.name,
+      optional: constraints.isOptional ?? false,
+      serviceIdentifier: constraints.serviceIdentifier,
+      tags,
+    };
+  }
+
+  return {
+    isMultiple: constraints.isMultiple,
+    name: constraints.name,
+    optional: constraints.isOptional ?? false,
+    serviceIdentifier: constraints.serviceIdentifier,
+    tags,
+  };
+}

--- a/packages/container/libraries/core/src/planning/actions/addRootServiceNodeBindingIfContextFree.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/addRootServiceNodeBindingIfContextFree.spec.ts
@@ -9,6 +9,9 @@ import {
   vitest,
 } from 'vitest';
 
+vitest.mock(
+  import('../../common/calculations/buildBuildServiceNodeOptionsFromPlanParamsConstraints.js'),
+);
 vitest.mock(import('../calculations/buildPlanBindingConstraintsList.js'));
 vitest.mock(import('./addServiceNodeBindingIfContextFree.js'));
 
@@ -18,9 +21,11 @@ import { type Binding } from '../../binding/models/Binding.js';
 import { type InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation.js';
 import { bindingScopeValues } from '../../binding/models/BindingScope.js';
 import { bindingTypeValues } from '../../binding/models/BindingType.js';
+import { buildBuildServiceNodeOptionsFromPlanParamsConstraints } from '../../common/calculations/buildBuildServiceNodeOptionsFromPlanParamsConstraints.js';
 import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList.js';
 import { type PlanServiceNodeBindingAddedResult } from '../../metadata/models/PlanServiceNodeBindingAddedResult.js';
 import { buildPlanBindingConstraintsList } from '../calculations/buildPlanBindingConstraintsList.js';
+import { type BuildServiceNodeOptions } from '../models/BuildServiceNodeOptions.js';
 import { LazyPlanServiceNode } from '../models/LazyPlanServiceNode.js';
 import { type PlanParams } from '../models/PlanParams.js';
 import { type PlanParamsOperations } from '../models/PlanParamsOperations.js';
@@ -132,6 +137,7 @@ describe(addRootServiceNodeBindingIfContextFree, () => {
 
     describe('when called', () => {
       let buildPlanBindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
+      let buildServiceNodeOptionsFixture: BuildServiceNodeOptions;
       let planServiceNodeBindingAddedResultFixture: PlanServiceNodeBindingAddedResult;
 
       let result: unknown;
@@ -145,6 +151,9 @@ describe(addRootServiceNodeBindingIfContextFree, () => {
           1,
         );
 
+        buildServiceNodeOptionsFixture =
+          Symbol() as unknown as BuildServiceNodeOptions;
+
         planServiceNodeBindingAddedResultFixture = {
           isContextFreeBinding: true,
           shouldInvalidateServiceNode: false,
@@ -153,6 +162,10 @@ describe(addRootServiceNodeBindingIfContextFree, () => {
         vitest
           .mocked(buildPlanBindingConstraintsList)
           .mockReturnValueOnce(buildPlanBindingConstraintsListFixture);
+
+        vitest
+          .mocked(buildBuildServiceNodeOptionsFromPlanParamsConstraints)
+          .mockReturnValueOnce(buildServiceNodeOptionsFixture);
 
         vitest
           .mocked(addServiceNodeBindingIfContextFree)
@@ -169,6 +182,12 @@ describe(addRootServiceNodeBindingIfContextFree, () => {
         vitest.clearAllMocks();
       });
 
+      it('should call buildBuildServiceNodeOptionsFromPlanParamsConstraints()', () => {
+        expect(
+          buildBuildServiceNodeOptionsFromPlanParamsConstraints,
+        ).toHaveBeenCalledExactlyOnceWith(paramsFixture.rootConstraints);
+      });
+
       it('should call addServiceNodeBindingIfContextFree()', () => {
         expect(
           addServiceNodeBindingIfContextFree,
@@ -177,7 +196,7 @@ describe(addRootServiceNodeBindingIfContextFree, () => {
           lazyPlanServiceNodeFixture,
           bindingMock,
           buildPlanBindingConstraintsListFixture,
-          false,
+          buildServiceNodeOptionsFixture,
         );
       });
 

--- a/packages/container/libraries/core/src/planning/actions/addRootServiceNodeBindingIfContextFree.ts
+++ b/packages/container/libraries/core/src/planning/actions/addRootServiceNodeBindingIfContextFree.ts
@@ -1,5 +1,6 @@
 import { type Binding } from '../../binding/models/Binding.js';
 import { type InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation.js';
+import { buildBuildServiceNodeOptionsFromPlanParamsConstraints } from '../../common/calculations/buildBuildServiceNodeOptionsFromPlanParamsConstraints.js';
 import { type SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList.js';
 import { type PlanServiceNodeBindingAddedResult } from '../../metadata/models/PlanServiceNodeBindingAddedResult.js';
 import { buildPlanBindingConstraintsList } from '../calculations/buildPlanBindingConstraintsList.js';
@@ -30,14 +31,13 @@ export function addRootServiceNodeBindingIfContextFree(
   const bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints> =
     buildPlanBindingConstraintsList(params);
 
-  const chained: boolean =
-    params.rootConstraints.isMultiple && params.rootConstraints.chained;
-
   return addServiceNodeBindingIfContextFree(
     params,
     serviceNode,
     binding,
     bindingConstraintsList,
-    chained,
+    buildBuildServiceNodeOptionsFromPlanParamsConstraints(
+      params.rootConstraints,
+    ),
   );
 }

--- a/packages/container/libraries/core/src/planning/actions/addServiceNodeBindingIfContextFree.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/addServiceNodeBindingIfContextFree.spec.ts
@@ -46,6 +46,7 @@ import { InversifyCoreErrorKind } from '../../error/models/InversifyCoreErrorKin
 import { type PlanServiceNodeBindingAddedResult } from '../../metadata/models/PlanServiceNodeBindingAddedResult.js';
 import { type BasePlanParams } from '../models/BasePlanParams.js';
 import { type BindingNodeParent } from '../models/BindingNodeParent.js';
+import { type BuildServiceNodeOptions } from '../models/BuildServiceNodeOptions.js';
 import { LazyPlanServiceNode } from '../models/LazyPlanServiceNode.js';
 import { type PlanBindingNode } from '../models/PlanBindingNode.js';
 import { type PlanServiceNode } from '../models/PlanServiceNode.js';
@@ -77,7 +78,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
       bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
       serviceBindings: Binding<unknown>[],
       parentNode: BindingNodeParent,
-      chainedBindings: boolean,
+      options: BuildServiceNodeOptions,
     ) => PlanBindingNode[]
   >;
 
@@ -93,7 +94,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
 
     let bindingMock: Mocked<Binding<unknown>>;
     let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
-    let chainedBindings: boolean;
+    let buildServiceNodeOptionsFixture: BuildServiceNodeOptions;
 
     beforeAll(() => {
       paramsFixture = Symbol() as unknown as BasePlanParams;
@@ -130,7 +131,14 @@ describe(addServiceNodeBindingIfContextFree, () => {
           1,
         );
 
-      chainedBindings = false;
+      buildServiceNodeOptionsFixture = {
+        chained: false,
+        isMultiple: true,
+        name: undefined,
+        optional: false,
+        serviceIdentifier: Symbol(),
+        tags: new Map(),
+      };
     });
 
     describe('when called, and binding.isSatisfiedBy() returns true, and buildServiceNodeBindings throws an stack overflow error', () => {
@@ -162,7 +170,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
           lazyPlanServiceNodeFixture,
           bindingMock,
           bindingConstraintsListFixture,
-          chainedBindings,
+          buildServiceNodeOptionsFixture,
         );
       });
 
@@ -184,7 +192,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
           bindingConstraintsListFixture,
           [bindingMock],
           lazyPlanServiceNodeFixture,
-          chainedBindings,
+          buildServiceNodeOptionsFixture,
         );
       });
 
@@ -238,7 +246,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
           lazyPlanServiceNodeFixture,
           bindingMock,
           bindingConstraintsListFixture,
-          chainedBindings,
+          buildServiceNodeOptionsFixture,
         );
       });
 
@@ -260,7 +268,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
           bindingConstraintsListFixture,
           [bindingMock],
           lazyPlanServiceNodeFixture,
-          chainedBindings,
+          buildServiceNodeOptionsFixture,
         );
       });
 
@@ -312,7 +320,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
             lazyPlanServiceNodeFixture,
             bindingMock,
             bindingConstraintsListFixture,
-            chainedBindings,
+            buildServiceNodeOptionsFixture,
           );
         } catch (error: unknown) {
           result = error;
@@ -337,7 +345,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
           bindingConstraintsListFixture,
           [bindingMock],
           lazyPlanServiceNodeFixture,
-          chainedBindings,
+          buildServiceNodeOptionsFixture,
         );
       });
 
@@ -373,7 +381,14 @@ describe(addServiceNodeBindingIfContextFree, () => {
           lazyPlanServiceNodeFixture,
           Symbol() as unknown as Binding<unknown>,
           Symbol() as unknown as SingleImmutableLinkedList<InternalBindingConstraints>,
-          false,
+          {
+            chained: false,
+            isMultiple: true,
+            name: undefined,
+            optional: false,
+            serviceIdentifier: Symbol(),
+            tags: new Map(),
+          },
         );
       });
 
@@ -397,7 +412,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
     let lazyPlanServiceNodeFixture: LazyPlanServiceNode;
     let bindingMock: Mocked<Binding<unknown>>;
     let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
-    let chainedBindings: boolean;
+    let buildServiceNodeOptionsFixture: BuildServiceNodeOptions;
 
     beforeAll(() => {
       paramsFixture = Symbol() as unknown as BasePlanParams;
@@ -444,7 +459,14 @@ describe(addServiceNodeBindingIfContextFree, () => {
           1,
         );
 
-      chainedBindings = false;
+      buildServiceNodeOptionsFixture = {
+        chained: false,
+        isMultiple: true,
+        name: undefined,
+        optional: false,
+        serviceIdentifier: Symbol(),
+        tags: new Map(),
+      };
     });
 
     describe('when called, and binding.isSatisfiedBy() returns false', () => {
@@ -458,7 +480,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
           lazyPlanServiceNodeFixture,
           bindingMock,
           bindingConstraintsListFixture,
-          chainedBindings,
+          buildServiceNodeOptionsFixture,
         );
       });
 
@@ -504,7 +526,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
           lazyPlanServiceNodeFixture,
           bindingMock,
           bindingConstraintsListFixture,
-          chainedBindings,
+          buildServiceNodeOptionsFixture,
         );
       });
 
@@ -526,7 +548,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
           bindingConstraintsListFixture,
           [bindingMock],
           lazyPlanServiceNodeFixture,
-          chainedBindings,
+          buildServiceNodeOptionsFixture,
         );
       });
 
@@ -547,7 +569,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
     let lazyPlanServiceNodeFixture: LazyPlanServiceNode;
     let bindingMock: Mocked<Binding<unknown>>;
     let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
-    let chainedBindings: boolean;
+    let buildServiceNodeOptionsFixture: BuildServiceNodeOptions;
 
     beforeAll(() => {
       paramsFixture = Symbol() as unknown as BasePlanParams;
@@ -594,7 +616,14 @@ describe(addServiceNodeBindingIfContextFree, () => {
           1,
         );
 
-      chainedBindings = false;
+      buildServiceNodeOptionsFixture = {
+        chained: false,
+        isMultiple: true,
+        name: undefined,
+        optional: false,
+        serviceIdentifier: Symbol(),
+        tags: new Map(),
+      };
     });
 
     describe('when called, and binding.isSatisfiedBy() returns true', () => {
@@ -608,7 +637,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
           lazyPlanServiceNodeFixture,
           bindingMock,
           bindingConstraintsListFixture,
-          chainedBindings,
+          buildServiceNodeOptionsFixture,
         );
       });
 
@@ -641,7 +670,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
     let lazyPlanServiceNodeFixture: LazyPlanServiceNode;
     let bindingMock: Mocked<Binding<unknown>>;
     let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
-    let chainedBindings: boolean;
+    let buildServiceNodeOptionsFixture: BuildServiceNodeOptions;
 
     beforeAll(() => {
       paramsFixture = Symbol() as unknown as BasePlanParams;
@@ -688,7 +717,14 @@ describe(addServiceNodeBindingIfContextFree, () => {
           1,
         );
 
-      chainedBindings = false;
+      buildServiceNodeOptionsFixture = {
+        chained: false,
+        isMultiple: true,
+        name: undefined,
+        optional: false,
+        serviceIdentifier: Symbol(),
+        tags: new Map(),
+      };
     });
 
     describe('when called, and binding.isSatisfiedBy() returns true', () => {
@@ -710,7 +746,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
           lazyPlanServiceNodeFixture,
           bindingMock,
           bindingConstraintsListFixture,
-          chainedBindings,
+          buildServiceNodeOptionsFixture,
         );
       });
 
@@ -732,7 +768,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
           bindingConstraintsListFixture,
           [bindingMock],
           lazyPlanServiceNodeFixture,
-          chainedBindings,
+          buildServiceNodeOptionsFixture,
         );
       });
 
@@ -753,7 +789,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
     let lazyPlanServiceNodeFixture: LazyPlanServiceNode;
     let bindingMock: Mocked<Binding<unknown>>;
     let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
-    let chainedBindings: boolean;
+    let buildServiceNodeOptionsFixture: BuildServiceNodeOptions;
 
     beforeAll(() => {
       paramsFixture = Symbol() as unknown as BasePlanParams;
@@ -800,7 +836,14 @@ describe(addServiceNodeBindingIfContextFree, () => {
           1,
         );
 
-      chainedBindings = false;
+      buildServiceNodeOptionsFixture = {
+        chained: false,
+        isMultiple: true,
+        name: undefined,
+        optional: false,
+        serviceIdentifier: Symbol(),
+        tags: new Map(),
+      };
     });
 
     describe('when called, and binding.isSatisfiedBy() returns true', () => {
@@ -822,7 +865,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
           lazyPlanServiceNodeFixture,
           bindingMock,
           bindingConstraintsListFixture,
-          chainedBindings,
+          buildServiceNodeOptionsFixture,
         );
       });
 
@@ -844,7 +887,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
           bindingConstraintsListFixture,
           [bindingMock],
           lazyPlanServiceNodeFixture,
-          chainedBindings,
+          buildServiceNodeOptionsFixture,
         );
       });
 
@@ -865,7 +908,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
     let planServiceNodeFixture: PlanServiceNode;
     let bindingMock: Mocked<Binding<unknown>>;
     let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
-    let chainedBindings: boolean;
+    let buildServiceNodeOptionsFixture: BuildServiceNodeOptions;
 
     beforeAll(() => {
       paramsFixture = Symbol() as unknown as BasePlanParams;
@@ -908,7 +951,14 @@ describe(addServiceNodeBindingIfContextFree, () => {
           1,
         );
 
-      chainedBindings = false;
+      buildServiceNodeOptionsFixture = {
+        chained: false,
+        isMultiple: true,
+        name: undefined,
+        optional: false,
+        serviceIdentifier: Symbol(),
+        tags: new Map(),
+      };
     });
 
     describe('when called, and binding.isSatisfiedBy() returns true', () => {
@@ -931,7 +981,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
             planServiceNodeFixture,
             bindingMock,
             bindingConstraintsListFixture,
-            chainedBindings,
+            buildServiceNodeOptionsFixture,
           );
         } catch (error: unknown) {
           result = error;
@@ -956,7 +1006,7 @@ describe(addServiceNodeBindingIfContextFree, () => {
           bindingConstraintsListFixture,
           [bindingMock],
           planServiceNodeFixture,
-          chainedBindings,
+          buildServiceNodeOptionsFixture,
         );
       });
 

--- a/packages/container/libraries/core/src/planning/actions/addServiceNodeBindingIfContextFree.ts
+++ b/packages/container/libraries/core/src/planning/actions/addServiceNodeBindingIfContextFree.ts
@@ -34,7 +34,7 @@ const buildServiceNodeBindings: (
   bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   serviceBindings: Binding<unknown>[],
   parentNode: BindingNodeParent,
-  chainedBindings: boolean,
+  buildServiceNodeOptions: BuildServiceNodeOptions,
 ) => PlanBindingNode[] = curryBuildServiceNodeBindings(subplan);
 
 const lazyBuildPlanServiceNodeFromOptions: (
@@ -71,7 +71,7 @@ export function addServiceNodeBindingIfContextFree(
   serviceNode: PlanServiceNode,
   binding: Binding<unknown>,
   bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
-  chainedBindings: boolean,
+  buildServiceNodeOptions: BuildServiceNodeOptions,
 ): PlanServiceNodeBindingAddedResult {
   if (LazyPlanServiceNode.is(serviceNode) && !serviceNode.isExpanded()) {
     return {
@@ -99,7 +99,7 @@ export function addServiceNodeBindingIfContextFree(
     serviceNode,
     binding,
     bindingConstraintsList,
-    chainedBindings,
+    buildServiceNodeOptions,
   );
 }
 
@@ -108,7 +108,7 @@ function addServiceNodeSatisfiedBindingIfContextFree(
   serviceNode: PlanServiceNode,
   binding: Binding<unknown>,
   bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
-  chainedBindings: boolean,
+  buildServiceNodeOptions: BuildServiceNodeOptions,
 ): PlanServiceNodeBindingAddedResult {
   let serviceNodeBinding: PlanBindingNode;
 
@@ -118,7 +118,7 @@ function addServiceNodeSatisfiedBindingIfContextFree(
       bindingConstraintsList,
       [binding],
       serviceNode,
-      chainedBindings,
+      buildServiceNodeOptions,
     ) as [PlanBindingNode];
   } catch (error: unknown) {
     if (

--- a/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNode.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNode.spec.ts
@@ -8,6 +8,9 @@ import {
   vitest,
 } from 'vitest';
 
+vitest.mock(
+  import('../../common/calculations/buildBuildServiceNodeOptionsFromPlanParamsConstraints.js'),
+);
 vitest.mock(import('../calculations/buildFilteredServiceBindings.js'));
 vitest.mock(import('../calculations/buildPlanBindingConstraintsList.js'));
 vitest.mock(
@@ -19,12 +22,14 @@ import {
   BindingConstraintsImplementation,
   type InternalBindingConstraints,
 } from '../../binding/models/BindingConstraintsImplementation.js';
+import { buildBuildServiceNodeOptionsFromPlanParamsConstraints } from '../../common/calculations/buildBuildServiceNodeOptionsFromPlanParamsConstraints.js';
 import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList.js';
 import { buildFilteredServiceBindings } from '../calculations/buildFilteredServiceBindings.js';
 import { buildPlanBindingConstraintsList } from '../calculations/buildPlanBindingConstraintsList.js';
 import { checkServiceNodeSingleInjectionBindings } from '../calculations/checkServiceNodeSingleInjectionBindings.js';
 import { type BasePlanParams } from '../models/BasePlanParams.js';
 import { type BindingNodeParent } from '../models/BindingNodeParent.js';
+import { type BuildServiceNodeOptions } from '../models/BuildServiceNodeOptions.js';
 import { type PlanBindingNode } from '../models/PlanBindingNode.js';
 import { type PlanParams } from '../models/PlanParams.js';
 import { type PlanParamsOperations } from '../models/PlanParamsOperations.js';
@@ -38,7 +43,7 @@ describe(curryBuildPlanServiceNode, () => {
       bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
       serviceBindings: Binding<unknown>[],
       parentNode: BindingNodeParent,
-      chainedBindings: boolean,
+      options: BuildServiceNodeOptions,
     ) => PlanBindingNode[]
   >;
 
@@ -65,6 +70,7 @@ describe(curryBuildPlanServiceNode, () => {
     describe('when called', () => {
       let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
       let bindingsFixture: Binding<unknown>[];
+      let buildServiceNodeOptionsFixture: BuildServiceNodeOptions;
       let planBindingNodesFixture: PlanBindingNode[];
 
       let result: unknown;
@@ -80,6 +86,8 @@ describe(curryBuildPlanServiceNode, () => {
           );
 
         bindingsFixture = [Symbol() as unknown as Binding<unknown>];
+        buildServiceNodeOptionsFixture =
+          Symbol() as unknown as BuildServiceNodeOptions;
         planBindingNodesFixture = [Symbol() as unknown as PlanBindingNode];
 
         vitest
@@ -89,6 +97,10 @@ describe(curryBuildPlanServiceNode, () => {
         vitest
           .mocked(buildFilteredServiceBindings)
           .mockReturnValueOnce(bindingsFixture);
+
+        vitest
+          .mocked(buildBuildServiceNodeOptionsFromPlanParamsConstraints)
+          .mockReturnValueOnce(buildServiceNodeOptionsFixture);
 
         buildServiceNodeBindingsMock.mockReturnValueOnce(
           planBindingNodesFixture,
@@ -119,6 +131,12 @@ describe(curryBuildPlanServiceNode, () => {
         );
       });
 
+      it('should call buildBuildServiceNodeOptionsFromPlanParamsConstraints()', () => {
+        expect(
+          buildBuildServiceNodeOptionsFromPlanParamsConstraints,
+        ).toHaveBeenCalledExactlyOnceWith(planParamsFixture.rootConstraints);
+      });
+
       it('should call buildServiceNodeBindings()', () => {
         const expectedServiceNode: BindingNodeParent = {
           bindings: planBindingNodesFixture,
@@ -132,7 +150,7 @@ describe(curryBuildPlanServiceNode, () => {
           bindingConstraintsListFixture,
           bindingsFixture,
           expectedServiceNode,
-          false,
+          buildServiceNodeOptionsFixture,
         );
       });
 
@@ -167,6 +185,7 @@ describe(curryBuildPlanServiceNode, () => {
     describe('when called', () => {
       let bindingConstraintsListFixture: SingleImmutableLinkedList<InternalBindingConstraints>;
       let bindingsFixture: Binding<unknown>[];
+      let buildServiceNodeOptionsFixture: BuildServiceNodeOptions;
       let planBindingNodeFixture: PlanBindingNode;
 
       let result: unknown;
@@ -182,6 +201,8 @@ describe(curryBuildPlanServiceNode, () => {
           );
 
         bindingsFixture = [Symbol() as unknown as Binding<unknown>];
+        buildServiceNodeOptionsFixture =
+          Symbol() as unknown as BuildServiceNodeOptions;
         planBindingNodeFixture = Symbol() as unknown as PlanBindingNode;
 
         vitest
@@ -191,6 +212,10 @@ describe(curryBuildPlanServiceNode, () => {
         vitest
           .mocked(buildFilteredServiceBindings)
           .mockReturnValueOnce(bindingsFixture);
+
+        vitest
+          .mocked(buildBuildServiceNodeOptionsFromPlanParamsConstraints)
+          .mockReturnValueOnce(buildServiceNodeOptionsFixture);
 
         buildServiceNodeBindingsMock.mockReturnValueOnce([
           planBindingNodeFixture,
@@ -221,6 +246,12 @@ describe(curryBuildPlanServiceNode, () => {
         );
       });
 
+      it('should call buildBuildServiceNodeOptionsFromPlanParamsConstraints()', () => {
+        expect(
+          buildBuildServiceNodeOptionsFromPlanParamsConstraints,
+        ).toHaveBeenCalledExactlyOnceWith(planParamsFixture.rootConstraints);
+      });
+
       it('should call buildServiceNodeBindings()', () => {
         const expectedServiceNode: BindingNodeParent = {
           bindings: planBindingNodeFixture,
@@ -234,7 +265,7 @@ describe(curryBuildPlanServiceNode, () => {
           bindingConstraintsListFixture,
           bindingsFixture,
           expectedServiceNode,
-          false,
+          buildServiceNodeOptionsFixture,
         );
       });
 

--- a/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNode.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNode.ts
@@ -4,12 +4,14 @@ import {
   BindingConstraintsImplementation,
   type InternalBindingConstraints,
 } from '../../binding/models/BindingConstraintsImplementation.js';
+import { buildBuildServiceNodeOptionsFromPlanParamsConstraints } from '../../common/calculations/buildBuildServiceNodeOptionsFromPlanParamsConstraints.js';
 import { type SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList.js';
 import { buildFilteredServiceBindings } from '../calculations/buildFilteredServiceBindings.js';
 import { buildPlanBindingConstraintsList } from '../calculations/buildPlanBindingConstraintsList.js';
 import { checkServiceNodeSingleInjectionBindings } from '../calculations/checkServiceNodeSingleInjectionBindings.js';
 import { type BasePlanParams } from '../models/BasePlanParams.js';
 import { type BindingNodeParent } from '../models/BindingNodeParent.js';
+import { type BuildServiceNodeOptions } from '../models/BuildServiceNodeOptions.js';
 import { type PlanBindingNode } from '../models/PlanBindingNode.js';
 import { type PlanParams } from '../models/PlanParams.js';
 import { type PlanServiceNode } from '../models/PlanServiceNode.js';
@@ -20,7 +22,7 @@ export function curryBuildPlanServiceNode(
     bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     serviceBindings: Binding<unknown>[],
     parentNode: BindingNodeParent,
-    chainedBindings: boolean,
+    buildServiceNodeOptions: BuildServiceNodeOptions,
   ) => PlanBindingNode[],
 ): (params: PlanParams) => PlanServiceNode {
   return (params: PlanParams): PlanServiceNode => {
@@ -52,7 +54,9 @@ export function curryBuildPlanServiceNode(
         bindingConstraintsList,
         filteredServiceBindings,
         serviceNode,
-        chained,
+        buildBuildServiceNodeOptionsFromPlanParamsConstraints(
+          params.rootConstraints,
+        ),
       ),
     );
 

--- a/packages/container/libraries/core/src/planning/actions/curryBuildServiceNodeBindings.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildServiceNodeBindings.spec.ts
@@ -102,7 +102,14 @@ describe(curryBuildServiceNodeBindings, () => {
           bindingConstraintsListFixture,
           [instanceBindingFixture],
           parentNodeFixture,
-          false,
+          {
+            chained: false,
+            isMultiple: true,
+            name: undefined,
+            optional: false,
+            serviceIdentifier: Symbol(),
+            tags: new Map(),
+          },
         );
       });
 
@@ -194,7 +201,14 @@ describe(curryBuildServiceNodeBindings, () => {
           bindingConstraintsListFixture,
           [resolvedValueBindingFixture],
           parentNodeFixture,
-          false,
+          {
+            chained: false,
+            isMultiple: true,
+            name: undefined,
+            optional: false,
+            serviceIdentifier: Symbol(),
+            tags: new Map(),
+          },
         );
       });
 
@@ -278,7 +292,14 @@ describe(curryBuildServiceNodeBindings, () => {
           bindingConstraintsListFixture,
           [serviceRedirectionBindingFixture],
           parentNodeFixture,
-          false,
+          {
+            chained: false,
+            isMultiple: true,
+            name: undefined,
+            optional: false,
+            serviceIdentifier: Symbol(),
+            tags: new Map(),
+          },
         );
       });
 

--- a/packages/container/libraries/core/src/planning/actions/curryBuildServiceNodeBindings.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildServiceNodeBindings.ts
@@ -21,6 +21,7 @@ import { buildFilteredServiceBindings } from '../calculations/buildFilteredServi
 import { isPlanServiceRedirectionBindingNode } from '../calculations/isPlanServiceRedirectionBindingNode.js';
 import { type BasePlanParams } from '../models/BasePlanParams.js';
 import { type BindingNodeParent } from '../models/BindingNodeParent.js';
+import { type BuildServiceNodeOptions } from '../models/BuildServiceNodeOptions.js';
 import { ConstantValueBindingNode } from '../models/ConstantValueBindingNode.js';
 import { DynamicValueBindingNode } from '../models/DynamicValueBindingNode.js';
 import { FactoryBindingNodeImplementation } from '../models/FactoryBindingNodeImplementation.js';
@@ -42,7 +43,7 @@ export function curryBuildServiceNodeBindings(
   bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   serviceBindings: Binding<unknown>[],
   parentNode: BindingNodeParent,
-  chainedBindings: boolean,
+  buildServiceNodeOptions: BuildServiceNodeOptions,
 ) => PlanBindingNode[] {
   const buildInstancePlanBindingNode: (
     params: BasePlanParams,
@@ -60,13 +61,13 @@ export function curryBuildServiceNodeBindings(
     bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     serviceBindings: Binding<unknown>[],
     parentNode: BindingNodeParent,
-    chainedBindings: boolean,
+    buildServiceNodeOptions: BuildServiceNodeOptions,
   ) => PlanBindingNode[] = (
     params: BasePlanParams,
     bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     serviceBindings: Binding<unknown>[],
     parentNode: BindingNodeParent,
-    chainedBindings: boolean,
+    buildServiceNodeOptions: BuildServiceNodeOptions,
   ): PlanBindingNode[] => {
     const serviceIdentifier: ServiceIdentifier =
       isPlanServiceRedirectionBindingNode(parentNode)
@@ -122,7 +123,7 @@ export function curryBuildServiceNodeBindings(
               params,
               bindingConstraintsList,
               binding,
-              chainedBindings,
+              buildServiceNodeOptions,
             );
 
           planBindingNodes.push(planBindingNode);
@@ -141,7 +142,7 @@ export function curryBuildServiceNodeBindings(
     params: BasePlanParams,
     bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     binding: ServiceRedirectionBinding<unknown>,
-    chainedBindings: boolean,
+    buildServiceNodeOptions: BuildServiceNodeOptions,
   ) => PlanBindingNode = curryBuildServiceRedirectionPlanBindingNode(
     buildServiceNodeBindings,
   );
@@ -217,19 +218,19 @@ function curryBuildServiceRedirectionPlanBindingNode(
     bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     serviceBindings: Binding<unknown>[],
     parentNode: BindingNodeParent,
-    chainedBindings: boolean,
+    buildServiceNodeOptions: BuildServiceNodeOptions,
   ) => PlanBindingNode[],
 ): (
   params: BasePlanParams,
   bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   binding: ServiceRedirectionBinding<unknown>,
-  chainedBindings: boolean,
+  buildServiceNodeOptions: BuildServiceNodeOptions,
 ) => PlanBindingNode {
   return (
     params: BasePlanParams,
     bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     binding: ServiceRedirectionBinding<unknown>,
-    chainedBindings: boolean,
+    buildServiceNodeOptions: BuildServiceNodeOptions,
   ): PlanBindingNode => {
     const childNode: PlanServiceRedirectionBindingNode = {
       binding,
@@ -241,7 +242,8 @@ function curryBuildServiceRedirectionPlanBindingNode(
 
     const filteredServiceBindings: Binding<unknown>[] =
       buildFilteredServiceBindings(params, bindingConstraints, {
-        chained: chainedBindings,
+        chained:
+          buildServiceNodeOptions.isMultiple && buildServiceNodeOptions.chained,
         customServiceIdentifier: binding.targetServiceIdentifier,
       });
 
@@ -251,7 +253,7 @@ function curryBuildServiceRedirectionPlanBindingNode(
         bindingConstraintsList,
         filteredServiceBindings,
         childNode,
-        chainedBindings,
+        buildServiceNodeOptions,
       ),
     );
 

--- a/packages/container/libraries/core/src/planning/actions/currySubplan.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/currySubplan.spec.ts
@@ -37,6 +37,7 @@ import { type BuildServiceNodeOptions } from '../models/BuildServiceNodeOptions.
 import { type GetPlanOptions } from '../models/GetPlanOptions.js';
 import { type InstanceBindingNode } from '../models/InstanceBindingNode.js';
 import { LazyPlanServiceNode } from '../models/LazyPlanServiceNode.js';
+import { type NonCachedServiceNodeContext } from '../models/NonCachedServiceNodeContext.js';
 import { type PlanParamsOperations } from '../models/PlanParamsOperations.js';
 import { type PlanResult } from '../models/PlanResult.js';
 import { type PlanServiceNode } from '../models/PlanServiceNode.js';
@@ -282,9 +283,9 @@ describe(currySubplan, () => {
           expect.any(LazyPlanServiceNode),
           {
             bindingConstraintsList: bindingConstraintsListFixture,
-            chainedBindings: false,
+            buildServiceNodeOptions: buildServiceNodeOptionsFixture,
             optionalBindings: false,
-          },
+          } satisfies NonCachedServiceNodeContext,
         );
       });
 
@@ -372,9 +373,9 @@ describe(currySubplan, () => {
           expect.any(LazyPlanServiceNode),
           {
             bindingConstraintsList: bindingConstraintsListFixture,
-            chainedBindings: false,
+            buildServiceNodeOptions: buildServiceNodeOptionsFixture,
             optionalBindings: false,
-          },
+          } satisfies NonCachedServiceNodeContext,
         );
       });
 
@@ -557,9 +558,9 @@ describe(currySubplan, () => {
           expect.any(LazyPlanServiceNode),
           {
             bindingConstraintsList: bindingConstraintsListFixture,
-            chainedBindings: false,
+            buildServiceNodeOptions: buildServiceNodeOptionsFixture,
             optionalBindings: false,
-          },
+          } satisfies NonCachedServiceNodeContext,
         );
       });
 
@@ -671,9 +672,9 @@ describe(currySubplan, () => {
           expect.any(LazyPlanServiceNode),
           {
             bindingConstraintsList: bindingConstraintsListFixture,
-            chainedBindings: false,
+            buildServiceNodeOptions: buildServiceNodeOptionsFixture,
             optionalBindings: false,
-          },
+          } satisfies NonCachedServiceNodeContext,
         );
       });
 
@@ -769,9 +770,9 @@ describe(currySubplan, () => {
           expect.any(LazyPlanServiceNode),
           {
             bindingConstraintsList: bindingConstraintsListFixture,
-            chainedBindings: false,
+            buildServiceNodeOptions: buildServiceNodeOptionsFixture,
             optionalBindings: false,
-          },
+          } satisfies NonCachedServiceNodeContext,
         );
       });
 
@@ -966,9 +967,9 @@ describe(currySubplan, () => {
           expect.any(LazyPlanServiceNode),
           {
             bindingConstraintsList: bindingConstraintsListFixture,
-            chainedBindings: false,
+            buildServiceNodeOptions: buildServiceNodeOptionsFixture,
             optionalBindings: false,
-          },
+          } satisfies NonCachedServiceNodeContext,
         );
       });
 
@@ -1070,9 +1071,9 @@ describe(currySubplan, () => {
           expect.any(LazyPlanServiceNode),
           {
             bindingConstraintsList: bindingConstraintsListFixture,
-            chainedBindings: false,
+            buildServiceNodeOptions: buildServiceNodeOptionsFixture,
             optionalBindings: false,
-          },
+          } satisfies NonCachedServiceNodeContext,
         );
       });
 

--- a/packages/container/libraries/core/src/planning/actions/currySubplan.ts
+++ b/packages/container/libraries/core/src/planning/actions/currySubplan.ts
@@ -8,7 +8,6 @@ import { type ClassElementMetadata } from '../../metadata/models/ClassElementMet
 import { ClassElementMetadataKind } from '../../metadata/models/ClassElementMetadataKind.js';
 import { type ClassMetadata } from '../../metadata/models/ClassMetadata.js';
 import { type ResolvedValueElementMetadata } from '../../metadata/models/ResolvedValueElementMetadata.js';
-import { ResolvedValueElementMetadataKind } from '../../metadata/models/ResolvedValueElementMetadataKind.js';
 import { type ResolvedValueMetadata } from '../../metadata/models/ResolvedValueMetadata.js';
 import { isInstanceBindingNode } from '../calculations/isInstanceBindingNode.js';
 import { tryBuildGetPlanOptionsFromManagedClassElementMetadata } from '../calculations/tryBuildGetPlanOptionsFromManagedClassElementMetadata.js';
@@ -293,9 +292,7 @@ function curryHandlePlanServiceNodeBuildFromClassElementMetadata(
       lazyPlanServiceNode,
       {
         bindingConstraintsList,
-        chainedBindings:
-          elementMetadata.kind === ClassElementMetadataKind.multipleInjection &&
-          elementMetadata.chained,
+        buildServiceNodeOptions: options,
         optionalBindings: elementMetadata.optional,
       },
     );
@@ -359,10 +356,7 @@ function curryHandlePlanServiceNodeBuildFromResolvedValueElementMetadata(
       lazyPlanServiceNode,
       {
         bindingConstraintsList,
-        chainedBindings:
-          elementMetadata.kind ===
-            ResolvedValueElementMetadataKind.multipleInjection &&
-          elementMetadata.chained,
+        buildServiceNodeOptions: options,
         optionalBindings: elementMetadata.optional,
       },
     );

--- a/packages/container/libraries/core/src/planning/actions/plan.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/plan.spec.ts
@@ -27,6 +27,7 @@ import { type SingleImmutableLinkedList } from '../../common/models/SingleImmuta
 import { buildGetPlanOptionsFromPlanParams } from '../calculations/buildGetPlanOptionsFromPlanParams.js';
 import { type BasePlanParams } from '../models/BasePlanParams.js';
 import { type BindingNodeParent } from '../models/BindingNodeParent.js';
+import { type BuildServiceNodeOptions } from '../models/BuildServiceNodeOptions.js';
 import { type GetPlanOptions } from '../models/GetPlanOptions.js';
 import { type PlanBindingNode } from '../models/PlanBindingNode.js';
 import { type PlanParams } from '../models/PlanParams.js';
@@ -49,7 +50,7 @@ describe(plan, () => {
           bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
           serviceBindings: Binding<unknown>[],
           parentNode: BindingNodeParent,
-          chainedBindings: boolean,
+          options: BuildServiceNodeOptions,
         ) => PlanBindingNode[],
       ),
     );

--- a/packages/container/libraries/core/src/planning/actions/plan.ts
+++ b/packages/container/libraries/core/src/planning/actions/plan.ts
@@ -53,7 +53,7 @@ const buildServiceNodeBindings: (
   bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   serviceBindings: Binding<unknown>[],
   parentNode: BindingNodeParent,
-  chainedBindings: boolean,
+  buildServiceNodeOptions: BuildServiceNodeOptions,
 ) => PlanBindingNode[] = curryBuildServiceNodeBindings(subplan);
 
 function circularBuildServiceNodeBindings(
@@ -61,14 +61,14 @@ function circularBuildServiceNodeBindings(
   bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
   serviceBindings: Binding<unknown>[],
   parentNode: BindingNodeParent,
-  chainedBindings: boolean,
+  buildServiceNodeOptions: BuildServiceNodeOptions,
 ): PlanBindingNode[] {
   return buildServiceNodeBindings(
     params,
     bindingConstraintsList,
     serviceBindings,
     parentNode,
-    chainedBindings,
+    buildServiceNodeOptions,
   );
 }
 

--- a/packages/container/libraries/core/src/planning/calculations/curryBuildPlanServiceNodeFromOptions.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/curryBuildPlanServiceNodeFromOptions.spec.ts
@@ -29,6 +29,7 @@ import { BuildSingleBindingServiceNodeOptionsFixtures } from '../fixtures/BuildS
 import { type BasePlanParams } from '../models/BasePlanParams.js';
 import { type BindingNodeParent } from '../models/BindingNodeParent.js';
 import { type BuildMultipleBindingServiceNodeOptions } from '../models/BuildMultipleBindingServiceNodeOptions.js';
+import { type BuildServiceNodeOptions } from '../models/BuildServiceNodeOptions.js';
 import { type BuildSingleBindingServiceNodeOptions } from '../models/BuildSingleBindingServiceNodeOptions.js';
 import { type PlanBindingNode } from '../models/PlanBindingNode.js';
 import { type PlanServiceNode } from '../models/PlanServiceNode.js';
@@ -42,7 +43,7 @@ describe(curryBuildPlanServiceNodeFromOptions, () => {
       bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
       serviceBindings: Binding<unknown>[],
       parentNode: BindingNodeParent,
-      chainedBindings: boolean,
+      options: BuildServiceNodeOptions,
     ) => PlanBindingNode[]
   >;
 
@@ -125,7 +126,7 @@ describe(curryBuildPlanServiceNodeFromOptions, () => {
           ),
           bindingsFixture,
           expectedServiceNode,
-          optionsFixture.chained,
+          optionsFixture,
         );
       });
 
@@ -220,7 +221,7 @@ describe(curryBuildPlanServiceNodeFromOptions, () => {
           ),
           bindingsFixture,
           expectedServiceNode,
-          false,
+          optionsFixture,
         );
       });
 

--- a/packages/container/libraries/core/src/planning/calculations/curryBuildPlanServiceNodeFromOptions.ts
+++ b/packages/container/libraries/core/src/planning/calculations/curryBuildPlanServiceNodeFromOptions.ts
@@ -22,7 +22,7 @@ export function curryBuildPlanServiceNodeFromOptions(
     bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     serviceBindings: Binding<unknown>[],
     parentNode: BindingNodeParent,
-    chainedBindings: boolean,
+    buildServiceNodeOptions: BuildServiceNodeOptions,
   ) => PlanBindingNode[],
 ): (
   params: SubplanParams,
@@ -68,7 +68,7 @@ export function curryBuildPlanServiceNodeFromOptions(
         updatedBindingConstraintsList,
         filteredServiceBindings,
         serviceNode,
-        chained,
+        options,
       ),
     );
 

--- a/packages/container/libraries/core/src/planning/calculations/curryLazyBuildPlanServiceNodeFromOptions.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/curryLazyBuildPlanServiceNodeFromOptions.spec.ts
@@ -25,13 +25,13 @@ import { curryBuildPlanServiceNodeFromOptions } from './curryBuildPlanServiceNod
 import { curryLazyBuildPlanServiceNodeFromOptions } from './curryLazyBuildPlanServiceNodeFromOptions.js';
 
 describe(curryLazyBuildPlanServiceNodeFromOptions, () => {
-  let buildServiceNodeBindingsFixture: Mock<
+  let buildServiceNodeBindingsMock: Mock<
     (
       params: BasePlanParams,
       bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
       serviceBindings: Binding<unknown>[],
       parentNode: BindingNodeParent,
-      chainedBindings: boolean,
+      opitons: BuildServiceNodeOptions,
     ) => PlanBindingNode[]
   >;
 
@@ -40,7 +40,7 @@ describe(curryLazyBuildPlanServiceNodeFromOptions, () => {
   let optionsFixture: BuildServiceNodeOptions;
 
   beforeAll(() => {
-    buildServiceNodeBindingsFixture = vitest.fn();
+    buildServiceNodeBindingsMock = vitest.fn();
 
     paramsFixture = Symbol() as unknown as SubplanParams;
     bindingConstraintsListFixture =
@@ -73,7 +73,7 @@ describe(curryLazyBuildPlanServiceNodeFromOptions, () => {
         .mockReturnValueOnce(buildPlanServiceNodeFromOptionsMock);
 
       result = curryLazyBuildPlanServiceNodeFromOptions(
-        buildServiceNodeBindingsFixture,
+        buildServiceNodeBindingsMock,
       )(paramsFixture, bindingConstraintsListFixture, optionsFixture);
     });
 
@@ -84,7 +84,7 @@ describe(curryLazyBuildPlanServiceNodeFromOptions, () => {
     it('should call curryBuildPlanServiceNodeFromOptions()', () => {
       expect(
         curryBuildPlanServiceNodeFromOptions,
-      ).toHaveBeenCalledExactlyOnceWith(buildServiceNodeBindingsFixture);
+      ).toHaveBeenCalledExactlyOnceWith(buildServiceNodeBindingsMock);
     });
 
     it('should return a PlanServiceNode', () => {
@@ -119,9 +119,11 @@ describe(curryLazyBuildPlanServiceNodeFromOptions, () => {
         .mockReturnValueOnce(buildPlanServiceNodeFromOptionsMock);
 
       try {
-        curryLazyBuildPlanServiceNodeFromOptions(
-          buildServiceNodeBindingsFixture,
-        )(paramsFixture, bindingConstraintsListFixture, optionsFixture);
+        curryLazyBuildPlanServiceNodeFromOptions(buildServiceNodeBindingsMock)(
+          paramsFixture,
+          bindingConstraintsListFixture,
+          optionsFixture,
+        );
       } catch (error: unknown) {
         result = error;
       }
@@ -134,7 +136,7 @@ describe(curryLazyBuildPlanServiceNodeFromOptions, () => {
     it('should call curryBuildPlanServiceNodeFromOptions()', () => {
       expect(
         curryBuildPlanServiceNodeFromOptions,
-      ).toHaveBeenCalledExactlyOnceWith(buildServiceNodeBindingsFixture);
+      ).toHaveBeenCalledExactlyOnceWith(buildServiceNodeBindingsMock);
     });
 
     it('should throw an Error', () => {
@@ -172,7 +174,7 @@ describe(curryLazyBuildPlanServiceNodeFromOptions, () => {
         .mockReturnValueOnce(buildPlanServiceNodeFromOptionsMock);
 
       result = curryLazyBuildPlanServiceNodeFromOptions(
-        buildServiceNodeBindingsFixture,
+        buildServiceNodeBindingsMock,
       )(paramsFixture, bindingConstraintsListFixture, optionsFixture);
     });
 
@@ -183,7 +185,7 @@ describe(curryLazyBuildPlanServiceNodeFromOptions, () => {
     it('should call curryBuildPlanServiceNodeFromOptions()', () => {
       expect(
         curryBuildPlanServiceNodeFromOptions,
-      ).toHaveBeenCalledExactlyOnceWith(buildServiceNodeBindingsFixture);
+      ).toHaveBeenCalledExactlyOnceWith(buildServiceNodeBindingsMock);
     });
 
     it('should return undefined', () => {

--- a/packages/container/libraries/core/src/planning/calculations/curryLazyBuildPlanServiceNodeFromOptions.ts
+++ b/packages/container/libraries/core/src/planning/calculations/curryLazyBuildPlanServiceNodeFromOptions.ts
@@ -17,7 +17,7 @@ export function curryLazyBuildPlanServiceNodeFromOptions(
     bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>,
     serviceBindings: Binding<unknown>[],
     parentNode: BindingNodeParent,
-    chainedBindings: boolean,
+    buildServiceNodeOptions: BuildServiceNodeOptions,
   ) => PlanBindingNode[],
 ): (
   params: SubplanParams,

--- a/packages/container/libraries/core/src/planning/models/NonCachedServiceNodeContext.ts
+++ b/packages/container/libraries/core/src/planning/models/NonCachedServiceNodeContext.ts
@@ -1,8 +1,9 @@
 import { type InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation.js';
 import { type SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList.js';
+import { type BuildServiceNodeOptions } from './BuildServiceNodeOptions.js';
 
 export interface NonCachedServiceNodeContext {
   bindingConstraintsList: SingleImmutableLinkedList<InternalBindingConstraints>;
-  chainedBindings: boolean;
+  buildServiceNodeOptions: BuildServiceNodeOptions;
   optionalBindings: boolean;
 }

--- a/packages/container/libraries/core/src/planning/services/PlanResultCacheService.spec.ts
+++ b/packages/container/libraries/core/src/planning/services/PlanResultCacheService.spec.ts
@@ -1528,7 +1528,14 @@ describe(PlanResultCacheService, () => {
                 {
                   bindingConstraintsList:
                     Symbol() as unknown as SingleImmutableLinkedList<InternalBindingConstraints>,
-                  chainedBindings: false,
+                  buildServiceNodeOptions: {
+                    chained: false,
+                    isMultiple: true,
+                    name: undefined,
+                    optional: false,
+                    serviceIdentifier: Symbol(),
+                    tags: new Map(),
+                  },
                   optionalBindings: false,
                 },
               );
@@ -1753,7 +1760,14 @@ describe(PlanResultCacheService, () => {
                 {
                   bindingConstraintsList:
                     Symbol() as unknown as SingleImmutableLinkedList<InternalBindingConstraints>,
-                  chainedBindings: false,
+                  buildServiceNodeOptions: {
+                    chained: false,
+                    isMultiple: true,
+                    name: undefined,
+                    optional: false,
+                    serviceIdentifier: Symbol(),
+                    tags: new Map(),
+                  },
                   optionalBindings: false,
                 },
               );
@@ -1983,7 +1997,14 @@ describe(PlanResultCacheService, () => {
                 {
                   bindingConstraintsList:
                     Symbol() as unknown as SingleImmutableLinkedList<InternalBindingConstraints>,
-                  chainedBindings: false,
+                  buildServiceNodeOptions: {
+                    chained: false,
+                    isMultiple: true,
+                    name: undefined,
+                    optional: false,
+                    serviceIdentifier: Symbol(),
+                    tags: new Map(),
+                  },
                   optionalBindings: false,
                 },
               );
@@ -2075,7 +2096,14 @@ describe(PlanResultCacheService, () => {
           nonCachedServiceNodeContextFixture = {
             bindingConstraintsList:
               Symbol() as unknown as SingleImmutableLinkedList<InternalBindingConstraints>,
-            chainedBindings: false,
+            buildServiceNodeOptions: {
+              chained: false,
+              isMultiple: true,
+              name: undefined,
+              optional: false,
+              serviceIdentifier: Symbol(),
+              tags: new Map(),
+            },
             optionalBindings: false,
           };
 
@@ -2117,7 +2145,7 @@ describe(PlanResultCacheService, () => {
             lazyPlanServiceNodeFixture,
             planResultCacheServiceInvalidationFixture.binding,
             nonCachedServiceNodeContextFixture.bindingConstraintsList,
-            nonCachedServiceNodeContextFixture.chainedBindings,
+            false,
           );
         });
 
@@ -2173,7 +2201,14 @@ describe(PlanResultCacheService, () => {
           nonCachedServiceNodeContextFixture = {
             bindingConstraintsList:
               Symbol() as unknown as SingleImmutableLinkedList<InternalBindingConstraints>,
-            chainedBindings: false,
+            buildServiceNodeOptions: {
+              chained: false,
+              isMultiple: true,
+              name: undefined,
+              optional: false,
+              serviceIdentifier: Symbol(),
+              tags: new Map(),
+            },
             optionalBindings: false,
           };
 
@@ -2210,7 +2245,7 @@ describe(PlanResultCacheService, () => {
             lazyPlanServiceNodeFixture,
             planResultCacheServiceInvalidationFixture.binding,
             nonCachedServiceNodeContextFixture.bindingConstraintsList,
-            nonCachedServiceNodeContextFixture.chainedBindings,
+            false,
           );
         });
 

--- a/packages/container/libraries/core/src/planning/services/PlanResultCacheService.spec.ts
+++ b/packages/container/libraries/core/src/planning/services/PlanResultCacheService.spec.ts
@@ -2145,7 +2145,7 @@ describe(PlanResultCacheService, () => {
             lazyPlanServiceNodeFixture,
             planResultCacheServiceInvalidationFixture.binding,
             nonCachedServiceNodeContextFixture.bindingConstraintsList,
-            false,
+            nonCachedServiceNodeContextFixture.buildServiceNodeOptions,
           );
         });
 
@@ -2245,7 +2245,7 @@ describe(PlanResultCacheService, () => {
             lazyPlanServiceNodeFixture,
             planResultCacheServiceInvalidationFixture.binding,
             nonCachedServiceNodeContextFixture.bindingConstraintsList,
-            false,
+            nonCachedServiceNodeContextFixture.buildServiceNodeOptions,
           );
         });
 

--- a/packages/container/libraries/core/src/planning/services/PlanResultCacheService.ts
+++ b/packages/container/libraries/core/src/planning/services/PlanResultCacheService.ts
@@ -457,8 +457,7 @@ export class PlanResultCacheService {
                 serviceNode,
                 invalidation.binding,
                 context.bindingConstraintsList,
-                context.buildServiceNodeOptions.isMultiple &&
-                  context.buildServiceNodeOptions.chained,
+                context.buildServiceNodeOptions,
               );
 
             if (result.isContextFreeBinding) {

--- a/packages/container/libraries/core/src/planning/services/PlanResultCacheService.ts
+++ b/packages/container/libraries/core/src/planning/services/PlanResultCacheService.ts
@@ -457,7 +457,8 @@ export class PlanResultCacheService {
                 serviceNode,
                 invalidation.binding,
                 context.bindingConstraintsList,
-                context.chainedBindings,
+                context.buildServiceNodeOptions.isMultiple &&
+                  context.buildServiceNodeOptions.chained,
               );
 
             if (result.isContextFreeBinding) {


### PR DESCRIPTION
### Changed
- Updated `buildServiceNodeBindings` to receive `buildServiceNodeOptions`.
- Removed `NonCachedServiceNodeContext.chainedBindings` in favor of `buildServiceNodeOptions`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Planning and caching now carry richer service-node options, improving how binding behavior is handled across the container.

* **Bug Fixes**
  * Fixed cache invalidation and binding planning to use the updated service-node option data consistently.
  * Added coverage for multiple binding scenarios, including optional names, tags, and lazy service nodes.

* **Chores**
  * Updated release notes to reflect major version bumps and a breaking API change.
  * Added repository ignore rules for local pnpm storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->