### PR TITLE
[Perf]: Instance resolution with properties

### DIFF
--- a/.changeset/public-nails-cheer.md
+++ b/.changeset/public-nails-cheer.md
@@ -1,0 +1,7 @@
+---
+"@inversifyjs/core": patch
+"@inversifyjs/container": patch
+"inversify": patch
+---
+
+- Updated instance resolution flow to rely on inlined functions also in property injected services.

--- a/packages/container/libraries/core/src/planning/calculations/buildConstructorArgumentsResolver.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildConstructorArgumentsResolver.spec.ts
@@ -19,9 +19,34 @@ class Foo {
   }
 }
 
+type FooWithProperties = Foo & Record<string | symbol, unknown>;
+
+interface PropertyFixture {
+  key: string | symbol;
+  value: string;
+}
+
 function buildNodeFixtureForArguments(
   length: number,
+  propertyFixtures: PropertyFixture[] = [],
 ): InstanceBindingNode<Foo, InstanceBinding<Foo>> {
+  const properties: Map<string | symbol, ClassElementMetadata> = new Map<
+    string | symbol,
+    ClassElementMetadata
+  >();
+
+  for (const propertyFixture of propertyFixtures) {
+    properties.set(
+      propertyFixture.key,
+      Symbol() as unknown as ClassElementMetadata,
+    );
+  }
+
+  const propertyParams: Map<string | symbol, PlanServiceNode> = new Map<
+    string | symbol,
+    PlanServiceNode
+  >();
+
   return {
     classMetadata: {
       constructorArguments: new Array<ClassElementMetadata>(length).fill(
@@ -31,10 +56,11 @@ function buildNodeFixtureForArguments(
         postConstructMethodNames: new Set(),
         preDestroyMethodNames: new Set(),
       },
-      properties: new Map<string | symbol, unknown>(),
+      properties,
       scope: undefined,
     },
     constructorParams: [] as PlanServiceNode[],
+    propertyParams,
   } as Partial<
     InstanceBindingNode<Foo, InstanceBinding<Foo>>
   > as InstanceBindingNode<Foo, InstanceBinding<Foo>>;
@@ -213,4 +239,359 @@ describe(buildConstructorArgumentsResolver, () => {
       });
     },
   );
