### PR TITLE
Improved singleton scoped resolution

### DIFF
--- a/.changeset/major-mirrors-like.md
+++ b/.changeset/major-mirrors-like.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": major
+---
+
+- Updated `ResolutionParams.requestScopedCache` to allow `undefined` value.

--- a/packages/container/libraries/container/src/container/services/ServiceResolutionManager.spec.ts
+++ b/packages/container/libraries/container/src/container/services/ServiceResolutionManager.spec.ts
@@ -59,6 +59,7 @@ describe(ServiceResolutionManager, () => {
       onReset: vitest.fn(),
       planResultCacheService: {
         get: vitest.fn(),
+        getByServiceIdentifier: vitest.fn(),
         set: vitest.fn(),
         setNonCachedServiceNode: vitest.fn(),
       } as Partial<PlanResultCacheService> as PlanResultCacheService,
@@ -160,7 +161,7 @@ describe(ServiceResolutionManager, () => {
             },
             getActivations: expect.any(Function),
             planResult: planResultFixture,
-            requestScopeCache: new Map(),
+            requestScopeCache: undefined,
           };
 
           expect(resolve).toHaveBeenCalledExactlyOnceWith(
@@ -257,7 +258,7 @@ describe(ServiceResolutionManager, () => {
             },
             getActivations: expect.any(Function),
             planResult: planResultFixture,
-            requestScopeCache: new Map(),
+            requestScopeCache: undefined,
           };
 
           expect(resolve).toHaveBeenCalledExactlyOnceWith(
@@ -377,7 +378,7 @@ describe(ServiceResolutionManager, () => {
             },
             getActivations: expect.any(Function),
             planResult: planResultFixture,
-            requestScopeCache: new Map(),
+            requestScopeCache: undefined,
           };
 
           expect(resolve).toHaveBeenCalledExactlyOnceWith(
@@ -487,7 +488,7 @@ describe(ServiceResolutionManager, () => {
             },
             getActivations: expect.any(Function),
             planResult: planResultFixture,
-            requestScopeCache: new Map(),
+            requestScopeCache: undefined,
           };
 
           expect(resolve).toHaveBeenCalledExactlyOnceWith(
@@ -598,7 +599,7 @@ describe(ServiceResolutionManager, () => {
             },
             getActivations: expect.any(Function),
             planResult: planResultFixture,
-            requestScopeCache: new Map(),
+            requestScopeCache: undefined,
           };
 
           expect(resolve).toHaveBeenCalledExactlyOnceWith(
@@ -692,7 +693,7 @@ describe(ServiceResolutionManager, () => {
           },
           getActivations: expect.any(Function),
           planResult: planResultFixture,
-          requestScopeCache: new Map(),
+          requestScopeCache: undefined,
         };
 
         expect(resolve).toHaveBeenCalledExactlyOnceWith(expectedResolveParams);
@@ -700,6 +701,165 @@ describe(ServiceResolutionManager, () => {
 
       it('should return expected value', () => {
         expect(result).toBe(resolvedValueFixture);
+      });
+    });
+
+    describe('having a serviceResolutionManager with no options', () => {
+      let serviceResolutionManager: ServiceResolutionManager;
+
+      beforeAll(() => {
+        serviceResolutionManager = new ServiceResolutionManager(
+          planParamsOperationsManagerFixture,
+          serviceReferenceManagerMock,
+          autobindFixture,
+          defaultScopeFixture,
+        );
+      });
+
+      describe('when called, and serviceReferenceManager.planResultCacheService.getByServiceIdentifier() returns PlanResult', () => {
+        let serviceIdentifierFixture: ServiceIdentifier;
+
+        let planResultFixture: PlanResult;
+
+        let resolvedValueFixture: unknown;
+
+        let result: unknown;
+
+        beforeAll(() => {
+          serviceIdentifierFixture = 'service-id';
+
+          planResultFixture = Symbol() as unknown as PlanResult;
+
+          resolvedValueFixture = Symbol();
+
+          vitest
+            .mocked(
+              serviceReferenceManagerMock.planResultCacheService
+                .getByServiceIdentifier,
+            )
+            .mockReturnValueOnce(planResultFixture);
+
+          vitest.mocked(resolve).mockReturnValueOnce(resolvedValueFixture);
+
+          result = serviceResolutionManager.get(serviceIdentifierFixture);
+        });
+
+        afterAll(() => {
+          vitest.clearAllMocks();
+        });
+
+        it('should call serviceReferenceManager.planResultCacheService.getByServiceIdentifier()', () => {
+          expect(
+            serviceReferenceManagerMock.planResultCacheService
+              .getByServiceIdentifier,
+          ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
+        });
+
+        it('should not call serviceReferenceManager.planResultCacheService.get()', () => {
+          expect(
+            serviceReferenceManagerMock.planResultCacheService.get,
+          ).not.toHaveBeenCalled();
+        });
+
+        it('should not call plan()', () => {
+          expect(plan).not.toHaveBeenCalled();
+        });
+
+        it('should call resolve()', () => {
+          const expectedResolveParams: ResolutionParams = {
+            context: {
+              get: expect.any(Function),
+              getAll: expect.any(Function),
+              getAllAsync: expect.any(Function),
+              getAsync: expect.any(Function),
+            },
+            getActivations: expect.any(Function),
+            planResult: planResultFixture,
+            requestScopeCache: undefined,
+          };
+
+          expect(resolve).toHaveBeenCalledExactlyOnceWith(
+            expectedResolveParams,
+          );
+        });
+
+        it('should return expected value', () => {
+          expect(result).toBe(resolvedValueFixture);
+        });
+      });
+
+      describe('when called, and serviceReferenceManager.planResultCacheService.getByServiceIdentifier() returns undefined', () => {
+        let serviceIdentifierFixture: ServiceIdentifier;
+
+        let planResultFixture: PlanResult;
+
+        let resolvedValueFixture: unknown;
+
+        let result: unknown;
+
+        beforeAll(() => {
+          serviceIdentifierFixture = 'service-id';
+
+          planResultFixture = Symbol() as unknown as PlanResult;
+
+          resolvedValueFixture = Symbol();
+
+          vitest
+            .mocked(
+              serviceReferenceManagerMock.planResultCacheService
+                .getByServiceIdentifier,
+            )
+            .mockReturnValueOnce(undefined);
+
+          vitest.mocked(plan).mockReturnValueOnce(planResultFixture);
+
+          vitest.mocked(resolve).mockReturnValueOnce(resolvedValueFixture);
+
+          result = serviceResolutionManager.get(serviceIdentifierFixture);
+        });
+
+        afterAll(() => {
+          vitest.clearAllMocks();
+        });
+
+        it('should call serviceReferenceManager.planResultCacheService.getByServiceIdentifier()', () => {
+          expect(
+            serviceReferenceManagerMock.planResultCacheService
+              .getByServiceIdentifier,
+          ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
+        });
+
+        it('should call serviceReferenceManager.planResultCacheService.get()', () => {
+          const expectedGetPlanOptions: GetPlanOptions = {
+            isMultiple: false,
+            name: undefined,
+            optional: false,
+            serviceIdentifier: serviceIdentifierFixture,
+            tag: undefined,
+          };
+
+          expect(
+            serviceReferenceManagerMock.planResultCacheService.get,
+          ).toHaveBeenCalledExactlyOnceWith(expectedGetPlanOptions);
+        });
+
+        it('should call plan()', () => {
+          const expectedPlanParams: PlanParams = {
+            autobindOptions: undefined,
+            operations: planParamsOperationsManagerFixture.planParamsOperations,
+            rootConstraints: {
+              isMultiple: false,
+              serviceIdentifier: serviceIdentifierFixture,
+            },
+            servicesBranch: [],
+          };
+
+          expect(plan).toHaveBeenCalledExactlyOnceWith(expectedPlanParams);
+        });
+
+        it('should return expected value', () => {
+          expect(result).toBe(resolvedValueFixture);
+        });
       });
     });
   });
@@ -782,7 +942,7 @@ describe(ServiceResolutionManager, () => {
             },
             getActivations: expect.any(Function),
             planResult: planResultFixture,
-            requestScopeCache: new Map(),
+            requestScopeCache: undefined,
           };
 
           expect(resolve).toHaveBeenCalledExactlyOnceWith(
@@ -880,7 +1040,7 @@ describe(ServiceResolutionManager, () => {
           },
           getActivations: expect.any(Function),
           planResult: planResultFixture,
-          requestScopeCache: new Map(),
+          requestScopeCache: undefined,
         };
 
         expect(resolve).toHaveBeenCalledExactlyOnceWith(expectedResolveParams);
@@ -979,7 +1139,7 @@ describe(ServiceResolutionManager, () => {
           },
           getActivations: expect.any(Function),
           planResult: planResultFixture,
-          requestScopeCache: new Map(),
+          requestScopeCache: undefined,
         };
 
         expect(resolve).toHaveBeenCalledExactlyOnceWith(expectedResolveParams);
@@ -1084,7 +1244,7 @@ describe(ServiceResolutionManager, () => {
           },
           getActivations: expect.any(Function),
           planResult: planResultFixture,
-          requestScopeCache: new Map(),
+          requestScopeCache: undefined,
         };
 
         expect(resolve).toHaveBeenCalledExactlyOnceWith(expectedResolveParams);
@@ -1179,7 +1339,7 @@ describe(ServiceResolutionManager, () => {
           },
           getActivations: expect.any(Function),
           planResult: planResultFixture,
-          requestScopeCache: new Map(),
+          requestScopeCache: undefined,
         };
 
         expect(resolve).toHaveBeenCalledExactlyOnceWith(expectedResolveParams);

--- a/packages/container/libraries/container/src/container/services/ServiceResolutionManager.ts
+++ b/packages/container/libraries/container/src/container/services/ServiceResolutionManager.ts
@@ -241,6 +241,21 @@ export class ServiceResolutionManager {
     serviceIdentifier: ServiceIdentifier,
     options: GetOptions | GetAllOptions | undefined,
   ): PlanResult {
+    /**
+     * This avoids allocating a {@link GetPlanOptions} object and the extra
+     * branching performed by the plan result cache service.
+     */
+    if (!isMultiple && options === undefined) {
+      const cachedPlanResultFromServiceIdentifier: PlanResult | undefined =
+        this.#serviceReferenceManager.planResultCacheService.getByServiceIdentifier(
+          serviceIdentifier,
+        );
+
+      if (cachedPlanResultFromServiceIdentifier !== undefined) {
+        return cachedPlanResultFromServiceIdentifier;
+      }
+    }
+
     const getPlanOptions: GetPlanOptions = this.#buildGetPlanOptions(
       isMultiple,
       serviceIdentifier,
@@ -280,7 +295,7 @@ export class ServiceResolutionManager {
       context: this.#resolutionContext,
       getActivations: this.#getActivationsResolutionParam,
       planResult,
-      requestScopeCache: new Map(),
+      requestScopeCache: undefined,
     }) as T;
   }
 

--- a/packages/container/libraries/core/src/planning/services/PlanResultCacheService.spec.ts
+++ b/packages/container/libraries/core/src/planning/services/PlanResultCacheService.spec.ts
@@ -12,6 +12,8 @@ import {
 vitest.mock(import('../actions/addRootServiceNodeBindingIfContextFree.js'));
 vitest.mock(import('../actions/addServiceNodeBindingIfContextFree.js'));
 
+import { type ServiceIdentifier } from '@inversifyjs/common';
+
 import { type Binding } from '../../binding/models/Binding.js';
 import { type InternalBindingConstraints } from '../../binding/models/BindingConstraintsImplementation.js';
 import { bindingScopeValues } from '../../binding/models/BindingScope.js';
@@ -2253,6 +2255,86 @@ describe(PlanResultCacheService, () => {
               .internalServiceNode,
           ).toBeUndefined();
         });
+      });
+    });
+  });
+
+  describe('.getByServiceIdentifier', () => {
+    describe('having a service identifier with a cached plan result', () => {
+      let serviceIdentifierFixture: ServiceIdentifier;
+      let planService: PlanResultCacheService;
+      let planResultFixture: PlanResult;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        serviceIdentifierFixture = 'service-id';
+        planService = new PlanResultCacheService();
+        planResultFixture = {} as PlanResult;
+
+        planService.set(
+          {
+            isMultiple: false,
+            name: undefined,
+            optional: false,
+            serviceIdentifier: serviceIdentifierFixture,
+            tag: undefined,
+          },
+          planResultFixture,
+        );
+
+        result = planService.getByServiceIdentifier(serviceIdentifierFixture);
+      });
+
+      it('should return the cached plan result', () => {
+        expect(result).toBe(planResultFixture);
+      });
+    });
+
+    describe('having a service identifier with no cached plan result', () => {
+      let serviceIdentifierFixture: ServiceIdentifier;
+      let planService: PlanResultCacheService;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        serviceIdentifierFixture = 'service-id';
+        planService = new PlanResultCacheService();
+
+        result = planService.getByServiceIdentifier(serviceIdentifierFixture);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('having a service identifier with a cached plan result under different options', () => {
+      let serviceIdentifierFixture: ServiceIdentifier;
+      let planService: PlanResultCacheService;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        serviceIdentifierFixture = 'service-id';
+        planService = new PlanResultCacheService();
+
+        planService.set(
+          {
+            isMultiple: false,
+            name: 'name',
+            optional: false,
+            serviceIdentifier: serviceIdentifierFixture,
+            tag: undefined,
+          },
+          {} as PlanResult,
+        );
+
+        result = planService.getByServiceIdentifier(serviceIdentifierFixture);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
       });
     });
   });

