### PR TITLE
Improve async resolution performance

### DIFF
--- a/packages/container/libraries/core/src/planning/calculations/buildInstanceBindingNodeResolver.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildInstanceBindingNodeResolver.ts
@@ -23,6 +23,9 @@ import {
   type SyncResolved,
 } from '../../resolution/models/Resolved.js';
 import { type InstanceBindingNode } from '../models/InstanceBindingNode.js';
+import { resolveFour } from './resolveFour.js';
+import { resolveThree } from './resolveThree.js';
+import { resolveTwo } from './resolveTwo.js';
 
 const ZERO_CONSTRUCTOR_ARGUMENTS: number = 0;
 const ONE_CONSTRUCTOR_ARGUMENT: number = 1;
@@ -123,17 +126,17 @@ function buildSimpleInstanceBindingNodeResolver<TActivated>(
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           node.constructorParams[1]!.resolve(params);
 
-        if (isPromise(firstResolvedValue) || isPromise(secondResolvedValue)) {
-          return resolveInstanceBindingNodeAsyncFromOnlyConstructorParams(
-            Promise.all([firstResolvedValue, secondResolvedValue]),
-            params,
-            node,
-          );
-        }
-
-        return resolveActivations(
-          params,
-          new implementationType(firstResolvedValue, secondResolvedValue),
+        return resolveTwo(
+          firstResolvedValue,
+          secondResolvedValue,
+          (
+            resolvedFirstValue: unknown,
+            resolvedSecondValue: unknown,
+          ): Resolved<TActivated> =>
+            resolveActivations(
+              params,
+              new implementationType(resolvedFirstValue, resolvedSecondValue),
+            ),
         );
       };
       break;
@@ -149,29 +152,23 @@ function buildSimpleInstanceBindingNodeResolver<TActivated>(
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           node.constructorParams[2]!.resolve(params);
 
-        if (
-          isPromise(firstResolvedValue) ||
-          isPromise(secondResolvedValue) ||
-          isPromise(thirdResolvedValue)
-        ) {
-          return resolveInstanceBindingNodeAsyncFromOnlyConstructorParams(
-            Promise.all([
-              firstResolvedValue,
-              secondResolvedValue,
-              thirdResolvedValue,
-            ]),
-            params,
-            node,
-          );
-        }
-
-        return resolveActivations(
-          params,
-          new implementationType(
-            firstResolvedValue,
-            secondResolvedValue,
-            thirdResolvedValue,
-          ),
+        return resolveThree(
+          firstResolvedValue,
+          secondResolvedValue,
+          thirdResolvedValue,
+          (
+            resolvedFirstValue: unknown,
+            resolvedSecondValue: unknown,
+            resolvedThirdValue: unknown,
+          ): Resolved<TActivated> =>
+            resolveActivations(
+              params,
+              new implementationType(
+                resolvedFirstValue,
+                resolvedSecondValue,
+                resolvedThirdValue,
+              ),
+            ),
         );
       };
       break;
@@ -190,32 +187,26 @@ function buildSimpleInstanceBindingNodeResolver<TActivated>(
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           node.constructorParams[3]!.resolve(params);
 
-        if (
-          isPromise(firstResolvedValue) ||
-          isPromise(secondResolvedValue) ||
-          isPromise(thirdResolvedValue) ||
-          isPromise(fourthResolvedValue)
-        ) {
-          return resolveInstanceBindingNodeAsyncFromOnlyConstructorParams(
-            Promise.all([
-              firstResolvedValue,
-              secondResolvedValue,
-              thirdResolvedValue,
-              fourthResolvedValue,
-            ]),
-            params,
-            node,
-          );
-        }
-
-        return resolveActivations(
-          params,
-          new implementationType(
-            firstResolvedValue,
-            secondResolvedValue,
-            thirdResolvedValue,
-            fourthResolvedValue,
-          ),
+        return resolveFour(
+          firstResolvedValue,
+          secondResolvedValue,
+          thirdResolvedValue,
+          fourthResolvedValue,
+          (
+            resolvedFirstValue: unknown,
+            resolvedSecondValue: unknown,
+            resolvedThirdValue: unknown,
+            resolvedFourthValue: unknown,
+          ): Resolved<TActivated> =>
+            resolveActivations(
+              params,
+              new implementationType(
+                resolvedFirstValue,
+                resolvedSecondValue,
+                resolvedThirdValue,
+                resolvedFourthValue,
+              ),
+            ),
         );
       };
       break;

--- a/packages/container/libraries/core/src/planning/calculations/buildResolvedValueBindingNodeResolver.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildResolvedValueBindingNodeResolver.ts
@@ -9,6 +9,9 @@ import { resolveScopedWithNoActivations } from '../../resolution/actions/resolve
 import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
 import { type Resolved } from '../../resolution/models/Resolved.js';
 import { type ResolvedValueBindingNode } from '../models/ResolvedValueBindingNode.js';
+import { resolveFour } from './resolveFour.js';
+import { resolveThree } from './resolveThree.js';
+import { resolveTwo } from './resolveTwo.js';
 
 const ZERO_PARAMS: number = 0;
 const ONE_PARAM: number = 1;
@@ -84,19 +87,17 @@ function buildSimpleResolvedValueBindingNodeResolver<TActivated>(
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           node.params[1]!.resolve(params);
 
-        if (isPromise(firstResolvedValue) || isPromise(secondResolvedValue)) {
-          return Promise.all([firstResolvedValue, secondResolvedValue]).then(
-            (resolvedValues: unknown[]): Resolved<TActivated> =>
-              resolveActivations(
-                params,
-                factory(resolvedValues[0], resolvedValues[1]),
-              ),
-          );
-        }
-
-        return resolveActivations(
-          params,
-          factory(firstResolvedValue, secondResolvedValue),
+        return resolveTwo(
+          firstResolvedValue,
+          secondResolvedValue,
+          (
+            resolvedFirstValue: unknown,
+            resolvedSecondValue: unknown,
+          ): Resolved<TActivated> =>
+            resolveActivations(
+              params,
+              factory(resolvedFirstValue, resolvedSecondValue),
+            ),
         );
       };
       break;
@@ -112,26 +113,23 @@ function buildSimpleResolvedValueBindingNodeResolver<TActivated>(
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           node.params[2]!.resolve(params);
 
-        if (
-          isPromise(firstResolvedValue) ||
-          isPromise(secondResolvedValue) ||
-          isPromise(thirdResolvedValue)
-        ) {
-          return Promise.all([
-            firstResolvedValue,
-            secondResolvedValue,
-            thirdResolvedValue,
-          ]).then((resolvedValues: unknown[]): Resolved<TActivated> =>
+        return resolveThree(
+          firstResolvedValue,
+          secondResolvedValue,
+          thirdResolvedValue,
+          (
+            resolvedFirstValue: unknown,
+            resolvedSecondValue: unknown,
+            resolvedThirdValue: unknown,
+          ): Resolved<TActivated> =>
             resolveActivations(
               params,
-              factory(resolvedValues[0], resolvedValues[1], resolvedValues[2]),
+              factory(
+                resolvedFirstValue,
+                resolvedSecondValue,
+                resolvedThirdValue,
+              ),
             ),
-          );
-        }
-
-        return resolveActivations(
-          params,
-          factory(firstResolvedValue, secondResolvedValue, thirdResolvedValue),
         );
       };
       break;
@@ -150,38 +148,26 @@ function buildSimpleResolvedValueBindingNodeResolver<TActivated>(
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           node.params[3]!.resolve(params);
 
-        if (
-          isPromise(firstResolvedValue) ||
-          isPromise(secondResolvedValue) ||
-          isPromise(thirdResolvedValue) ||
-          isPromise(fourthResolvedValue)
-        ) {
-          return Promise.all([
-            firstResolvedValue,
-            secondResolvedValue,
-            thirdResolvedValue,
-            fourthResolvedValue,
-          ]).then((resolvedValues: unknown[]): Resolved<TActivated> =>
+        return resolveFour(
+          firstResolvedValue,
+          secondResolvedValue,
+          thirdResolvedValue,
+          fourthResolvedValue,
+          (
+            resolvedFirstValue: unknown,
+            resolvedSecondValue: unknown,
+            resolvedThirdValue: unknown,
+            resolvedFourthValue: unknown,
+          ): Resolved<TActivated> =>
             resolveActivations(
               params,
               factory(
-                resolvedValues[0],
-                resolvedValues[1],
-                resolvedValues[2],
-                resolvedValues[3],
+                resolvedFirstValue,
+                resolvedSecondValue,
+                resolvedThirdValue,
+                resolvedFourthValue,
               ),
             ),
-          );
-        }
-
-        return resolveActivations(
-          params,
-          factory(
-            firstResolvedValue,
-            secondResolvedValue,
-            thirdResolvedValue,
-            fourthResolvedValue,
-          ),
         );
       };
       break;

--- a/packages/container/libraries/core/src/planning/calculations/resolveFour.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/resolveFour.spec.ts
@@ -1,0 +1,165 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { type Resolved } from '../../resolution/models/Resolved.js';
+import { resolveFour } from './resolveFour.js';
+
+describe.each<
+  [
+    string,
+    Resolved<number>,
+    Resolved<number>,
+    Resolved<number>,
+    Resolved<number>,
+    Resolved<number[]>,
+  ]
+>([
+  ['four values', 1, 2, 3, 4, [1, 2, 3, 4]],
+  [
+    'three values and one promise',
+    1,
+    2,
+    3,
+    Promise.resolve(4),
+    Promise.resolve([1, 2, 3, 4]),
+  ],
+  [
+    'two values, one promise and one value',
+    1,
+    2,
+    Promise.resolve(3),
+    4,
+    Promise.resolve([1, 2, 3, 4]),
+  ],
+  [
+    'two values and two promises',
+    1,
+    2,
+    Promise.resolve(3),
+    Promise.resolve(4),
+    Promise.resolve([1, 2, 3, 4]),
+  ],
+  [
+    'one value, one promise and two values',
+    1,
+    Promise.resolve(2),
+    3,
+    4,
+    Promise.resolve([1, 2, 3, 4]),
+  ],
+  [
+    'one value, one promise, one value and one promise',
+    1,
+    Promise.resolve(2),
+    3,
+    Promise.resolve(4),
+    Promise.resolve([1, 2, 3, 4]),
+  ],
+  [
+    'one value, two promises and one value',
+    1,
+    Promise.resolve(2),
+    Promise.resolve(3),
+    4,
+    Promise.resolve([1, 2, 3, 4]),
+  ],
+  [
+    'one value and three promises',
+    1,
+    Promise.resolve(2),
+    Promise.resolve(3),
+    Promise.resolve(4),
+    Promise.resolve([1, 2, 3, 4]),
+  ],
+  [
+    'one promise and three values',
+    Promise.resolve(1),
+    2,
+    3,
+    4,
+    Promise.resolve([1, 2, 3, 4]),
+  ],
+  [
+    'one promise, two values and one promise',
+    Promise.resolve(1),
+    2,
+    3,
+    Promise.resolve(4),
+    Promise.resolve([1, 2, 3, 4]),
+  ],
+  [
+    'one promise, one value, one promise and one value',
+    Promise.resolve(1),
+    2,
+    Promise.resolve(3),
+    4,
+    Promise.resolve([1, 2, 3, 4]),
+  ],
+  [
+    'one promise, one value and two promises',
+    Promise.resolve(1),
+    2,
+    Promise.resolve(3),
+    Promise.resolve(4),
+    Promise.resolve([1, 2, 3, 4]),
+  ],
+  [
+    'two promises and two values',
+    Promise.resolve(1),
+    Promise.resolve(2),
+    3,
+    4,
+    Promise.resolve([1, 2, 3, 4]),
+  ],
+  [
+    'two promises, one value and one promise',
+    Promise.resolve(1),
+    Promise.resolve(2),
+    3,
+    Promise.resolve(4),
+    Promise.resolve([1, 2, 3, 4]),
+  ],
+  [
+    'three promises and one value',
+    Promise.resolve(1),
+    Promise.resolve(2),
+    Promise.resolve(3),
+    4,
+    Promise.resolve([1, 2, 3, 4]),
+  ],
+  [
+    'four promises',
+    Promise.resolve(1),
+    Promise.resolve(2),
+    Promise.resolve(3),
+    Promise.resolve(4),
+    Promise.resolve([1, 2, 3, 4]),
+  ],
+])(
+  'having %s',
+  (
+    _: string,
+    value1: Resolved<number>,
+    value2: Resolved<number>,
+    value3: Resolved<number>,
+    value4: Resolved<number>,
+    expected: Resolved<number[]>,
+  ) => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = resolveFour(
+          value1,
+          value2,
+          value3,
+          value4,
+          (a: number, b: number, c: number, d: number) => [a, b, c, d],
+        );
+      });
+
+      it('should resolve four values', () => {
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  },
+);

--- a/packages/container/libraries/core/src/planning/calculations/resolveFour.ts
+++ b/packages/container/libraries/core/src/planning/calculations/resolveFour.ts
@@ -23,178 +23,244 @@ export function resolveFour<TParam, TResult>(
       if (isPromise(value3)) {
         if (isPromise(value4)) {
           return new Promise(
-            (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+            (
+              resolve: (value: TResult | PromiseLike<TResult>) => void,
+              reject: (reason?: unknown) => void,
+            ) => {
               let resolvedValues: number = 0;
               let resolvedValue1: TParam;
               let resolvedValue2: TParam;
               let resolvedValue3: TParam;
               let resolvedValue4: TParam;
 
-              void value1.then((resolvedValue: TParam) => {
-                if (++resolvedValues === FOUR_PARAMS) {
-                  resolve(
-                    build(
-                      resolvedValue,
-                      resolvedValue2,
-                      resolvedValue3,
-                      resolvedValue4,
-                    ),
-                  );
-                } else {
-                  resolvedValue1 = resolvedValue;
-                }
-              });
+              void value1
+                .then((resolvedValue: TParam) => {
+                  if (++resolvedValues === FOUR_PARAMS) {
+                    resolve(
+                      build(
+                        resolvedValue,
+                        resolvedValue2,
+                        resolvedValue3,
+                        resolvedValue4,
+                      ),
+                    );
+                  } else {
+                    resolvedValue1 = resolvedValue;
+                  }
+                })
+                .catch(reject);
 
-              void value2.then((resolvedValue: TParam) => {
-                if (++resolvedValues === FOUR_PARAMS) {
-                  resolve(
-                    build(
-                      resolvedValue1,
-                      resolvedValue,
-                      resolvedValue3,
-                      resolvedValue4,
-                    ),
-                  );
-                } else {
-                  resolvedValue2 = resolvedValue;
-                }
-              });
+              void value2
+                .then((resolvedValue: TParam) => {
+                  if (++resolvedValues === FOUR_PARAMS) {
+                    resolve(
+                      build(
+                        resolvedValue1,
+                        resolvedValue,
+                        resolvedValue3,
+                        resolvedValue4,
+                      ),
+                    );
+                  } else {
+                    resolvedValue2 = resolvedValue;
+                  }
+                })
+                .catch(reject);
 
-              void value3.then((resolvedValue: TParam) => {
-                if (++resolvedValues === FOUR_PARAMS) {
-                  resolve(
-                    build(
-                      resolvedValue1,
-                      resolvedValue2,
-                      resolvedValue,
-                      resolvedValue4,
-                    ),
-                  );
-                } else {
-                  resolvedValue3 = resolvedValue;
-                }
-              });
+              void value3
+                .then((resolvedValue: TParam) => {
+                  if (++resolvedValues === FOUR_PARAMS) {
+                    resolve(
+                      build(
+                        resolvedValue1,
+                        resolvedValue2,
+                        resolvedValue,
+                        resolvedValue4,
+                      ),
+                    );
+                  } else {
+                    resolvedValue3 = resolvedValue;
+                  }
+                })
+                .catch(reject);
 
-              void value4.then((resolvedValue: TParam) => {
-                if (++resolvedValues === FOUR_PARAMS) {
-                  resolve(
-                    build(
-                      resolvedValue1,
-                      resolvedValue2,
-                      resolvedValue3,
-                      resolvedValue,
-                    ),
-                  );
-                } else {
-                  resolvedValue4 = resolvedValue;
-                }
-              });
+              void value4
+                .then((resolvedValue: TParam) => {
+                  if (++resolvedValues === FOUR_PARAMS) {
+                    resolve(
+                      build(
+                        resolvedValue1,
+                        resolvedValue2,
+                        resolvedValue3,
+                        resolvedValue,
+                      ),
+                    );
+                  } else {
+                    resolvedValue4 = resolvedValue;
+                  }
+                })
+                .catch(reject);
             },
           );
         }
 
         return new Promise(
-          (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+          (
+            resolve: (value: TResult | PromiseLike<TResult>) => void,
+            reject: (reason?: unknown) => void,
+          ) => {
             let resolvedValues: number = 0;
             let resolvedValue1: TParam;
             let resolvedValue2: TParam;
             let resolvedValue3: TParam;
 
-            void value1.then((resolvedValue: TParam) => {
-              if (++resolvedValues === THREE_PARAMS) {
-                resolve(
-                  build(resolvedValue, resolvedValue2, resolvedValue3, value4),
-                );
-              } else {
-                resolvedValue1 = resolvedValue;
-              }
-            });
+            void value1
+              .then((resolvedValue: TParam) => {
+                if (++resolvedValues === THREE_PARAMS) {
+                  resolve(
+                    build(
+                      resolvedValue,
+                      resolvedValue2,
+                      resolvedValue3,
+                      value4,
+                    ),
+                  );
+                } else {
+                  resolvedValue1 = resolvedValue;
+                }
+              })
+              .catch(reject);
 
-            void value2.then((resolvedValue: TParam) => {
-              if (++resolvedValues === THREE_PARAMS) {
-                resolve(
-                  build(resolvedValue1, resolvedValue, resolvedValue3, value4),
-                );
-              } else {
-                resolvedValue2 = resolvedValue;
-              }
-            });
+            void value2
+              .then((resolvedValue: TParam) => {
+                if (++resolvedValues === THREE_PARAMS) {
+                  resolve(
+                    build(
+                      resolvedValue1,
+                      resolvedValue,
+                      resolvedValue3,
+                      value4,
+                    ),
+                  );
+                } else {
+                  resolvedValue2 = resolvedValue;
+                }
+              })
+              .catch(reject);
 
-            void value3.then((resolvedValue: TParam) => {
-              if (++resolvedValues === THREE_PARAMS) {
-                resolve(
-                  build(resolvedValue1, resolvedValue2, resolvedValue, value4),
-                );
-              } else {
-                resolvedValue3 = resolvedValue;
-              }
-            });
+            void value3
+              .then((resolvedValue: TParam) => {
+                if (++resolvedValues === THREE_PARAMS) {
+                  resolve(
+                    build(
+                      resolvedValue1,
+                      resolvedValue2,
+                      resolvedValue,
+                      value4,
+                    ),
+                  );
+                } else {
+                  resolvedValue3 = resolvedValue;
+                }
+              })
+              .catch(reject);
           },
         );
       }
 
       if (isPromise(value4)) {
         return new Promise(
-          (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+          (
+            resolve: (value: TResult | PromiseLike<TResult>) => void,
+            reject: (reason?: unknown) => void,
+          ) => {
             let resolvedValues: number = 0;
             let resolvedValue1: TParam;
             let resolvedValue2: TParam;
             let resolvedValue4: TParam;
 
-            void value1.then((resolvedValue: TParam) => {
-              if (++resolvedValues === THREE_PARAMS) {
-                resolve(
-                  build(resolvedValue, resolvedValue2, value3, resolvedValue4),
-                );
-              } else {
-                resolvedValue1 = resolvedValue;
-              }
-            });
+            void value1
+              .then((resolvedValue: TParam) => {
+                if (++resolvedValues === THREE_PARAMS) {
+                  resolve(
+                    build(
+                      resolvedValue,
+                      resolvedValue2,
+                      value3,
+                      resolvedValue4,
+                    ),
+                  );
+                } else {
+                  resolvedValue1 = resolvedValue;
+                }
+              })
+              .catch(reject);
 
-            void value2.then((resolvedValue: TParam) => {
-              if (++resolvedValues === THREE_PARAMS) {
-                resolve(
-                  build(resolvedValue1, resolvedValue, value3, resolvedValue4),
-                );
-              } else {
-                resolvedValue2 = resolvedValue;
-              }
-            });
+            void value2
+              .then((resolvedValue: TParam) => {
+                if (++resolvedValues === THREE_PARAMS) {
+                  resolve(
+                    build(
+                      resolvedValue1,
+                      resolvedValue,
+                      value3,
+                      resolvedValue4,
+                    ),
+                  );
+                } else {
+                  resolvedValue2 = resolvedValue;
+                }
+              })
+              .catch(reject);
 
-            void value4.then((resolvedValue: TParam) => {
-              if (++resolvedValues === THREE_PARAMS) {
-                resolve(
-                  build(resolvedValue1, resolvedValue2, value3, resolvedValue),
-                );
-              } else {
-                resolvedValue4 = resolvedValue;
-              }
-            });
+            void value4
+              .then((resolvedValue: TParam) => {
+                if (++resolvedValues === THREE_PARAMS) {
+                  resolve(
+                    build(
+                      resolvedValue1,
+                      resolvedValue2,
+                      value3,
+                      resolvedValue,
+                    ),
+                  );
+                } else {
+                  resolvedValue4 = resolvedValue;
+                }
+              })
+              .catch(reject);
           },
         );
       }
 
       return new Promise(
-        (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+        (
+          resolve: (value: TResult | PromiseLike<TResult>) => void,
+          reject: (reason?: unknown) => void,
+        ) => {
           let resolvedValues: number = 0;
           let resolvedValue1: TParam;
           let resolvedValue2: TParam;
 
-          void value1.then((resolvedValue: TParam) => {
-            if (++resolvedValues === TWO_PARAMS) {
-              resolve(build(resolvedValue, resolvedValue2, value3, value4));
-            } else {
-              resolvedValue1 = resolvedValue;
-            }
-          });
+          void value1
+            .then((resolvedValue: TParam) => {
+              if (++resolvedValues === TWO_PARAMS) {
+                resolve(build(resolvedValue, resolvedValue2, value3, value4));
+              } else {
+                resolvedValue1 = resolvedValue;
+              }
+            })
+            .catch(reject);
 
-          void value2.then((resolvedValue: TParam) => {
-            if (++resolvedValues === TWO_PARAMS) {
-              resolve(build(resolvedValue1, resolvedValue, value3, value4));
-            } else {
-              resolvedValue2 = resolvedValue;
-            }
-          });
+          void value2
+            .then((resolvedValue: TParam) => {
+              if (++resolvedValues === TWO_PARAMS) {
+                resolve(build(resolvedValue1, resolvedValue, value3, value4));
+              } else {
+                resolvedValue2 = resolvedValue;
+              }
+            })
+            .catch(reject);
         },
       );
     }
@@ -202,92 +268,130 @@ export function resolveFour<TParam, TResult>(
     if (isPromise(value3)) {
       if (isPromise(value4)) {
         return new Promise(
-          (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+          (
+            resolve: (value: TResult | PromiseLike<TResult>) => void,
+            reject: (reason?: unknown) => void,
+          ) => {
             let resolvedValues: number = 0;
             let resolvedValue1: TParam;
             let resolvedValue3: TParam;
             let resolvedValue4: TParam;
 
-            void value1.then((resolvedValue: TParam) => {
-              if (++resolvedValues === THREE_PARAMS) {
-                resolve(
-                  build(resolvedValue, value2, resolvedValue3, resolvedValue4),
-                );
-              } else {
-                resolvedValue1 = resolvedValue;
-              }
-            });
+            void value1
+              .then((resolvedValue: TParam) => {
+                if (++resolvedValues === THREE_PARAMS) {
+                  resolve(
+                    build(
+                      resolvedValue,
+                      value2,
+                      resolvedValue3,
+                      resolvedValue4,
+                    ),
+                  );
+                } else {
+                  resolvedValue1 = resolvedValue;
+                }
+              })
+              .catch(reject);
 
-            void value3.then((resolvedValue: TParam) => {
-              if (++resolvedValues === THREE_PARAMS) {
-                resolve(
-                  build(resolvedValue1, value2, resolvedValue, resolvedValue4),
-                );
-              } else {
-                resolvedValue3 = resolvedValue;
-              }
-            });
+            void value3
+              .then((resolvedValue: TParam) => {
+                if (++resolvedValues === THREE_PARAMS) {
+                  resolve(
+                    build(
+                      resolvedValue1,
+                      value2,
+                      resolvedValue,
+                      resolvedValue4,
+                    ),
+                  );
+                } else {
+                  resolvedValue3 = resolvedValue;
+                }
+              })
+              .catch(reject);
 
-            void value4.then((resolvedValue: TParam) => {
-              if (++resolvedValues === THREE_PARAMS) {
-                resolve(
-                  build(resolvedValue1, value2, resolvedValue3, resolvedValue),
-                );
-              } else {
-                resolvedValue4 = resolvedValue;
-              }
-            });
+            void value4
+              .then((resolvedValue: TParam) => {
+                if (++resolvedValues === THREE_PARAMS) {
+                  resolve(
+                    build(
+                      resolvedValue1,
+                      value2,
+                      resolvedValue3,
+                      resolvedValue,
+                    ),
+                  );
+                } else {
+                  resolvedValue4 = resolvedValue;
+                }
+              })
+              .catch(reject);
           },
         );
       }
 
       return new Promise(
-        (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+        (
+          resolve: (value: TResult | PromiseLike<TResult>) => void,
+          reject: (reason?: unknown) => void,
+        ) => {
           let resolvedValues: number = 0;
           let resolvedValue1: TParam;
           let resolvedValue3: TParam;
 
-          void value1.then((resolvedValue: TParam) => {
-            if (++resolvedValues === TWO_PARAMS) {
-              resolve(build(resolvedValue, value2, resolvedValue3, value4));
-            } else {
-              resolvedValue1 = resolvedValue;
-            }
-          });
+          void value1
+            .then((resolvedValue: TParam) => {
+              if (++resolvedValues === TWO_PARAMS) {
+                resolve(build(resolvedValue, value2, resolvedValue3, value4));
+              } else {
+                resolvedValue1 = resolvedValue;
+              }
+            })
+            .catch(reject);
 
-          void value3.then((resolvedValue: TParam) => {
-            if (++resolvedValues === TWO_PARAMS) {
-              resolve(build(resolvedValue1, value2, resolvedValue, value4));
-            } else {
-              resolvedValue3 = resolvedValue;
-            }
-          });
+          void value3
+            .then((resolvedValue: TParam) => {
+              if (++resolvedValues === TWO_PARAMS) {
+                resolve(build(resolvedValue1, value2, resolvedValue, value4));
+              } else {
+                resolvedValue3 = resolvedValue;
+              }
+            })
+            .catch(reject);
         },
       );
     }
 
     if (isPromise(value4)) {
       return new Promise(
-        (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+        (
+          resolve: (value: TResult | PromiseLike<TResult>) => void,
+          reject: (reason?: unknown) => void,
+        ) => {
           let resolvedValues: number = 0;
           let resolvedValue1: TParam;
           let resolvedValue4: TParam;
 
-          void value1.then((resolvedValue: TParam) => {
-            if (++resolvedValues === TWO_PARAMS) {
-              resolve(build(resolvedValue, value2, value3, resolvedValue4));
-            } else {
-              resolvedValue1 = resolvedValue;
-            }
-          });
+          void value1
+            .then((resolvedValue: TParam) => {
+              if (++resolvedValues === TWO_PARAMS) {
+                resolve(build(resolvedValue, value2, value3, resolvedValue4));
+              } else {
+                resolvedValue1 = resolvedValue;
+              }
+            })
+            .catch(reject);
 
-          void value4.then((resolvedValue: TParam) => {
-            if (++resolvedValues === TWO_PARAMS) {
-              resolve(build(resolvedValue1, value2, value3, resolvedValue));
-            } else {
-              resolvedValue4 = resolvedValue;
-            }
-          });
+          void value4
+            .then((resolvedValue: TParam) => {
+              if (++resolvedValues === TWO_PARAMS) {
+                resolve(build(resolvedValue1, value2, value3, resolvedValue));
+              } else {
+                resolvedValue4 = resolvedValue;
+              }
+            })
+            .catch(reject);
         },
       );
     }
@@ -301,92 +405,130 @@ export function resolveFour<TParam, TResult>(
     if (isPromise(value3)) {
       if (isPromise(value4)) {
         return new Promise(
-          (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+          (
+            resolve: (value: TResult | PromiseLike<TResult>) => void,
+            reject: (reason?: unknown) => void,
+          ) => {
             let resolvedValues: number = 0;
             let resolvedValue2: TParam;
             let resolvedValue3: TParam;
             let resolvedValue4: TParam;
 
-            void value2.then((resolvedValue: TParam) => {
-              if (++resolvedValues === THREE_PARAMS) {
-                resolve(
-                  build(value1, resolvedValue, resolvedValue3, resolvedValue4),
-                );
-              } else {
-                resolvedValue2 = resolvedValue;
-              }
-            });
+            void value2
+              .then((resolvedValue: TParam) => {
+                if (++resolvedValues === THREE_PARAMS) {
+                  resolve(
+                    build(
+                      value1,
+                      resolvedValue,
+                      resolvedValue3,
+                      resolvedValue4,
+                    ),
+                  );
+                } else {
+                  resolvedValue2 = resolvedValue;
+                }
+              })
+              .catch(reject);
 
-            void value3.then((resolvedValue: TParam) => {
-              if (++resolvedValues === THREE_PARAMS) {
-                resolve(
-                  build(value1, resolvedValue2, resolvedValue, resolvedValue4),
-                );
-              } else {
-                resolvedValue3 = resolvedValue;
-              }
-            });
+            void value3
+              .then((resolvedValue: TParam) => {
+                if (++resolvedValues === THREE_PARAMS) {
+                  resolve(
+                    build(
+                      value1,
+                      resolvedValue2,
+                      resolvedValue,
+                      resolvedValue4,
+                    ),
+                  );
+                } else {
+                  resolvedValue3 = resolvedValue;
+                }
+              })
+              .catch(reject);
 
-            void value4.then((resolvedValue: TParam) => {
-              if (++resolvedValues === THREE_PARAMS) {
-                resolve(
-                  build(value1, resolvedValue2, resolvedValue3, resolvedValue),
-                );
-              } else {
-                resolvedValue4 = resolvedValue;
-              }
-            });
+            void value4
+              .then((resolvedValue: TParam) => {
+                if (++resolvedValues === THREE_PARAMS) {
+                  resolve(
+                    build(
+                      value1,
+                      resolvedValue2,
+                      resolvedValue3,
+                      resolvedValue,
+                    ),
+                  );
+                } else {
+                  resolvedValue4 = resolvedValue;
+                }
+              })
+              .catch(reject);
           },
         );
       }
 
       return new Promise(
-        (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+        (
+          resolve: (value: TResult | PromiseLike<TResult>) => void,
+          reject: (reason?: unknown) => void,
+        ) => {
           let resolvedValues: number = 0;
           let resolvedValue2: TParam;
           let resolvedValue3: TParam;
 
-          void value2.then((resolvedValue: TParam) => {
-            if (++resolvedValues === TWO_PARAMS) {
-              resolve(build(value1, resolvedValue, resolvedValue3, value4));
-            } else {
-              resolvedValue2 = resolvedValue;
-            }
-          });
+          void value2
+            .then((resolvedValue: TParam) => {
+              if (++resolvedValues === TWO_PARAMS) {
+                resolve(build(value1, resolvedValue, resolvedValue3, value4));
+              } else {
+                resolvedValue2 = resolvedValue;
+              }
+            })
+            .catch(reject);
 
-          void value3.then((resolvedValue: TParam) => {
-            if (++resolvedValues === TWO_PARAMS) {
-              resolve(build(value1, resolvedValue2, resolvedValue, value4));
-            } else {
-              resolvedValue3 = resolvedValue;
-            }
-          });
+          void value3
+            .then((resolvedValue: TParam) => {
+              if (++resolvedValues === TWO_PARAMS) {
+                resolve(build(value1, resolvedValue2, resolvedValue, value4));
+              } else {
+                resolvedValue3 = resolvedValue;
+              }
+            })
+            .catch(reject);
         },
       );
     }
 
     if (isPromise(value4)) {
       return new Promise(
-        (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+        (
+          resolve: (value: TResult | PromiseLike<TResult>) => void,
+          reject: (reason?: unknown) => void,
+        ) => {
           let resolvedValues: number = 0;
           let resolvedValue2: TParam;
           let resolvedValue4: TParam;
 
-          void value2.then((resolvedValue: TParam) => {
-            if (++resolvedValues === TWO_PARAMS) {
-              resolve(build(value1, resolvedValue, value3, resolvedValue4));
-            } else {
-              resolvedValue2 = resolvedValue;
-            }
-          });
+          void value2
+            .then((resolvedValue: TParam) => {
+              if (++resolvedValues === TWO_PARAMS) {
+                resolve(build(value1, resolvedValue, value3, resolvedValue4));
+              } else {
+                resolvedValue2 = resolvedValue;
+              }
+            })
+            .catch(reject);
 
-          void value4.then((resolvedValue: TParam) => {
-            if (++resolvedValues === TWO_PARAMS) {
-              resolve(build(value1, resolvedValue2, value3, resolvedValue));
-            } else {
-              resolvedValue4 = resolvedValue;
-            }
-          });
+          void value4
+            .then((resolvedValue: TParam) => {
+              if (++resolvedValues === TWO_PARAMS) {
+                resolve(build(value1, resolvedValue2, value3, resolvedValue));
+              } else {
+                resolvedValue4 = resolvedValue;
+              }
+            })
+            .catch(reject);
         },
       );
     }
@@ -399,26 +541,33 @@ export function resolveFour<TParam, TResult>(
   if (isPromise(value3)) {
     if (isPromise(value4)) {
       return new Promise(
-        (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+        (
+          resolve: (value: TResult | PromiseLike<TResult>) => void,
+          reject: (reason?: unknown) => void,
+        ) => {
           let resolvedValues: number = 0;
           let resolvedValue3: TParam;
           let resolvedValue4: TParam;
 
-          void value3.then((resolvedValue: TParam) => {
-            if (++resolvedValues === TWO_PARAMS) {
-              resolve(build(value1, value2, resolvedValue, resolvedValue4));
-            } else {
-              resolvedValue3 = resolvedValue;
-            }
-          });
+          void value3
+            .then((resolvedValue: TParam) => {
+              if (++resolvedValues === TWO_PARAMS) {
+                resolve(build(value1, value2, resolvedValue, resolvedValue4));
+              } else {
+                resolvedValue3 = resolvedValue;
+              }
+            })
+            .catch(reject);
 
-          void value4.then((resolvedValue: TParam) => {
-            if (++resolvedValues === TWO_PARAMS) {
-              resolve(build(value1, value2, resolvedValue3, resolvedValue));
-            } else {
-              resolvedValue4 = resolvedValue;
-            }
-          });
+          void value4
+            .then((resolvedValue: TParam) => {
+              if (++resolvedValues === TWO_PARAMS) {
+                resolve(build(value1, value2, resolvedValue3, resolvedValue));
+              } else {
+                resolvedValue4 = resolvedValue;
+              }
+            })
+            .catch(reject);
         },
       );
     }

--- a/packages/container/libraries/core/src/planning/calculations/resolveFour.ts
+++ b/packages/container/libraries/core/src/planning/calculations/resolveFour.ts
@@ -1,0 +1,438 @@
+import { isPromise } from '@inversifyjs/common';
+
+import { type Resolved } from '../../resolution/models/Resolved.js';
+
+const TWO_PARAMS: number = 2;
+const THREE_PARAMS: number = 3;
+const FOUR_PARAMS: number = 4;
+
+export function resolveFour<TParam, TResult>(
+  value1: Resolved<TParam>,
+  value2: Resolved<TParam>,
+  value3: Resolved<TParam>,
+  value4: Resolved<TParam>,
+  build: (
+    value1: TParam,
+    value2: TParam,
+    value3: TParam,
+    value4: TParam,
+  ) => Resolved<TResult>,
+): Resolved<TResult> {
+  if (isPromise(value1)) {
+    if (isPromise(value2)) {
+      if (isPromise(value3)) {
+        if (isPromise(value4)) {
+          return new Promise(
+            (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+              let resolvedValues: number = 0;
+              let resolvedValue1: TParam;
+              let resolvedValue2: TParam;
+              let resolvedValue3: TParam;
+              let resolvedValue4: TParam;
+
+              void value1.then((resolvedValue: TParam) => {
+                if (++resolvedValues === FOUR_PARAMS) {
+                  resolve(
+                    build(
+                      resolvedValue,
+                      resolvedValue2,
+                      resolvedValue3,
+                      resolvedValue4,
+                    ),
+                  );
+                } else {
+                  resolvedValue1 = resolvedValue;
+                }
+              });
+
+              void value2.then((resolvedValue: TParam) => {
+                if (++resolvedValues === FOUR_PARAMS) {
+                  resolve(
+                    build(
+                      resolvedValue1,
+                      resolvedValue,
+                      resolvedValue3,
+                      resolvedValue4,
+                    ),
+                  );
+                } else {
+                  resolvedValue2 = resolvedValue;
+                }
+              });
+
+              void value3.then((resolvedValue: TParam) => {
+                if (++resolvedValues === FOUR_PARAMS) {
+                  resolve(
+                    build(
+                      resolvedValue1,
+                      resolvedValue2,
+                      resolvedValue,
+                      resolvedValue4,
+                    ),
+                  );
+                } else {
+                  resolvedValue3 = resolvedValue;
+                }
+              });
+
+              void value4.then((resolvedValue: TParam) => {
+                if (++resolvedValues === FOUR_PARAMS) {
+                  resolve(
+                    build(
+                      resolvedValue1,
+                      resolvedValue2,
+                      resolvedValue3,
+                      resolvedValue,
+                    ),
+                  );
+                } else {
+                  resolvedValue4 = resolvedValue;
+                }
+              });
+            },
+          );
+        }
+
+        return new Promise(
+          (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+            let resolvedValues: number = 0;
+            let resolvedValue1: TParam;
+            let resolvedValue2: TParam;
+            let resolvedValue3: TParam;
+
+            void value1.then((resolvedValue: TParam) => {
+              if (++resolvedValues === THREE_PARAMS) {
+                resolve(
+                  build(resolvedValue, resolvedValue2, resolvedValue3, value4),
+                );
+              } else {
+                resolvedValue1 = resolvedValue;
+              }
+            });
+
+            void value2.then((resolvedValue: TParam) => {
+              if (++resolvedValues === THREE_PARAMS) {
+                resolve(
+                  build(resolvedValue1, resolvedValue, resolvedValue3, value4),
+                );
+              } else {
+                resolvedValue2 = resolvedValue;
+              }
+            });
+
+            void value3.then((resolvedValue: TParam) => {
+              if (++resolvedValues === THREE_PARAMS) {
+                resolve(
+                  build(resolvedValue1, resolvedValue2, resolvedValue, value4),
+                );
+              } else {
+                resolvedValue3 = resolvedValue;
+              }
+            });
+          },
+        );
+      }
+
+      if (isPromise(value4)) {
+        return new Promise(
+          (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+            let resolvedValues: number = 0;
+            let resolvedValue1: TParam;
+            let resolvedValue2: TParam;
+            let resolvedValue4: TParam;
+
+            void value1.then((resolvedValue: TParam) => {
+              if (++resolvedValues === THREE_PARAMS) {
+                resolve(
+                  build(resolvedValue, resolvedValue2, value3, resolvedValue4),
+                );
+              } else {
+                resolvedValue1 = resolvedValue;
+              }
+            });
+
+            void value2.then((resolvedValue: TParam) => {
+              if (++resolvedValues === THREE_PARAMS) {
+                resolve(
+                  build(resolvedValue1, resolvedValue, value3, resolvedValue4),
+                );
+              } else {
+                resolvedValue2 = resolvedValue;
+              }
+            });
+
+            void value4.then((resolvedValue: TParam) => {
+              if (++resolvedValues === THREE_PARAMS) {
+                resolve(
+                  build(resolvedValue1, resolvedValue2, value3, resolvedValue),
+                );
+              } else {
+                resolvedValue4 = resolvedValue;
+              }
+            });
+          },
+        );
+      }
+
+      return new Promise(
+        (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+          let resolvedValues: number = 0;
+          let resolvedValue1: TParam;
+          let resolvedValue2: TParam;
+
+          void value1.then((resolvedValue: TParam) => {
+            if (++resolvedValues === TWO_PARAMS) {
+              resolve(build(resolvedValue, resolvedValue2, value3, value4));
+            } else {
+              resolvedValue1 = resolvedValue;
+            }
+          });
+
+          void value2.then((resolvedValue: TParam) => {
+            if (++resolvedValues === TWO_PARAMS) {
+              resolve(build(resolvedValue1, resolvedValue, value3, value4));
+            } else {
+              resolvedValue2 = resolvedValue;
+            }
+          });
+        },
+      );
+    }
+
+    if (isPromise(value3)) {
+      if (isPromise(value4)) {
+        return new Promise(
+          (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+            let resolvedValues: number = 0;
+            let resolvedValue1: TParam;
+            let resolvedValue3: TParam;
+            let resolvedValue4: TParam;
+
+            void value1.then((resolvedValue: TParam) => {
+              if (++resolvedValues === THREE_PARAMS) {
+                resolve(
+                  build(resolvedValue, value2, resolvedValue3, resolvedValue4),
+                );
+              } else {
+                resolvedValue1 = resolvedValue;
+              }
+            });
+
+            void value3.then((resolvedValue: TParam) => {
+              if (++resolvedValues === THREE_PARAMS) {
+                resolve(
+                  build(resolvedValue1, value2, resolvedValue, resolvedValue4),
+                );
+              } else {
+                resolvedValue3 = resolvedValue;
+              }
+            });
+
+            void value4.then((resolvedValue: TParam) => {
+              if (++resolvedValues === THREE_PARAMS) {
+                resolve(
+                  build(resolvedValue1, value2, resolvedValue3, resolvedValue),
+                );
+              } else {
+                resolvedValue4 = resolvedValue;
+              }
+            });
+          },
+        );
+      }
+
+      return new Promise(
+        (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+          let resolvedValues: number = 0;
+          let resolvedValue1: TParam;
+          let resolvedValue3: TParam;
+
+          void value1.then((resolvedValue: TParam) => {
+            if (++resolvedValues === TWO_PARAMS) {
+              resolve(build(resolvedValue, value2, resolvedValue3, value4));
+            } else {
+              resolvedValue1 = resolvedValue;
+            }
+          });
+
+          void value3.then((resolvedValue: TParam) => {
+            if (++resolvedValues === TWO_PARAMS) {
+              resolve(build(resolvedValue1, value2, resolvedValue, value4));
+            } else {
+              resolvedValue3 = resolvedValue;
+            }
+          });
+        },
+      );
+    }
+
+    if (isPromise(value4)) {
+      return new Promise(
+        (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+          let resolvedValues: number = 0;
+          let resolvedValue1: TParam;
+          let resolvedValue4: TParam;
+
+          void value1.then((resolvedValue: TParam) => {
+            if (++resolvedValues === TWO_PARAMS) {
+              resolve(build(resolvedValue, value2, value3, resolvedValue4));
+            } else {
+              resolvedValue1 = resolvedValue;
+            }
+          });
+
+          void value4.then((resolvedValue: TParam) => {
+            if (++resolvedValues === TWO_PARAMS) {
+              resolve(build(resolvedValue1, value2, value3, resolvedValue));
+            } else {
+              resolvedValue4 = resolvedValue;
+            }
+          });
+        },
+      );
+    }
+
+    return value1.then(async (resolvedValue1: TParam): Promise<TResult> =>
+      build(resolvedValue1, value2, value3, value4),
+    );
+  }
+
+  if (isPromise(value2)) {
+    if (isPromise(value3)) {
+      if (isPromise(value4)) {
+        return new Promise(
+          (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+            let resolvedValues: number = 0;
+            let resolvedValue2: TParam;
+            let resolvedValue3: TParam;
+            let resolvedValue4: TParam;
+
+            void value2.then((resolvedValue: TParam) => {
+              if (++resolvedValues === THREE_PARAMS) {
+                resolve(
+                  build(value1, resolvedValue, resolvedValue3, resolvedValue4),
+                );
+              } else {
+                resolvedValue2 = resolvedValue;
+              }
+            });
+
+            void value3.then((resolvedValue: TParam) => {
+              if (++resolvedValues === THREE_PARAMS) {
+                resolve(
+                  build(value1, resolvedValue2, resolvedValue, resolvedValue4),
+                );
+              } else {
+                resolvedValue3 = resolvedValue;
+              }
+            });
+
+            void value4.then((resolvedValue: TParam) => {
+              if (++resolvedValues === THREE_PARAMS) {
+                resolve(
+                  build(value1, resolvedValue2, resolvedValue3, resolvedValue),
+                );
+              } else {
+                resolvedValue4 = resolvedValue;
+              }
+            });
+          },
+        );
+      }
+
+      return new Promise(
+        (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+          let resolvedValues: number = 0;
+          let resolvedValue2: TParam;
+          let resolvedValue3: TParam;
+
+          void value2.then((resolvedValue: TParam) => {
+            if (++resolvedValues === TWO_PARAMS) {
+              resolve(build(value1, resolvedValue, resolvedValue3, value4));
+            } else {
+              resolvedValue2 = resolvedValue;
+            }
+          });
+
+          void value3.then((resolvedValue: TParam) => {
+            if (++resolvedValues === TWO_PARAMS) {
+              resolve(build(value1, resolvedValue2, resolvedValue, value4));
+            } else {
+              resolvedValue3 = resolvedValue;
+            }
+          });
+        },
+      );
+    }
+
+    if (isPromise(value4)) {
+      return new Promise(
+        (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+          let resolvedValues: number = 0;
+          let resolvedValue2: TParam;
+          let resolvedValue4: TParam;
+
+          void value2.then((resolvedValue: TParam) => {
+            if (++resolvedValues === TWO_PARAMS) {
+              resolve(build(value1, resolvedValue, value3, resolvedValue4));
+            } else {
+              resolvedValue2 = resolvedValue;
+            }
+          });
+
+          void value4.then((resolvedValue: TParam) => {
+            if (++resolvedValues === TWO_PARAMS) {
+              resolve(build(value1, resolvedValue2, value3, resolvedValue));
+            } else {
+              resolvedValue4 = resolvedValue;
+            }
+          });
+        },
+      );
+    }
+
+    return value2.then(async (resolvedValue2: TParam): Promise<TResult> =>
+      build(value1, resolvedValue2, value3, value4),
+    );
+  }
+
+  if (isPromise(value3)) {
+    if (isPromise(value4)) {
+      return new Promise(
+        (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+          let resolvedValues: number = 0;
+          let resolvedValue3: TParam;
+          let resolvedValue4: TParam;
+
+          void value3.then((resolvedValue: TParam) => {
+            if (++resolvedValues === TWO_PARAMS) {
+              resolve(build(value1, value2, resolvedValue, resolvedValue4));
+            } else {
+              resolvedValue3 = resolvedValue;
+            }
+          });
+
+          void value4.then((resolvedValue: TParam) => {
+            if (++resolvedValues === TWO_PARAMS) {
+              resolve(build(value1, value2, resolvedValue3, resolvedValue));
+            } else {
+              resolvedValue4 = resolvedValue;
+            }
+          });
+        },
+      );
+    }
+
+    return value3.then(async (resolvedValue3: TParam): Promise<TResult> =>
+      build(value1, value2, resolvedValue3, value4),
+    );
+  }
+
+  if (isPromise(value4)) {
+    return value4.then(async (resolvedValue4: TParam): Promise<TResult> =>
+      build(value1, value2, value3, resolvedValue4),
+    );
+  }
+
+  return build(value1, value2, value3, value4);
+}

--- a/packages/container/libraries/core/src/planning/calculations/resolveThree.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/resolveThree.spec.ts
@@ -1,0 +1,91 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { type Resolved } from '../../resolution/models/Resolved.js';
+import { resolveThree } from './resolveThree.js';
+
+describe.each<
+  [
+    string,
+    Resolved<number>,
+    Resolved<number>,
+    Resolved<number>,
+    Resolved<number[]>,
+  ]
+>([
+  ['three values', 1, 2, 3, [1, 2, 3]],
+  [
+    'two values and one promise',
+    1,
+    2,
+    Promise.resolve(3),
+    Promise.resolve([1, 2, 3]),
+  ],
+  [
+    'one value, one promise and one value',
+    1,
+    Promise.resolve(2),
+    3,
+    Promise.resolve([1, 2, 3]),
+  ],
+  [
+    'one value and two promises',
+    1,
+    Promise.resolve(2),
+    Promise.resolve(3),
+    Promise.resolve([1, 2, 3]),
+  ],
+  [
+    'one promise and two values',
+    Promise.resolve(1),
+    2,
+    3,
+    Promise.resolve([1, 2, 3]),
+  ],
+  [
+    'one promise, one value and one promise',
+    Promise.resolve(1),
+    2,
+    Promise.resolve(3),
+    Promise.resolve([1, 2, 3]),
+  ],
+  [
+    'two promises and one value',
+    Promise.resolve(1),
+    Promise.resolve(2),
+    3,
+    Promise.resolve([1, 2, 3]),
+  ],
+  [
+    'three promises',
+    Promise.resolve(1),
+    Promise.resolve(2),
+    Promise.resolve(3),
+    Promise.resolve([1, 2, 3]),
+  ],
+])(
+  'having %s',
+  (
+    _: string,
+    value1: Resolved<number>,
+    value2: Resolved<number>,
+    value3: Resolved<number>,
+    expected: Resolved<number[]>,
+  ) => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = resolveThree(
+          value1,
+          value2,
+          value3,
+          (a: number, b: number, c: number) => [a, b, c],
+        );
+      });
+
+      it('should resolve three values', () => {
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  },
+);

--- a/packages/container/libraries/core/src/planning/calculations/resolveThree.ts
+++ b/packages/container/libraries/core/src/planning/calculations/resolveThree.ts
@@ -1,0 +1,146 @@
+import { isPromise } from '@inversifyjs/common';
+
+import { type Resolved } from '../../resolution/models/Resolved.js';
+
+const TWO_PARAMS: number = 2;
+const THREE_PARAMS: number = 3;
+
+export function resolveThree<TParam, TResult>(
+  value1: Resolved<TParam>,
+  value2: Resolved<TParam>,
+  value3: Resolved<TParam>,
+  build: (value1: TParam, value2: TParam, value3: TParam) => Resolved<TResult>,
+): Resolved<TResult> {
+  if (isPromise(value1)) {
+    if (isPromise(value2)) {
+      if (isPromise(value3)) {
+        return new Promise(
+          (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+            let resolvedValues: number = 0;
+            let resolvedValue1: TParam;
+            let resolvedValue2: TParam;
+            let resolvedValue3: TParam;
+
+            void value1.then((resolvedValue: TParam) => {
+              if (++resolvedValues === THREE_PARAMS) {
+                resolve(build(resolvedValue, resolvedValue2, resolvedValue3));
+              } else {
+                resolvedValue1 = resolvedValue;
+              }
+            });
+
+            void value2.then((resolvedValue: TParam) => {
+              if (++resolvedValues === THREE_PARAMS) {
+                resolve(build(resolvedValue1, resolvedValue, resolvedValue3));
+              } else {
+                resolvedValue2 = resolvedValue;
+              }
+            });
+
+            void value3.then((resolvedValue: TParam) => {
+              if (++resolvedValues === THREE_PARAMS) {
+                resolve(build(resolvedValue1, resolvedValue2, resolvedValue));
+              } else {
+                resolvedValue3 = resolvedValue;
+              }
+            });
+          },
+        );
+      }
+
+      return new Promise(
+        (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+          let resolvedValues: number = 0;
+          let resolvedValue1: TParam;
+          let resolvedValue2: TParam;
+
+          void value1.then((resolvedValue: TParam) => {
+            if (++resolvedValues === TWO_PARAMS) {
+              resolve(build(resolvedValue, resolvedValue2, value3));
+            } else {
+              resolvedValue1 = resolvedValue;
+            }
+          });
+
+          void value2.then((resolvedValue: TParam) => {
+            if (++resolvedValues === TWO_PARAMS) {
+              resolve(build(resolvedValue1, resolvedValue, value3));
+            } else {
+              resolvedValue2 = resolvedValue;
+            }
+          });
+        },
+      );
+    }
+
+    if (isPromise(value3)) {
+      return new Promise(
+        (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+          let resolvedValues: number = 0;
+          let resolvedValue1: TParam;
+          let resolvedValue3: TParam;
+
+          void value1.then((resolvedValue: TParam) => {
+            if (++resolvedValues === TWO_PARAMS) {
+              resolve(build(resolvedValue, value2, resolvedValue3));
+            } else {
+              resolvedValue1 = resolvedValue;
+            }
+          });
+
+          void value3.then((resolvedValue: TParam) => {
+            if (++resolvedValues === TWO_PARAMS) {
+              resolve(build(resolvedValue1, value2, resolvedValue));
+            } else {
+              resolvedValue3 = resolvedValue;
+            }
+          });
+        },
+      );
+    }
+
+    return value1.then(async (resolvedValue1: TParam): Promise<TResult> =>
+      build(resolvedValue1, value2, value3),
+    );
+  }
+
+  if (isPromise(value2)) {
+    if (isPromise(value3)) {
+      return new Promise(
+        (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+          let resolvedValues: number = 0;
+          let resolvedValue2: TParam;
+          let resolvedValue3: TParam;
+
+          void value2.then((resolvedValue: TParam) => {
+            if (++resolvedValues === TWO_PARAMS) {
+              resolve(build(value1, resolvedValue, resolvedValue3));
+            } else {
+              resolvedValue2 = resolvedValue;
+            }
+          });
+
+          void value3.then((resolvedValue: TParam) => {
+            if (++resolvedValues === TWO_PARAMS) {
+              resolve(build(value1, resolvedValue2, resolvedValue));
+            } else {
+              resolvedValue3 = resolvedValue;
+            }
+          });
+        },
+      );
+    }
+
+    return value2.then(async (resolvedValue2: TParam): Promise<TResult> =>
+      build(value1, resolvedValue2, value3),
+    );
+  }
+
+  if (isPromise(value3)) {
+    return value3.then(async (resolvedValue3: TParam): Promise<TResult> =>
+      build(value1, value2, resolvedValue3),
+    );
+  }
+
+  return build(value1, value2, value3);
+}

--- a/packages/container/libraries/core/src/planning/calculations/resolveThree.ts
+++ b/packages/container/libraries/core/src/planning/calculations/resolveThree.ts
@@ -15,86 +15,109 @@ export function resolveThree<TParam, TResult>(
     if (isPromise(value2)) {
       if (isPromise(value3)) {
         return new Promise(
-          (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+          (
+            resolve: (value: TResult | PromiseLike<TResult>) => void,
+            reject: (reason?: unknown) => void,
+          ) => {
             let resolvedValues: number = 0;
             let resolvedValue1: TParam;
             let resolvedValue2: TParam;
             let resolvedValue3: TParam;
 
-            void value1.then((resolvedValue: TParam) => {
-              if (++resolvedValues === THREE_PARAMS) {
-                resolve(build(resolvedValue, resolvedValue2, resolvedValue3));
-              } else {
-                resolvedValue1 = resolvedValue;
-              }
-            });
+            void value1
+              .then((resolvedValue: TParam) => {
+                if (++resolvedValues === THREE_PARAMS) {
+                  resolve(build(resolvedValue, resolvedValue2, resolvedValue3));
+                } else {
+                  resolvedValue1 = resolvedValue;
+                }
+              })
+              .catch(reject);
 
-            void value2.then((resolvedValue: TParam) => {
-              if (++resolvedValues === THREE_PARAMS) {
-                resolve(build(resolvedValue1, resolvedValue, resolvedValue3));
-              } else {
-                resolvedValue2 = resolvedValue;
-              }
-            });
+            void value2
+              .then((resolvedValue: TParam) => {
+                if (++resolvedValues === THREE_PARAMS) {
+                  resolve(build(resolvedValue1, resolvedValue, resolvedValue3));
+                } else {
+                  resolvedValue2 = resolvedValue;
+                }
+              })
+              .catch(reject);
 
-            void value3.then((resolvedValue: TParam) => {
-              if (++resolvedValues === THREE_PARAMS) {
-                resolve(build(resolvedValue1, resolvedValue2, resolvedValue));
-              } else {
-                resolvedValue3 = resolvedValue;
-              }
-            });
+            void value3
+              .then((resolvedValue: TParam) => {
+                if (++resolvedValues === THREE_PARAMS) {
+                  resolve(build(resolvedValue1, resolvedValue2, resolvedValue));
+                } else {
+                  resolvedValue3 = resolvedValue;
+                }
+              })
+              .catch(reject);
           },
         );
       }
 
       return new Promise(
-        (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+        (
+          resolve: (value: TResult | PromiseLike<TResult>) => void,
+          reject: (reason?: unknown) => void,
+        ) => {
           let resolvedValues: number = 0;
           let resolvedValue1: TParam;
           let resolvedValue2: TParam;
 
-          void value1.then((resolvedValue: TParam) => {
-            if (++resolvedValues === TWO_PARAMS) {
-              resolve(build(resolvedValue, resolvedValue2, value3));
-            } else {
-              resolvedValue1 = resolvedValue;
-            }
-          });
+          void value1
+            .then((resolvedValue: TParam) => {
+              if (++resolvedValues === TWO_PARAMS) {
+                resolve(build(resolvedValue, resolvedValue2, value3));
+              } else {
+                resolvedValue1 = resolvedValue;
+              }
+            })
+            .catch(reject);
 
-          void value2.then((resolvedValue: TParam) => {
-            if (++resolvedValues === TWO_PARAMS) {
-              resolve(build(resolvedValue1, resolvedValue, value3));
-            } else {
-              resolvedValue2 = resolvedValue;
-            }
-          });
+          void value2
+            .then((resolvedValue: TParam) => {
+              if (++resolvedValues === TWO_PARAMS) {
+                resolve(build(resolvedValue1, resolvedValue, value3));
+              } else {
+                resolvedValue2 = resolvedValue;
+              }
+            })
+            .catch(reject);
         },
       );
     }
 
     if (isPromise(value3)) {
       return new Promise(
-        (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+        (
+          resolve: (value: TResult | PromiseLike<TResult>) => void,
+          reject: (reason?: unknown) => void,
+        ) => {
           let resolvedValues: number = 0;
           let resolvedValue1: TParam;
           let resolvedValue3: TParam;
 
-          void value1.then((resolvedValue: TParam) => {
-            if (++resolvedValues === TWO_PARAMS) {
-              resolve(build(resolvedValue, value2, resolvedValue3));
-            } else {
-              resolvedValue1 = resolvedValue;
-            }
-          });
+          void value1
+            .then((resolvedValue: TParam) => {
+              if (++resolvedValues === TWO_PARAMS) {
+                resolve(build(resolvedValue, value2, resolvedValue3));
+              } else {
+                resolvedValue1 = resolvedValue;
+              }
+            })
+            .catch(reject);
 
-          void value3.then((resolvedValue: TParam) => {
-            if (++resolvedValues === TWO_PARAMS) {
-              resolve(build(resolvedValue1, value2, resolvedValue));
-            } else {
-              resolvedValue3 = resolvedValue;
-            }
-          });
+          void value3
+            .then((resolvedValue: TParam) => {
+              if (++resolvedValues === TWO_PARAMS) {
+                resolve(build(resolvedValue1, value2, resolvedValue));
+              } else {
+                resolvedValue3 = resolvedValue;
+              }
+            })
+            .catch(reject);
         },
       );
     }
@@ -107,26 +130,33 @@ export function resolveThree<TParam, TResult>(
   if (isPromise(value2)) {
     if (isPromise(value3)) {
       return new Promise(
-        (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+        (
+          resolve: (value: TResult | PromiseLike<TResult>) => void,
+          reject: (reason?: unknown) => void,
+        ) => {
           let resolvedValues: number = 0;
           let resolvedValue2: TParam;
           let resolvedValue3: TParam;
 
-          void value2.then((resolvedValue: TParam) => {
-            if (++resolvedValues === TWO_PARAMS) {
-              resolve(build(value1, resolvedValue, resolvedValue3));
-            } else {
-              resolvedValue2 = resolvedValue;
-            }
-          });
+          void value2
+            .then((resolvedValue: TParam) => {
+              if (++resolvedValues === TWO_PARAMS) {
+                resolve(build(value1, resolvedValue, resolvedValue3));
+              } else {
+                resolvedValue2 = resolvedValue;
+              }
+            })
+            .catch(reject);
 
-          void value3.then((resolvedValue: TParam) => {
-            if (++resolvedValues === TWO_PARAMS) {
-              resolve(build(value1, resolvedValue2, resolvedValue));
-            } else {
-              resolvedValue3 = resolvedValue;
-            }
-          });
+          void value3
+            .then((resolvedValue: TParam) => {
+              if (++resolvedValues === TWO_PARAMS) {
+                resolve(build(value1, resolvedValue2, resolvedValue));
+              } else {
+                resolvedValue3 = resolvedValue;
+              }
+            })
+            .catch(reject);
         },
       );
     }

--- a/packages/container/libraries/core/src/planning/calculations/resolveTwo.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/resolveTwo.spec.ts
@@ -1,0 +1,48 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { type Resolved } from '../../resolution/models/Resolved.js';
+import { resolveTwo } from './resolveTwo.js';
+
+describe.each<[string, Resolved<number>, Resolved<number>, Resolved<number[]>]>(
+  [
+    ['two values', 1, 2, [1, 2]],
+    [
+      'two promises',
+      Promise.resolve(1),
+      Promise.resolve(2),
+      Promise.resolve([1, 2]),
+    ],
+    [
+      'one value and one promise',
+      1,
+      Promise.resolve(2),
+      Promise.resolve([1, 2]),
+    ],
+    [
+      'one promise and one value',
+      Promise.resolve(1),
+      2,
+      Promise.resolve([1, 2]),
+    ],
+  ],
+)(
+  'having %s',
+  (
+    _: string,
+    value1: Resolved<number>,
+    value2: Resolved<number>,
+    expected: Resolved<number[]>,
+  ) => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = resolveTwo(value1, value2, (a: number, b: number) => [a, b]);
+      });
+
+      it('should resolve two values', () => {
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  },
+);

--- a/packages/container/libraries/core/src/planning/calculations/resolveTwo.ts
+++ b/packages/container/libraries/core/src/planning/calculations/resolveTwo.ts
@@ -1,0 +1,51 @@
+import { isPromise } from '@inversifyjs/common';
+
+import { type Resolved } from '../../resolution/models/Resolved.js';
+
+const PARAMS: number = 2;
+
+export function resolveTwo<TParam, TResult>(
+  value1: Resolved<TParam>,
+  value2: Resolved<TParam>,
+  build: (value1: TParam, value2: TParam) => Resolved<TResult>,
+): Resolved<TResult> {
+  if (isPromise(value1)) {
+    if (isPromise(value2)) {
+      return new Promise(
+        (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+          let resolvedValues: number = 0;
+          let resolvedValue1: TParam;
+          let resolvedValue2: TParam;
+
+          void value1.then((resolvedValue: TParam) => {
+            if (++resolvedValues === PARAMS) {
+              resolve(build(resolvedValue, resolvedValue2));
+            } else {
+              resolvedValue1 = resolvedValue;
+            }
+          });
+
+          void value2.then((resolvedValue: TParam) => {
+            if (++resolvedValues === PARAMS) {
+              resolve(build(resolvedValue1, resolvedValue));
+            } else {
+              resolvedValue2 = resolvedValue;
+            }
+          });
+        },
+      );
+    }
+
+    return value1.then(async (resolvedValue1: TParam): Promise<TResult> =>
+      build(resolvedValue1, value2),
+    );
+  }
+
+  if (isPromise(value2)) {
+    return value2.then(async (resolvedValue2: TParam): Promise<TResult> =>
+      build(value1, resolvedValue2),
+    );
+  }
+
+  return build(value1, value2);
+}

--- a/packages/container/libraries/core/src/planning/calculations/resolveTwo.ts
+++ b/packages/container/libraries/core/src/planning/calculations/resolveTwo.ts
@@ -12,26 +12,33 @@ export function resolveTwo<TParam, TResult>(
   if (isPromise(value1)) {
     if (isPromise(value2)) {
       return new Promise(
-        (resolve: (value: TResult | PromiseLike<TResult>) => void) => {
+        (
+          resolve: (value: TResult | PromiseLike<TResult>) => void,
+          reject: (reason?: unknown) => void,
+        ) => {
           let resolvedValues: number = 0;
           let resolvedValue1: TParam;
           let resolvedValue2: TParam;
 
-          void value1.then((resolvedValue: TParam) => {
-            if (++resolvedValues === PARAMS) {
-              resolve(build(resolvedValue, resolvedValue2));
-            } else {
-              resolvedValue1 = resolvedValue;
-            }
-          });
+          void value1
+            .then((resolvedValue: TParam) => {
+              if (++resolvedValues === PARAMS) {
+                resolve(build(resolvedValue, resolvedValue2));
+              } else {
+                resolvedValue1 = resolvedValue;
+              }
+            })
+            .catch(reject);
 
-          void value2.then((resolvedValue: TParam) => {
-            if (++resolvedValues === PARAMS) {
-              resolve(build(resolvedValue1, resolvedValue));
-            } else {
-              resolvedValue2 = resolvedValue;
-            }
-          });
+          void value2
+            .then((resolvedValue: TParam) => {
+              if (++resolvedValues === PARAMS) {
+                resolve(build(resolvedValue1, resolvedValue));
+              } else {
+                resolvedValue2 = resolvedValue;
+              }
+            })
+            .catch(reject);
         },
       );
     }

--- a/packages/container/tools/container-benchmarks/src/bin/run.ts
+++ b/packages/container/tools/container-benchmarks/src/bin/run.ts
@@ -12,18 +12,22 @@ import { AwilixGetComplexServiceInSingletonScope } from '../scenario/awilix/Awil
 import { AwilixGetComplexServiceInTransientScope } from '../scenario/awilix/AwilixGetComplexServiceInTransientScope.js';
 import { AwilixGetServiceInSingletonScope } from '../scenario/awilix/AwilixGetServiceInSingletonScope.js';
 import { AwilixGetServiceInTransientScope } from '../scenario/awilix/AwilixGetServiceInTransientScope.js';
+import { Inversify6GetComplexAsyncServiceInTransientScope } from '../scenario/Inversify6/Inversify6GetComplexAsyncServiceInTransientScope.js';
 import { Inversify6GetComplexServiceInSingletonScope } from '../scenario/Inversify6/Inversify6GetComplexServiceInSingletonScope.js';
 import { Inversify6GetComplexServiceInTransientScope } from '../scenario/Inversify6/Inversify6GetComplexServiceInTransientScope.js';
 import { Inversify6GetServiceInSingletonScope } from '../scenario/Inversify6/Inversify6GetServiceInSingletonScope.js';
 import { Inversify6GetServiceInTransientScope } from '../scenario/Inversify6/Inversify6GetServiceInTransientScope.js';
+import { Inversify7GetComplexAsyncServiceInTransientScope } from '../scenario/Inversify7/Inversify7GetComplexAsyncServiceInTransientScope.js';
 import { Inversify7GetComplexServiceInSingletonScope } from '../scenario/Inversify7/Inversify7GetComplexServiceInSingletonScope.js';
 import { Inversify7GetComplexServiceInTransientScope } from '../scenario/Inversify7/Inversify7GetComplexServiceInTransientScope.js';
 import { Inversify7GetServiceInSingletonScope } from '../scenario/Inversify7/Inversify7GetServiceInSingletonScope.js';
 import { Inversify7GetServiceInTransientScope } from '../scenario/Inversify7/Inversify7GetServiceInTransientScope.js';
+import { Inversify8GetComplexAsyncServiceInTransientScope } from '../scenario/inversify8/Inversify8GetComplexAsyncServiceInTransientScope.js';
 import { Inversify8GetComplexServiceInSingletonScope } from '../scenario/inversify8/Inversify8GetComplexServiceInSingletonScope.js';
 import { Inversify8GetComplexServiceInTransientScope } from '../scenario/inversify8/Inversify8GetComplexServiceInTransientScope.js';
 import { Inversify8GetServiceInSingletonScope } from '../scenario/inversify8/Inversify8GetServiceInSingletonScope.js';
 import { Inversify8GetServiceInTransientScope } from '../scenario/inversify8/Inversify8GetServiceInTransientScope.js';
+import { InversifyCurrentGetComplexAsyncServiceInTransientScope } from '../scenario/inversifyCurrent/InversifyCurrentGetComplexAsyncServiceInTransientScope.js';
 import { InversifyCurrentGetComplexResolvedValueServiceInTransientScope } from '../scenario/inversifyCurrent/InversifyCurrentGetComplexResolvedValueServiceInTranstientScope.js';
 import { InversifyCurrentGetComplexServiceInSingletonScope } from '../scenario/inversifyCurrent/InversifyCurrentGetComplexServiceInSingletonScope.js';
 import { InversifyCurrentGetComplexServiceInTransientScope } from '../scenario/inversifyCurrent/InversifyCurrentGetComplexServiceInTransientScope.js';
@@ -124,6 +128,26 @@ export async function run(): Promise<void> {
         new AwilixGetComplexServiceInTransientScope(),
         new NestCoreGetComplexServiceInTransientScopeScenario(),
         new TsyringeGetComplexServiceInTransientScope(),
+      ],
+    });
+
+    await benchmark.run();
+
+    printBenchmarkResults(benchmark);
+  }
+
+  // Run get complex async service in transient scope scenarios
+  {
+    const benchmark: Bench = buildBenchmark({
+      benchOptions: {
+        name: 'Get complex async service in transient scope',
+        time: MS_PER_SCENARIO,
+      },
+      scenarios: [
+        new InversifyCurrentGetComplexAsyncServiceInTransientScope(),
+        new Inversify6GetComplexAsyncServiceInTransientScope(),
+        new Inversify7GetComplexAsyncServiceInTransientScope(),
+        new Inversify8GetComplexAsyncServiceInTransientScope(),
       ],
     });
 

--- a/packages/container/tools/container-benchmarks/src/scenario/Inversify6/Inversify6GetComplexAsyncServiceInTransientScope.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/Inversify6/Inversify6GetComplexAsyncServiceInTransientScope.ts
@@ -1,0 +1,187 @@
+import { injectable } from 'inversify6';
+
+import { Inversify6BaseScenario } from './Inversify6BaseScenario.js';
+
+@injectable()
+class FinalNode {
+  public log() {
+    return 'log!';
+  }
+}
+
+@injectable()
+class Node10 {
+  private readonly node1: FinalNode;
+  private readonly node2: FinalNode;
+
+  constructor(node1: FinalNode, node2: FinalNode) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node9 {
+  private readonly node1: Node10;
+  private readonly node2: Node10;
+
+  constructor(node1: Node10, node2: Node10) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node8 {
+  private readonly node1: Node9;
+  private readonly node2: Node9;
+
+  constructor(node1: Node9, node2: Node9) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node7 {
+  private readonly node1: Node8;
+  private readonly node2: Node8;
+
+  constructor(node1: Node8, node2: Node8) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node6 {
+  private readonly node1: Node7;
+  private readonly node2: Node7;
+
+  constructor(node1: Node7, node2: Node7) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node5 {
+  private readonly node1: Node6;
+  private readonly node2: Node6;
+
+  constructor(node1: Node6, node2: Node6) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node4 {
+  private readonly node1: Node5;
+  private readonly node2: Node5;
+
+  constructor(node1: Node5, node2: Node5) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node3 {
+  private readonly node1: Node4;
+  private readonly node2: Node4;
+
+  constructor(node1: Node4, node2: Node4) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node2 {
+  private readonly node1: Node3;
+  private readonly node2: Node3;
+
+  constructor(node1: Node3, node2: Node3) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node1 {
+  private readonly node1: Node2;
+  private readonly node2: Node2;
+
+  constructor(node1: Node2, node2: Node2) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+export class Inversify6GetComplexAsyncServiceInTransientScope extends Inversify6BaseScenario {
+  public override async setUp(): Promise<void> {
+    this._container
+      .bind(FinalNode)
+      .toDynamicValue(async () => new FinalNode())
+      .inTransientScope();
+    this._container.bind(Node1).toSelf().inTransientScope();
+    this._container.bind(Node2).toSelf().inTransientScope();
+    this._container.bind(Node3).toSelf().inTransientScope();
+    this._container.bind(Node4).toSelf().inTransientScope();
+    this._container.bind(Node5).toSelf().inTransientScope();
+    this._container.bind(Node6).toSelf().inTransientScope();
+    this._container.bind(Node7).toSelf().inTransientScope();
+    this._container.bind(Node8).toSelf().inTransientScope();
+    this._container.bind(Node9).toSelf().inTransientScope();
+    this._container.bind(Node10).toSelf().inTransientScope();
+  }
+
+  public async execute(): Promise<void> {
+    await this._container.getAsync(Node1);
+  }
+
+  public override async tearDown(): Promise<void> {
+    this._container.unbindAll();
+  }
+}

--- a/packages/container/tools/container-benchmarks/src/scenario/Inversify7/Inversify7GetComplexAsyncServiceInTransientScope.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/Inversify7/Inversify7GetComplexAsyncServiceInTransientScope.ts
@@ -1,0 +1,187 @@
+import { injectable } from 'inversify7';
+
+import { Inversify7BaseScenario } from './Inversify7BaseScenario.js';
+
+@injectable()
+class FinalNode {
+  public log() {
+    return 'log!';
+  }
+}
+
+@injectable()
+class Node10 {
+  private readonly node1: FinalNode;
+  private readonly node2: FinalNode;
+
+  constructor(node1: FinalNode, node2: FinalNode) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node9 {
+  private readonly node1: Node10;
+  private readonly node2: Node10;
+
+  constructor(node1: Node10, node2: Node10) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node8 {
+  private readonly node1: Node9;
+  private readonly node2: Node9;
+
+  constructor(node1: Node9, node2: Node9) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node7 {
+  private readonly node1: Node8;
+  private readonly node2: Node8;
+
+  constructor(node1: Node8, node2: Node8) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node6 {
+  private readonly node1: Node7;
+  private readonly node2: Node7;
+
+  constructor(node1: Node7, node2: Node7) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node5 {
+  private readonly node1: Node6;
+  private readonly node2: Node6;
+
+  constructor(node1: Node6, node2: Node6) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node4 {
+  private readonly node1: Node5;
+  private readonly node2: Node5;
+
+  constructor(node1: Node5, node2: Node5) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node3 {
+  private readonly node1: Node4;
+  private readonly node2: Node4;
+
+  constructor(node1: Node4, node2: Node4) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node2 {
+  private readonly node1: Node3;
+  private readonly node2: Node3;
+
+  constructor(node1: Node3, node2: Node3) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node1 {
+  private readonly node1: Node2;
+  private readonly node2: Node2;
+
+  constructor(node1: Node2, node2: Node2) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+export class Inversify7GetComplexAsyncServiceInTransientScope extends Inversify7BaseScenario {
+  public override async setUp(): Promise<void> {
+    this._container
+      .bind(FinalNode)
+      .toResolvedValue(async () => new FinalNode())
+      .inTransientScope();
+    this._container.bind(Node1).toSelf().inTransientScope();
+    this._container.bind(Node2).toSelf().inTransientScope();
+    this._container.bind(Node3).toSelf().inTransientScope();
+    this._container.bind(Node4).toSelf().inTransientScope();
+    this._container.bind(Node5).toSelf().inTransientScope();
+    this._container.bind(Node6).toSelf().inTransientScope();
+    this._container.bind(Node7).toSelf().inTransientScope();
+    this._container.bind(Node8).toSelf().inTransientScope();
+    this._container.bind(Node9).toSelf().inTransientScope();
+    this._container.bind(Node10).toSelf().inTransientScope();
+  }
+
+  public async execute(): Promise<void> {
+    await this._container.getAsync(Node1);
+  }
+
+  public override async tearDown(): Promise<void> {
+    this._container.unbindAllSync();
+  }
+}

--- a/packages/container/tools/container-benchmarks/src/scenario/inversify8/Inversify8GetComplexAsyncServiceInTransientScope.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/inversify8/Inversify8GetComplexAsyncServiceInTransientScope.ts
@@ -1,0 +1,187 @@
+import { injectable } from 'inversify8';
+
+import { Inversify8BaseScenario } from './Inversify8BaseScenario.js';
+
+@injectable()
+class FinalNode {
+  public log() {
+    return 'log!';
+  }
+}
+
+@injectable()
+class Node10 {
+  private readonly node1: FinalNode;
+  private readonly node2: FinalNode;
+
+  constructor(node1: FinalNode, node2: FinalNode) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node9 {
+  private readonly node1: Node10;
+  private readonly node2: Node10;
+
+  constructor(node1: Node10, node2: Node10) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node8 {
+  private readonly node1: Node9;
+  private readonly node2: Node9;
+
+  constructor(node1: Node9, node2: Node9) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node7 {
+  private readonly node1: Node8;
+  private readonly node2: Node8;
+
+  constructor(node1: Node8, node2: Node8) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node6 {
+  private readonly node1: Node7;
+  private readonly node2: Node7;
+
+  constructor(node1: Node7, node2: Node7) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node5 {
+  private readonly node1: Node6;
+  private readonly node2: Node6;
+
+  constructor(node1: Node6, node2: Node6) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node4 {
+  private readonly node1: Node5;
+  private readonly node2: Node5;
+
+  constructor(node1: Node5, node2: Node5) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node3 {
+  private readonly node1: Node4;
+  private readonly node2: Node4;
+
+  constructor(node1: Node4, node2: Node4) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node2 {
+  private readonly node1: Node3;
+  private readonly node2: Node3;
+
+  constructor(node1: Node3, node2: Node3) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node1 {
+  private readonly node1: Node2;
+  private readonly node2: Node2;
+
+  constructor(node1: Node2, node2: Node2) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+export class Inversify8GetComplexAsyncServiceInTransientScope extends Inversify8BaseScenario {
+  public override async setUp(): Promise<void> {
+    this._container
+      .bind(FinalNode)
+      .toResolvedValue(async () => new FinalNode())
+      .inTransientScope();
+    this._container.bind(Node1).toSelf().inTransientScope();
+    this._container.bind(Node2).toSelf().inTransientScope();
+    this._container.bind(Node3).toSelf().inTransientScope();
+    this._container.bind(Node4).toSelf().inTransientScope();
+    this._container.bind(Node5).toSelf().inTransientScope();
+    this._container.bind(Node6).toSelf().inTransientScope();
+    this._container.bind(Node7).toSelf().inTransientScope();
+    this._container.bind(Node8).toSelf().inTransientScope();
+    this._container.bind(Node9).toSelf().inTransientScope();
+    this._container.bind(Node10).toSelf().inTransientScope();
+  }
+
+  public async execute(): Promise<void> {
+    await this._container.getAsync(Node1);
+  }
+
+  public override async tearDown(): Promise<void> {
+    this._container.unbindAll();
+  }
+}

--- a/packages/container/tools/container-benchmarks/src/scenario/inversifyCurrent/InversifyCurrentGetComplexAsyncServiceInTransientScope.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/inversifyCurrent/InversifyCurrentGetComplexAsyncServiceInTransientScope.ts
@@ -1,0 +1,187 @@
+import { injectable } from '@inversifyjs/core';
+
+import { InversifyCurrentBaseScenario } from './InversifyCurrentBaseScenario.js';
+
+@injectable()
+class FinalNode {
+  public log() {
+    return 'log!';
+  }
+}
+
+@injectable()
+class Node10 {
+  private readonly node1: FinalNode;
+  private readonly node2: FinalNode;
+
+  constructor(node1: FinalNode, node2: FinalNode) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node9 {
+  private readonly node1: Node10;
+  private readonly node2: Node10;
+
+  constructor(node1: Node10, node2: Node10) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node8 {
+  private readonly node1: Node9;
+  private readonly node2: Node9;
+
+  constructor(node1: Node9, node2: Node9) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node7 {
+  private readonly node1: Node8;
+  private readonly node2: Node8;
+
+  constructor(node1: Node8, node2: Node8) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node6 {
+  private readonly node1: Node7;
+  private readonly node2: Node7;
+
+  constructor(node1: Node7, node2: Node7) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node5 {
+  private readonly node1: Node6;
+  private readonly node2: Node6;
+
+  constructor(node1: Node6, node2: Node6) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node4 {
+  private readonly node1: Node5;
+  private readonly node2: Node5;
+
+  constructor(node1: Node5, node2: Node5) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node3 {
+  private readonly node1: Node4;
+  private readonly node2: Node4;
+
+  constructor(node1: Node4, node2: Node4) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node2 {
+  private readonly node1: Node3;
+  private readonly node2: Node3;
+
+  constructor(node1: Node3, node2: Node3) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node1 {
+  private readonly node1: Node2;
+  private readonly node2: Node2;
+
+  constructor(node1: Node2, node2: Node2) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+export class InversifyCurrentGetComplexAsyncServiceInTransientScope extends InversifyCurrentBaseScenario {
+  public override async setUp(): Promise<void> {
+    this._container
+      .bind(FinalNode)
+      .toResolvedValue(async () => new FinalNode())
+      .inTransientScope();
+    this._container.bind(Node1).toSelf().inTransientScope();
+    this._container.bind(Node2).toSelf().inTransientScope();
+    this._container.bind(Node3).toSelf().inTransientScope();
+    this._container.bind(Node4).toSelf().inTransientScope();
+    this._container.bind(Node5).toSelf().inTransientScope();
+    this._container.bind(Node6).toSelf().inTransientScope();
+    this._container.bind(Node7).toSelf().inTransientScope();
+    this._container.bind(Node8).toSelf().inTransientScope();
+    this._container.bind(Node9).toSelf().inTransientScope();
+    this._container.bind(Node10).toSelf().inTransientScope();
+  }
+
+  public async execute(): Promise<void> {
+    await this._container.getAsync(Node1);
+  }
+
+  public override async tearDown(): Promise<void> {
+    this._container.unbindAll();
+  }
+}


### PR DESCRIPTION
### Added
- Added `resolveTwo`.
- Added `resolveThree`.
- Added `resolveFour`.
- Added benchmark async resolution scenario.

### Changed
- Updated resolvers with arity related calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved async-aware dependency resolution for bindings with 2–4 constructor arguments by introducing reusable 2-, 3-, and 4-value resolution helpers.
  * Added new benchmark scenarios for getting complex async services in transient scope (including expanded Inversify 6/7/8 coverage).

* **Refactor**
  * Updated internal binding/value resolution to route 2/3/4 argument cases through the new helpers for consistent behavior.

* **Tests**
  * Added Vitest coverage for the 2-, 3-, and 4-value resolution helpers across sync and promise-based inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->