+
+  describe.each<
+    [string, number, ResolveAsyncValues, string[], PropertyFixture[]]
+  >([
+    [
+      'two constructor arguments and two properties',
+      2,
+      resolveFour,
+      ['value-0', 'value-1'],
+      [
+        { key: 'propertyA', value: 'property-0' },
+        { key: 'propertyB', value: 'property-1' },
+      ],
+    ],
+  ])(
+    'having %s',
+    (
+      _description: string,
+      paramsCount: number,
+      resolveAsyncValues: ResolveAsyncValues,
+      valueFixtures: string[],
+      propertyFixtures: PropertyFixture[],
+    ) => {
+      let paramsFixture: ResolutionParams;
+
+      beforeAll(() => {
+        paramsFixture = Symbol() as unknown as ResolutionParams;
+      });
+
+      function populatePropertyResolvers(
+        nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>,
+        resolveAsync: boolean,
+      ): void {
+        for (const propertyFixture of propertyFixtures) {
+          nodeFixture.propertyParams.set(propertyFixture.key, {
+            bindings: [],
+            resolve: resolveAsync
+              ? async (resolveParams: ResolutionParams): Promise<string> => {
+                  expect(resolveParams).toBe(paramsFixture);
+
+                  return propertyFixture.value;
+                }
+              : (resolveParams: ResolutionParams): string => {
+                  expect(resolveParams).toBe(paramsFixture);
+
+                  return propertyFixture.value;
+                },
+          } as Partial<PlanServiceNode> as PlanServiceNode);
+        }
+      }
+
+      describe('when called, and resolveActivations is not provided', () => {
+        describe('when called, and node.constructorParams is populated after the resolveNode is built', () => {
+          let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+          let result: unknown;
+
+          beforeAll(() => {
+            nodeFixture = buildNodeFixtureForArguments(
+              paramsCount,
+              propertyFixtures,
+            );
+
+            const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+              buildConstructorArgumentsResolver(
+                nodeFixture,
+                Foo,
+                resolveAsyncValues,
+              );
+
+            nodeFixture.constructorParams.push(
+              ...valueFixtures.map(
+                (value: string): PlanServiceNode =>
+                  ({
+                    resolve: (): string => value,
+                  }) as Partial<PlanServiceNode> as PlanServiceNode,
+              ),
+            );
+
+            populatePropertyResolvers(nodeFixture, false);
+
+            result = resolveNode(paramsFixture);
+          });
+
+          it('should build an instance with the resolved constructor arguments and properties in order', () => {
+            expect(result).toBeInstanceOf(Foo);
+            expect((result as Foo).args).toStrictEqual(valueFixtures);
+
+            for (const propertyFixture of propertyFixtures) {
+              expect((result as FooWithProperties)[propertyFixture.key]).toBe(
+                propertyFixture.value,
+              );
+            }
+          });
+        });
+
+        describe('when called, and constructor arguments and properties resolve asynchronously', () => {
+          let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+          let result: unknown;
+
+          beforeAll(async () => {
+            nodeFixture = buildNodeFixtureForArguments(
+              paramsCount,
+              propertyFixtures,
+            );
+
+            const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+              buildConstructorArgumentsResolver(
+                nodeFixture,
+                Foo,
+                resolveAsyncValues,
+              );
+
+            nodeFixture.constructorParams.push(
+              ...valueFixtures.map(
+                (value: string): PlanServiceNode =>
+                  ({
+                    resolve: async (): Promise<string> => value,
+                  }) as Partial<PlanServiceNode> as PlanServiceNode,
+              ),
+            );
+
+            populatePropertyResolvers(nodeFixture, true);
+
+            result = await resolveNode(paramsFixture);
+          });
+
+          it('should build an instance with the resolved constructor arguments and properties in order', () => {
+            expect(result).toBeInstanceOf(Foo);
+            expect((result as Foo).args).toStrictEqual(valueFixtures);
+
+            for (const propertyFixture of propertyFixtures) {
+              expect((result as FooWithProperties)[propertyFixture.key]).toBe(
+                propertyFixture.value,
+              );
+            }
+          });
+        });
+      });
+
+      describe('when called, and resolveActivations is provided', () => {
+        let resolveActivations: (
+          params: ResolutionParams,
+          instance: Resolved<Foo>,
+        ) => Resolved<Foo>;
+
+        beforeAll(() => {
+          resolveActivations = (
+            _params: ResolutionParams,
+            instance: Resolved<Foo>,
+          ): Resolved<Foo> => instance;
+        });
+
+        describe('when called, and node.constructorParams is populated after the resolveNode is built', () => {
+          let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+          let result: unknown;
+
+          beforeAll(() => {
+            nodeFixture = buildNodeFixtureForArguments(
+              paramsCount,
+              propertyFixtures,
+            );
+
+            const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+              buildConstructorArgumentsResolver(
+                nodeFixture,
+                Foo,
+                resolveAsyncValues,
+                resolveActivations,
+              );
+
+            nodeFixture.constructorParams.push(
+              ...valueFixtures.map(
+                (value: string): PlanServiceNode =>
+                  ({
+                    resolve: (): string => value,
+                  }) as Partial<PlanServiceNode> as PlanServiceNode,
+              ),
+            );
+
+            populatePropertyResolvers(nodeFixture, false);
+
+            result = resolveNode(paramsFixture);
+          });
+
+          it('should build an instance with the resolved constructor arguments and properties in order', () => {
+            expect(result).toBeInstanceOf(Foo);
+            expect((result as Foo).args).toStrictEqual(valueFixtures);
+
+            for (const propertyFixture of propertyFixtures) {
+              expect((result as FooWithProperties)[propertyFixture.key]).toBe(
+                propertyFixture.value,
+              );
+            }
+          });
+        });
+
+        describe('when called, and constructor arguments and properties resolve asynchronously', () => {
+          let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+          let result: unknown;
+
+          beforeAll(async () => {
+            nodeFixture = buildNodeFixtureForArguments(
+              paramsCount,
+              propertyFixtures,
+            );
+
+            const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+              buildConstructorArgumentsResolver(
+                nodeFixture,
+                Foo,
+                resolveAsyncValues,
+                resolveActivations,
+              );
+
+            nodeFixture.constructorParams.push(
+              ...valueFixtures.map(
+                (value: string): PlanServiceNode =>
+                  ({
+                    resolve: async (): Promise<string> => value,
+                  }) as Partial<PlanServiceNode> as PlanServiceNode,
+              ),
+            );
+
+            populatePropertyResolvers(nodeFixture, true);
+
+            result = await resolveNode(paramsFixture);
+          });
+
+          it('should build an instance with the resolved constructor arguments and properties in order', () => {
+            expect(result).toBeInstanceOf(Foo);
+            expect((result as Foo).args).toStrictEqual(valueFixtures);
+
+            for (const propertyFixture of propertyFixtures) {
+              expect((result as FooWithProperties)[propertyFixture.key]).toBe(
+                propertyFixture.value,
+              );
+            }
+          });
+        });
+      });
+    },
+  );
+
+  describe('having two constructor arguments and one property with no bindings', () => {
+    class FooWithDefaultProperty extends Foo {
+      public propertyA: string = 'default-property-0';
+    }
+
+    const propertyKeyFixture: string = 'propertyA';
+
+    let paramsFixture: ResolutionParams;
+
+    beforeAll(() => {
+      paramsFixture = Symbol() as unknown as ResolutionParams;
+    });
+
+    function buildNodeFixtureWithUnboundProperty(): InstanceBindingNode<
+      FooWithDefaultProperty,
+      InstanceBinding<FooWithDefaultProperty>
+    > {
+      const properties: Map<string | symbol, ClassElementMetadata> = new Map<
+        string | symbol,
+        ClassElementMetadata
+      >([[propertyKeyFixture, Symbol() as unknown as ClassElementMetadata]]);
+
+      const propertyParams: Map<string | symbol, PlanServiceNode> = new Map<
+        string | symbol,
+        PlanServiceNode
+      >([
+        [
+          propertyKeyFixture,
+          {
+            bindings: undefined,
+            resolve: (): string => {
+              throw new Error(
+                'resolve should not be called when the property has no bindings',
+              );
+            },
+          } as Partial<PlanServiceNode> as PlanServiceNode,
+        ],
+      ]);
+
+      return {
+        classMetadata: {
+          constructorArguments: new Array<ClassElementMetadata>(2).fill(
+            Symbol() as unknown as ClassElementMetadata,
+          ),
+          lifecycle: {
+            postConstructMethodNames: new Set(),
+            preDestroyMethodNames: new Set(),
+          },
+          properties,
+          scope: undefined,
+        },
+        constructorParams: [] as PlanServiceNode[],
+        propertyParams,
+      } as Partial<
+        InstanceBindingNode<
+          FooWithDefaultProperty,
+          InstanceBinding<FooWithDefaultProperty>
+        >
+      > as InstanceBindingNode<
+        FooWithDefaultProperty,
+        InstanceBinding<FooWithDefaultProperty>
+      >;
+    }
+
+    describe('when called, and the property has no bindings', () => {
+      let nodeFixture: InstanceBindingNode<
+        FooWithDefaultProperty,
+        InstanceBinding<FooWithDefaultProperty>
+      >;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        nodeFixture = buildNodeFixtureWithUnboundProperty();
+
+        const resolveNode: (
+          params: ResolutionParams,
+        ) => Resolved<FooWithDefaultProperty> =
+          buildConstructorArgumentsResolver(
+            nodeFixture,
+            FooWithDefaultProperty,
+            resolveThree,
+          );
+
+        nodeFixture.constructorParams.push(
+          ...['value-0', 'value-1'].map(
+            (value: string): PlanServiceNode =>
+              ({
+                resolve: (): string => value,
+              }) as Partial<PlanServiceNode> as PlanServiceNode,
+          ),
+        );
+
+        result = resolveNode(paramsFixture);
+      });
+
+      it('should build an instance preserving the default property value', () => {
+        expect(result).toBeInstanceOf(FooWithDefaultProperty);
+        expect((result as FooWithDefaultProperty).args).toStrictEqual([
+          'value-0',
+          'value-1',
+        ]);
+        expect((result as FooWithDefaultProperty).propertyA).toBe(
+          'default-property-0',
+        );
+      });
+    });
+  });
 });

--- a/packages/container/libraries/core/src/planning/calculations/buildConstructorArgumentsResolver.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildConstructorArgumentsResolver.ts
@@ -26,16 +26,81 @@ export function buildConstructorArgumentsResolver<TActivated>(
     (_: unknown, index: number) => index,
   );
 
-  const resolveValueConcatenation: string = constructorArgumentIndexes
+  const constructorValuesConcatenation: string = constructorArgumentIndexes
     .map((index: number) => `value$${index.toString()}`)
     .join(', ');
-  let resolveValueDeclarations: string = '';
+  let constructorValuesDeclarations: string = '';
 
   for (const index of constructorArgumentIndexes) {
-    resolveValueDeclarations += `const value$${index.toString()} = node$${id}.constructorParams[${index.toString()}].resolve(params$${id});\n`;
+    constructorValuesDeclarations += `const value$${index.toString()} = node$${id}.constructorParams[${index.toString()}].resolve(params$${id});\n`;
   }
 