--- a/packages/container/libraries/core/src/planning/services/PlanResultCacheService.ts
+++ b/packages/container/libraries/core/src/planning/services/PlanResultCacheService.ts
@@ -26,6 +26,8 @@ import { type PlanServiceNode } from '../models/PlanServiceNode.js';
 import { type PlanServiceRedirectionBindingNode } from '../models/PlanServiceRedirectionBindingNode.js';
 import { type ResolvedValueBindingNode } from '../models/ResolvedValueBindingNode.js';
 
+const NO_OPTIONS_INDEX: number = 0;
+
 const CHAINED_MASK: number = 0x4;
 const IS_MULTIPLE_MASK: number = 0x2;
 const OPTIONAL_MASK: number = 0x1;
@@ -83,6 +85,17 @@ export class PlanResultCacheService {
     for (const subscriber of this.#subscribers) {
       subscriber.clearCache();
     }
+  }
+
+  public getByServiceIdentifier(
+    serviceIdentifier: ServiceIdentifier,
+  ): PlanResult | undefined {
+    return (
+      this.#serviceIdToValuePlanMap[NO_OPTIONS_INDEX] as Map<
+        ServiceIdentifier,
+        PlanResult
+      >
+    ).get(serviceIdentifier);
   }
 
   public get(options: GetPlanOptions): PlanResult | undefined {

--- a/packages/container/libraries/core/src/resolution/actions/resolveScoped.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveScoped.spec.ts
@@ -244,7 +244,58 @@ describe(resolveScoped, () => {
 
         it('should set request scope value()', () => {
           expect(
-            paramsFixture.requestScopeCache.get(nodeFixture.binding.id),
+            paramsFixture.requestScopeCache?.get(nodeFixture.binding.id),
+          ).toBe(resolveMockResult);
+        });
+
+        it('should return expected value', () => {
+          expect(result).toBe(resolveMockResult);
+        });
+      });
+
+      describe('when resolveFunction is called, and params.requestScopeCache is undefined', () => {
+        let paramsFixture: ResolutionParams;
+        let resolveMockResult: unknown;
+
+        let result: unknown;
+
+        beforeAll(() => {
+          paramsFixture = {
+            requestScopeCache: undefined,
+          } as Partial<ResolutionParams> as ResolutionParams;
+          resolveMockResult = Symbol();
+
+          resolveMock.mockReturnValueOnce(resolveMockResult);
+
+          vitest
+            .mocked(resolveBindingActivations)
+            .mockReturnValueOnce(resolveMockResult);
+
+          result = resolveFunction(paramsFixture);
+        });
+
+        afterAll(() => {
+          vitest.clearAllMocks();
+        });
+
+        it('should call resolveMock()', () => {
+          expect(resolveMock).toHaveBeenCalledExactlyOnceWith(
+            paramsFixture,
+            nodeFixture,
+          );
+        });
+
+        it('should call resolveBindingActivations()', () => {
+          expect(resolveBindingActivations).toHaveBeenCalledExactlyOnceWith(
+            paramsFixture,
+            nodeFixture.binding,
+            resolveMockResult,
+          );
+        });
+
+        it('should lazily create the request scope cache and set the value', () => {
+          expect(
+            paramsFixture.requestScopeCache?.get(nodeFixture.binding.id),
           ).toBe(resolveMockResult);
         });
 

--- a/packages/container/libraries/core/src/resolution/actions/resolveScoped.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveScoped.ts
@@ -42,7 +42,7 @@ export function resolveScoped<
     }
     case bindingScopeValues.Request: {
       return (params: ResolutionParams): Resolved<TActivated> => {
-        if (params.requestScopeCache.has(binding.id)) {
+        if (params.requestScopeCache?.has(binding.id) === true) {
           return params.requestScopeCache.get(
             binding.id,
           ) as Resolved<TActivated>;
@@ -55,7 +55,7 @@ export function resolveScoped<
             resolve(params, node),
           );
 
-        params.requestScopeCache.set(binding.id, resolvedValue);
+        (params.requestScopeCache ??= new Map()).set(binding.id, resolvedValue);
 
         return resolvedValue;
       };

--- a/packages/container/libraries/core/src/resolution/actions/resolveScopedWithNoActivations.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveScopedWithNoActivations.spec.ts
@@ -180,7 +180,43 @@ describe(resolveScopedWithNoActivations, () => {
         });
 
         it('should set request scope value()', () => {
-          expect(paramsFixture.requestScopeCache.get(bindingFixture.id)).toBe(
+          expect(paramsFixture.requestScopeCache?.get(bindingFixture.id)).toBe(
+            resolveMockResult,
+          );
+        });
+
+        it('should return expected value', () => {
+          expect(result).toBe(resolveMockResult);
+        });
+      });
+
+      describe('when resolveFunction is called, and params.requestScopeCache is undefined', () => {
+        let paramsFixture: ResolutionParams;
+        let resolveMockResult: unknown;
+
+        let result: unknown;
+
+        beforeAll(() => {
+          paramsFixture = {
+            requestScopeCache: undefined,
+          } as Partial<ResolutionParams> as ResolutionParams;
+          resolveMockResult = Symbol();
+
+          resolveMock.mockReturnValueOnce(resolveMockResult);
+
+          result = resolveFunction(paramsFixture);
+        });
+
+        afterAll(() => {
+          vitest.clearAllMocks();
+        });
+
+        it('should call resolveMock()', () => {
+          expect(resolveMock).toHaveBeenCalledExactlyOnceWith(paramsFixture);
+        });
+
+        it('should lazily create the request scope cache and set the value', () => {
+          expect(paramsFixture.requestScopeCache?.get(bindingFixture.id)).toBe(
             resolveMockResult,
           );
         });

--- a/packages/container/libraries/core/src/resolution/actions/resolveScopedWithNoActivations.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveScopedWithNoActivations.ts
@@ -28,7 +28,7 @@ export function resolveScopedWithNoActivations<TActivated>(
     }
     case bindingScopeValues.Request: {
       return (params: ResolutionParams): Resolved<TActivated> => {
-        if (params.requestScopeCache.has(binding.id)) {
+        if (params.requestScopeCache?.has(binding.id) === true) {
           return params.requestScopeCache.get(
             binding.id,
           ) as Resolved<TActivated>;
@@ -36,7 +36,7 @@ export function resolveScopedWithNoActivations<TActivated>(
 
         const resolvedValue: Resolved<TActivated> = resolve(params);
 
-        params.requestScopeCache.set(binding.id, resolvedValue);
+        (params.requestScopeCache ??= new Map()).set(binding.id, resolvedValue);
 
         return resolvedValue;
       };

--- a/packages/container/libraries/core/src/resolution/models/ResolutionParams.ts
+++ b/packages/container/libraries/core/src/resolution/models/ResolutionParams.ts
@@ -10,5 +10,5 @@ export interface ResolutionParams {
     serviceIdentifier: ServiceIdentifier<TActivated>,
   ) => Iterable<BindingActivation<TActivated>> | undefined;
   planResult: PlanResult;
-  requestScopeCache: Map<number, unknown>;
+  requestScopeCache: Map<number, unknown> | undefined;
 }


### PR DESCRIPTION
### Changed
- Updated `PlanResolutionParams` to lazily load request scope cache.
- Added cache provision hot path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Request-scoped resolutions now work even when the request cache starts out empty, avoiding errors and creating the cache only when needed.
  * Improved service lookup behavior so single-service resolutions without extra options can reuse an existing cached result when available.
  * Updated request-scoped behavior to better handle missing cached values during resolution.
* **Breaking Changes**
  * The request-scope cache is now optional in resolution scenarios, which may affect integrations relying on it always being present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->