+  const propertiesArgumentsCount: number = node.classMetadata.properties.size;
+
+  const propertiesArgumentIndexes: number[] = Array.from(
+    { length: propertiesArgumentsCount },
+    (_: unknown, index: number) => index,
+  );
+
+  const propertiesValuesConcatenation: string = propertiesArgumentIndexes
+    .map((index: number) => `property$${index.toString()}`)
+    .join(', ');
+
+  let propertyValuesDeclarations: string = `let propertyIterator = node$${id}.propertyParams.entries();\n`;
+
+  for (const index of propertiesArgumentIndexes) {
+    propertyValuesDeclarations += `const propertyNode$${index.toString()} = propertyIterator.next().value;
+  const propertyKey$${index.toString()} = propertyNode$${index.toString()}[0];
+  const propertyBound$${index.toString()} = propertyNode$${index.toString()}[1].bindings !== undefined;
+  const property$${index.toString()} = propertyBound$${index.toString()} ? propertyNode$${index.toString()}[1].resolve(params$${id}) : undefined;\n`;
+  }
+
+  const propertyAssignments: string = propertiesArgumentIndexes
+    .map(
+      (index: number): string =>
+        `if (propertyBound$${index.toString()}) { instance[propertyKey$${index.toString()}] = property$${index.toString()}; }`,
+    )
+    .join('      \n');
+
+  const resolveAsyncValuesArguments: string = [
+    constructorValuesConcatenation,
+    propertiesValuesConcatenation,
+  ]
+    .filter((value: string) => value.length > 0)
+    .join(', ');
+
+  const resolveAsyncValuesBuildArguments: string = resolveAsyncValuesArguments;
+
   if (resolveActivations === undefined) {
+    const buildResolveNodeBody: string =
+      propertiesArgumentsCount === 0
+        ? `return function resolveNode$${id}(params$${id}) {
+  ${constructorValuesDeclarations}
+
+  return resolveAsyncValues$${id}(
+    ${constructorValuesConcatenation},
+    function (${constructorValuesConcatenation}) {
+      return new ctor$${id}(${constructorValuesConcatenation});
+    },
+  );
+}`
+        : `return function resolveNode$${id}(params$${id}) {
+  ${constructorValuesDeclarations}
+
+  ${propertyValuesDeclarations}
+
+  return resolveAsyncValues$${id}(
+    ${resolveAsyncValuesArguments},
+    function (${resolveAsyncValuesBuildArguments}) {
+      const instance = new ctor$${id}(${constructorValuesConcatenation});
+
+      ${propertyAssignments}
+
+      return instance;
+    },
+  );
+}`;
+
     const buildResolveNode: (
       boundNode: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
       ctor: Newable<TActivated>,
@@ -46,16 +111,7 @@ export function buildConstructorArgumentsResolver<TActivated>(
       `node$${id}`,
       `ctor$${id}`,
       `resolveAsyncValues$${id}`,
-      `return function resolveNode$${id}(params$${id}) {
-  ${resolveValueDeclarations}
-
-  return resolveAsyncValues$${id}(
-    ${resolveValueConcatenation},
-    function (${resolveValueConcatenation}) {
-      return new ctor$${id}(${resolveValueConcatenation});
-    },
-  );
-}`,
+      buildResolveNodeBody,
     ) as (
       node: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
       implementationType: Newable<TActivated>,
@@ -65,6 +121,41 @@ export function buildConstructorArgumentsResolver<TActivated>(
 
     return buildResolveNode(node, implementationType, resolveAsyncValues);
   }
+
+  const buildResolveNodeBody: string =
+    propertiesArgumentsCount === 0
+      ? `return function resolveNode$${id}(params$${id}) {
+  ${constructorValuesDeclarations}
+
+  return resolveAsyncValues$${id}(
+    ${constructorValuesConcatenation},
+    function (${constructorValuesConcatenation}) {
+      return activate$${id}(
+        params$${id},
+        new ctor$${id}(${constructorValuesConcatenation}),
+      );
+    },
+  );
+}`
+      : `return function resolveNode$${id}(params$${id}) {
+  ${constructorValuesDeclarations}
+
+  ${propertyValuesDeclarations}
+
+  return resolveAsyncValues$${id}(
+    ${resolveAsyncValuesArguments},
+    function (${resolveAsyncValuesBuildArguments}) {
+      const instance = new ctor$${id}(${constructorValuesConcatenation});
+
+      ${propertyAssignments}
+
+      return activate$${id}(
+        params$${id},
+        instance,
+      );
+    },
+  );
+}`;
 
   const buildResolveNode: (
     boundNode: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
@@ -81,19 +172,7 @@ export function buildConstructorArgumentsResolver<TActivated>(
     `ctor$${id}`,
     `activate$${id}`,
     `resolveAsyncValues$${id}`,
-    `return function resolveNode$${id}(params$${id}) {
-  ${resolveValueDeclarations}
-
-  return resolveAsyncValues$${id}(
-    ${resolveValueConcatenation},
-    function (${resolveValueConcatenation}) {
-      return activate$${id}(
-        params$${id},
-        new ctor$${id}(${resolveValueConcatenation}),
-      );
-    },
-  );
-}`,
+    buildResolveNodeBody,
   ) as (
     node: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
     implementationType: Newable<TActivated>,

--- a/packages/container/libraries/core/src/planning/calculations/buildInstanceBindingNodeResolver.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildInstanceBindingNodeResolver.ts
@@ -20,6 +20,7 @@ import { type Resolved } from '../../resolution/models/Resolved.js';
 import { type InstanceBindingNode } from '../models/InstanceBindingNode.js';
 import { buildConstructorArgumentsResolver } from './buildConstructorArgumentsResolver.js';
 import { buildOneConstructorArgumentResolver } from './buildOneConstructorArgumentResolver.js';
+import { buildOnePropertyArgumentResolver } from './buildOnePropertyArgumentResolver.js';
 import { buildResolveMany } from './buildResolveMany.js';
 import { buildZeroConstructorArgumentsResolver } from './buildZeroConstructorArgumentsResolver.js';
 import { resolveFour } from './resolveFour.js';
@@ -102,7 +103,10 @@ function buildSimpleInstanceBindingNodeResolver<TActivated>(
 
   let resolveNode: (params: ResolutionParams) => Resolved<TActivated>;
 
-  switch (node.classMetadata.constructorArguments.length) {
+  switch (
+    node.classMetadata.constructorArguments.length +
+    node.classMetadata.properties.size
+  ) {
     case ZERO_CONSTRUCTOR_ARGUMENTS:
       resolveNode = buildZeroConstructorArgumentsResolver(
         implementationType,
@@ -110,11 +114,18 @@ function buildSimpleInstanceBindingNodeResolver<TActivated>(
       );
       break;
     case ONE_CONSTRUCTOR_ARGUMENT:
-      resolveNode = buildOneConstructorArgumentResolver(
-        node,
-        implementationType,
-        resolveActivations,
-      );
+      resolveNode =
+        node.classMetadata.properties.size === 0
+          ? buildOneConstructorArgumentResolver(
+              node,
+              implementationType,
+              resolveActivations,
+            )
+          : buildOnePropertyArgumentResolver(
+              node,
+              implementationType,
+              resolveActivations,
+            );
       break;
     case TWO_CONSTRUCTOR_ARGUMENTS:
       resolveNode = buildConstructorArgumentsResolver(
@@ -157,8 +168,7 @@ export function buildInstanceBindingNodeResolver<TActivated>(
 ): (params: ResolutionParams) => Resolved<TActivated> {
   if (
     node.classMetadata.lifecycle.postConstructMethodNames.size === 0 &&
-    node.binding.onActivation === undefined &&
-    node.classMetadata.properties.size === 0
+    node.binding.onActivation === undefined
   ) {
     return buildSimpleInstanceBindingNodeResolver(node);
   }

--- a/packages/container/libraries/core/src/planning/calculations/buildOnePropertyArgumentResolver.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildOnePropertyArgumentResolver.spec.ts
@@ -1,0 +1,310 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { type InstanceBinding } from '../../binding/models/InstanceBinding.js';
+import { type Writable } from '../../common/models/Writable.js';
+import { type ClassElementMetadata } from '../../metadata/models/ClassElementMetadata.js';
+import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
+import { type Resolved } from '../../resolution/models/Resolved.js';
+import { type InstanceBindingNode } from '../models/InstanceBindingNode.js';
+import { type PlanServiceNode } from '../models/PlanServiceNode.js';
+import { buildOnePropertyArgumentResolver } from './buildOnePropertyArgumentResolver.js';
+
+const propertyKeyFixture: string = 'propertyA';
+
+class Foo {
+  public readonly args: unknown[];
+
+  constructor(...args: unknown[]) {
+    this.args = args;
+  }
+}
+
+type FooWithProperties = Foo & Record<string | symbol, unknown>;
+
+function buildNodeFixture(): InstanceBindingNode<Foo, InstanceBinding<Foo>> {
+  return {
+    classMetadata: {
+      constructorArguments: [],
+      lifecycle: {
+        postConstructMethodNames: new Set(),
+        preDestroyMethodNames: new Set(),
+      },
+      properties: new Map<string | symbol, ClassElementMetadata>([
+        [propertyKeyFixture, Symbol() as unknown as ClassElementMetadata],
+      ]),
+      scope: undefined,
+    },
+    constructorParams: [],
+    propertyParams: new Map<string | symbol, PlanServiceNode>(),
+  } as Partial<
+    InstanceBindingNode<Foo, InstanceBinding<Foo>>
+  > as InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+}
+
+describe(buildOnePropertyArgumentResolver, () => {
+  let paramsFixture: ResolutionParams;
+
+  beforeAll(() => {
+    paramsFixture = Symbol() as unknown as ResolutionParams;
+  });
+
+  describe('when called, and resolveActivations is not provided', () => {
+    describe('when called, and node.propertyParams is populated after the resolveNode is built', () => {
+      let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        nodeFixture = buildNodeFixture();
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildOnePropertyArgumentResolver(nodeFixture, Foo);
+
+        nodeFixture.propertyParams.set(propertyKeyFixture, {
+          bindings: [],
+          resolve: (): string => 'property-0',
+        } as Partial<PlanServiceNode> as PlanServiceNode);
+
+        result = resolveNode(paramsFixture);
+      });
+
+      it('should build an instance with the resolved property', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual([]);
+        expect((result as FooWithProperties)[propertyKeyFixture]).toBe(
+          'property-0',
+        );
+      });
+    });
+
+    describe('when called, and the property resolves asynchronously', () => {
+      let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        nodeFixture = buildNodeFixture();
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildOnePropertyArgumentResolver(nodeFixture, Foo);
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).propertyParams = new Map<string | symbol, PlanServiceNode>([
+          [
+            propertyKeyFixture,
+            {
+              bindings: [],
+              resolve: async (): Promise<string> => 'property-0',
+            } as Partial<PlanServiceNode> as PlanServiceNode,
+          ],
+        ]);
+
+        result = await resolveNode(paramsFixture);
+      });
+
+      it('should build an instance with the resolved property', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual([]);
+        expect((result as FooWithProperties)[propertyKeyFixture]).toBe(
+          'property-0',
+        );
+      });
+    });
+
+    describe('when called, and the property has no bindings', () => {
+      let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        nodeFixture = buildNodeFixture();
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildOnePropertyArgumentResolver(nodeFixture, Foo);
+
+        nodeFixture.propertyParams.set(propertyKeyFixture, {
+          bindings: undefined,
+          resolve: (): string => {
+            throw new Error(
+              'resolve should not be called when the property has no bindings',
+            );
+          },
+        } as Partial<PlanServiceNode> as PlanServiceNode);
+
+        result = resolveNode(paramsFixture);
+      });
+
+      it('should build an instance without setting the property', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual([]);
+        expect(
+          (result as FooWithProperties)[propertyKeyFixture],
+        ).toBeUndefined();
+      });
+    });
+  });
+
+  describe('when called, and resolveActivations is provided', () => {
+    let resolveActivations: (
+      params: ResolutionParams,
+      instance: Resolved<Foo>,
+    ) => Resolved<Foo>;
+
+    beforeAll(() => {
+      resolveActivations = (
+        _params: ResolutionParams,
+        instance: Resolved<Foo>,
+      ): Resolved<Foo> => instance;
+    });
+
+    describe('when called, and node.propertyParams is populated after the resolveNode is built', () => {
+      let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        nodeFixture = buildNodeFixture();
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildOnePropertyArgumentResolver(
+            nodeFixture,
+            Foo,
+            resolveActivations,
+          );
+
+        nodeFixture.propertyParams.set(propertyKeyFixture, {
+          bindings: [],
+          resolve: (): string => 'property-0',
+        } as Partial<PlanServiceNode> as PlanServiceNode);
+
+        result = resolveNode(paramsFixture);
+      });
+
+      it('should build an instance with the resolved property', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual([]);
+        expect((result as FooWithProperties)[propertyKeyFixture]).toBe(
+          'property-0',
+        );
+      });
+    });
+
+    describe('when called, and the property resolves asynchronously', () => {
+      let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        nodeFixture = buildNodeFixture();
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildOnePropertyArgumentResolver(
+            nodeFixture,
+            Foo,
+            resolveActivations,
+          );
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).propertyParams = new Map<string | symbol, PlanServiceNode>([
+          [
+            propertyKeyFixture,
+            {
+              bindings: [],
+              resolve: async (): Promise<string> => 'property-0',
+            } as Partial<PlanServiceNode> as PlanServiceNode,
+          ],
+        ]);
+
+        result = await resolveNode(paramsFixture);
+      });
+
+      it('should build an instance with the resolved property', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual([]);
+        expect((result as FooWithProperties)[propertyKeyFixture]).toBe(
+          'property-0',
+        );
+      });
+    });
+
+    describe('when called, and the property has no bindings', () => {
+      let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        nodeFixture = buildNodeFixture();
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildOnePropertyArgumentResolver(
+            nodeFixture,
+            Foo,
+            resolveActivations,
+          );
+
+        nodeFixture.propertyParams.set(propertyKeyFixture, {
+          bindings: undefined,
+          resolve: (): string => {
+            throw new Error(
+              'resolve should not be called when the property has no bindings',
+            );
+          },
+        } as Partial<PlanServiceNode> as PlanServiceNode);
+
+        result = resolveNode(paramsFixture);
+      });
+
+      it('should build an instance without setting the property', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual([]);
+        expect(
+          (result as FooWithProperties)[propertyKeyFixture],
+        ).toBeUndefined();
+      });
+    });
+
+    describe('when called, and resolveActivations returns a promise', () => {
+      let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+      let expectedResult: unknown;
+      let result: unknown;
+
+      beforeAll(async () => {
+        nodeFixture = buildNodeFixture();
+
+        resolveActivations = (
+          _params: ResolutionParams,
+          instance: Resolved<Foo>,
+        ): Resolved<Foo> => {
+          expectedResult = instance;
+
+          return Promise.resolve(instance);
+        };
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildOnePropertyArgumentResolver(
+            nodeFixture,
+            Foo,
+            resolveActivations,
+          );
+
+        nodeFixture.propertyParams.set(propertyKeyFixture, {
+          bindings: [],
+          resolve: (): string => 'property-0',
+        } as Partial<PlanServiceNode> as PlanServiceNode);
+
+        result = await resolveNode(paramsFixture);
+      });
+
+      it('should return the resolved activation result', () => {
+        expect(result).toBe(expectedResult);
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/planning/calculations/buildOnePropertyArgumentResolver.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildOnePropertyArgumentResolver.ts
@@ -1,0 +1,114 @@
+import { isPromise, type Newable } from '@inversifyjs/common';
+
+import { type InstanceBinding } from '../../binding/models/InstanceBinding.js';
+import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
+import { type Resolved } from '../../resolution/models/Resolved.js';
+import { type InstanceBindingNode } from '../models/InstanceBindingNode.js';
+import { getGeneratedResolverId } from './getGeneratedResolverId.js';
+
+/**
+ * Same rationale as buildOneConstructorArgumentResolver, but
+ * for zero-argument instance bindings with one property.
+ */
+export function buildOnePropertyArgumentResolver<TActivated>(
+  node: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
+  implementationType: Newable<TActivated>,
+  resolveActivations?: (
+    params: ResolutionParams,
+    instance: Resolved<TActivated>,
+  ) => Resolved<TActivated>,
+): (params: ResolutionParams) => Resolved<TActivated> {
+  const id: string = getGeneratedResolverId().toString();
+
+  if (resolveActivations === undefined) {
+    const buildResolveNode: (
+      boundNode: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
+      ctor: Newable<TActivated>,
+      isPromiseFunction: typeof isPromise,
+      // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    ) => (params: ResolutionParams) => Resolved<TActivated> = new Function(
+      `node$${id}`,
+      `ctor$${id}`,
+      `isPromise$${id}`,
+      `return function resolveNode$${id}(params$${id}) {
+        const propertyEntry$${id} = node$${id}.propertyParams.entries().next().value;
+        const propertyKey$${id} = propertyEntry$${id}[0];
+        const instance$${id} = new ctor$${id}();
+
+        if (propertyEntry$${id}[1].bindings === undefined) {
+          return instance$${id};
+        }
+
+        const resolvedValue$${id} = propertyEntry$${id}[1].resolve(params$${id});
+
+        if (isPromise$${id}(resolvedValue$${id})) {
+          return resolvedValue$${id}.then(function (resolvedValue$${id}) {
+            instance$${id}[propertyKey$${id}] = resolvedValue$${id};
+            return instance$${id};
+          });
+        }
+
+        instance$${id}[propertyKey$${id}] = resolvedValue$${id};
+        return instance$${id};
+      };`,
+    ) as (
+      node: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
+      implementationType: Newable<TActivated>,
+      isPromise: <TParam>(object: unknown) => object is Promise<TParam>,
+    ) => (params: ResolutionParams) => Resolved<TActivated>;
+
+    return buildResolveNode(node, implementationType, isPromise);
+  }
+
+  const buildResolveNode: (
+    boundNode: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
+    ctor: Newable<TActivated>,
+    activate: (
+      params: ResolutionParams,
+      instance: Resolved<TActivated>,
+    ) => Resolved<TActivated>,
+    isPromiseFunction: typeof isPromise,
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  ) => (params: ResolutionParams) => Resolved<TActivated> = new Function(
+    `node$${id}`,
+    `ctor$${id}`,
+    `activate$${id}`,
+    `isPromise$${id}`,
+    `return function resolveNode$${id}(params$${id}) {
+        const propertyEntry$${id} = node$${id}.propertyParams.entries().next().value;
+        const propertyKey$${id} = propertyEntry$${id}[0];
+        const instance$${id} = new ctor$${id}();
+
+        if (propertyEntry$${id}[1].bindings === undefined) {
+          return activate$${id}(params$${id}, instance$${id});
+        }
+
+        const resolvedValue$${id} = propertyEntry$${id}[1].resolve(params$${id});
+
+        if (isPromise$${id}(resolvedValue$${id})) {
+          return resolvedValue$${id}.then(function (resolvedValue$${id}) {
+            instance$${id}[propertyKey$${id}] = resolvedValue$${id};
+            return activate$${id}(params$${id}, instance$${id});
+          });
+        }
+
+        instance$${id}[propertyKey$${id}] = resolvedValue$${id};
+        return activate$${id}(params$${id}, instance$${id});
+      };`,
+  ) as (
+    node: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
+    implementationType: Newable<TActivated>,
+    resolveActivations: (
+      params: ResolutionParams,
+      instance: Resolved<TActivated>,
+    ) => Resolved<TActivated>,
+    isPromise: <TParam>(object: unknown) => object is Promise<TParam>,
+  ) => (params: ResolutionParams) => Resolved<TActivated>;
+
+  return buildResolveNode(
+    node,
+    implementationType,
+    resolveActivations,
+    isPromise,
+  );
+}

--- a/packages/container/tools/container-benchmarks/src/bin/run.ts
+++ b/packages/container/tools/container-benchmarks/src/bin/run.ts
@@ -16,18 +16,21 @@ import { AwilixGetWideServiceInTransientScope } from '../scenario/awilix/AwilixG
 import { Inversify6GetComplexAsyncServiceInTransientScope } from '../scenario/Inversify6/Inversify6GetComplexAsyncServiceInTransientScope.js';
 import { Inversify6GetComplexServiceInSingletonScope } from '../scenario/Inversify6/Inversify6GetComplexServiceInSingletonScope.js';
 import { Inversify6GetComplexServiceInTransientScope } from '../scenario/Inversify6/Inversify6GetComplexServiceInTransientScope.js';
+import { Inversify6GetComplexServiceWithPropertiesInTransientScope } from '../scenario/Inversify6/Inversify6GetComplexServiceWithPropertiesInTransientScope.js';
 import { Inversify6GetServiceInSingletonScope } from '../scenario/Inversify6/Inversify6GetServiceInSingletonScope.js';
 import { Inversify6GetServiceInTransientScope } from '../scenario/Inversify6/Inversify6GetServiceInTransientScope.js';
 import { Inversify6GetWideServiceInTransientScope } from '../scenario/Inversify6/Inversify6GetWideServiceInTransientScope.js';
 import { Inversify7GetComplexAsyncServiceInTransientScope } from '../scenario/Inversify7/Inversify7GetComplexAsyncServiceInTransientScope.js';
 import { Inversify7GetComplexServiceInSingletonScope } from '../scenario/Inversify7/Inversify7GetComplexServiceInSingletonScope.js';
 import { Inversify7GetComplexServiceInTransientScope } from '../scenario/Inversify7/Inversify7GetComplexServiceInTransientScope.js';
+import { Inversify7GetComplexServiceWithPropertiesInTransientScope } from '../scenario/Inversify7/Inversify7GetComplexServiceWithPropertiesInTransientScope.js';
 import { Inversify7GetServiceInSingletonScope } from '../scenario/Inversify7/Inversify7GetServiceInSingletonScope.js';
 import { Inversify7GetServiceInTransientScope } from '../scenario/Inversify7/Inversify7GetServiceInTransientScope.js';
 import { Inversify7GetWideServiceInTransientScope } from '../scenario/Inversify7/Inversify7GetWideServiceInTransientScope.js';
 import { Inversify8GetComplexAsyncServiceInTransientScope } from '../scenario/inversify8/Inversify8GetComplexAsyncServiceInTransientScope.js';
 import { Inversify8GetComplexServiceInSingletonScope } from '../scenario/inversify8/Inversify8GetComplexServiceInSingletonScope.js';
 import { Inversify8GetComplexServiceInTransientScope } from '../scenario/inversify8/Inversify8GetComplexServiceInTransientScope.js';
+import { Inversify8GetComplexServiceWithPropertiesInTransientScope } from '../scenario/inversify8/Inversify8GetComplexServiceWithPropertiesInTransientScope.js';
 import { Inversify8GetServiceInSingletonScope } from '../scenario/inversify8/Inversify8GetServiceInSingletonScope.js';
 import { Inversify8GetServiceInTransientScope } from '../scenario/inversify8/Inversify8GetServiceInTransientScope.js';
 import { Inversify8GetWideServiceInTransientScope } from '../scenario/inversify8/Inversify8GetWideServiceInTransientScope.js';
@@ -35,11 +38,13 @@ import { InversifyCurrentGetComplexAsyncServiceInTransientScope } from '../scena
 import { InversifyCurrentGetComplexResolvedValueServiceInTransientScope } from '../scenario/inversifyCurrent/InversifyCurrentGetComplexResolvedValueServiceInTranstientScope.js';
 import { InversifyCurrentGetComplexServiceInSingletonScope } from '../scenario/inversifyCurrent/InversifyCurrentGetComplexServiceInSingletonScope.js';
 import { InversifyCurrentGetComplexServiceInTransientScope } from '../scenario/inversifyCurrent/InversifyCurrentGetComplexServiceInTransientScope.js';
+import { InversifyCurrentGetComplexServiceWithPropertiesInTransientScope } from '../scenario/inversifyCurrent/InversifyCurrentGetComplexServiceWithPropertiesInTransientScope.js';
 import { InversifyCurrentGetServiceInSingletonScope } from '../scenario/inversifyCurrent/InversifyCurrentGetServiceInSingletonScope.js';
 import { InversifyCurrentGetServiceInTransientScope } from '../scenario/inversifyCurrent/InversifyCurrentGetServiceInTransientScope.js';
 import { InversifyCurrentGetWideServiceInTransientScope } from '../scenario/inversifyCurrent/InversifyCurrentGetWideServiceInTransientScope.js';
 import { NestCoreGetComplexServiceInSingletonScopeScenario } from '../scenario/nestCore/NestCoreGetComplexServiceInSingletonScopeScenario.js';
 import { NestCoreGetComplexServiceInTransientScopeScenario } from '../scenario/nestCore/NestCoreGetComplexServiceInTransientScopeScenario.js';
+import { NestCoreGetComplexServiceWithPropertiesInTransientScopeScenario } from '../scenario/nestCore/NestCoreGetComplexServiceWithPropertiesInTransientScopeScenario.js';
 import { NestCoreGetServiceInSingletonScopeScenario } from '../scenario/nestCore/NestCoreGetServiceInSingletonScopeScenario.js';
 import { NestCoreGetServiceInTransientScopeScenario } from '../scenario/nestCore/NestCoreGetServiceInTransientScopeScenario.js';
 import { NestCoreGetWideServiceInTransientScopeScenario } from '../scenario/nestCore/NestCoreGetWideServiceInTransientScopeScenario.js';
@@ -158,6 +163,27 @@ export async function run(): Promise<void> {
         new AwilixGetComplexServiceInTransientScope(),
         new NestCoreGetComplexServiceInTransientScopeScenario(),
         new TsyringeGetComplexServiceInTransientScope(),
+      ],
+    });
+
+    await benchmark.run();
+
+    printBenchmarkResults(benchmark);
+  }
+
+  // Run get complex service with properties in transient scope scenarios
+  {
+    const benchmark: Bench = buildBenchmark({
+      benchOptions: {
+        name: 'Get complex service with properties in transient scope',
+        time: MS_PER_SCENARIO,
+      },
+      scenarios: [
+        new InversifyCurrentGetComplexServiceWithPropertiesInTransientScope(),
+        new Inversify6GetComplexServiceWithPropertiesInTransientScope(),
+        new Inversify7GetComplexServiceWithPropertiesInTransientScope(),
+        new Inversify8GetComplexServiceWithPropertiesInTransientScope(),
+        new NestCoreGetComplexServiceWithPropertiesInTransientScopeScenario(),
       ],
     });
 

--- a/packages/container/tools/container-benchmarks/src/scenario/Inversify6/Inversify6GetComplexServiceWithPropertiesInTransientScope.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/Inversify6/Inversify6GetComplexServiceWithPropertiesInTransientScope.ts
@@ -1,0 +1,194 @@
+import { inject, injectable } from 'inversify6';
+
+import { Inversify6BaseScenario } from './Inversify6BaseScenario.js';
+
+@injectable()
+class FinalNode {
+  public log() {
+    return 'log!';
+  }
+}
+
+@injectable()
+class Node10 {
+  @inject(FinalNode)
+  private readonly node2!: FinalNode;
+
+  private readonly node1: FinalNode;
+
+  constructor(node1: FinalNode) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node9 {
+  @inject(Node10)
+  private readonly node2!: Node10;
+
+  private readonly node1: Node10;
+
+  constructor(node1: Node10) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node8 {
+  @inject(Node9)
+  private readonly node2!: Node9;
+
+  private readonly node1: Node9;
+
+  constructor(node1: Node9) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node7 {
+  @inject(Node8)
+  private readonly node2!: Node8;
+
+  private readonly node1: Node8;
+
+  constructor(node1: Node8) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node6 {
+  @inject(Node7)
+  private readonly node2!: Node7;
+
+  private readonly node1: Node7;
+
+  constructor(node1: Node7) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node5 {
+  @inject(Node6)
+  private readonly node2!: Node6;
+
+  private readonly node1: Node6;
+
+  constructor(node1: Node6) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node4 {
+  @inject(Node5)
+  private readonly node2!: Node5;
+
+  private readonly node1: Node5;
+
+  constructor(node1: Node5) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node3 {
+  @inject(Node4)
+  private readonly node2!: Node4;
+
+  private readonly node1: Node4;
+
+  constructor(node1: Node4) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node2 {
+  @inject(Node3)
+  private readonly node2!: Node3;
+
+  private readonly node1: Node3;
+
+  constructor(node1: Node3) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node1 {
+  @inject(Node2)
+  private readonly node2!: Node2;
+
+  private readonly node1: Node2;
+
+  constructor(node1: Node2) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+export class Inversify6GetComplexServiceWithPropertiesInTransientScope extends Inversify6BaseScenario {
+  public override async setUp(): Promise<void> {
+    this._container.bind(FinalNode).toSelf().inTransientScope();
+    this._container.bind(Node1).toSelf().inTransientScope();
+    this._container.bind(Node2).toSelf().inTransientScope();
+    this._container.bind(Node3).toSelf().inTransientScope();
+    this._container.bind(Node4).toSelf().inTransientScope();
+    this._container.bind(Node5).toSelf().inTransientScope();
+    this._container.bind(Node6).toSelf().inTransientScope();
+    this._container.bind(Node7).toSelf().inTransientScope();
+    this._container.bind(Node8).toSelf().inTransientScope();
+    this._container.bind(Node9).toSelf().inTransientScope();
+    this._container.bind(Node10).toSelf().inTransientScope();
+  }
+
+  public async execute(): Promise<void> {
+    this._container.get(Node1);
+  }
+
+  public override async tearDown(): Promise<void> {
+    this._container.unbindAll();
+  }
+}

--- a/packages/container/tools/container-benchmarks/src/scenario/Inversify7/Inversify7GetComplexServiceWithPropertiesInTransientScope.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/Inversify7/Inversify7GetComplexServiceWithPropertiesInTransientScope.ts
@@ -1,0 +1,194 @@
+import { inject, injectable } from 'inversify7';
+
+import { Inversify7BaseScenario } from './Inversify7BaseScenario.js';
+
+@injectable()
+class FinalNode {
+  public log() {
+    return 'log!';
+  }
+}
+
+@injectable()
+class Node10 {
+  @inject(FinalNode)
+  private readonly node2!: FinalNode;
+
+  private readonly node1: FinalNode;
+
+  constructor(node1: FinalNode) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node9 {
+  @inject(Node10)
+  private readonly node2!: Node10;
+
+  private readonly node1: Node10;
+
+  constructor(node1: Node10) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node8 {
+  @inject(Node9)
+  private readonly node2!: Node9;
+
+  private readonly node1: Node9;
+
+  constructor(node1: Node9) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node7 {
+  @inject(Node8)
+  private readonly node2!: Node8;
+
+  private readonly node1: Node8;
+
+  constructor(node1: Node8) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node6 {
+  @inject(Node7)
+  private readonly node2!: Node7;
+
+  private readonly node1: Node7;
+
+  constructor(node1: Node7) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node5 {
+  @inject(Node6)
+  private readonly node2!: Node6;
+
+  private readonly node1: Node6;
+
+  constructor(node1: Node6) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node4 {
+  @inject(Node5)
+  private readonly node2!: Node5;
+
+  private readonly node1: Node5;
+
+  constructor(node1: Node5) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node3 {
+  @inject(Node4)
+  private readonly node2!: Node4;
+
+  private readonly node1: Node4;
+
+  constructor(node1: Node4) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node2 {
+  @inject(Node3)
+  private readonly node2!: Node3;
+
+  private readonly node1: Node3;
+
+  constructor(node1: Node3) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node1 {
+  @inject(Node2)
+  private readonly node2!: Node2;
+
+  private readonly node1: Node2;
+
+  constructor(node1: Node2) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+export class Inversify7GetComplexServiceWithPropertiesInTransientScope extends Inversify7BaseScenario {
+  public override async setUp(): Promise<void> {
+    this._container.bind(FinalNode).toSelf().inTransientScope();
+    this._container.bind(Node1).toSelf().inTransientScope();
+    this._container.bind(Node2).toSelf().inTransientScope();
+    this._container.bind(Node3).toSelf().inTransientScope();
+    this._container.bind(Node4).toSelf().inTransientScope();
+    this._container.bind(Node5).toSelf().inTransientScope();
+    this._container.bind(Node6).toSelf().inTransientScope();
+    this._container.bind(Node7).toSelf().inTransientScope();
+    this._container.bind(Node8).toSelf().inTransientScope();
+    this._container.bind(Node9).toSelf().inTransientScope();
+    this._container.bind(Node10).toSelf().inTransientScope();
+  }
+
+  public async execute(): Promise<void> {
+    this._container.get(Node1);
+  }
+
+  public override async tearDown(): Promise<void> {
+    await this._container.unbindAll();
+  }
+}

--- a/packages/container/tools/container-benchmarks/src/scenario/inversify8/Inversify8GetComplexServiceWithPropertiesInTransientScope.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/inversify8/Inversify8GetComplexServiceWithPropertiesInTransientScope.ts
@@ -1,0 +1,194 @@
+import { inject, injectable } from 'inversify8';
+
+import { Inversify8BaseScenario } from './Inversify8BaseScenario.js';
+
+@injectable()
+class FinalNode {
+  public log() {
+    return 'log!';
+  }
+}
+
+@injectable()
+class Node10 {
+  @inject(FinalNode)
+  private readonly node2!: FinalNode;
+
+  private readonly node1: FinalNode;
+
+  constructor(node1: FinalNode) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node9 {
+  @inject(Node10)
+  private readonly node2!: Node10;
+
+  private readonly node1: Node10;
+
+  constructor(node1: Node10) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node8 {
+  @inject(Node9)
+  private readonly node2!: Node9;
+
+  private readonly node1: Node9;
+
+  constructor(node1: Node9) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node7 {
+  @inject(Node8)
+  private readonly node2!: Node8;
+
+  private readonly node1: Node8;
+
+  constructor(node1: Node8) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node6 {
+  @inject(Node7)
+  private readonly node2!: Node7;
+
+  private readonly node1: Node7;
+
+  constructor(node1: Node7) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node5 {
+  @inject(Node6)
+  private readonly node2!: Node6;
+
+  private readonly node1: Node6;
+
+  constructor(node1: Node6) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node4 {
+  @inject(Node5)
+  private readonly node2!: Node5;
+
+  private readonly node1: Node5;
+
+  constructor(node1: Node5) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node3 {
+  @inject(Node4)
+  private readonly node2!: Node4;
+
+  private readonly node1: Node4;
+
+  constructor(node1: Node4) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node2 {
+  @inject(Node3)
+  private readonly node2!: Node3;
+
+  private readonly node1: Node3;
+
+  constructor(node1: Node3) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node1 {
+  @inject(Node2)
+  private readonly node2!: Node2;
+
+  private readonly node1: Node2;
+
+  constructor(node1: Node2) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+export class Inversify8GetComplexServiceWithPropertiesInTransientScope extends Inversify8BaseScenario {
+  public override async setUp(): Promise<void> {
+    this._container.bind(FinalNode).toSelf().inTransientScope();
+    this._container.bind(Node1).toSelf().inTransientScope();
+    this._container.bind(Node2).toSelf().inTransientScope();
+    this._container.bind(Node3).toSelf().inTransientScope();
+    this._container.bind(Node4).toSelf().inTransientScope();
+    this._container.bind(Node5).toSelf().inTransientScope();
+    this._container.bind(Node6).toSelf().inTransientScope();
+    this._container.bind(Node7).toSelf().inTransientScope();
+    this._container.bind(Node8).toSelf().inTransientScope();
+    this._container.bind(Node9).toSelf().inTransientScope();
+    this._container.bind(Node10).toSelf().inTransientScope();
+  }
+
+  public async execute(): Promise<void> {
+    this._container.get(Node1);
+  }
+
+  public override async tearDown(): Promise<void> {
+    await this._container.unbindAllAsync();
+  }
+}

--- a/packages/container/tools/container-benchmarks/src/scenario/inversifyCurrent/InversifyCurrentGetComplexServiceWithPropertiesInTransientScope.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/inversifyCurrent/InversifyCurrentGetComplexServiceWithPropertiesInTransientScope.ts
@@ -1,0 +1,194 @@
+import { inject, injectable } from '@inversifyjs/core';
+
+import { InversifyCurrentBaseScenario } from './InversifyCurrentBaseScenario.js';
+
+@injectable()
+class FinalNode {
+  public log() {
+    return 'log!';
+  }
+}
+
+@injectable()
+class Node10 {
+  @inject(FinalNode)
+  private readonly node2!: FinalNode;
+
+  private readonly node1: FinalNode;
+
+  constructor(node1: FinalNode) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node9 {
+  @inject(Node10)
+  private readonly node2!: Node10;
+
+  private readonly node1: Node10;
+
+  constructor(node1: Node10) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node8 {
+  @inject(Node9)
+  private readonly node2!: Node9;
+
+  private readonly node1: Node9;
+
+  constructor(node1: Node9) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node7 {
+  @inject(Node8)
+  private readonly node2!: Node8;
+
+  private readonly node1: Node8;
+
+  constructor(node1: Node8) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node6 {
+  @inject(Node7)
+  private readonly node2!: Node7;
+
+  private readonly node1: Node7;
+
+  constructor(node1: Node7) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node5 {
+  @inject(Node6)
+  private readonly node2!: Node6;
+
+  private readonly node1: Node6;
+
+  constructor(node1: Node6) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node4 {
+  @inject(Node5)
+  private readonly node2!: Node5;
+
+  private readonly node1: Node5;
+
+  constructor(node1: Node5) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node3 {
+  @inject(Node4)
+  private readonly node2!: Node4;
+
+  private readonly node1: Node4;
+
+  constructor(node1: Node4) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node2 {
+  @inject(Node3)
+  private readonly node2!: Node3;
+
+  private readonly node1: Node3;
+
+  constructor(node1: Node3) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node1 {
+  @inject(Node2)
+  private readonly node2!: Node2;
+
+  private readonly node1: Node2;
+
+  constructor(node1: Node2) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+export class InversifyCurrentGetComplexServiceWithPropertiesInTransientScope extends InversifyCurrentBaseScenario {
+  public override async setUp(): Promise<void> {
+    this._container.bind(FinalNode).toSelf().inTransientScope();
+    this._container.bind(Node1).toSelf().inTransientScope();
+    this._container.bind(Node2).toSelf().inTransientScope();
+    this._container.bind(Node3).toSelf().inTransientScope();
+    this._container.bind(Node4).toSelf().inTransientScope();
+    this._container.bind(Node5).toSelf().inTransientScope();
+    this._container.bind(Node6).toSelf().inTransientScope();
+    this._container.bind(Node7).toSelf().inTransientScope();
+    this._container.bind(Node8).toSelf().inTransientScope();
+    this._container.bind(Node9).toSelf().inTransientScope();
+    this._container.bind(Node10).toSelf().inTransientScope();
+  }
+
+  public async execute(): Promise<void> {
+    this._container.get(Node1);
+  }
+
+  public override async tearDown(): Promise<void> {
+    await this._container.unbindAllAsync();
+  }
+}

--- a/packages/container/tools/container-benchmarks/src/scenario/nestCore/NestCoreGetComplexServiceWithPropertiesInTransientScopeScenario.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/nestCore/NestCoreGetComplexServiceWithPropertiesInTransientScopeScenario.ts
@@ -1,0 +1,221 @@
+import { Scenario } from '@inversifyjs/benchmark-utils';
+import {
+  INestApplicationContext,
+  Inject,
+  Injectable,
+  Module,
+  Scope,
+} from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+
+import { Platform } from '../models/Platform.js';
+
+@Injectable({ scope: Scope.TRANSIENT })
+class FinalNode {
+  public log() {
+    return 'log!';
+  }
+}
+
+@Injectable({ scope: Scope.TRANSIENT })
+class Node10 {
+  @Inject()
+  private readonly node2!: FinalNode;
+
+  private readonly node1: FinalNode;
+
+  constructor(node1: FinalNode) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@Injectable({ scope: Scope.TRANSIENT })
+class Node9 {
+  @Inject()
+  private readonly node2!: Node10;
+
+  private readonly node1: Node10;
+
+  constructor(node1: Node10) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@Injectable({ scope: Scope.TRANSIENT })
+class Node8 {
+  @Inject()
+  private readonly node2!: Node9;
+
+  private readonly node1: Node9;
+
+  constructor(node1: Node9) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@Injectable({ scope: Scope.TRANSIENT })
+class Node7 {
+  @Inject()
+  private readonly node2!: Node8;
+
+  private readonly node1: Node8;
+
+  constructor(node1: Node8) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@Injectable({ scope: Scope.TRANSIENT })
+class Node6 {
+  @Inject()
+  private readonly node2!: Node7;
+
+  private readonly node1: Node7;
+
+  constructor(node1: Node7) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@Injectable({ scope: Scope.TRANSIENT })
+class Node5 {
+  @Inject()
+  private readonly node2!: Node6;
+
+  private readonly node1: Node6;
+
+  constructor(node1: Node6) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@Injectable({ scope: Scope.TRANSIENT })
+class Node4 {
+  @Inject()
+  private readonly node2!: Node5;
+
+  private readonly node1: Node5;
+
+  constructor(node1: Node5) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@Injectable({ scope: Scope.TRANSIENT })
+class Node3 {
+  @Inject()
+  private readonly node2!: Node4;
+
+  private readonly node1: Node4;
+
+  constructor(node1: Node4) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@Injectable({ scope: Scope.TRANSIENT })
+class Node2 {
+  @Inject()
+  private readonly node2!: Node3;
+
+  private readonly node1: Node3;
+
+  constructor(node1: Node3) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@Injectable({ scope: Scope.TRANSIENT })
+class Node1 {
+  @Inject()
+  private readonly node2!: Node2;
+
+  private readonly node1: Node2;
+
+  constructor(node1: Node2) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@Module({
+  exports: [Node1],
+  providers: [
+    Node1,
+    Node2,
+    Node3,
+    Node4,
+    Node5,
+    Node6,
+    Node7,
+    Node8,
+    Node9,
+    Node10,
+    FinalNode,
+  ],
+})
+class ContainerModule {}
+
+export class NestCoreGetComplexServiceWithPropertiesInTransientScopeScenario implements Scenario<Platform> {
+  public readonly name: Platform;
+
+  #context!: INestApplicationContext;
+
+  constructor() {
+    this.name = Platform.nestJs;
+  }
+
+  public async setUp(): Promise<void> {
+    this.#context = await NestFactory.createApplicationContext(
+      ContainerModule,
+      { logger: false },
+    );
+  }
+
+  public async tearDown(): Promise<void> {
+    await this.#context.close();
+  }
+
+  public async execute(): Promise<void> {
+    await this.#context.resolve(Node1);
+  }
+}


### PR DESCRIPTION
### Added
- Extracted `buildOnePropertyArgumentResolver`.
- Added new benchmarks scenario.

### Changed
- Updated instance binding resolution with inlined constructor calls on property injected services context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dependency resolution for services using property injection.
  - Correctly handles synchronous and asynchronous property values.
  - Preserves default property values when no binding is available.
  - Ensures activation callbacks run correctly after property assignment.

- **Tests**
  - Expanded coverage for constructor and property injection scenarios.

- **Benchmarks**
  - Added performance scenarios for complex transient services with property injection across supported integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->