### PR TITLE
Fix resolution on csp env

### DIFF
--- a/.changeset/eager-areas-ask.md
+++ b/.changeset/eager-areas-ask.md
@@ -1,0 +1,6 @@
+---
+"@inversifyjs/container": minor
+"inversify": minor
+---
+
+- Updated `ContainerOptions` with optional `jitless` (default true).

--- a/.changeset/sour-buttons-cheat.md
+++ b/.changeset/sour-buttons-cheat.md
@@ -1,0 +1,7 @@
+---
+"@inversifyjs/container": patch
+"@inversifyjs/core": patch
+"inversify": patch
+---
+
+- Updated resolution algorithm to rely on jit options to avoid CSP related issues.

--- a/.changeset/tame-bars-do.md
+++ b/.changeset/tame-bars-do.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": major
+---
+
+- Updated `BasePlanParams` with `jitEnabled` option.

--- a/packages/container/libraries/container/src/container/models/ContainerOptions.ts
+++ b/packages/container/libraries/container/src/container/models/ContainerOptions.ts
@@ -5,5 +5,6 @@ import { type Container } from '../services/Container.js';
 export interface ContainerOptions {
   autobind?: true;
   defaultScope?: BindingScope | undefined;
+  jitless?: boolean | undefined;
   parent?: Container | undefined;
 }

--- a/packages/container/libraries/container/src/container/services/Container.spec.ts
+++ b/packages/container/libraries/container/src/container/services/Container.spec.ts
@@ -408,8 +408,8 @@ describe(Container, () => {
 
         it('should call PlanResultCacheService()', () => {
           expect(PlanResultCacheService).toHaveBeenCalledTimes(2);
-          expect(PlanResultCacheService).toHaveBeenNthCalledWith(1);
-          expect(PlanResultCacheService).toHaveBeenNthCalledWith(2);
+          expect(PlanResultCacheService).toHaveBeenNthCalledWith(1, false);
+          expect(PlanResultCacheService).toHaveBeenNthCalledWith(2, false);
         });
 
         it('should call planResultCacheService.subscribe()', () => {
@@ -493,7 +493,7 @@ describe(Container, () => {
         });
 
         it('should call PlanResultCacheService()', () => {
-          expect(PlanResultCacheService).toHaveBeenCalledExactlyOnceWith();
+          expect(PlanResultCacheService).toHaveBeenCalledExactlyOnceWith(false);
         });
 
         it('should not call planResultCacheService.subscribe()', () => {

--- a/packages/container/libraries/container/src/container/services/Container.ts
+++ b/packages/container/libraries/container/src/container/services/Container.ts
@@ -30,6 +30,7 @@ import { ServiceResolutionManager } from './ServiceResolutionManager.js';
 import { SnapshotManager } from './SnapshotManager.js';
 
 const DEFAULT_DEFAULT_SCOPE: BindingScope = bindingScopeValues.Transient;
+const DEFAULT_JITLESS: boolean = true;
 
 export class Container {
   readonly #bindingManager: BindingManager;
@@ -43,11 +44,13 @@ export class Container {
     const autobind: boolean = options?.autobind ?? false;
     const defaultScope: BindingScope =
       options?.defaultScope ?? DEFAULT_DEFAULT_SCOPE;
+    const jitless: boolean = options?.jitless ?? DEFAULT_JITLESS;
 
     this.#serviceReferenceManager = this.#buildServiceReferenceManager(
       options,
       autobind,
       defaultScope,
+      jitless,
     );
 
     const planParamsOperationsManager: PlanParamsOperationsManager =
@@ -80,6 +83,7 @@ export class Container {
       this.#serviceReferenceManager,
       autobind,
       defaultScope,
+      !jitless,
     );
     this.#pluginManager = new PluginManager(
       this,
@@ -254,6 +258,7 @@ export class Container {
     options: ContainerOptions | undefined,
     autobind: boolean,
     defaultScope: BindingScope,
+    jitless: boolean,
   ): ServiceReferenceManager {
     const autobindOptions: AutobindOptions | undefined =
       this.#buildAutobindOptions(autobind, defaultScope);
@@ -263,12 +268,12 @@ export class Container {
         ActivationsService.build(() => undefined),
         BindingService.build(() => undefined, autobindOptions),
         DeactivationsService.build(() => undefined),
-        new PlanResultCacheService(),
+        new PlanResultCacheService(!jitless),
       );
     }
 
     const planResultCacheService: PlanResultCacheService =
-      new PlanResultCacheService();
+      new PlanResultCacheService(!jitless);
 
     const parent: Container = options.parent;
 

--- a/packages/container/libraries/container/src/container/services/ServiceResolutionManager.spec.ts
+++ b/packages/container/libraries/container/src/container/services/ServiceResolutionManager.spec.ts
@@ -78,6 +78,7 @@ describe(ServiceResolutionManager, () => {
           serviceReferenceManagerMock,
           autobindFixture,
           defaultScopeFixture,
+          true,
         );
       });
 
@@ -137,6 +138,7 @@ describe(ServiceResolutionManager, () => {
         it('should call plan()', () => {
           const expectedPlanParams: PlanParams = {
             autobindOptions: undefined,
+            jitEnabled: true,
             operations: planParamsOperationsManagerFixture.planParamsOperations,
             rootConstraints: {
               isMultiple: false,
@@ -234,6 +236,7 @@ describe(ServiceResolutionManager, () => {
         it('should call plan()', () => {
           const expectedPlanParams: PlanParams = {
             autobindOptions: undefined,
+            jitEnabled: true,
             operations: planParamsOperationsManagerFixture.planParamsOperations,
             rootConstraints: {
               isMultiple: false,
@@ -339,6 +342,7 @@ describe(ServiceResolutionManager, () => {
         it('should call plan()', () => {
           const expectedPlanParams: PlanParams = {
             autobindOptions: undefined,
+            jitEnabled: true,
             operations: planParamsOperationsManagerFixture.planParamsOperations,
             rootConstraints: {
               isMultiple: false,
@@ -403,6 +407,7 @@ describe(ServiceResolutionManager, () => {
           serviceReferenceManagerMock,
           true,
           defaultScopeFixture,
+          true,
         );
       });
 
@@ -464,6 +469,7 @@ describe(ServiceResolutionManager, () => {
             autobindOptions: {
               scope: defaultScopeFixture,
             },
+            jitEnabled: true,
             operations: planParamsOperationsManagerFixture.planParamsOperations,
             rootConstraints: {
               isMultiple: false,
@@ -513,6 +519,7 @@ describe(ServiceResolutionManager, () => {
           serviceReferenceManagerMock,
           false,
           defaultScopeFixture,
+          true,
         );
       });
 
@@ -575,6 +582,7 @@ describe(ServiceResolutionManager, () => {
             autobindOptions: {
               scope: defaultScopeFixture,
             },
+            jitEnabled: true,
             operations: planParamsOperationsManagerFixture.planParamsOperations,
             rootConstraints: {
               isMultiple: false,
@@ -633,6 +641,7 @@ describe(ServiceResolutionManager, () => {
           serviceReferenceManagerMock,
           false,
           defaultScopeFixture,
+          true,
         );
 
         serviceIdentifierFixture = 'service-id';
@@ -713,6 +722,7 @@ describe(ServiceResolutionManager, () => {
           serviceReferenceManagerMock,
           autobindFixture,
           defaultScopeFixture,
+          true,
         );
       });
 
@@ -846,6 +856,7 @@ describe(ServiceResolutionManager, () => {
         it('should call plan()', () => {
           const expectedPlanParams: PlanParams = {
             autobindOptions: undefined,
+            jitEnabled: true,
             operations: planParamsOperationsManagerFixture.planParamsOperations,
             rootConstraints: {
               isMultiple: false,
@@ -895,6 +906,7 @@ describe(ServiceResolutionManager, () => {
             serviceReferenceManagerMock,
             autobindFixture,
             defaultScopeFixture,
+            true,
           ).getAll(serviceIdentifierFixture, getAllOptionsFixture);
         });
 
@@ -920,6 +932,7 @@ describe(ServiceResolutionManager, () => {
         it('should call plan()', () => {
           const expectedPlanParams: PlanParams = {
             autobindOptions: undefined,
+            jitEnabled: true,
             operations: planParamsOperationsManagerFixture.planParamsOperations,
             rootConstraints: {
               chained: true,
@@ -990,6 +1003,7 @@ describe(ServiceResolutionManager, () => {
           serviceReferenceManagerMock,
           autobindFixture,
           defaultScopeFixture,
+          true,
         ).getAll(serviceIdentifierFixture, getOptionsFixture);
       });
 
@@ -1015,6 +1029,7 @@ describe(ServiceResolutionManager, () => {
       it('should call plan()', () => {
         const expectedPlanParams: PlanParams = {
           autobindOptions: undefined,
+          jitEnabled: true,
           operations: planParamsOperationsManagerFixture.planParamsOperations,
           rootConstraints: {
             chained: false,
@@ -1086,6 +1101,7 @@ describe(ServiceResolutionManager, () => {
             serviceReferenceManagerMock,
             autobindFixture,
             defaultScopeFixture,
+            true,
           ).getAll(serviceIdentifierFixture, getOptionsFixture);
         } catch (error: unknown) {
           result = error;
@@ -1114,6 +1130,7 @@ describe(ServiceResolutionManager, () => {
       it('should call plan()', () => {
         const expectedPlanParams: PlanParams = {
           autobindOptions: undefined,
+          jitEnabled: true,
           operations: planParamsOperationsManagerFixture.planParamsOperations,
           rootConstraints: {
             chained: false,
@@ -1194,6 +1211,7 @@ describe(ServiceResolutionManager, () => {
           serviceReferenceManagerMock,
           autobindFixture,
           defaultScopeFixture,
+          true,
         ).getAllAsync(serviceIdentifierFixture, getOptionsFixture);
       });
 
@@ -1219,6 +1237,7 @@ describe(ServiceResolutionManager, () => {
       it('should call plan()', () => {
         const expectedPlanParams: PlanParams = {
           autobindOptions: undefined,
+          jitEnabled: true,
           operations: planParamsOperationsManagerFixture.planParamsOperations,
           rootConstraints: {
             chained: false,
@@ -1291,6 +1310,7 @@ describe(ServiceResolutionManager, () => {
           serviceReferenceManagerMock,
           autobindFixture,
           defaultScopeFixture,
+          true,
         ).getAsync(serviceIdentifierFixture, getOptionsFixture);
       });
 
@@ -1315,6 +1335,7 @@ describe(ServiceResolutionManager, () => {
       it('should call plan()', () => {
         const expectedPlanParams: PlanParams = {
           autobindOptions: undefined,
+          jitEnabled: true,
           operations: planParamsOperationsManagerFixture.planParamsOperations,
           rootConstraints: {
             isMultiple: false,

--- a/packages/container/libraries/container/src/container/services/ServiceResolutionManager.ts
+++ b/packages/container/libraries/container/src/container/services/ServiceResolutionManager.ts
@@ -31,6 +31,7 @@ export class ServiceResolutionManager {
   readonly #getActivationsResolutionParam: <TActivated>(
     serviceIdentifier: ServiceIdentifier<TActivated>,
   ) => Iterable<BindingActivation<TActivated>> | undefined;
+  readonly #jitEnabled: boolean;
   #resolutionContext: ResolutionContext;
   readonly #onPlanHandlers: ((
     options: GetPlanOptions,
@@ -44,13 +45,14 @@ export class ServiceResolutionManager {
     serviceReferenceManager: ServiceReferenceManager,
     autobind: boolean,
     defaultScope: BindingScope,
+    jitEnabled: boolean,
   ) {
     this.#planParamsOperationsManager = planParamsOperationsManager;
     this.#serviceReferenceManager = serviceReferenceManager;
     this.#resolutionContext = this.#buildResolutionContext();
     this.#autobind = autobind;
     this.#defaultScope = defaultScope;
-
+    this.#jitEnabled = jitEnabled;
     this.#getActivationsResolutionParam = <TActivated>(
       serviceIdentifier: ServiceIdentifier<TActivated>,
     ): Iterable<BindingActivation<TActivated>> | undefined =>
@@ -203,6 +205,7 @@ export class ServiceResolutionManager {
               scope: this.#defaultScope,
             }
           : undefined,
+      jitEnabled: this.#jitEnabled,
       operations: this.#planParamsOperationsManager.planParamsOperations,
       rootConstraints: this.#buildPlanParamsConstraints(
         serviceIdentifier,

--- a/packages/container/libraries/core/src/planning/actions/addRootServiceNodeBindingIfContextFree.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/addRootServiceNodeBindingIfContextFree.spec.ts
@@ -98,6 +98,7 @@ describe(addRootServiceNodeBindingIfContextFree, () => {
     beforeAll(() => {
       paramsFixture = {
         autobindOptions: undefined,
+        jitEnabled: true,
         operations: Symbol() as unknown as PlanParamsOperations,
         rootConstraints: {
           chained: false,

--- a/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNode.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildPlanServiceNode.spec.ts
@@ -59,6 +59,7 @@ describe(curryBuildPlanServiceNode, () => {
     beforeAll(() => {
       planParamsFixture = {
         autobindOptions: undefined,
+        jitEnabled: true,
         operations: {} as Partial<PlanParamsOperations> as PlanParamsOperations,
         rootConstraints: {
           chained: false,
@@ -173,6 +174,7 @@ describe(curryBuildPlanServiceNode, () => {
     beforeAll(() => {
       planParamsFixture = {
         autobindOptions: undefined,
+        jitEnabled: true,
         operations: {} as Partial<PlanParamsOperations> as PlanParamsOperations,
         rootConstraints: {
           isMultiple: false,

--- a/packages/container/libraries/core/src/planning/actions/curryBuildServiceNodeBindings.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildServiceNodeBindings.spec.ts
@@ -53,6 +53,7 @@ describe(curryBuildServiceNodeBindings, () => {
         autobindOptions: {
           scope: bindingScopeValues.Transient,
         },
+        jitEnabled: true,
         operations: {
           getClassMetadata: vitest.fn(),
         } as Partial<PlanParamsOperations> as PlanParamsOperations,
@@ -123,6 +124,7 @@ describe(curryBuildServiceNodeBindings, () => {
       it('should call subplan()', () => {
         const expectedSubplanParams: SubplanParams = {
           autobindOptions: basePlanParamsMock.autobindOptions,
+          jitEnabled: true,
           node: {
             binding: instanceBindingFixture,
             classMetadata: classMetadataFixture,
@@ -157,6 +159,7 @@ describe(curryBuildServiceNodeBindings, () => {
         autobindOptions: {
           scope: bindingScopeValues.Transient,
         },
+        jitEnabled: true,
         operations: {
           getClassMetadata: vitest.fn(),
         } as Partial<PlanParamsOperations> as PlanParamsOperations,
@@ -213,6 +216,7 @@ describe(curryBuildServiceNodeBindings, () => {
       it('should call subplan()', () => {
         const expectedSubplanParams: SubplanParams = {
           autobindOptions: basePlanParamsMock.autobindOptions,
+          jitEnabled: true,
           node: {
             binding: resolvedValueBindingFixture,
             params: [],
@@ -245,6 +249,7 @@ describe(curryBuildServiceNodeBindings, () => {
         autobindOptions: {
           scope: bindingScopeValues.Transient,
         },
+        jitEnabled: true,
         operations: {
           getClassMetadata: vitest.fn(),
         } as Partial<PlanParamsOperations> as PlanParamsOperations,
@@ -308,6 +313,7 @@ describe(curryBuildServiceNodeBindings, () => {
             serviceIdentifier:
               serviceRedirectionBindingFixture.targetServiceIdentifier,
           },
+          jitEnabled: true,
           node: new PlanServiceRedirectionBindingNodeImplementation(
             serviceRedirectionBindingFixture,
           ),

--- a/packages/container/libraries/core/src/planning/actions/curryBuildServiceNodeBindings.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildServiceNodeBindings.ts
@@ -167,10 +167,15 @@ function curryBuildInstancePlanBindingNode(
     );
 
     const childNode: InstanceBindingNode =
-      new InstanceBindingNodeImplementation(binding, classMetadata);
+      new InstanceBindingNodeImplementation(
+        binding,
+        classMetadata,
+        params.jitEnabled,
+      );
 
     const subplanParams: SubplanParams = {
       autobindOptions: params.autobindOptions,
+      jitEnabled: params.jitEnabled,
       node: childNode,
       operations: params.operations,
       servicesBranch: params.servicesBranch,
@@ -200,6 +205,7 @@ function curryBuildResolvedValuePlanBindingNode(
 
     const subplanParams: SubplanParams = {
       autobindOptions: params.autobindOptions,
+      jitEnabled: params.jitEnabled,
       node: childNode,
       operations: params.operations,
       servicesBranch: params.servicesBranch,
@@ -235,6 +241,7 @@ function curryBuildServiceRedirectionPlanBindingNode(
         ...buildServiceNodeOptions,
         serviceIdentifier: binding.targetServiceIdentifier,
       },
+      jitEnabled: params.jitEnabled,
       node: childNode,
       operations: params.operations,
       servicesBranch: params.servicesBranch,

--- a/packages/container/libraries/core/src/planning/actions/currySubplan.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/currySubplan.spec.ts
@@ -84,6 +84,7 @@ describe(currySubplan, () => {
 
       subplanParamsFixture = {
         autobindOptions: undefined,
+        jitEnabled: true,
         node: instanceBindingNodeFixture,
         operations: {
           getPlan: vitest.fn(),
@@ -142,6 +143,7 @@ describe(currySubplan, () => {
 
       subplanParamsMock = {
         autobindOptions: undefined,
+        jitEnabled: true,
         node: instanceBindingNodeFixture,
         operations: {
           getPlan: vitest.fn(),
@@ -206,6 +208,7 @@ describe(currySubplan, () => {
 
       subplanParamsMock = {
         autobindOptions: undefined,
+        jitEnabled: true,
         node: instanceBindingNodeFixture,
         operations: {
           getPlan: vitest.fn(),
@@ -582,6 +585,7 @@ describe(currySubplan, () => {
 
       subplanParamsMock = {
         autobindOptions: undefined,
+        jitEnabled: true,
         node: instanceBindingNodeFixture,
         operations: {
           getPlan: vitest.fn(),
@@ -984,6 +988,7 @@ describe(currySubplan, () => {
 
       subplanParamsMock = {
         autobindOptions: undefined,
+        jitEnabled: true,
         node: resolvedValueBindingNodeFixture,
         operations: {
           getPlan: vitest.fn(),

--- a/packages/container/libraries/core/src/planning/actions/currySubplan.ts
+++ b/packages/container/libraries/core/src/planning/actions/currySubplan.ts
@@ -236,6 +236,7 @@ function currySubplanRedirectionBindingNode(
     const redirectionSubplanParams: RedirectionSubplanParams = {
       autobindOptions: params.autobindOptions,
       buildServiceNodeOptions: params.buildServiceNodeOptions,
+      jitEnabled: params.jitEnabled,
       node,
       operations: params.operations,
       servicesBranch: params.servicesBranch,

--- a/packages/container/libraries/core/src/planning/actions/plan.int.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/plan.int.spec.ts
@@ -393,7 +393,7 @@ describe(plan, () => {
       getOwnReflectMetadata(type, classMetadataReflectKey) ??
       getDefaultClassMetadata();
 
-    planResultCacheService = new PlanResultCacheService();
+    planResultCacheService = new PlanResultCacheService(true);
   });
 
   describe.each<[string, PlanParamsConstraint, () => PlanResult]>([
@@ -471,6 +471,7 @@ describe(plan, () => {
         beforeAll(() => {
           result = plan({
             autobindOptions: undefined,
+            jitEnabled: true,
             operations: {
               getBindings: bindingService.get.bind(bindingService),
               getBindingsChained:
@@ -545,6 +546,7 @@ Binding constraints:
           try {
             plan({
               autobindOptions: undefined,
+              jitEnabled: true,
               operations: {
                 getBindings: bindingService.get.bind(bindingService),
                 getBindingsChained:

--- a/packages/container/libraries/core/src/planning/actions/plan.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/plan.spec.ts
@@ -58,6 +58,7 @@ describe(plan, () => {
 
     paramsFixture = {
       autobindOptions: undefined,
+      jitEnabled: true,
       operations: {
         getPlan: vitest.fn(),
         setPlan: vitest.fn(),

--- a/packages/container/libraries/core/src/planning/actions/removeRootServiceNodeBindingIfContextFree.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/removeRootServiceNodeBindingIfContextFree.spec.ts
@@ -93,6 +93,7 @@ describe(removeRootServiceNodeBindingIfContextFree, () => {
     beforeAll(() => {
       paramsFixture = {
         autobindOptions: undefined,
+        jitEnabled: true,
         operations: Symbol() as unknown as PlanParamsOperations,
         rootConstraints: {
           chained: false,

--- a/packages/container/libraries/core/src/planning/calculations/buildConstructorArgumentsResolverOnCsp.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildConstructorArgumentsResolverOnCsp.spec.ts
@@ -1,0 +1,593 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { type InstanceBinding } from '../../binding/models/InstanceBinding.js';
+import { type ClassElementMetadata } from '../../metadata/models/ClassElementMetadata.js';
+import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
+import { type Resolved } from '../../resolution/models/Resolved.js';
+import { type InstanceBindingNode } from '../models/InstanceBindingNode.js';
+import { type PlanServiceNode } from '../models/PlanServiceNode.js';
+import { buildConstructorArgumentsResolverOnCsp } from './buildConstructorArgumentsResolverOnCsp.js';
+import { resolveFour } from './resolveFour.js';
+import { resolveThree } from './resolveThree.js';
+import { resolveTwo } from './resolveTwo.js';
+
+class Foo {
+  public readonly args: unknown[];
+
+  constructor(...args: unknown[]) {
+    this.args = args;
+  }
+}
+
+type FooWithProperties = Foo & Record<string | symbol, unknown>;
+
+interface PropertyFixture {
+  key: string | symbol;
+  value: string;
+}
+
+function buildNodeFixtureForArguments(
+  length: number,
+  propertyFixtures: PropertyFixture[] = [],
+): InstanceBindingNode<Foo, InstanceBinding<Foo>> {
+  const properties: Map<string | symbol, ClassElementMetadata> = new Map<
+    string | symbol,
+    ClassElementMetadata
+  >();
+
+  for (const propertyFixture of propertyFixtures) {
+    properties.set(
+      propertyFixture.key,
+      Symbol() as unknown as ClassElementMetadata,
+    );
+  }
+
+  const propertyParams: Map<string | symbol, PlanServiceNode> = new Map<
+    string | symbol,
+    PlanServiceNode
+  >();
+
+  return {
+    binding: {
+      implementationType: Foo,
+    } as Partial<InstanceBinding<Foo>> as InstanceBinding<Foo>,
+    classMetadata: {
+      constructorArguments: new Array<ClassElementMetadata>(length).fill(
+        Symbol() as unknown as ClassElementMetadata,
+      ),
+      lifecycle: {
+        postConstructMethodNames: new Set(),
+        preDestroyMethodNames: new Set(),
+      },
+      properties,
+      scope: undefined,
+    },
+    constructorParams: [] as PlanServiceNode[],
+    propertyParams,
+  } as Partial<
+    InstanceBindingNode<Foo, InstanceBinding<Foo>>
+  > as InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ResolveAsyncValues = (...args: any[]) => any;
+
+describe(buildConstructorArgumentsResolverOnCsp, () => {
+  describe.each<[string, number, ResolveAsyncValues, string[]]>([
+    ['two', 2, resolveTwo, ['value-0', 'value-1']],
+    ['three', 3, resolveThree, ['value-0', 'value-1', 'value-2']],
+    ['four', 4, resolveFour, ['value-0', 'value-1', 'value-2', 'value-3']],
+  ])(
+    'having %s constructor arguments',
+    (
+      _description: string,
+      paramsCount: number,
+      resolveAsyncValues: ResolveAsyncValues,
+      valueFixtures: string[],
+    ) => {
+      let paramsFixture: ResolutionParams;
+
+      beforeAll(() => {
+        paramsFixture = Symbol() as unknown as ResolutionParams;
+      });
+
+      describe('when called, and resolveActivations is not provided', () => {
+        describe('when called, and node.constructorParams is populated after the resolveNode is built', () => {
+          let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+          let result: unknown;
+
+          beforeAll(() => {
+            nodeFixture = buildNodeFixtureForArguments(paramsCount);
+
+            const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+              buildConstructorArgumentsResolverOnCsp(
+                nodeFixture,
+                resolveAsyncValues,
+              );
+
+            nodeFixture.constructorParams.push(
+              ...valueFixtures.map(
+                (value: string): PlanServiceNode =>
+                  ({
+                    resolve: (): string => value,
+                  }) as Partial<PlanServiceNode> as PlanServiceNode,
+              ),
+            );
+
+            result = resolveNode(paramsFixture);
+          });
+
+          it('should build an instance with the resolved constructor arguments in order', () => {
+            expect(result).toBeInstanceOf(Foo);
+            expect((result as Foo).args).toStrictEqual(valueFixtures);
+          });
+        });
+
+        describe('when called, and constructor arguments resolve asynchronously', () => {
+          let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+          let result: unknown;
+
+          beforeAll(async () => {
+            nodeFixture = buildNodeFixtureForArguments(paramsCount);
+
+            const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+              buildConstructorArgumentsResolverOnCsp(
+                nodeFixture,
+                resolveAsyncValues,
+              );
+
+            nodeFixture.constructorParams.push(
+              ...valueFixtures.map(
+                (value: string): PlanServiceNode =>
+                  ({
+                    resolve: async (): Promise<string> => value,
+                  }) as Partial<PlanServiceNode> as PlanServiceNode,
+              ),
+            );
+
+            result = await resolveNode(paramsFixture);
+          });
+
+          it('should build an instance with the resolved constructor arguments in order', () => {
+            expect(result).toBeInstanceOf(Foo);
+            expect((result as Foo).args).toStrictEqual(valueFixtures);
+          });
+        });
+      });
+
+      describe('when called, and resolveActivations is provided', () => {
+        let resolveActivations: (
+          params: ResolutionParams,
+          instance: Resolved<Foo>,
+        ) => Resolved<Foo>;
+
+        beforeAll(() => {
+          resolveActivations = (
+            _params: ResolutionParams,
+            instance: Resolved<Foo>,
+          ): Resolved<Foo> => instance;
+        });
+
+        describe('when called, and node.constructorParams is populated after the resolveNode is built', () => {
+          let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+          let result: unknown;
+
+          beforeAll(() => {
+            nodeFixture = buildNodeFixtureForArguments(paramsCount);
+
+            const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+              buildConstructorArgumentsResolverOnCsp(
+                nodeFixture,
+                resolveAsyncValues,
+                resolveActivations,
+              );
+
+            nodeFixture.constructorParams.push(
+              ...valueFixtures.map(
+                (value: string): PlanServiceNode =>
+                  ({
+                    resolve: (): string => value,
+                  }) as Partial<PlanServiceNode> as PlanServiceNode,
+              ),
+            );
+
+            result = resolveNode(paramsFixture);
+          });
+
+          it('should build an instance with the resolved constructor arguments in order', () => {
+            expect(result).toBeInstanceOf(Foo);
+            expect((result as Foo).args).toStrictEqual(valueFixtures);
+          });
+        });
+
+        describe('when called, and constructor arguments resolve asynchronously', () => {
+          let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+          let result: unknown;
+
+          beforeAll(async () => {
+            nodeFixture = buildNodeFixtureForArguments(paramsCount);
+
+            const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+              buildConstructorArgumentsResolverOnCsp(
+                nodeFixture,
+                resolveAsyncValues,
+                resolveActivations,
+              );
+
+            nodeFixture.constructorParams.push(
+              ...valueFixtures.map(
+                (value: string): PlanServiceNode =>
+                  ({
+                    resolve: async (): Promise<string> => value,
+                  }) as Partial<PlanServiceNode> as PlanServiceNode,
+              ),
+            );
+
+            result = await resolveNode(paramsFixture);
+          });
+
+          it('should build an instance with the resolved constructor arguments in order', () => {
+            expect(result).toBeInstanceOf(Foo);
+            expect((result as Foo).args).toStrictEqual(valueFixtures);
+          });
+        });
+      });
+    },
+  );
+
+  describe.each<
+    [string, number, ResolveAsyncValues, string[], PropertyFixture[]]
+  >([
+    [
+      'two constructor arguments and two properties',
+      2,
+      resolveTwo,
+      ['value-0', 'value-1'],
+      [
+        { key: 'propertyA', value: 'property-0' },
+        { key: 'propertyB', value: 'property-1' },
+      ],
+    ],
+  ])(
+    'having %s',
+    (
+      _description: string,
+      paramsCount: number,
+      resolveAsyncValues: ResolveAsyncValues,
+      valueFixtures: string[],
+      propertyFixtures: PropertyFixture[],
+    ) => {
+      let paramsFixture: ResolutionParams;
+
+      beforeAll(() => {
+        paramsFixture = Symbol() as unknown as ResolutionParams;
+      });
+
+      function populatePropertyResolvers(
+        nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>,
+        resolveAsync: boolean,
+      ): void {
+        for (const propertyFixture of propertyFixtures) {
+          nodeFixture.propertyParams.set(propertyFixture.key, {
+            bindings: [],
+            resolve: resolveAsync
+              ? async (resolveParams: ResolutionParams): Promise<string> => {
+                  expect(resolveParams).toBe(paramsFixture);
+
+                  return propertyFixture.value;
+                }
+              : (resolveParams: ResolutionParams): string => {
+                  expect(resolveParams).toBe(paramsFixture);
+
+                  return propertyFixture.value;
+                },
+          } as Partial<PlanServiceNode> as PlanServiceNode);
+        }
+      }
+
+      describe('when called, and resolveActivations is not provided', () => {
+        describe('when called, and node.constructorParams is populated after the resolveNode is built', () => {
+          let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+          let result: unknown;
+
+          beforeAll(() => {
+            nodeFixture = buildNodeFixtureForArguments(
+              paramsCount,
+              propertyFixtures,
+            );
+
+            const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+              buildConstructorArgumentsResolverOnCsp(
+                nodeFixture,
+                resolveAsyncValues,
+              );
+
+            nodeFixture.constructorParams.push(
+              ...valueFixtures.map(
+                (value: string): PlanServiceNode =>
+                  ({
+                    resolve: (): string => value,
+                  }) as Partial<PlanServiceNode> as PlanServiceNode,
+              ),
+            );
+
+            populatePropertyResolvers(nodeFixture, false);
+
+            result = resolveNode(paramsFixture);
+          });
+
+          it('should build an instance with the resolved constructor arguments and properties in order', () => {
+            expect(result).toBeInstanceOf(Foo);
+            expect((result as Foo).args).toStrictEqual(valueFixtures);
+
+            for (const propertyFixture of propertyFixtures) {
+              expect((result as FooWithProperties)[propertyFixture.key]).toBe(
+                propertyFixture.value,
+              );
+            }
+          });
+        });
+
+        describe('when called, and constructor arguments and properties resolve asynchronously', () => {
+          let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+          let result: unknown;
+
+          beforeAll(async () => {
+            nodeFixture = buildNodeFixtureForArguments(
+              paramsCount,
+              propertyFixtures,
+            );
+
+            const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+              buildConstructorArgumentsResolverOnCsp(
+                nodeFixture,
+                resolveAsyncValues,
+              );
+
+            nodeFixture.constructorParams.push(
+              ...valueFixtures.map(
+                (value: string): PlanServiceNode =>
+                  ({
+                    resolve: async (): Promise<string> => value,
+                  }) as Partial<PlanServiceNode> as PlanServiceNode,
+              ),
+            );
+
+            populatePropertyResolvers(nodeFixture, true);
+
+            result = await resolveNode(paramsFixture);
+          });
+
+          it('should build an instance with the resolved constructor arguments and properties in order', () => {
+            expect(result).toBeInstanceOf(Foo);
+            expect((result as Foo).args).toStrictEqual(valueFixtures);
+
+            for (const propertyFixture of propertyFixtures) {
+              expect((result as FooWithProperties)[propertyFixture.key]).toBe(
+                propertyFixture.value,
+              );
+            }
+          });
+        });
+      });
+
+      describe('when called, and resolveActivations is provided', () => {
+        let resolveActivations: (
+          params: ResolutionParams,
+          instance: Resolved<Foo>,
+        ) => Resolved<Foo>;
+
+        beforeAll(() => {
+          resolveActivations = (
+            _params: ResolutionParams,
+            instance: Resolved<Foo>,
+          ): Resolved<Foo> => instance;
+        });
+
+        describe('when called, and node.constructorParams is populated after the resolveNode is built', () => {
+          let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+          let result: unknown;
+
+          beforeAll(() => {
+            nodeFixture = buildNodeFixtureForArguments(
+              paramsCount,
+              propertyFixtures,
+            );
+
+            const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+              buildConstructorArgumentsResolverOnCsp(
+                nodeFixture,
+                resolveAsyncValues,
+                resolveActivations,
+              );
+
+            nodeFixture.constructorParams.push(
+              ...valueFixtures.map(
+                (value: string): PlanServiceNode =>
+                  ({
+                    resolve: (): string => value,
+                  }) as Partial<PlanServiceNode> as PlanServiceNode,
+              ),
+            );
+
+            populatePropertyResolvers(nodeFixture, false);
+
+            result = resolveNode(paramsFixture);
+          });
+
+          it('should build an instance with the resolved constructor arguments and properties in order', () => {
+            expect(result).toBeInstanceOf(Foo);
+            expect((result as Foo).args).toStrictEqual(valueFixtures);
+
+            for (const propertyFixture of propertyFixtures) {
+              expect((result as FooWithProperties)[propertyFixture.key]).toBe(
+                propertyFixture.value,
+              );
+            }
+          });
+        });
+
+        describe('when called, and constructor arguments and properties resolve asynchronously', () => {
+          let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+          let result: unknown;
+
+          beforeAll(async () => {
+            nodeFixture = buildNodeFixtureForArguments(
+              paramsCount,
+              propertyFixtures,
+            );
+
+            const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+              buildConstructorArgumentsResolverOnCsp(
+                nodeFixture,
+                resolveAsyncValues,
+                resolveActivations,
+              );
+
+            nodeFixture.constructorParams.push(
+              ...valueFixtures.map(
+                (value: string): PlanServiceNode =>
+                  ({
+                    resolve: async (): Promise<string> => value,
+                  }) as Partial<PlanServiceNode> as PlanServiceNode,
+              ),
+            );
+
+            populatePropertyResolvers(nodeFixture, true);
+
+            result = await resolveNode(paramsFixture);
+          });
+
+          it('should build an instance with the resolved constructor arguments and properties in order', () => {
+            expect(result).toBeInstanceOf(Foo);
+            expect((result as Foo).args).toStrictEqual(valueFixtures);
+
+            for (const propertyFixture of propertyFixtures) {
+              expect((result as FooWithProperties)[propertyFixture.key]).toBe(
+                propertyFixture.value,
+              );
+            }
+          });
+        });
+      });
+    },
+  );
+
+  describe('having two constructor arguments and one property with no bindings', () => {
+    class FooWithDefaultProperty extends Foo {
+      public propertyA: string = 'default-property-0';
+    }
+
+    const propertyKeyFixture: string = 'propertyA';
+
+    let paramsFixture: ResolutionParams;
+
+    beforeAll(() => {
+      paramsFixture = Symbol() as unknown as ResolutionParams;
+    });
+
+    function buildNodeFixtureWithUnboundProperty(): InstanceBindingNode<
+      FooWithDefaultProperty,
+      InstanceBinding<FooWithDefaultProperty>
+    > {
+      const properties: Map<string | symbol, ClassElementMetadata> = new Map<
+        string | symbol,
+        ClassElementMetadata
+      >([[propertyKeyFixture, Symbol() as unknown as ClassElementMetadata]]);
+
+      const propertyParams: Map<string | symbol, PlanServiceNode> = new Map<
+        string | symbol,
+        PlanServiceNode
+      >([
+        [
+          propertyKeyFixture,
+          {
+            bindings: undefined,
+            resolve: (): string => {
+              throw new Error(
+                'resolve should not be called when the property has no bindings',
+              );
+            },
+          } as Partial<PlanServiceNode> as PlanServiceNode,
+        ],
+      ]);
+
+      return {
+        binding: {
+          implementationType: FooWithDefaultProperty,
+        } as Partial<
+          InstanceBinding<FooWithDefaultProperty>
+        > as InstanceBinding<FooWithDefaultProperty>,
+        classMetadata: {
+          constructorArguments: new Array<ClassElementMetadata>(2).fill(
+            Symbol() as unknown as ClassElementMetadata,
+          ),
+          lifecycle: {
+            postConstructMethodNames: new Set(),
+            preDestroyMethodNames: new Set(),
+          },
+          properties,
+          scope: undefined,
+        },
+        constructorParams: [] as PlanServiceNode[],
+        propertyParams,
+      } as Partial<
+        InstanceBindingNode<
+          FooWithDefaultProperty,
+          InstanceBinding<FooWithDefaultProperty>
+        >
+      > as InstanceBindingNode<
+        FooWithDefaultProperty,
+        InstanceBinding<FooWithDefaultProperty>
+      >;
+    }
+
+    describe('when called, and the property has no bindings', () => {
+      let nodeFixture: InstanceBindingNode<
+        FooWithDefaultProperty,
+        InstanceBinding<FooWithDefaultProperty>
+      >;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        nodeFixture = buildNodeFixtureWithUnboundProperty();
+
+        const resolveNode: (
+          params: ResolutionParams,
+        ) => Resolved<FooWithDefaultProperty> =
+          buildConstructorArgumentsResolverOnCsp(nodeFixture, resolveTwo);
+
+        nodeFixture.constructorParams.push(
+          ...['value-0', 'value-1'].map(
+            (value: string): PlanServiceNode =>
+              ({
+                resolve: (): string => value,
+              }) as Partial<PlanServiceNode> as PlanServiceNode,
+          ),
+        );
+
+        result = resolveNode(paramsFixture);
+      });
+
+      it('should build an instance preserving the default property value', () => {
+        expect(result).toBeInstanceOf(FooWithDefaultProperty);
+        expect((result as FooWithDefaultProperty).args).toStrictEqual([
+          'value-0',
+          'value-1',
+        ]);
+        expect((result as FooWithDefaultProperty).propertyA).toBe(
+          'default-property-0',
+        );
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/planning/calculations/buildConstructorArgumentsResolverOnCsp.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildConstructorArgumentsResolverOnCsp.ts
@@ -1,0 +1,139 @@
+import { isPromise } from '@inversifyjs/common';
+
+import { type InstanceBinding } from '../../binding/models/InstanceBinding.js';
+import { setInstanceProperties } from '../../resolution/actions/setInstanceProperties.js';
+import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
+import {
+  type Resolved,
+  type SyncResolved,
+} from '../../resolution/models/Resolved.js';
+import { type ConstructorNoParamNode } from '../models/ConstructorNoParamNode.js';
+import { type InstanceBindingNode } from '../models/InstanceBindingNode.js';
+import { type PlanServiceNode } from '../models/PlanServiceNode.js';
+
+/**
+ * Same rationale as buildZeroConstructorArgumentsResolverOnCsp, but for
+ * instance bindings with two or more constructor arguments. Equivalent to
+ * `buildConstructorArgumentsResolver`, but implemented with a plain closure
+ * instead of the `Function` constructor, so it works in environments
+ * enforcing a strict Content Security Policy (no `unsafe-eval`).
+ *
+ * When the bound class has no properties to inject,
+ * `node.classMetadata.properties` is empty and the returned `resolveNode`
+ * never performs any property related check, matching the zero-property
+ * fast path performance of `buildConstructorArgumentsResolver`.
+ */
+export function buildConstructorArgumentsResolverOnCsp<TActivated>(
+  node: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  resolveAsyncValues: Function,
+  resolveActivations?: (
+    params: ResolutionParams,
+    instance: Resolved<TActivated>,
+  ) => Resolved<TActivated>,
+): (params: ResolutionParams) => Resolved<TActivated> {
+  const constructorArgumentsCount: number =
+    node.classMetadata.constructorArguments.length;
+
+  function resolveConstructorValues(params: ResolutionParams): unknown[] {
+    const values: unknown[] = new Array<unknown>(constructorArgumentsCount);
+
+    for (let index: number = 0; index < constructorArgumentsCount; index++) {
+      values[index] = (
+        node.constructorParams[index] as
+          PlanServiceNode | ConstructorNoParamNode
+      ).resolve(params);
+    }
+
+    return values;
+  }
+
+  if (node.classMetadata.properties.size === 0) {
+    if (resolveActivations === undefined) {
+      return function resolveNode(
+        params: ResolutionParams,
+      ): Resolved<TActivated> {
+        const values: unknown[] = resolveConstructorValues(params);
+
+        function build(...resolvedValues: unknown[]): TActivated {
+          return new node.binding.implementationType(...resolvedValues);
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return
+        return resolveAsyncValues(...values, build);
+      };
+    }
+
+    return function resolveNode(
+      params: ResolutionParams,
+    ): Resolved<TActivated> {
+      const values: unknown[] = resolveConstructorValues(params);
+
+      const build: (...resolvedValues: unknown[]) => Resolved<TActivated> = (
+        ...resolvedValues: unknown[]
+      ): Resolved<TActivated> =>
+        resolveActivations(
+          params,
+          new node.binding.implementationType(...resolvedValues),
+        );
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return
+      return resolveAsyncValues(...values, build);
+    };
+  }
+
+  if (resolveActivations === undefined) {
+    return function resolveNode(
+      params: ResolutionParams,
+    ): Resolved<TActivated> {
+      const values: unknown[] = resolveConstructorValues(params);
+
+      function build(...resolvedValues: unknown[]): Resolved<TActivated> {
+        const instance: SyncResolved<TActivated> &
+          Record<string | symbol, unknown> =
+          new node.binding.implementationType(
+            ...resolvedValues,
+          ) as SyncResolved<TActivated> & Record<string | symbol, unknown>;
+
+        const propertiesAssignmentResult: void | Promise<void> =
+          setInstanceProperties(params, instance, node);
+
+        if (isPromise(propertiesAssignmentResult)) {
+          return propertiesAssignmentResult.then((): TActivated => instance);
+        }
+
+        return instance;
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return
+      return resolveAsyncValues(...values, build);
+    };
+  }
+
+  return function resolveNode(params: ResolutionParams): Resolved<TActivated> {
+    const values: unknown[] = resolveConstructorValues(params);
+
+    const build: (...resolvedValues: unknown[]) => Resolved<TActivated> = (
+      ...resolvedValues: unknown[]
+    ): Resolved<TActivated> => {
+      const instance: SyncResolved<TActivated> &
+        Record<string | symbol, unknown> = new node.binding.implementationType(
+        ...resolvedValues,
+      ) as SyncResolved<TActivated> & Record<string | symbol, unknown>;
+
+      const propertiesAssignmentResult: void | Promise<void> =
+        setInstanceProperties(params, instance, node);
+
+      if (isPromise(propertiesAssignmentResult)) {
+        return propertiesAssignmentResult.then((): Resolved<TActivated> =>
+          resolveActivations(params, instance),
+        );
+      }
+
+      return resolveActivations(params, instance);
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return
+    return resolveAsyncValues(...values, build);
+  };
+}

--- a/packages/container/libraries/core/src/planning/calculations/buildFourConstructorArgumentResolverOnCsp.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildFourConstructorArgumentResolverOnCsp.spec.ts
@@ -1,0 +1,556 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+vitest.mock(import('../../resolution/actions/setInstanceProperties.js'));
+
+import { type InstanceBinding } from '../../binding/models/InstanceBinding.js';
+import { type Writable } from '../../common/models/Writable.js';
+import { type ClassElementMetadata } from '../../metadata/models/ClassElementMetadata.js';
+import { setInstanceProperties } from '../../resolution/actions/setInstanceProperties.js';
+import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
+import { type Resolved } from '../../resolution/models/Resolved.js';
+import { type InstanceBindingNode } from '../models/InstanceBindingNode.js';
+import { type PlanServiceNode } from '../models/PlanServiceNode.js';
+import { buildFourConstructorArgumentResolverOnCsp } from './buildFourConstructorArgumentResolverOnCsp.js';
+
+class Foo {
+  public readonly args: unknown[];
+
+  constructor(...args: unknown[]) {
+    this.args = args;
+  }
+}
+
+const expectedArgs: string[] = ['value-0', 'value-1', 'value-2', 'value-3'];
+
+function buildNodeFixture(
+  propertiesSize: number = 0,
+): InstanceBindingNode<Foo, InstanceBinding<Foo>> {
+  const properties: Map<string | symbol, ClassElementMetadata> = new Map();
+
+  for (let index: number = 0; index < propertiesSize; ++index) {
+    properties.set(
+      `property-${index.toString()}`,
+      Symbol() as unknown as ClassElementMetadata,
+    );
+  }
+
+  return {
+    binding: {
+      implementationType: Foo,
+    } as Partial<InstanceBinding<Foo>> as InstanceBinding<Foo>,
+    classMetadata: {
+      constructorArguments: new Array<ClassElementMetadata>(4).fill(
+        Symbol() as unknown as ClassElementMetadata,
+      ),
+      lifecycle: {
+        postConstructMethodNames: new Set(),
+        preDestroyMethodNames: new Set(),
+      },
+      properties,
+      scope: undefined,
+    },
+    constructorParams: [] as PlanServiceNode[],
+    propertyParams: new Map(),
+  } as Partial<
+    InstanceBindingNode<Foo, InstanceBinding<Foo>>
+  > as InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+}
+
+function buildConstructorParamsFixture(
+  resolve0: () => unknown,
+  resolve1: () => unknown,
+  resolve2: () => unknown,
+  resolve3: () => unknown,
+): PlanServiceNode[] {
+  return [
+    {
+      resolve: resolve0,
+    } as Partial<PlanServiceNode> as PlanServiceNode,
+    {
+      resolve: resolve1,
+    } as Partial<PlanServiceNode> as PlanServiceNode,
+    {
+      resolve: resolve2,
+    } as Partial<PlanServiceNode> as PlanServiceNode,
+    {
+      resolve: resolve3,
+    } as Partial<PlanServiceNode> as PlanServiceNode,
+  ];
+}
+
+describe(buildFourConstructorArgumentResolverOnCsp, () => {
+  let paramsFixture: ResolutionParams;
+
+  beforeAll(() => {
+    paramsFixture = Symbol() as unknown as ResolutionParams;
+  });
+
+  describe('having node.classMetadata.properties empty and resolveActivations not provided', () => {
+    let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+    beforeAll(() => {
+      nodeFixture = buildNodeFixture();
+    });
+
+    describe('when called, and node.constructorParams is populated after the resolveNode is built', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildFourConstructorArgumentResolverOnCsp(nodeFixture);
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          (): string => 'value-0',
+          (): string => 'value-1',
+          (): string => 'value-2',
+          (): string => 'value-3',
+        );
+
+        result = resolveNode(paramsFixture);
+      });
+
+      it('should build an instance with the resolved constructor arguments', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual(expectedArgs);
+      });
+
+      it('should not call setInstanceProperties()', () => {
+        expect(setInstanceProperties).not.toHaveBeenCalled();
+      });
+    });
+
+    describe.each<
+      [string, () => unknown, () => unknown, () => unknown, () => unknown]
+    >([
+      [
+        'all constructor arguments resolve asynchronously',
+        async (): Promise<string> => 'value-0',
+        async (): Promise<string> => 'value-1',
+        async (): Promise<string> => 'value-2',
+        async (): Promise<string> => 'value-3',
+      ],
+      [
+        'the first constructor argument resolves asynchronously',
+        async (): Promise<string> => 'value-0',
+        (): string => 'value-1',
+        (): string => 'value-2',
+        (): string => 'value-3',
+      ],
+      [
+        'the second constructor argument resolves asynchronously',
+        (): string => 'value-0',
+        async (): Promise<string> => 'value-1',
+        (): string => 'value-2',
+        (): string => 'value-3',
+      ],
+      [
+        'the third constructor argument resolves asynchronously',
+        (): string => 'value-0',
+        (): string => 'value-1',
+        async (): Promise<string> => 'value-2',
+        (): string => 'value-3',
+      ],
+      [
+        'the fourth constructor argument resolves asynchronously',
+        (): string => 'value-0',
+        (): string => 'value-1',
+        (): string => 'value-2',
+        async (): Promise<string> => 'value-3',
+      ],
+    ])(
+      'when called, and %s',
+      (
+        _: string,
+        resolve0: () => unknown,
+        resolve1: () => unknown,
+        resolve2: () => unknown,
+        resolve3: () => unknown,
+      ) => {
+        let result: unknown;
+
+        beforeAll(async () => {
+          const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+            buildFourConstructorArgumentResolverOnCsp(nodeFixture);
+
+          (
+            nodeFixture as Writable<
+              InstanceBindingNode<Foo, InstanceBinding<Foo>>
+            >
+          ).constructorParams = buildConstructorParamsFixture(
+            resolve0,
+            resolve1,
+            resolve2,
+            resolve3,
+          );
+
+          result = await resolveNode(paramsFixture);
+        });
+
+        it('should build an instance with the resolved constructor arguments', () => {
+          expect(result).toBeInstanceOf(Foo);
+          expect((result as Foo).args).toStrictEqual(expectedArgs);
+        });
+      },
+    );
+  });
+
+  describe('having node.classMetadata.properties empty and resolveActivations provided', () => {
+    let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+    let resolveActivations: (
+      params: ResolutionParams,
+      instance: Resolved<Foo>,
+    ) => Resolved<Foo>;
+
+    beforeAll(() => {
+      nodeFixture = buildNodeFixture();
+
+      resolveActivations = (
+        _params: ResolutionParams,
+        instance: Resolved<Foo>,
+      ): Resolved<Foo> => instance;
+    });
+
+    describe('when called, and node.constructorParams is populated after the resolveNode is built', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildFourConstructorArgumentResolverOnCsp(
+            nodeFixture,
+            resolveActivations,
+          );
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          (): string => 'value-0',
+          (): string => 'value-1',
+          (): string => 'value-2',
+          (): string => 'value-3',
+        );
+
+        result = resolveNode(paramsFixture);
+      });
+
+      it('should build an instance with the resolved constructor arguments', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual(expectedArgs);
+      });
+    });
+
+    describe('when called, and all constructor arguments resolve asynchronously', () => {
+      let result: unknown;
+
+      beforeAll(async () => {
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildFourConstructorArgumentResolverOnCsp(
+            nodeFixture,
+            resolveActivations,
+          );
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          async (): Promise<string> => 'value-0',
+          async (): Promise<string> => 'value-1',
+          async (): Promise<string> => 'value-2',
+          async (): Promise<string> => 'value-3',
+        );
+
+        result = await resolveNode(paramsFixture);
+      });
+
+      it('should build an instance with the resolved constructor arguments', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual(expectedArgs);
+      });
+    });
+
+    describe('when called, and resolveActivations returns a promise', () => {
+      let expectedResult: unknown;
+      let result: unknown;
+
+      beforeAll(async () => {
+        resolveActivations = (
+          _params: ResolutionParams,
+          instance: Resolved<Foo>,
+        ): Resolved<Foo> => {
+          expectedResult = instance;
+
+          return Promise.resolve(instance);
+        };
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildFourConstructorArgumentResolverOnCsp(
+            nodeFixture,
+            resolveActivations,
+          );
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          (): string => 'value-0',
+          (): string => 'value-1',
+          (): string => 'value-2',
+          (): string => 'value-3',
+        );
+
+        result = await resolveNode(paramsFixture);
+      });
+
+      it('should return the resolved activation result', () => {
+        expect(result).toBe(expectedResult);
+      });
+    });
+  });
+
+  describe('having node.classMetadata.properties not empty and resolveActivations not provided', () => {
+    let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+    beforeAll(() => {
+      nodeFixture = buildNodeFixture(1);
+    });
+
+    describe('when called, and setInstanceProperties() returns undefined', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest.mocked(setInstanceProperties).mockReturnValueOnce(undefined);
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          (): string => 'value-0',
+          (): string => 'value-1',
+          (): string => 'value-2',
+          (): string => 'value-3',
+        );
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildFourConstructorArgumentResolverOnCsp(nodeFixture);
+
+        result = resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should build an instance with the resolved constructor arguments', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual(expectedArgs);
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+
+    describe('when called, and setInstanceProperties() returns a promise', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest.mocked(setInstanceProperties).mockResolvedValueOnce(undefined);
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          (): string => 'value-0',
+          (): string => 'value-1',
+          (): string => 'value-2',
+          (): string => 'value-3',
+        );
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildFourConstructorArgumentResolverOnCsp(nodeFixture);
+
+        result = resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should build an instance with the resolved constructor arguments', () => {
+        expect(result).toStrictEqual(Promise.resolve(expect.any(Foo)));
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+
+    describe('when called, and all constructor arguments resolve asynchronously', () => {
+      let result: unknown;
+
+      beforeAll(async () => {
+        vitest.mocked(setInstanceProperties).mockReturnValueOnce(undefined);
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          async (): Promise<string> => 'value-0',
+          async (): Promise<string> => 'value-1',
+          async (): Promise<string> => 'value-2',
+          async (): Promise<string> => 'value-3',
+        );
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildFourConstructorArgumentResolverOnCsp(nodeFixture);
+
+        result = await resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should build an instance with the resolved constructor arguments', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual(expectedArgs);
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+  });
+
+  describe('having node.classMetadata.properties not empty and resolveActivations provided', () => {
+    let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+    beforeAll(() => {
+      nodeFixture = buildNodeFixture(1);
+    });
+
+    describe('when called, and setInstanceProperties() returns undefined', () => {
+      let expectedResult: unknown;
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest.mocked(setInstanceProperties).mockReturnValueOnce(undefined);
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          (): string => 'value-0',
+          (): string => 'value-1',
+          (): string => 'value-2',
+          (): string => 'value-3',
+        );
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildFourConstructorArgumentResolverOnCsp(
+            nodeFixture,
+            (
+              _params: ResolutionParams,
+              instance: Resolved<Foo>,
+            ): Resolved<Foo> => {
+              expectedResult = instance;
+
+              return instance;
+            },
+          );
+
+        result = resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should return the activation result', () => {
+        expect(result).toBe(expectedResult);
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+
+    describe('when called, and setInstanceProperties() returns a promise', () => {
+      let expectedResult: unknown;
+      let result: unknown;
+
+      beforeAll(async () => {
+        vitest.mocked(setInstanceProperties).mockResolvedValueOnce(undefined);
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          (): string => 'value-0',
+          (): string => 'value-1',
+          (): string => 'value-2',
+          (): string => 'value-3',
+        );
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildFourConstructorArgumentResolverOnCsp(
+            nodeFixture,
+            (
+              _params: ResolutionParams,
+              instance: Resolved<Foo>,
+            ): Resolved<Foo> => {
+              expectedResult = instance;
+
+              return Promise.resolve(instance);
+            },
+          );
+
+        result = await resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should return the resolved activation result', () => {
+        expect(result).toBe(expectedResult);
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/planning/calculations/buildFourConstructorArgumentResolverOnCsp.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildFourConstructorArgumentResolverOnCsp.ts
@@ -1,0 +1,228 @@
+import { isPromise } from '@inversifyjs/common';
+
+import { type InstanceBinding } from '../../binding/models/InstanceBinding.js';
+import { setInstanceProperties } from '../../resolution/actions/setInstanceProperties.js';
+import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
+import {
+  type Resolved,
+  type SyncResolved,
+} from '../../resolution/models/Resolved.js';
+import { type ConstructorNoParamNode } from '../models/ConstructorNoParamNode.js';
+import { type InstanceBindingNode } from '../models/InstanceBindingNode.js';
+import { type PlanServiceNode } from '../models/PlanServiceNode.js';
+import { resolveFour } from './resolveFour.js';
+
+/**
+ * Same rationale as buildZeroConstructorArgumentsResolverOnCsp, but for
+ * four-argument instance bindings. Equivalent to
+ * `buildConstructorArgumentsResolver` with `resolveFour`, but implemented
+ * with a plain closure instead of the `Function` constructor, so it works in
+ * environments enforcing a strict Content Security Policy (no
+ * `unsafe-eval`).
+ *
+ * When the bound class has no properties to inject,
+ * `node.classMetadata.properties` is empty and the returned `resolveNode`
+ * never performs any property related check, matching the zero-property
+ * fast path performance of `buildConstructorArgumentsResolver` with
+ * `resolveFour`.
+ */
+export function buildFourConstructorArgumentResolverOnCsp<TActivated>(
+  node: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
+  resolveActivations?: (
+    params: ResolutionParams,
+    instance: Resolved<TActivated>,
+  ) => Resolved<TActivated>,
+): (params: ResolutionParams) => Resolved<TActivated> {
+  if (node.classMetadata.properties.size === 0) {
+    if (resolveActivations === undefined) {
+      return function resolveNode(
+        params: ResolutionParams,
+      ): Resolved<TActivated> {
+        const resolvedValue0: unknown = (
+          node.constructorParams[0] as PlanServiceNode | ConstructorNoParamNode
+        ).resolve(params);
+        const resolvedValue1: unknown = (
+          node.constructorParams[1] as PlanServiceNode | ConstructorNoParamNode
+        ).resolve(params);
+        const resolvedValue2: unknown = (
+          node.constructorParams[2] as PlanServiceNode | ConstructorNoParamNode
+        ).resolve(params);
+        const resolvedValue3: unknown = (
+          node.constructorParams[3] as PlanServiceNode | ConstructorNoParamNode
+        ).resolve(params);
+
+        return resolveFour(
+          resolvedValue0,
+          resolvedValue1,
+          resolvedValue2,
+          resolvedValue3,
+          (
+            resolvedValue0: unknown,
+            resolvedValue1: unknown,
+            resolvedValue2: unknown,
+            resolvedValue3: unknown,
+          ): TActivated =>
+            new node.binding.implementationType(
+              resolvedValue0,
+              resolvedValue1,
+              resolvedValue2,
+              resolvedValue3,
+            ),
+        );
+      };
+    }
+
+    return function resolveNode(
+      params: ResolutionParams,
+    ): Resolved<TActivated> {
+      const resolvedValue0: unknown = (
+        node.constructorParams[0] as PlanServiceNode | ConstructorNoParamNode
+      ).resolve(params);
+      const resolvedValue1: unknown = (
+        node.constructorParams[1] as PlanServiceNode | ConstructorNoParamNode
+      ).resolve(params);
+      const resolvedValue2: unknown = (
+        node.constructorParams[2] as PlanServiceNode | ConstructorNoParamNode
+      ).resolve(params);
+      const resolvedValue3: unknown = (
+        node.constructorParams[3] as PlanServiceNode | ConstructorNoParamNode
+      ).resolve(params);
+
+      return resolveFour(
+        resolvedValue0,
+        resolvedValue1,
+        resolvedValue2,
+        resolvedValue3,
+        (
+          resolvedValue0: unknown,
+          resolvedValue1: unknown,
+          resolvedValue2: unknown,
+          resolvedValue3: unknown,
+        ): Resolved<TActivated> =>
+          resolveActivations(
+            params,
+            new node.binding.implementationType(
+              resolvedValue0,
+              resolvedValue1,
+              resolvedValue2,
+              resolvedValue3,
+            ),
+          ),
+      );
+    };
+  }
+
+  if (resolveActivations === undefined) {
+    const finalizeInstance: (
+      params: ResolutionParams,
+      instance: SyncResolved<TActivated> & Record<string | symbol, unknown>,
+    ) => Resolved<TActivated> = (
+      params: ResolutionParams,
+      instance: SyncResolved<TActivated> & Record<string | symbol, unknown>,
+    ): Resolved<TActivated> => {
+      const propertiesAssignmentResult: void | Promise<void> =
+        setInstanceProperties(params, instance, node);
+
+      if (isPromise(propertiesAssignmentResult)) {
+        return propertiesAssignmentResult.then((): TActivated => instance);
+      }
+
+      return instance;
+    };
+
+    return function resolveNode(
+      params: ResolutionParams,
+    ): Resolved<TActivated> {
+      const resolvedValue0: unknown = (
+        node.constructorParams[0] as PlanServiceNode | ConstructorNoParamNode
+      ).resolve(params);
+      const resolvedValue1: unknown = (
+        node.constructorParams[1] as PlanServiceNode | ConstructorNoParamNode
+      ).resolve(params);
+      const resolvedValue2: unknown = (
+        node.constructorParams[2] as PlanServiceNode | ConstructorNoParamNode
+      ).resolve(params);
+      const resolvedValue3: unknown = (
+        node.constructorParams[3] as PlanServiceNode | ConstructorNoParamNode
+      ).resolve(params);
+
+      return resolveFour(
+        resolvedValue0,
+        resolvedValue1,
+        resolvedValue2,
+        resolvedValue3,
+        (
+          resolvedValue0: unknown,
+          resolvedValue1: unknown,
+          resolvedValue2: unknown,
+          resolvedValue3: unknown,
+        ): Resolved<TActivated> =>
+          finalizeInstance(
+            params,
+            new node.binding.implementationType(
+              resolvedValue0,
+              resolvedValue1,
+              resolvedValue2,
+              resolvedValue3,
+            ) as SyncResolved<TActivated> & Record<string | symbol, unknown>,
+          ),
+      );
+    };
+  }
+
+  const finalizeInstance: (
+    params: ResolutionParams,
+    instance: SyncResolved<TActivated> & Record<string | symbol, unknown>,
+  ) => Resolved<TActivated> = (
+    params: ResolutionParams,
+    instance: SyncResolved<TActivated> & Record<string | symbol, unknown>,
+  ): Resolved<TActivated> => {
+    const propertiesAssignmentResult: void | Promise<void> =
+      setInstanceProperties(params, instance, node);
+
+    if (isPromise(propertiesAssignmentResult)) {
+      return propertiesAssignmentResult.then((): Resolved<TActivated> =>
+        resolveActivations(params, instance),
+      );
+    }
+
+    return resolveActivations(params, instance);
+  };
+
+  return function resolveNode(params: ResolutionParams): Resolved<TActivated> {
+    const resolvedValue0: unknown = (
+      node.constructorParams[0] as PlanServiceNode | ConstructorNoParamNode
+    ).resolve(params);
+    const resolvedValue1: unknown = (
+      node.constructorParams[1] as PlanServiceNode | ConstructorNoParamNode
+    ).resolve(params);
+    const resolvedValue2: unknown = (
+      node.constructorParams[2] as PlanServiceNode | ConstructorNoParamNode
+    ).resolve(params);
+    const resolvedValue3: unknown = (
+      node.constructorParams[3] as PlanServiceNode | ConstructorNoParamNode
+    ).resolve(params);
+
+    return resolveFour(
+      resolvedValue0,
+      resolvedValue1,
+      resolvedValue2,
+      resolvedValue3,
+      (
+        resolvedValue0: unknown,
+        resolvedValue1: unknown,
+        resolvedValue2: unknown,
+        resolvedValue3: unknown,
+      ): Resolved<TActivated> =>
+        finalizeInstance(
+          params,
+          new node.binding.implementationType(
+            resolvedValue0,
+            resolvedValue1,
+            resolvedValue2,
+            resolvedValue3,
+          ) as SyncResolved<TActivated> & Record<string | symbol, unknown>,
+        ),
+    );
+  };
+}

--- a/packages/container/libraries/core/src/planning/calculations/buildInstanceBindingNodeResolver.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildInstanceBindingNodeResolver.ts
@@ -1,37 +1,15 @@
-import {
-  isPromise,
-  type Newable,
-  type ServiceIdentifier,
-} from '@inversifyjs/common';
-
-import { type BindingActivation } from '../../binding/models/BindingActivation.js';
 import { type bindingTypeValues } from '../../binding/models/BindingType.js';
 import { type InstanceBinding } from '../../binding/models/InstanceBinding.js';
-import { resolveBindingActivationsFromIterator } from '../../resolution/actions/resolveBindingActivationsFromIterator.js';
-import { resolveBindingActivationsFromIteratorAsync } from '../../resolution/actions/resolveBindingActivationsFromIteratorAsync.js';
 import { resolveInstanceBindingConstructorParams } from '../../resolution/actions/resolveInstanceBindingConstructorParams.js';
 import { resolveInstanceBindingNode as curryResolveInstanceBindingNode } from '../../resolution/actions/resolveInstanceBindingNode.js';
 import { resolveInstanceBindingNodeAsyncFromConstructorParams } from '../../resolution/actions/resolveInstanceBindingNodeAsyncFromConstructorParams.js';
 import { resolveInstanceBindingNodeFromConstructorParams } from '../../resolution/actions/resolveInstanceBindingNodeFromConstructorParams.js';
 import { resolveScoped } from '../../resolution/actions/resolveScoped.js';
-import { resolveScopedWithNoActivations } from '../../resolution/actions/resolveScopedWithNoActivations.js';
 import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
 import { type Resolved } from '../../resolution/models/Resolved.js';
 import { type InstanceBindingNode } from '../models/InstanceBindingNode.js';
-import { buildConstructorArgumentsResolver } from './buildConstructorArgumentsResolver.js';
-import { buildOneConstructorArgumentResolver } from './buildOneConstructorArgumentResolver.js';
-import { buildOnePropertyArgumentResolver } from './buildOnePropertyArgumentResolver.js';
-import { buildResolveMany } from './buildResolveMany.js';
-import { buildZeroConstructorArgumentsResolver } from './buildZeroConstructorArgumentsResolver.js';
-import { resolveFour } from './resolveFour.js';
-import { resolveThree } from './resolveThree.js';
-import { resolveTwo } from './resolveTwo.js';
-
-const ZERO_CONSTRUCTOR_ARGUMENTS: number = 0;
-const ONE_CONSTRUCTOR_ARGUMENT: number = 1;
-const TWO_CONSTRUCTOR_ARGUMENTS: number = 2;
-const THREE_CONSTRUCTOR_ARGUMENTS: number = 3;
-const FOUR_CONSTRUCTOR_ARGUMENTS: number = 4;
+import { buildNoActivationsInstanceBindingNodeResolver } from './buildNoActivationsInstanceBindingNodeResolver.js';
+import { buildNoActivationsInstanceBindingNodeResolverOnCsp } from './buildNoActivationsInstanceBindingNodeResolverOnCsp.js';
 
 const resolveInstanceBindingNode: <
   TActivated,
@@ -58,119 +36,19 @@ const resolveScopedInstanceBindingNode: <TActivated>(
     InstanceBindingNode<TActivated, InstanceBinding<TActivated>>
   >(node, resolveInstanceBindingNode);
 
-/**
- * Builds a resolver for instance binding nodes with no properties to set,
- * no post construct methods and no binding activation.
- *
- * The resolution logic is inlined in a single closure to minimize function
- * call dispatch overhead: this is the hottest resolution path. Common small
- * constructor arities are specialized to avoid constructor values array
- * allocations and spread construct calls.
- */
-function buildSimpleInstanceBindingNodeResolver<TActivated>(
-  node: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
-): (params: ResolutionParams) => Resolved<TActivated> {
-  const implementationType: Newable<TActivated> =
-    node.binding.implementationType;
-  const serviceIdentifier: ServiceIdentifier<TActivated> =
-    node.binding.serviceIdentifier;
-
-  function resolveActivations(
-    params: ResolutionParams,
-    instance: Resolved<TActivated>,
-  ): Resolved<TActivated> {
-    const activations: Iterable<BindingActivation<TActivated>> | undefined =
-      params.getActivations(serviceIdentifier);
-
-    if (activations === undefined) {
-      return instance;
-    }
-
-    if (isPromise(instance)) {
-      return resolveBindingActivationsFromIteratorAsync(
-        params,
-        instance,
-        activations[Symbol.iterator](),
-      );
-    }
-
-    return resolveBindingActivationsFromIterator(
-      params,
-      instance,
-      activations[Symbol.iterator](),
-    );
-  }
-
-  let resolveNode: (params: ResolutionParams) => Resolved<TActivated>;
-
-  switch (
-    node.classMetadata.constructorArguments.length +
-    node.classMetadata.properties.size
-  ) {
-    case ZERO_CONSTRUCTOR_ARGUMENTS:
-      resolveNode = buildZeroConstructorArgumentsResolver(
-        implementationType,
-        resolveActivations,
-      );
-      break;
-    case ONE_CONSTRUCTOR_ARGUMENT:
-      resolveNode =
-        node.classMetadata.properties.size === 0
-          ? buildOneConstructorArgumentResolver(
-              node,
-              implementationType,
-              resolveActivations,
-            )
-          : buildOnePropertyArgumentResolver(
-              node,
-              implementationType,
-              resolveActivations,
-            );
-      break;
-    case TWO_CONSTRUCTOR_ARGUMENTS:
-      resolveNode = buildConstructorArgumentsResolver(
-        node,
-        implementationType,
-        resolveTwo,
-        resolveActivations,
-      );
-      break;
-    case THREE_CONSTRUCTOR_ARGUMENTS:
-      resolveNode = buildConstructorArgumentsResolver(
-        node,
-        implementationType,
-        resolveThree,
-        resolveActivations,
-      );
-      break;
-    case FOUR_CONSTRUCTOR_ARGUMENTS:
-      resolveNode = buildConstructorArgumentsResolver(
-        node,
-        implementationType,
-        resolveFour,
-        resolveActivations,
-      );
-      break;
-    default:
-      resolveNode = buildConstructorArgumentsResolver(
-        node,
-        implementationType,
-        buildResolveMany(node),
-        resolveActivations,
-      );
-  }
-
-  return resolveScopedWithNoActivations(node.binding, resolveNode);
-}
-
 export function buildInstanceBindingNodeResolver<TActivated>(
   node: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
+  jitEnabled: boolean,
 ): (params: ResolutionParams) => Resolved<TActivated> {
   if (
     node.classMetadata.lifecycle.postConstructMethodNames.size === 0 &&
     node.binding.onActivation === undefined
   ) {
-    return buildSimpleInstanceBindingNodeResolver(node);
+    if (jitEnabled) {
+      return buildNoActivationsInstanceBindingNodeResolver(node);
+    } else {
+      return buildNoActivationsInstanceBindingNodeResolverOnCsp(node);
+    }
   }
 
   return resolveScopedInstanceBindingNode(node);

--- a/packages/container/libraries/core/src/planning/calculations/buildNoActivationsInstanceBindingNodeResolver.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildNoActivationsInstanceBindingNodeResolver.ts
@@ -1,0 +1,106 @@
+import { type Newable, type ServiceIdentifier } from '@inversifyjs/common';
+
+import { type InstanceBinding } from '../../binding/models/InstanceBinding.js';
+import { resolveScopedWithNoActivations } from '../../resolution/actions/resolveScopedWithNoActivations.js';
+import { resolveServiceActivations } from '../../resolution/actions/resolveServiceActivations.js';
+import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
+import { type Resolved } from '../../resolution/models/Resolved.js';
+import { type InstanceBindingNode } from '../models/InstanceBindingNode.js';
+import { buildConstructorArgumentsResolver } from './buildConstructorArgumentsResolver.js';
+import { buildOneConstructorArgumentResolver } from './buildOneConstructorArgumentResolver.js';
+import { buildOnePropertyArgumentResolver } from './buildOnePropertyArgumentResolver.js';
+import { buildResolveMany } from './buildResolveMany.js';
+import { buildZeroConstructorArgumentsResolver } from './buildZeroConstructorArgumentsResolver.js';
+import { resolveFour } from './resolveFour.js';
+import { resolveThree } from './resolveThree.js';
+import { resolveTwo } from './resolveTwo.js';
+
+const ZERO_CONSTRUCTOR_ARGUMENTS: number = 0;
+const ONE_CONSTRUCTOR_ARGUMENT: number = 1;
+const TWO_CONSTRUCTOR_ARGUMENTS: number = 2;
+const THREE_CONSTRUCTOR_ARGUMENTS: number = 3;
+const FOUR_CONSTRUCTOR_ARGUMENTS: number = 4;
+
+/**
+ * Builds a resolver for instance binding nodes with
+ * no post construct methods and no binding activation.
+ *
+ * The resolution logic is inlined in a single closure to minimize function
+ * call dispatch overhead: this is the hottest resolution path. Common small
+ * constructor arities are specialized to avoid constructor values array
+ * allocations and spread construct calls.
+ */
+export function buildNoActivationsInstanceBindingNodeResolver<TActivated>(
+  node: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
+): (params: ResolutionParams) => Resolved<TActivated> {
+  const implementationType: Newable<TActivated> =
+    node.binding.implementationType;
+  const serviceIdentifier: ServiceIdentifier<TActivated> =
+    node.binding.serviceIdentifier;
+
+  const resolveActivations: (
+    params: ResolutionParams,
+    value: Resolved<TActivated>,
+  ) => Resolved<TActivated> = resolveServiceActivations(serviceIdentifier);
+
+  let resolveNode: (params: ResolutionParams) => Resolved<TActivated>;
+
+  switch (
+    node.classMetadata.constructorArguments.length +
+    node.classMetadata.properties.size
+  ) {
+    case ZERO_CONSTRUCTOR_ARGUMENTS:
+      resolveNode = buildZeroConstructorArgumentsResolver(
+        implementationType,
+        resolveActivations,
+      );
+      break;
+    case ONE_CONSTRUCTOR_ARGUMENT:
+      resolveNode =
+        node.classMetadata.properties.size === 0
+          ? buildOneConstructorArgumentResolver(
+              node,
+              implementationType,
+              resolveActivations,
+            )
+          : buildOnePropertyArgumentResolver(
+              node,
+              implementationType,
+              resolveActivations,
+            );
+      break;
+    case TWO_CONSTRUCTOR_ARGUMENTS:
+      resolveNode = buildConstructorArgumentsResolver(
+        node,
+        implementationType,
+        resolveTwo,
+        resolveActivations,
+      );
+      break;
+    case THREE_CONSTRUCTOR_ARGUMENTS:
+      resolveNode = buildConstructorArgumentsResolver(
+        node,
+        implementationType,
+        resolveThree,
+        resolveActivations,
+      );
+      break;
+    case FOUR_CONSTRUCTOR_ARGUMENTS:
+      resolveNode = buildConstructorArgumentsResolver(
+        node,
+        implementationType,
+        resolveFour,
+        resolveActivations,
+      );
+      break;
+    default:
+      resolveNode = buildConstructorArgumentsResolver(
+        node,
+        implementationType,
+        buildResolveMany(node),
+        resolveActivations,
+      );
+  }
+
+  return resolveScopedWithNoActivations(node.binding, resolveNode);
+}

--- a/packages/container/libraries/core/src/planning/calculations/buildNoActivationsInstanceBindingNodeResolverOnCsp.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildNoActivationsInstanceBindingNodeResolverOnCsp.ts
@@ -1,0 +1,106 @@
+import { type Newable, type ServiceIdentifier } from '@inversifyjs/common';
+
+import { type InstanceBinding } from '../../binding/models/InstanceBinding.js';
+import { resolveScopedWithNoActivations } from '../../resolution/actions/resolveScopedWithNoActivations.js';
+import { resolveServiceActivations } from '../../resolution/actions/resolveServiceActivations.js';
+import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
+import { type Resolved } from '../../resolution/models/Resolved.js';
+import { type InstanceBindingNode } from '../models/InstanceBindingNode.js';
+import { buildConstructorArgumentsResolver } from './buildConstructorArgumentsResolver.js';
+import { buildOneConstructorArgumentResolver } from './buildOneConstructorArgumentResolver.js';
+import { buildOnePropertyArgumentResolver } from './buildOnePropertyArgumentResolver.js';
+import { buildResolveMany } from './buildResolveMany.js';
+import { buildZeroConstructorArgumentsResolverOnCsp } from './buildZeroConstructorArgumentsResolverOnCsp.js';
+import { resolveFour } from './resolveFour.js';
+import { resolveThree } from './resolveThree.js';
+import { resolveTwo } from './resolveTwo.js';
+
+const ZERO_CONSTRUCTOR_ARGUMENTS: number = 0;
+const ONE_CONSTRUCTOR_ARGUMENT: number = 1;
+const TWO_CONSTRUCTOR_ARGUMENTS: number = 2;
+const THREE_CONSTRUCTOR_ARGUMENTS: number = 3;
+const FOUR_CONSTRUCTOR_ARGUMENTS: number = 4;
+
+/**
+ * Builds a resolver for instance binding nodes with
+ * no post construct methods and no binding activation.
+ *
+ * The resolution logic is inlined in a single closure to minimize function
+ * call dispatch overhead: this is the hottest resolution path. Common small
+ * constructor arities are specialized to avoid constructor values array
+ * allocations and spread construct calls.
+ */
+export function buildNoActivationsInstanceBindingNodeResolverOnCsp<TActivated>(
+  node: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
+): (params: ResolutionParams) => Resolved<TActivated> {
+  const implementationType: Newable<TActivated> =
+    node.binding.implementationType;
+  const serviceIdentifier: ServiceIdentifier<TActivated> =
+    node.binding.serviceIdentifier;
+
+  const resolveActivations: (
+    params: ResolutionParams,
+    value: Resolved<TActivated>,
+  ) => Resolved<TActivated> = resolveServiceActivations(serviceIdentifier);
+
+  let resolveNode: (params: ResolutionParams) => Resolved<TActivated>;
+
+  switch (
+    node.classMetadata.constructorArguments.length +
+    node.classMetadata.properties.size
+  ) {
+    case ZERO_CONSTRUCTOR_ARGUMENTS:
+      resolveNode = buildZeroConstructorArgumentsResolverOnCsp(
+        node,
+        resolveActivations,
+      );
+      break;
+    case ONE_CONSTRUCTOR_ARGUMENT:
+      resolveNode =
+        node.classMetadata.properties.size === 0
+          ? buildOneConstructorArgumentResolver(
+              node,
+              implementationType,
+              resolveActivations,
+            )
+          : buildOnePropertyArgumentResolver(
+              node,
+              implementationType,
+              resolveActivations,
+            );
+      break;
+    case TWO_CONSTRUCTOR_ARGUMENTS:
+      resolveNode = buildConstructorArgumentsResolver(
+        node,
+        implementationType,
+        resolveTwo,
+        resolveActivations,
+      );
+      break;
+    case THREE_CONSTRUCTOR_ARGUMENTS:
+      resolveNode = buildConstructorArgumentsResolver(
+        node,
+        implementationType,
+        resolveThree,
+        resolveActivations,
+      );
+      break;
+    case FOUR_CONSTRUCTOR_ARGUMENTS:
+      resolveNode = buildConstructorArgumentsResolver(
+        node,
+        implementationType,
+        resolveFour,
+        resolveActivations,
+      );
+      break;
+    default:
+      resolveNode = buildConstructorArgumentsResolver(
+        node,
+        implementationType,
+        buildResolveMany(node),
+        resolveActivations,
+      );
+  }
+
+  return resolveScopedWithNoActivations(node.binding, resolveNode);
+}

--- a/packages/container/libraries/core/src/planning/calculations/buildNoActivationsInstanceBindingNodeResolverOnCsp.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildNoActivationsInstanceBindingNodeResolverOnCsp.ts
@@ -1,4 +1,4 @@
-import { type Newable, type ServiceIdentifier } from '@inversifyjs/common';
+import { type ServiceIdentifier } from '@inversifyjs/common';
 
 import { type InstanceBinding } from '../../binding/models/InstanceBinding.js';
 import { resolveScopedWithNoActivations } from '../../resolution/actions/resolveScopedWithNoActivations.js';
@@ -6,14 +6,13 @@ import { resolveServiceActivations } from '../../resolution/actions/resolveServi
 import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
 import { type Resolved } from '../../resolution/models/Resolved.js';
 import { type InstanceBindingNode } from '../models/InstanceBindingNode.js';
-import { buildConstructorArgumentsResolver } from './buildConstructorArgumentsResolver.js';
-import { buildOneConstructorArgumentResolver } from './buildOneConstructorArgumentResolver.js';
-import { buildOnePropertyArgumentResolver } from './buildOnePropertyArgumentResolver.js';
-import { buildResolveMany } from './buildResolveMany.js';
+import { buildConstructorArgumentsResolverOnCsp } from './buildConstructorArgumentsResolverOnCsp.js';
+import { buildFourConstructorArgumentResolverOnCsp } from './buildFourConstructorArgumentResolverOnCsp.js';
+import { buildOneConstructorArgumentResolverOnCsp } from './buildOneConstructorArgumentResolverOnCsp.js';
+import { buildThreeConstructorArgumentResolverOnCsp } from './buildThreeConstructorArgumentResolverOnCsp.js';
+import { buildTwoConstructorArgumentResolverOnCsp } from './buildTwoConstructorArgumentResolverOnCsp.js';
 import { buildZeroConstructorArgumentsResolverOnCsp } from './buildZeroConstructorArgumentsResolverOnCsp.js';
-import { resolveFour } from './resolveFour.js';
-import { resolveThree } from './resolveThree.js';
-import { resolveTwo } from './resolveTwo.js';
+import { resolveMany } from './resolveMany.js';
 
 const ZERO_CONSTRUCTOR_ARGUMENTS: number = 0;
 const ONE_CONSTRUCTOR_ARGUMENT: number = 1;
@@ -25,16 +24,14 @@ const FOUR_CONSTRUCTOR_ARGUMENTS: number = 4;
  * Builds a resolver for instance binding nodes with
  * no post construct methods and no binding activation.
  *
- * The resolution logic is inlined in a single closure to minimize function
- * call dispatch overhead: this is the hottest resolution path. Common small
- * constructor arities are specialized to avoid constructor values array
- * allocations and spread construct calls.
+ * Unlike the JIT path, specialized CSP resolvers key only on constructor
+ * arity: property injection is handled inside those resolvers via
+ * `setInstanceProperties`, so mixed ctor/property graphs must not be
+ * dispatched as if properties were extra constructor arguments.
  */
 export function buildNoActivationsInstanceBindingNodeResolverOnCsp<TActivated>(
   node: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
 ): (params: ResolutionParams) => Resolved<TActivated> {
-  const implementationType: Newable<TActivated> =
-    node.binding.implementationType;
   const serviceIdentifier: ServiceIdentifier<TActivated> =
     node.binding.serviceIdentifier;
 
@@ -45,10 +42,7 @@ export function buildNoActivationsInstanceBindingNodeResolverOnCsp<TActivated>(
 
   let resolveNode: (params: ResolutionParams) => Resolved<TActivated>;
 
-  switch (
-    node.classMetadata.constructorArguments.length +
-    node.classMetadata.properties.size
-  ) {
+  switch (node.classMetadata.constructorArguments.length) {
     case ZERO_CONSTRUCTOR_ARGUMENTS:
       resolveNode = buildZeroConstructorArgumentsResolverOnCsp(
         node,
@@ -56,48 +50,33 @@ export function buildNoActivationsInstanceBindingNodeResolverOnCsp<TActivated>(
       );
       break;
     case ONE_CONSTRUCTOR_ARGUMENT:
-      resolveNode =
-        node.classMetadata.properties.size === 0
-          ? buildOneConstructorArgumentResolver(
-              node,
-              implementationType,
-              resolveActivations,
-            )
-          : buildOnePropertyArgumentResolver(
-              node,
-              implementationType,
-              resolveActivations,
-            );
+      resolveNode = buildOneConstructorArgumentResolverOnCsp(
+        node,
+        resolveActivations,
+      );
       break;
     case TWO_CONSTRUCTOR_ARGUMENTS:
-      resolveNode = buildConstructorArgumentsResolver(
+      resolveNode = buildTwoConstructorArgumentResolverOnCsp(
         node,
-        implementationType,
-        resolveTwo,
         resolveActivations,
       );
       break;
     case THREE_CONSTRUCTOR_ARGUMENTS:
-      resolveNode = buildConstructorArgumentsResolver(
+      resolveNode = buildThreeConstructorArgumentResolverOnCsp(
         node,
-        implementationType,
-        resolveThree,
         resolveActivations,
       );
       break;
     case FOUR_CONSTRUCTOR_ARGUMENTS:
-      resolveNode = buildConstructorArgumentsResolver(
+      resolveNode = buildFourConstructorArgumentResolverOnCsp(
         node,
-        implementationType,
-        resolveFour,
         resolveActivations,
       );
       break;
     default:
-      resolveNode = buildConstructorArgumentsResolver(
+      resolveNode = buildConstructorArgumentsResolverOnCsp(
         node,
-        implementationType,
-        buildResolveMany(node),
+        resolveMany,
         resolveActivations,
       );
   }

--- a/packages/container/libraries/core/src/planning/calculations/buildOneConstructorArgumentResolverOnCsp.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildOneConstructorArgumentResolverOnCsp.spec.ts
@@ -1,0 +1,433 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+vitest.mock(import('../../resolution/actions/setInstanceProperties.js'));
+
+import { type InstanceBinding } from '../../binding/models/InstanceBinding.js';
+import { type Writable } from '../../common/models/Writable.js';
+import { type ClassElementMetadata } from '../../metadata/models/ClassElementMetadata.js';
+import { setInstanceProperties } from '../../resolution/actions/setInstanceProperties.js';
+import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
+import { type Resolved } from '../../resolution/models/Resolved.js';
+import { type InstanceBindingNode } from '../models/InstanceBindingNode.js';
+import { type PlanServiceNode } from '../models/PlanServiceNode.js';
+import { buildOneConstructorArgumentResolverOnCsp } from './buildOneConstructorArgumentResolverOnCsp.js';
+
+class Foo {
+  public readonly args: unknown[];
+
+  constructor(...args: unknown[]) {
+    this.args = args;
+  }
+}
+
+function buildNodeFixture(
+  propertiesSize: number = 0,
+): InstanceBindingNode<Foo, InstanceBinding<Foo>> {
+  const properties: Map<string | symbol, ClassElementMetadata> = new Map();
+
+  for (let index: number = 0; index < propertiesSize; ++index) {
+    properties.set(
+      `property-${index.toString()}`,
+      Symbol() as unknown as ClassElementMetadata,
+    );
+  }
+
+  return {
+    binding: {
+      implementationType: Foo,
+    } as Partial<InstanceBinding<Foo>> as InstanceBinding<Foo>,
+    classMetadata: {
+      constructorArguments: new Array<ClassElementMetadata>(1).fill(
+        Symbol() as unknown as ClassElementMetadata,
+      ),
+      lifecycle: {
+        postConstructMethodNames: new Set(),
+        preDestroyMethodNames: new Set(),
+      },
+      properties,
+      scope: undefined,
+    },
+    constructorParams: [] as PlanServiceNode[],
+    propertyParams: new Map(),
+  } as Partial<
+    InstanceBindingNode<Foo, InstanceBinding<Foo>>
+  > as InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+}
+
+describe(buildOneConstructorArgumentResolverOnCsp, () => {
+  let paramsFixture: ResolutionParams;
+
+  beforeAll(() => {
+    paramsFixture = Symbol() as unknown as ResolutionParams;
+  });
+
+  describe('having node.classMetadata.properties empty and resolveActivations not provided', () => {
+    let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+    beforeAll(() => {
+      nodeFixture = buildNodeFixture();
+    });
+
+    describe('when called, and node.constructorParams is populated after the resolveNode is built', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildOneConstructorArgumentResolverOnCsp(nodeFixture);
+
+        nodeFixture.constructorParams.push({
+          resolve: (): string => 'value-0',
+        } as Partial<PlanServiceNode> as PlanServiceNode);
+
+        result = resolveNode(paramsFixture);
+      });
+
+      it('should build an instance with the resolved constructor argument', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual(['value-0']);
+      });
+
+      it('should not call setInstanceProperties()', () => {
+        expect(setInstanceProperties).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when called, and the constructor argument resolves asynchronously', () => {
+      let result: unknown;
+
+      beforeAll(async () => {
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildOneConstructorArgumentResolverOnCsp(nodeFixture);
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = [
+          {
+            resolve: async (): Promise<string> => 'value-0',
+          } as Partial<PlanServiceNode> as PlanServiceNode,
+        ];
+
+        result = await resolveNode(paramsFixture);
+      });
+
+      it('should build an instance with the resolved constructor argument', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual(['value-0']);
+      });
+    });
+  });
+
+  describe('having node.classMetadata.properties empty and resolveActivations provided', () => {
+    let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+    let resolveActivations: (
+      params: ResolutionParams,
+      instance: Resolved<Foo>,
+    ) => Resolved<Foo>;
+
+    beforeAll(() => {
+      nodeFixture = buildNodeFixture();
+
+      resolveActivations = (
+        _params: ResolutionParams,
+        instance: Resolved<Foo>,
+      ): Resolved<Foo> => instance;
+    });
+
+    describe('when called, and node.constructorParams is populated after the resolveNode is built', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildOneConstructorArgumentResolverOnCsp(
+            nodeFixture,
+            resolveActivations,
+          );
+
+        nodeFixture.constructorParams.push({
+          resolve: (): string => 'value-0',
+        } as Partial<PlanServiceNode> as PlanServiceNode);
+
+        result = resolveNode(paramsFixture);
+      });
+
+      it('should build an instance with the resolved constructor argument', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual(['value-0']);
+      });
+    });
+
+    describe('when called, and the constructor argument resolves asynchronously', () => {
+      let result: unknown;
+
+      beforeAll(async () => {
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildOneConstructorArgumentResolverOnCsp(
+            nodeFixture,
+            resolveActivations,
+          );
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = [
+          {
+            resolve: async (): Promise<string> => 'value-0',
+          } as Partial<PlanServiceNode> as PlanServiceNode,
+        ];
+
+        result = await resolveNode(paramsFixture);
+      });
+
+      it('should build an instance with the resolved constructor argument', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual(['value-0']);
+      });
+    });
+
+    describe('when called, and resolveActivations returns a promise', () => {
+      let expectedResult: unknown;
+      let result: unknown;
+
+      beforeAll(async () => {
+        resolveActivations = (
+          _params: ResolutionParams,
+          instance: Resolved<Foo>,
+        ): Resolved<Foo> => {
+          expectedResult = instance;
+
+          return Promise.resolve(instance);
+        };
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildOneConstructorArgumentResolverOnCsp(
+            nodeFixture,
+            resolveActivations,
+          );
+
+        nodeFixture.constructorParams.push({
+          resolve: (): string => 'value-0',
+        } as Partial<PlanServiceNode> as PlanServiceNode);
+
+        result = await resolveNode(paramsFixture);
+      });
+
+      it('should return the resolved activation result', () => {
+        expect(result).toBe(expectedResult);
+      });
+    });
+  });
+
+  describe('having node.classMetadata.properties not empty and resolveActivations not provided', () => {
+    let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+    beforeAll(() => {
+      nodeFixture = buildNodeFixture(1);
+    });
+
+    describe('when called, and setInstanceProperties() returns undefined', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest.mocked(setInstanceProperties).mockReturnValueOnce(undefined);
+
+        nodeFixture.constructorParams.push({
+          resolve: (): string => 'value-0',
+        } as Partial<PlanServiceNode> as PlanServiceNode);
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildOneConstructorArgumentResolverOnCsp(nodeFixture);
+
+        result = resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should build an instance with the resolved constructor argument', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual(['value-0']);
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+
+    describe('when called, and setInstanceProperties() returns a promise', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest.mocked(setInstanceProperties).mockResolvedValueOnce(undefined);
+
+        nodeFixture.constructorParams.push({
+          resolve: (): string => 'value-0',
+        } as Partial<PlanServiceNode> as PlanServiceNode);
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildOneConstructorArgumentResolverOnCsp(nodeFixture);
+
+        result = resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should build an instance with the resolved constructor argument', () => {
+        expect(result).toStrictEqual(Promise.resolve(expect.any(Foo)));
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+
+    describe('when called, and the constructor argument resolves asynchronously', () => {
+      let result: unknown;
+
+      beforeAll(async () => {
+        vitest.mocked(setInstanceProperties).mockReturnValueOnce(undefined);
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = [
+          {
+            resolve: async (): Promise<string> => 'value-0',
+          } as Partial<PlanServiceNode> as PlanServiceNode,
+        ];
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildOneConstructorArgumentResolverOnCsp(nodeFixture);
+
+        result = await resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should build an instance with the resolved constructor argument', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual(['value-0']);
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+  });
+
+  describe('having node.classMetadata.properties not empty and resolveActivations provided', () => {
+    let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+    beforeAll(() => {
+      nodeFixture = buildNodeFixture(1);
+    });
+
+    describe('when called, and setInstanceProperties() returns undefined', () => {
+      let expectedResult: unknown;
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest.mocked(setInstanceProperties).mockReturnValueOnce(undefined);
+
+        nodeFixture.constructorParams.push({
+          resolve: (): string => 'value-0',
+        } as Partial<PlanServiceNode> as PlanServiceNode);
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildOneConstructorArgumentResolverOnCsp(
+            nodeFixture,
+            (
+              _params: ResolutionParams,
+              instance: Resolved<Foo>,
+            ): Resolved<Foo> => {
+              expectedResult = instance;
+
+              return instance;
+            },
+          );
+
+        result = resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should return the activation result', () => {
+        expect(result).toBe(expectedResult);
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+
+    describe('when called, and setInstanceProperties() returns a promise', () => {
+      let expectedResult: unknown;
+      let result: unknown;
+
+      beforeAll(async () => {
+        vitest.mocked(setInstanceProperties).mockResolvedValueOnce(undefined);
+
+        nodeFixture.constructorParams.push({
+          resolve: (): string => 'value-0',
+        } as Partial<PlanServiceNode> as PlanServiceNode);
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildOneConstructorArgumentResolverOnCsp(
+            nodeFixture,
+            (
+              _params: ResolutionParams,
+              instance: Resolved<Foo>,
+            ): Resolved<Foo> => {
+              expectedResult = instance;
+
+              return Promise.resolve(instance);
+            },
+          );
+
+        result = await resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should return the resolved activation result', () => {
+        expect(result).toBe(expectedResult);
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/planning/calculations/buildOneConstructorArgumentResolverOnCsp.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildOneConstructorArgumentResolverOnCsp.ts
@@ -1,0 +1,167 @@
+import { isPromise } from '@inversifyjs/common';
+
+import { type InstanceBinding } from '../../binding/models/InstanceBinding.js';
+import { setInstanceProperties } from '../../resolution/actions/setInstanceProperties.js';
+import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
+import {
+  type Resolved,
+  type SyncResolved,
+} from '../../resolution/models/Resolved.js';
+import { type ConstructorNoParamNode } from '../models/ConstructorNoParamNode.js';
+import { type InstanceBindingNode } from '../models/InstanceBindingNode.js';
+import { type PlanServiceNode } from '../models/PlanServiceNode.js';
+
+/**
+ * Same rationale as buildZeroConstructorArgumentsResolverOnCsp, but for
+ * one-argument instance bindings. Equivalent to
+ * `buildOneConstructorArgumentResolver`, but implemented with a plain
+ * closure instead of the `Function` constructor, so it works in
+ * environments enforcing a strict Content Security Policy (no
+ * `unsafe-eval`).
+ *
+ * When the bound class has no properties to inject,
+ * `node.classMetadata.properties` is empty and the returned `resolveNode`
+ * never performs any property related check, matching the zero-property
+ * fast path performance of `buildOneConstructorArgumentResolver`.
+ */
+export function buildOneConstructorArgumentResolverOnCsp<TActivated>(
+  node: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
+  resolveActivations?: (
+    params: ResolutionParams,
+    instance: Resolved<TActivated>,
+  ) => Resolved<TActivated>,
+): (params: ResolutionParams) => Resolved<TActivated> {
+  if (node.classMetadata.properties.size === 0) {
+    if (resolveActivations === undefined) {
+      return function resolveNode(
+        params: ResolutionParams,
+      ): Resolved<TActivated> {
+        const resolvedValue: unknown = (
+          node.constructorParams[0] as PlanServiceNode | ConstructorNoParamNode
+        ).resolve(params);
+
+        if (isPromise(resolvedValue)) {
+          return resolvedValue.then(
+            (resolvedValue: unknown): TActivated =>
+              new node.binding.implementationType(resolvedValue),
+          );
+        }
+
+        return new node.binding.implementationType(resolvedValue);
+      };
+    }
+
+    return function resolveNode(
+      params: ResolutionParams,
+    ): Resolved<TActivated> {
+      const resolvedValue: unknown = (
+        node.constructorParams[0] as PlanServiceNode | ConstructorNoParamNode
+      ).resolve(params);
+
+      if (isPromise(resolvedValue)) {
+        return resolvedValue.then(
+          (resolvedValue: unknown): Resolved<TActivated> =>
+            resolveActivations(
+              params,
+              new node.binding.implementationType(resolvedValue),
+            ),
+        );
+      }
+
+      return resolveActivations(
+        params,
+        new node.binding.implementationType(resolvedValue),
+      );
+    };
+  }
+
+  if (resolveActivations === undefined) {
+    const finalizeInstance: (
+      params: ResolutionParams,
+      instance: SyncResolved<TActivated> & Record<string | symbol, unknown>,
+    ) => Resolved<TActivated> = (
+      params: ResolutionParams,
+      instance: SyncResolved<TActivated> & Record<string | symbol, unknown>,
+    ): Resolved<TActivated> => {
+      const propertiesAssignmentResult: void | Promise<void> =
+        setInstanceProperties(params, instance, node);
+
+      if (isPromise(propertiesAssignmentResult)) {
+        return propertiesAssignmentResult.then((): TActivated => instance);
+      }
+
+      return instance;
+    };
+
+    return function resolveNode(
+      params: ResolutionParams,
+    ): Resolved<TActivated> {
+      const resolvedValue: unknown = (
+        node.constructorParams[0] as PlanServiceNode | ConstructorNoParamNode
+      ).resolve(params);
+
+      if (isPromise(resolvedValue)) {
+        return resolvedValue.then(
+          (resolvedValue: unknown): Resolved<TActivated> =>
+            finalizeInstance(
+              params,
+              new node.binding.implementationType(
+                resolvedValue,
+              ) as SyncResolved<TActivated> & Record<string | symbol, unknown>,
+            ),
+        );
+      }
+
+      return finalizeInstance(
+        params,
+        new node.binding.implementationType(
+          resolvedValue,
+        ) as SyncResolved<TActivated> & Record<string | symbol, unknown>,
+      );
+    };
+  }
+
+  const finalizeInstance: (
+    params: ResolutionParams,
+    instance: SyncResolved<TActivated> & Record<string | symbol, unknown>,
+  ) => Resolved<TActivated> = (
+    params: ResolutionParams,
+    instance: SyncResolved<TActivated> & Record<string | symbol, unknown>,
+  ): Resolved<TActivated> => {
+    const propertiesAssignmentResult: void | Promise<void> =
+      setInstanceProperties(params, instance, node);
+
+    if (isPromise(propertiesAssignmentResult)) {
+      return propertiesAssignmentResult.then((): Resolved<TActivated> =>
+        resolveActivations(params, instance),
+      );
+    }
+
+    return resolveActivations(params, instance);
+  };
+
+  return function resolveNode(params: ResolutionParams): Resolved<TActivated> {
+    const resolvedValue: unknown = (
+      node.constructorParams[0] as PlanServiceNode | ConstructorNoParamNode
+    ).resolve(params);
+
+    if (isPromise(resolvedValue)) {
+      return resolvedValue.then(
+        (resolvedValue: unknown): Resolved<TActivated> =>
+          finalizeInstance(
+            params,
+            new node.binding.implementationType(
+              resolvedValue,
+            ) as SyncResolved<TActivated> & Record<string | symbol, unknown>,
+          ),
+      );
+    }
+
+    return finalizeInstance(
+      params,
+      new node.binding.implementationType(
+        resolvedValue,
+      ) as SyncResolved<TActivated> & Record<string | symbol, unknown>,
+    );
+  };
+}

--- a/packages/container/libraries/core/src/planning/calculations/buildResolvedValueBindingNodeResolver.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildResolvedValueBindingNodeResolver.ts
@@ -1,13 +1,11 @@
-import { isPromise, type ServiceIdentifier } from '@inversifyjs/common';
+import { type ServiceIdentifier } from '@inversifyjs/common';
 
-import { type BindingActivation } from '../../binding/models/BindingActivation.js';
 import { type bindingTypeValues } from '../../binding/models/BindingType.js';
 import { type ResolvedValueBinding } from '../../binding/models/ResolvedValueBinding.js';
-import { resolveBindingActivationsFromIterator } from '../../resolution/actions/resolveBindingActivationsFromIterator.js';
-import { resolveBindingActivationsFromIteratorAsync } from '../../resolution/actions/resolveBindingActivationsFromIteratorAsync.js';
 import { resolveResolvedValueBindingNode } from '../../resolution/actions/resolveResolvedValueBindingNode.js';
 import { resolveScoped } from '../../resolution/actions/resolveScoped.js';
 import { resolveScopedWithNoActivations } from '../../resolution/actions/resolveScopedWithNoActivations.js';
+import { resolveServiceActivations } from '../../resolution/actions/resolveServiceActivations.js';
 import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
 import { type Resolved } from '../../resolution/models/Resolved.js';
 import { type ResolvedValueBindingNode } from '../models/ResolvedValueBindingNode.js';
@@ -45,31 +43,10 @@ function buildSimpleResolvedValueBindingNodeResolver<TActivated>(
   const serviceIdentifier: ServiceIdentifier<TActivated> =
     node.binding.serviceIdentifier;
 
-  function resolveActivations(
+  const resolveActivations: (
     params: ResolutionParams,
     value: Resolved<TActivated>,
-  ): Resolved<TActivated> {
-    const activations: Iterable<BindingActivation<TActivated>> | undefined =
-      params.getActivations(serviceIdentifier);
-
-    if (activations === undefined) {
-      return value;
-    }
-
-    if (isPromise(value)) {
-      return resolveBindingActivationsFromIteratorAsync(
-        params,
-        value,
-        activations[Symbol.iterator](),
-      );
-    }
-
-    return resolveBindingActivationsFromIterator(
-      params,
-      value,
-      activations[Symbol.iterator](),
-    );
-  }
+  ) => Resolved<TActivated> = resolveServiceActivations(serviceIdentifier);
 
   let resolveNode: (params: ResolutionParams) => Resolved<TActivated>;
 

--- a/packages/container/libraries/core/src/planning/calculations/buildThreeConstructorArgumentResolverOnCsp.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildThreeConstructorArgumentResolverOnCsp.spec.ts
@@ -1,0 +1,528 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+vitest.mock(import('../../resolution/actions/setInstanceProperties.js'));
+
+import { type InstanceBinding } from '../../binding/models/InstanceBinding.js';
+import { type Writable } from '../../common/models/Writable.js';
+import { type ClassElementMetadata } from '../../metadata/models/ClassElementMetadata.js';
+import { setInstanceProperties } from '../../resolution/actions/setInstanceProperties.js';
+import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
+import { type Resolved } from '../../resolution/models/Resolved.js';
+import { type InstanceBindingNode } from '../models/InstanceBindingNode.js';
+import { type PlanServiceNode } from '../models/PlanServiceNode.js';
+import { buildThreeConstructorArgumentResolverOnCsp } from './buildThreeConstructorArgumentResolverOnCsp.js';
+
+class Foo {
+  public readonly args: unknown[];
+
+  constructor(...args: unknown[]) {
+    this.args = args;
+  }
+}
+
+const expectedArgs: string[] = ['value-0', 'value-1', 'value-2'];
+
+function buildNodeFixture(
+  propertiesSize: number = 0,
+): InstanceBindingNode<Foo, InstanceBinding<Foo>> {
+  const properties: Map<string | symbol, ClassElementMetadata> = new Map();
+
+  for (let index: number = 0; index < propertiesSize; ++index) {
+    properties.set(
+      `property-${index.toString()}`,
+      Symbol() as unknown as ClassElementMetadata,
+    );
+  }
+
+  return {
+    binding: {
+      implementationType: Foo,
+    } as Partial<InstanceBinding<Foo>> as InstanceBinding<Foo>,
+    classMetadata: {
+      constructorArguments: new Array<ClassElementMetadata>(3).fill(
+        Symbol() as unknown as ClassElementMetadata,
+      ),
+      lifecycle: {
+        postConstructMethodNames: new Set(),
+        preDestroyMethodNames: new Set(),
+      },
+      properties,
+      scope: undefined,
+    },
+    constructorParams: [] as PlanServiceNode[],
+    propertyParams: new Map(),
+  } as Partial<
+    InstanceBindingNode<Foo, InstanceBinding<Foo>>
+  > as InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+}
+
+function buildConstructorParamsFixture(
+  resolve0: () => unknown,
+  resolve1: () => unknown,
+  resolve2: () => unknown,
+): PlanServiceNode[] {
+  return [
+    {
+      resolve: resolve0,
+    } as Partial<PlanServiceNode> as PlanServiceNode,
+    {
+      resolve: resolve1,
+    } as Partial<PlanServiceNode> as PlanServiceNode,
+    {
+      resolve: resolve2,
+    } as Partial<PlanServiceNode> as PlanServiceNode,
+  ];
+}
+
+describe(buildThreeConstructorArgumentResolverOnCsp, () => {
+  let paramsFixture: ResolutionParams;
+
+  beforeAll(() => {
+    paramsFixture = Symbol() as unknown as ResolutionParams;
+  });
+
+  describe('having node.classMetadata.properties empty and resolveActivations not provided', () => {
+    let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+    beforeAll(() => {
+      nodeFixture = buildNodeFixture();
+    });
+
+    describe('when called, and node.constructorParams is populated after the resolveNode is built', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildThreeConstructorArgumentResolverOnCsp(nodeFixture);
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          (): string => 'value-0',
+          (): string => 'value-1',
+          (): string => 'value-2',
+        );
+
+        result = resolveNode(paramsFixture);
+      });
+
+      it('should build an instance with the resolved constructor arguments', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual(expectedArgs);
+      });
+
+      it('should not call setInstanceProperties()', () => {
+        expect(setInstanceProperties).not.toHaveBeenCalled();
+      });
+    });
+
+    describe.each<[string, () => unknown, () => unknown, () => unknown]>([
+      [
+        'all constructor arguments resolve asynchronously',
+        async (): Promise<string> => 'value-0',
+        async (): Promise<string> => 'value-1',
+        async (): Promise<string> => 'value-2',
+      ],
+      [
+        'the first constructor argument resolves asynchronously',
+        async (): Promise<string> => 'value-0',
+        (): string => 'value-1',
+        (): string => 'value-2',
+      ],
+      [
+        'the second constructor argument resolves asynchronously',
+        (): string => 'value-0',
+        async (): Promise<string> => 'value-1',
+        (): string => 'value-2',
+      ],
+      [
+        'the third constructor argument resolves asynchronously',
+        (): string => 'value-0',
+        (): string => 'value-1',
+        async (): Promise<string> => 'value-2',
+      ],
+    ])(
+      'when called, and %s',
+      (
+        _: string,
+        resolve0: () => unknown,
+        resolve1: () => unknown,
+        resolve2: () => unknown,
+      ) => {
+        let result: unknown;
+
+        beforeAll(async () => {
+          const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+            buildThreeConstructorArgumentResolverOnCsp(nodeFixture);
+
+          (
+            nodeFixture as Writable<
+              InstanceBindingNode<Foo, InstanceBinding<Foo>>
+            >
+          ).constructorParams = buildConstructorParamsFixture(
+            resolve0,
+            resolve1,
+            resolve2,
+          );
+
+          result = await resolveNode(paramsFixture);
+        });
+
+        it('should build an instance with the resolved constructor arguments', () => {
+          expect(result).toBeInstanceOf(Foo);
+          expect((result as Foo).args).toStrictEqual(expectedArgs);
+        });
+      },
+    );
+  });
+
+  describe('having node.classMetadata.properties empty and resolveActivations provided', () => {
+    let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+    let resolveActivations: (
+      params: ResolutionParams,
+      instance: Resolved<Foo>,
+    ) => Resolved<Foo>;
+
+    beforeAll(() => {
+      nodeFixture = buildNodeFixture();
+
+      resolveActivations = (
+        _params: ResolutionParams,
+        instance: Resolved<Foo>,
+      ): Resolved<Foo> => instance;
+    });
+
+    describe('when called, and node.constructorParams is populated after the resolveNode is built', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildThreeConstructorArgumentResolverOnCsp(
+            nodeFixture,
+            resolveActivations,
+          );
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          (): string => 'value-0',
+          (): string => 'value-1',
+          (): string => 'value-2',
+        );
+
+        result = resolveNode(paramsFixture);
+      });
+
+      it('should build an instance with the resolved constructor arguments', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual(expectedArgs);
+      });
+    });
+
+    describe('when called, and all constructor arguments resolve asynchronously', () => {
+      let result: unknown;
+
+      beforeAll(async () => {
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildThreeConstructorArgumentResolverOnCsp(
+            nodeFixture,
+            resolveActivations,
+          );
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          async (): Promise<string> => 'value-0',
+          async (): Promise<string> => 'value-1',
+          async (): Promise<string> => 'value-2',
+        );
+
+        result = await resolveNode(paramsFixture);
+      });
+
+      it('should build an instance with the resolved constructor arguments', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual(expectedArgs);
+      });
+    });
+
+    describe('when called, and resolveActivations returns a promise', () => {
+      let expectedResult: unknown;
+      let result: unknown;
+
+      beforeAll(async () => {
+        resolveActivations = (
+          _params: ResolutionParams,
+          instance: Resolved<Foo>,
+        ): Resolved<Foo> => {
+          expectedResult = instance;
+
+          return Promise.resolve(instance);
+        };
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildThreeConstructorArgumentResolverOnCsp(
+            nodeFixture,
+            resolveActivations,
+          );
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          (): string => 'value-0',
+          (): string => 'value-1',
+          (): string => 'value-2',
+        );
+
+        result = await resolveNode(paramsFixture);
+      });
+
+      it('should return the resolved activation result', () => {
+        expect(result).toBe(expectedResult);
+      });
+    });
+  });
+
+  describe('having node.classMetadata.properties not empty and resolveActivations not provided', () => {
+    let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+    beforeAll(() => {
+      nodeFixture = buildNodeFixture(1);
+    });
+
+    describe('when called, and setInstanceProperties() returns undefined', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest.mocked(setInstanceProperties).mockReturnValueOnce(undefined);
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          (): string => 'value-0',
+          (): string => 'value-1',
+          (): string => 'value-2',
+        );
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildThreeConstructorArgumentResolverOnCsp(nodeFixture);
+
+        result = resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should build an instance with the resolved constructor arguments', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual(expectedArgs);
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+
+    describe('when called, and setInstanceProperties() returns a promise', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest.mocked(setInstanceProperties).mockResolvedValueOnce(undefined);
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          (): string => 'value-0',
+          (): string => 'value-1',
+          (): string => 'value-2',
+        );
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildThreeConstructorArgumentResolverOnCsp(nodeFixture);
+
+        result = resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should build an instance with the resolved constructor arguments', () => {
+        expect(result).toStrictEqual(Promise.resolve(expect.any(Foo)));
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+
+    describe('when called, and all constructor arguments resolve asynchronously', () => {
+      let result: unknown;
+
+      beforeAll(async () => {
+        vitest.mocked(setInstanceProperties).mockReturnValueOnce(undefined);
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          async (): Promise<string> => 'value-0',
+          async (): Promise<string> => 'value-1',
+          async (): Promise<string> => 'value-2',
+        );
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildThreeConstructorArgumentResolverOnCsp(nodeFixture);
+
+        result = await resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should build an instance with the resolved constructor arguments', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual(expectedArgs);
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+  });
+
+  describe('having node.classMetadata.properties not empty and resolveActivations provided', () => {
+    let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+    beforeAll(() => {
+      nodeFixture = buildNodeFixture(1);
+    });
+
+    describe('when called, and setInstanceProperties() returns undefined', () => {
+      let expectedResult: unknown;
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest.mocked(setInstanceProperties).mockReturnValueOnce(undefined);
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          (): string => 'value-0',
+          (): string => 'value-1',
+          (): string => 'value-2',
+        );
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildThreeConstructorArgumentResolverOnCsp(
+            nodeFixture,
+            (
+              _params: ResolutionParams,
+              instance: Resolved<Foo>,
+            ): Resolved<Foo> => {
+              expectedResult = instance;
+
+              return instance;
+            },
+          );
+
+        result = resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should return the activation result', () => {
+        expect(result).toBe(expectedResult);
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+
+    describe('when called, and setInstanceProperties() returns a promise', () => {
+      let expectedResult: unknown;
+      let result: unknown;
+
+      beforeAll(async () => {
+        vitest.mocked(setInstanceProperties).mockResolvedValueOnce(undefined);
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          (): string => 'value-0',
+          (): string => 'value-1',
+          (): string => 'value-2',
+        );
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildThreeConstructorArgumentResolverOnCsp(
+            nodeFixture,
+            (
+              _params: ResolutionParams,
+              instance: Resolved<Foo>,
+            ): Resolved<Foo> => {
+              expectedResult = instance;
+
+              return Promise.resolve(instance);
+            },
+          );
+
+        result = await resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should return the resolved activation result', () => {
+        expect(result).toBe(expectedResult);
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/planning/calculations/buildThreeConstructorArgumentResolverOnCsp.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildThreeConstructorArgumentResolverOnCsp.ts
@@ -1,0 +1,204 @@
+import { isPromise } from '@inversifyjs/common';
+
+import { type InstanceBinding } from '../../binding/models/InstanceBinding.js';
+import { setInstanceProperties } from '../../resolution/actions/setInstanceProperties.js';
+import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
+import {
+  type Resolved,
+  type SyncResolved,
+} from '../../resolution/models/Resolved.js';
+import { type ConstructorNoParamNode } from '../models/ConstructorNoParamNode.js';
+import { type InstanceBindingNode } from '../models/InstanceBindingNode.js';
+import { type PlanServiceNode } from '../models/PlanServiceNode.js';
+import { resolveThree } from './resolveThree.js';
+
+/**
+ * Same rationale as buildZeroConstructorArgumentsResolverOnCsp, but for
+ * three-argument instance bindings. Equivalent to
+ * `buildConstructorArgumentsResolver` with `resolveThree`, but implemented
+ * with a plain closure instead of the `Function` constructor, so it works in
+ * environments enforcing a strict Content Security Policy (no
+ * `unsafe-eval`).
+ *
+ * When the bound class has no properties to inject,
+ * `node.classMetadata.properties` is empty and the returned `resolveNode`
+ * never performs any property related check, matching the zero-property
+ * fast path performance of `buildConstructorArgumentsResolver` with
+ * `resolveThree`.
+ */
+export function buildThreeConstructorArgumentResolverOnCsp<TActivated>(
+  node: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
+  resolveActivations?: (
+    params: ResolutionParams,
+    instance: Resolved<TActivated>,
+  ) => Resolved<TActivated>,
+): (params: ResolutionParams) => Resolved<TActivated> {
+  if (node.classMetadata.properties.size === 0) {
+    if (resolveActivations === undefined) {
+      return function resolveNode(
+        params: ResolutionParams,
+      ): Resolved<TActivated> {
+        const resolvedValue0: unknown = (
+          node.constructorParams[0] as PlanServiceNode | ConstructorNoParamNode
+        ).resolve(params);
+        const resolvedValue1: unknown = (
+          node.constructorParams[1] as PlanServiceNode | ConstructorNoParamNode
+        ).resolve(params);
+        const resolvedValue2: unknown = (
+          node.constructorParams[2] as PlanServiceNode | ConstructorNoParamNode
+        ).resolve(params);
+
+        return resolveThree(
+          resolvedValue0,
+          resolvedValue1,
+          resolvedValue2,
+          (
+            resolvedValue0: unknown,
+            resolvedValue1: unknown,
+            resolvedValue2: unknown,
+          ): TActivated =>
+            new node.binding.implementationType(
+              resolvedValue0,
+              resolvedValue1,
+              resolvedValue2,
+            ),
+        );
+      };
+    }
+
+    return function resolveNode(
+      params: ResolutionParams,
+    ): Resolved<TActivated> {
+      const resolvedValue0: unknown = (
+        node.constructorParams[0] as PlanServiceNode | ConstructorNoParamNode
+      ).resolve(params);
+      const resolvedValue1: unknown = (
+        node.constructorParams[1] as PlanServiceNode | ConstructorNoParamNode
+      ).resolve(params);
+      const resolvedValue2: unknown = (
+        node.constructorParams[2] as PlanServiceNode | ConstructorNoParamNode
+      ).resolve(params);
+
+      return resolveThree(
+        resolvedValue0,
+        resolvedValue1,
+        resolvedValue2,
+        (
+          resolvedValue0: unknown,
+          resolvedValue1: unknown,
+          resolvedValue2: unknown,
+        ): Resolved<TActivated> =>
+          resolveActivations(
+            params,
+            new node.binding.implementationType(
+              resolvedValue0,
+              resolvedValue1,
+              resolvedValue2,
+            ),
+          ),
+      );
+    };
+  }
+
+  if (resolveActivations === undefined) {
+    const finalizeInstance: (
+      params: ResolutionParams,
+      instance: SyncResolved<TActivated> & Record<string | symbol, unknown>,
+    ) => Resolved<TActivated> = (
+      params: ResolutionParams,
+      instance: SyncResolved<TActivated> & Record<string | symbol, unknown>,
+    ): Resolved<TActivated> => {
+      const propertiesAssignmentResult: void | Promise<void> =
+        setInstanceProperties(params, instance, node);
+
+      if (isPromise(propertiesAssignmentResult)) {
+        return propertiesAssignmentResult.then((): TActivated => instance);
+      }
+
+      return instance;
+    };
+
+    return function resolveNode(
+      params: ResolutionParams,
+    ): Resolved<TActivated> {
+      const resolvedValue0: unknown = (
+        node.constructorParams[0] as PlanServiceNode | ConstructorNoParamNode
+      ).resolve(params);
+      const resolvedValue1: unknown = (
+        node.constructorParams[1] as PlanServiceNode | ConstructorNoParamNode
+      ).resolve(params);
+      const resolvedValue2: unknown = (
+        node.constructorParams[2] as PlanServiceNode | ConstructorNoParamNode
+      ).resolve(params);
+
+      return resolveThree(
+        resolvedValue0,
+        resolvedValue1,
+        resolvedValue2,
+        (
+          resolvedValue0: unknown,
+          resolvedValue1: unknown,
+          resolvedValue2: unknown,
+        ): Resolved<TActivated> =>
+          finalizeInstance(
+            params,
+            new node.binding.implementationType(
+              resolvedValue0,
+              resolvedValue1,
+              resolvedValue2,
+            ) as SyncResolved<TActivated> & Record<string | symbol, unknown>,
+          ),
+      );
+    };
+  }
+
+  const finalizeInstance: (
+    params: ResolutionParams,
+    instance: SyncResolved<TActivated> & Record<string | symbol, unknown>,
+  ) => Resolved<TActivated> = (
+    params: ResolutionParams,
+    instance: SyncResolved<TActivated> & Record<string | symbol, unknown>,
+  ): Resolved<TActivated> => {
+    const propertiesAssignmentResult: void | Promise<void> =
+      setInstanceProperties(params, instance, node);
+
+    if (isPromise(propertiesAssignmentResult)) {
+      return propertiesAssignmentResult.then((): Resolved<TActivated> =>
+        resolveActivations(params, instance),
+      );
+    }
+
+    return resolveActivations(params, instance);
+  };
+
+  return function resolveNode(params: ResolutionParams): Resolved<TActivated> {
+    const resolvedValue0: unknown = (
+      node.constructorParams[0] as PlanServiceNode | ConstructorNoParamNode
+    ).resolve(params);
+    const resolvedValue1: unknown = (
+      node.constructorParams[1] as PlanServiceNode | ConstructorNoParamNode
+    ).resolve(params);
+    const resolvedValue2: unknown = (
+      node.constructorParams[2] as PlanServiceNode | ConstructorNoParamNode
+    ).resolve(params);
+
+    return resolveThree(
+      resolvedValue0,
+      resolvedValue1,
+      resolvedValue2,
+      (
+        resolvedValue0: unknown,
+        resolvedValue1: unknown,
+        resolvedValue2: unknown,
+      ): Resolved<TActivated> =>
+        finalizeInstance(
+          params,
+          new node.binding.implementationType(
+            resolvedValue0,
+            resolvedValue1,
+            resolvedValue2,
+          ) as SyncResolved<TActivated> & Record<string | symbol, unknown>,
+        ),
+    );
+  };
+}

--- a/packages/container/libraries/core/src/planning/calculations/buildTwoConstructorArgumentResolverOnCsp.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildTwoConstructorArgumentResolverOnCsp.spec.ts
@@ -1,0 +1,498 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+vitest.mock(import('../../resolution/actions/setInstanceProperties.js'));
+
+import { type InstanceBinding } from '../../binding/models/InstanceBinding.js';
+import { type Writable } from '../../common/models/Writable.js';
+import { type ClassElementMetadata } from '../../metadata/models/ClassElementMetadata.js';
+import { setInstanceProperties } from '../../resolution/actions/setInstanceProperties.js';
+import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
+import { type Resolved } from '../../resolution/models/Resolved.js';
+import { type InstanceBindingNode } from '../models/InstanceBindingNode.js';
+import { type PlanServiceNode } from '../models/PlanServiceNode.js';
+import { buildTwoConstructorArgumentResolverOnCsp } from './buildTwoConstructorArgumentResolverOnCsp.js';
+
+class Foo {
+  public readonly args: unknown[];
+
+  constructor(...args: unknown[]) {
+    this.args = args;
+  }
+}
+
+function buildNodeFixture(
+  propertiesSize: number = 0,
+): InstanceBindingNode<Foo, InstanceBinding<Foo>> {
+  const properties: Map<string | symbol, ClassElementMetadata> = new Map();
+
+  for (let index: number = 0; index < propertiesSize; ++index) {
+    properties.set(
+      `property-${index.toString()}`,
+      Symbol() as unknown as ClassElementMetadata,
+    );
+  }
+
+  return {
+    binding: {
+      implementationType: Foo,
+    } as Partial<InstanceBinding<Foo>> as InstanceBinding<Foo>,
+    classMetadata: {
+      constructorArguments: new Array<ClassElementMetadata>(2).fill(
+        Symbol() as unknown as ClassElementMetadata,
+      ),
+      lifecycle: {
+        postConstructMethodNames: new Set(),
+        preDestroyMethodNames: new Set(),
+      },
+      properties,
+      scope: undefined,
+    },
+    constructorParams: [] as PlanServiceNode[],
+    propertyParams: new Map(),
+  } as Partial<
+    InstanceBindingNode<Foo, InstanceBinding<Foo>>
+  > as InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+}
+
+function buildConstructorParamsFixture(
+  resolve0: () => unknown,
+  resolve1: () => unknown,
+): PlanServiceNode[] {
+  return [
+    {
+      resolve: resolve0,
+    } as Partial<PlanServiceNode> as PlanServiceNode,
+    {
+      resolve: resolve1,
+    } as Partial<PlanServiceNode> as PlanServiceNode,
+  ];
+}
+
+describe(buildTwoConstructorArgumentResolverOnCsp, () => {
+  let paramsFixture: ResolutionParams;
+
+  beforeAll(() => {
+    paramsFixture = Symbol() as unknown as ResolutionParams;
+  });
+
+  describe('having node.classMetadata.properties empty and resolveActivations not provided', () => {
+    let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+    beforeAll(() => {
+      nodeFixture = buildNodeFixture();
+    });
+
+    describe('when called, and node.constructorParams is populated after the resolveNode is built', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildTwoConstructorArgumentResolverOnCsp(nodeFixture);
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          (): string => 'value-0',
+          (): string => 'value-1',
+        );
+
+        result = resolveNode(paramsFixture);
+      });
+
+      it('should build an instance with the resolved constructor arguments', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual(['value-0', 'value-1']);
+      });
+
+      it('should not call setInstanceProperties()', () => {
+        expect(setInstanceProperties).not.toHaveBeenCalled();
+      });
+    });
+
+    describe.each<[string, () => unknown, () => unknown]>([
+      [
+        'both constructor arguments resolve asynchronously',
+        async (): Promise<string> => 'value-0',
+        async (): Promise<string> => 'value-1',
+      ],
+      [
+        'the first constructor argument resolves asynchronously',
+        async (): Promise<string> => 'value-0',
+        (): string => 'value-1',
+      ],
+      [
+        'the second constructor argument resolves asynchronously',
+        (): string => 'value-0',
+        async (): Promise<string> => 'value-1',
+      ],
+    ])(
+      'when called, and %s',
+      (_: string, resolve0: () => unknown, resolve1: () => unknown) => {
+        let result: unknown;
+
+        beforeAll(async () => {
+          const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+            buildTwoConstructorArgumentResolverOnCsp(nodeFixture);
+
+          (
+            nodeFixture as Writable<
+              InstanceBindingNode<Foo, InstanceBinding<Foo>>
+            >
+          ).constructorParams = buildConstructorParamsFixture(
+            resolve0,
+            resolve1,
+          );
+
+          result = await resolveNode(paramsFixture);
+        });
+
+        it('should build an instance with the resolved constructor arguments', () => {
+          expect(result).toBeInstanceOf(Foo);
+          expect((result as Foo).args).toStrictEqual(['value-0', 'value-1']);
+        });
+      },
+    );
+  });
+
+  describe('having node.classMetadata.properties empty and resolveActivations provided', () => {
+    let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+    let resolveActivations: (
+      params: ResolutionParams,
+      instance: Resolved<Foo>,
+    ) => Resolved<Foo>;
+
+    beforeAll(() => {
+      nodeFixture = buildNodeFixture();
+
+      resolveActivations = (
+        _params: ResolutionParams,
+        instance: Resolved<Foo>,
+      ): Resolved<Foo> => instance;
+    });
+
+    describe('when called, and node.constructorParams is populated after the resolveNode is built', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildTwoConstructorArgumentResolverOnCsp(
+            nodeFixture,
+            resolveActivations,
+          );
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          (): string => 'value-0',
+          (): string => 'value-1',
+        );
+
+        result = resolveNode(paramsFixture);
+      });
+
+      it('should build an instance with the resolved constructor arguments', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual(['value-0', 'value-1']);
+      });
+    });
+
+    describe('when called, and both constructor arguments resolve asynchronously', () => {
+      let result: unknown;
+
+      beforeAll(async () => {
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildTwoConstructorArgumentResolverOnCsp(
+            nodeFixture,
+            resolveActivations,
+          );
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          async (): Promise<string> => 'value-0',
+          async (): Promise<string> => 'value-1',
+        );
+
+        result = await resolveNode(paramsFixture);
+      });
+
+      it('should build an instance with the resolved constructor arguments', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual(['value-0', 'value-1']);
+      });
+    });
+
+    describe('when called, and resolveActivations returns a promise', () => {
+      let expectedResult: unknown;
+      let result: unknown;
+
+      beforeAll(async () => {
+        resolveActivations = (
+          _params: ResolutionParams,
+          instance: Resolved<Foo>,
+        ): Resolved<Foo> => {
+          expectedResult = instance;
+
+          return Promise.resolve(instance);
+        };
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildTwoConstructorArgumentResolverOnCsp(
+            nodeFixture,
+            resolveActivations,
+          );
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          (): string => 'value-0',
+          (): string => 'value-1',
+        );
+
+        result = await resolveNode(paramsFixture);
+      });
+
+      it('should return the resolved activation result', () => {
+        expect(result).toBe(expectedResult);
+      });
+    });
+  });
+
+  describe('having node.classMetadata.properties not empty and resolveActivations not provided', () => {
+    let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+    beforeAll(() => {
+      nodeFixture = buildNodeFixture(1);
+    });
+
+    describe('when called, and setInstanceProperties() returns undefined', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest.mocked(setInstanceProperties).mockReturnValueOnce(undefined);
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          (): string => 'value-0',
+          (): string => 'value-1',
+        );
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildTwoConstructorArgumentResolverOnCsp(nodeFixture);
+
+        result = resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should build an instance with the resolved constructor arguments', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual(['value-0', 'value-1']);
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+
+    describe('when called, and setInstanceProperties() returns a promise', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest.mocked(setInstanceProperties).mockResolvedValueOnce(undefined);
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          (): string => 'value-0',
+          (): string => 'value-1',
+        );
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildTwoConstructorArgumentResolverOnCsp(nodeFixture);
+
+        result = resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should build an instance with the resolved constructor arguments', () => {
+        expect(result).toStrictEqual(Promise.resolve(expect.any(Foo)));
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+
+    describe('when called, and both constructor arguments resolve asynchronously', () => {
+      let result: unknown;
+
+      beforeAll(async () => {
+        vitest.mocked(setInstanceProperties).mockReturnValueOnce(undefined);
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          async (): Promise<string> => 'value-0',
+          async (): Promise<string> => 'value-1',
+        );
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildTwoConstructorArgumentResolverOnCsp(nodeFixture);
+
+        result = await resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should build an instance with the resolved constructor arguments', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual(['value-0', 'value-1']);
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+  });
+
+  describe('having node.classMetadata.properties not empty and resolveActivations provided', () => {
+    let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+    beforeAll(() => {
+      nodeFixture = buildNodeFixture(1);
+    });
+
+    describe('when called, and setInstanceProperties() returns undefined', () => {
+      let expectedResult: unknown;
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest.mocked(setInstanceProperties).mockReturnValueOnce(undefined);
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          (): string => 'value-0',
+          (): string => 'value-1',
+        );
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildTwoConstructorArgumentResolverOnCsp(
+            nodeFixture,
+            (
+              _params: ResolutionParams,
+              instance: Resolved<Foo>,
+            ): Resolved<Foo> => {
+              expectedResult = instance;
+
+              return instance;
+            },
+          );
+
+        result = resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should return the activation result', () => {
+        expect(result).toBe(expectedResult);
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+
+    describe('when called, and setInstanceProperties() returns a promise', () => {
+      let expectedResult: unknown;
+      let result: unknown;
+
+      beforeAll(async () => {
+        vitest.mocked(setInstanceProperties).mockResolvedValueOnce(undefined);
+
+        (
+          nodeFixture as Writable<
+            InstanceBindingNode<Foo, InstanceBinding<Foo>>
+          >
+        ).constructorParams = buildConstructorParamsFixture(
+          (): string => 'value-0',
+          (): string => 'value-1',
+        );
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildTwoConstructorArgumentResolverOnCsp(
+            nodeFixture,
+            (
+              _params: ResolutionParams,
+              instance: Resolved<Foo>,
+            ): Resolved<Foo> => {
+              expectedResult = instance;
+
+              return Promise.resolve(instance);
+            },
+          );
+
+        result = await resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should return the resolved activation result', () => {
+        expect(result).toBe(expectedResult);
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/planning/calculations/buildTwoConstructorArgumentResolverOnCsp.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildTwoConstructorArgumentResolverOnCsp.ts
@@ -1,0 +1,171 @@
+import { isPromise } from '@inversifyjs/common';
+
+import { type InstanceBinding } from '../../binding/models/InstanceBinding.js';
+import { setInstanceProperties } from '../../resolution/actions/setInstanceProperties.js';
+import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
+import {
+  type Resolved,
+  type SyncResolved,
+} from '../../resolution/models/Resolved.js';
+import { type ConstructorNoParamNode } from '../models/ConstructorNoParamNode.js';
+import { type InstanceBindingNode } from '../models/InstanceBindingNode.js';
+import { type PlanServiceNode } from '../models/PlanServiceNode.js';
+import { resolveTwo } from './resolveTwo.js';
+
+/**
+ * Same rationale as buildZeroConstructorArgumentsResolverOnCsp, but for
+ * two-argument instance bindings. Equivalent to
+ * `buildConstructorArgumentsResolver` with `resolveTwo`, but implemented with a
+ * plain closure instead of the `Function` constructor, so it works in
+ * environments enforcing a strict Content Security Policy (no
+ * `unsafe-eval`).
+ *
+ * When the bound class has no properties to inject,
+ * `node.classMetadata.properties` is empty and the returned `resolveNode`
+ * never performs any property related check, matching the zero-property
+ * fast path performance of `buildConstructorArgumentsResolver` with
+ * `resolveTwo`.
+ */
+export function buildTwoConstructorArgumentResolverOnCsp<TActivated>(
+  node: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
+  resolveActivations?: (
+    params: ResolutionParams,
+    instance: Resolved<TActivated>,
+  ) => Resolved<TActivated>,
+): (params: ResolutionParams) => Resolved<TActivated> {
+  if (node.classMetadata.properties.size === 0) {
+    if (resolveActivations === undefined) {
+      return function resolveNode(
+        params: ResolutionParams,
+      ): Resolved<TActivated> {
+        const resolvedValue0: unknown = (
+          node.constructorParams[0] as PlanServiceNode | ConstructorNoParamNode
+        ).resolve(params);
+        const resolvedValue1: unknown = (
+          node.constructorParams[1] as PlanServiceNode | ConstructorNoParamNode
+        ).resolve(params);
+
+        return resolveTwo(
+          resolvedValue0,
+          resolvedValue1,
+          (resolvedValue0: unknown, resolvedValue1: unknown): TActivated =>
+            new node.binding.implementationType(resolvedValue0, resolvedValue1),
+        );
+      };
+    }
+
+    return function resolveNode(
+      params: ResolutionParams,
+    ): Resolved<TActivated> {
+      const resolvedValue0: unknown = (
+        node.constructorParams[0] as PlanServiceNode | ConstructorNoParamNode
+      ).resolve(params);
+      const resolvedValue1: unknown = (
+        node.constructorParams[1] as PlanServiceNode | ConstructorNoParamNode
+      ).resolve(params);
+
+      return resolveTwo(
+        resolvedValue0,
+        resolvedValue1,
+        (
+          resolvedValue0: unknown,
+          resolvedValue1: unknown,
+        ): Resolved<TActivated> =>
+          resolveActivations(
+            params,
+            new node.binding.implementationType(resolvedValue0, resolvedValue1),
+          ),
+      );
+    };
+  }
+
+  if (resolveActivations === undefined) {
+    const finalizeInstance: (
+      params: ResolutionParams,
+      instance: SyncResolved<TActivated> & Record<string | symbol, unknown>,
+    ) => Resolved<TActivated> = (
+      params: ResolutionParams,
+      instance: SyncResolved<TActivated> & Record<string | symbol, unknown>,
+    ): Resolved<TActivated> => {
+      const propertiesAssignmentResult: void | Promise<void> =
+        setInstanceProperties(params, instance, node);
+
+      if (isPromise(propertiesAssignmentResult)) {
+        return propertiesAssignmentResult.then((): TActivated => instance);
+      }
+
+      return instance;
+    };
+
+    return function resolveNode(
+      params: ResolutionParams,
+    ): Resolved<TActivated> {
+      const resolvedValue0: unknown = (
+        node.constructorParams[0] as PlanServiceNode | ConstructorNoParamNode
+      ).resolve(params);
+      const resolvedValue1: unknown = (
+        node.constructorParams[1] as PlanServiceNode | ConstructorNoParamNode
+      ).resolve(params);
+
+      return resolveTwo(
+        resolvedValue0,
+        resolvedValue1,
+        (
+          resolvedValue0: unknown,
+          resolvedValue1: unknown,
+        ): Resolved<TActivated> =>
+          finalizeInstance(
+            params,
+            new node.binding.implementationType(
+              resolvedValue0,
+              resolvedValue1,
+            ) as SyncResolved<TActivated> & Record<string | symbol, unknown>,
+          ),
+      );
+    };
+  }
+
+  const finalizeInstance: (
+    params: ResolutionParams,
+    instance: SyncResolved<TActivated> & Record<string | symbol, unknown>,
+  ) => Resolved<TActivated> = (
+    params: ResolutionParams,
+    instance: SyncResolved<TActivated> & Record<string | symbol, unknown>,
+  ): Resolved<TActivated> => {
+    const propertiesAssignmentResult: void | Promise<void> =
+      setInstanceProperties(params, instance, node);
+
+    if (isPromise(propertiesAssignmentResult)) {
+      return propertiesAssignmentResult.then((): Resolved<TActivated> =>
+        resolveActivations(params, instance),
+      );
+    }
+
+    return resolveActivations(params, instance);
+  };
+
+  return function resolveNode(params: ResolutionParams): Resolved<TActivated> {
+    const resolvedValue0: unknown = (
+      node.constructorParams[0] as PlanServiceNode | ConstructorNoParamNode
+    ).resolve(params);
+    const resolvedValue1: unknown = (
+      node.constructorParams[1] as PlanServiceNode | ConstructorNoParamNode
+    ).resolve(params);
+
+    return resolveTwo(
+      resolvedValue0,
+      resolvedValue1,
+      (
+        resolvedValue0: unknown,
+        resolvedValue1: unknown,
+      ): Resolved<TActivated> =>
+        finalizeInstance(
+          params,
+          new node.binding.implementationType(
+            resolvedValue0,
+            resolvedValue1,
+          ) as SyncResolved<TActivated> & Record<string | symbol, unknown>,
+        ),
+    );
+  };
+}

--- a/packages/container/libraries/core/src/planning/calculations/buildZeroConstructorArgumentsResolverOnCsp.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildZeroConstructorArgumentsResolverOnCsp.spec.ts
@@ -1,0 +1,297 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+vitest.mock(import('../../resolution/actions/setInstanceProperties.js'));
+
+import { type InstanceBinding } from '../../binding/models/InstanceBinding.js';
+import { setInstanceProperties } from '../../resolution/actions/setInstanceProperties.js';
+import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
+import { type Resolved } from '../../resolution/models/Resolved.js';
+import { type InstanceBindingNode } from '../models/InstanceBindingNode.js';
+import { buildZeroConstructorArgumentsResolverOnCsp } from './buildZeroConstructorArgumentsResolverOnCsp.js';
+
+class Foo {
+  public readonly args: unknown[];
+
+  constructor(...args: unknown[]) {
+    this.args = args;
+  }
+}
+
+function buildNodeFixture(
+  propertiesSize: number = 0,
+): InstanceBindingNode<Foo, InstanceBinding<Foo>> {
+  const properties: Map<string | symbol, unknown> = new Map<
+    string | symbol,
+    unknown
+  >();
+
+  for (let index: number = 0; index < propertiesSize; ++index) {
+    properties.set(`property-${index.toString()}`, Symbol());
+  }
+
+  return {
+    binding: {
+      implementationType: Foo,
+    } as Partial<InstanceBinding<Foo>> as InstanceBinding<Foo>,
+    classMetadata: {
+      constructorArguments: [],
+      lifecycle: {
+        postConstructMethodNames: new Set(),
+        preDestroyMethodNames: new Set(),
+      },
+      properties,
+      scope: undefined,
+    },
+    constructorParams: [],
+    propertyParams: new Map(),
+  } as Partial<
+    InstanceBindingNode<Foo, InstanceBinding<Foo>>
+  > as InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+}
+
+describe(buildZeroConstructorArgumentsResolverOnCsp, () => {
+  let paramsFixture: ResolutionParams;
+
+  beforeAll(() => {
+    paramsFixture = Symbol() as unknown as ResolutionParams;
+  });
+
+  describe('having node.classMetadata.properties empty and resolveActivations not provided', () => {
+    let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+    beforeAll(() => {
+      nodeFixture = buildNodeFixture();
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildZeroConstructorArgumentsResolverOnCsp(nodeFixture);
+
+        result = resolveNode(paramsFixture);
+      });
+
+      it('should build an instance with no constructor arguments', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual([]);
+      });
+
+      it('should not call setInstanceProperties()', () => {
+        expect(setInstanceProperties).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('having node.classMetadata.properties empty and resolveActivations provided', () => {
+    let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+    beforeAll(() => {
+      nodeFixture = buildNodeFixture();
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildZeroConstructorArgumentsResolverOnCsp(
+            nodeFixture,
+            (
+              _params: ResolutionParams,
+              instance: Resolved<Foo>,
+            ): Resolved<Foo> => instance,
+          );
+
+        result = resolveNode(paramsFixture);
+      });
+
+      it('should build an instance with no constructor arguments', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual([]);
+      });
+    });
+
+    describe('when called, and resolveActivations returns a promise', () => {
+      let expectedResult: unknown;
+      let result: unknown;
+
+      beforeAll(async () => {
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildZeroConstructorArgumentsResolverOnCsp(
+            nodeFixture,
+            (
+              _params: ResolutionParams,
+              instance: Resolved<Foo>,
+            ): Resolved<Foo> => {
+              expectedResult = instance;
+
+              return Promise.resolve(instance);
+            },
+          );
+
+        result = await resolveNode(paramsFixture);
+      });
+
+      it('should return the resolved activation result', () => {
+        expect(result).toBe(expectedResult);
+      });
+    });
+  });
+
+  describe('having node.classMetadata.properties not empty and resolveActivations not provided', () => {
+    let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+    beforeAll(() => {
+      nodeFixture = buildNodeFixture(1);
+    });
+
+    describe('when called, and setInstanceProperties() returns undefined', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest.mocked(setInstanceProperties).mockReturnValueOnce(undefined);
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildZeroConstructorArgumentsResolverOnCsp(nodeFixture);
+
+        result = resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should build an instance with no constructor arguments', () => {
+        expect(result).toBeInstanceOf(Foo);
+        expect((result as Foo).args).toStrictEqual([]);
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+
+    describe('when called, and setInstanceProperties() returns a promise', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest.mocked(setInstanceProperties).mockResolvedValueOnce(undefined);
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildZeroConstructorArgumentsResolverOnCsp(nodeFixture);
+
+        result = resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should build an instance with no constructor arguments', () => {
+        expect(result).toStrictEqual(Promise.resolve(expect.any(Foo)));
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+  });
+
+  describe('having node.classMetadata.properties not empty and resolveActivations provided', () => {
+    let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+    beforeAll(() => {
+      nodeFixture = buildNodeFixture(1);
+    });
+
+    describe('when called, and setInstanceProperties() returns undefined', () => {
+      let expectedResult: unknown;
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest.mocked(setInstanceProperties).mockReturnValueOnce(undefined);
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildZeroConstructorArgumentsResolverOnCsp(
+            nodeFixture,
+            (
+              _params: ResolutionParams,
+              instance: Resolved<Foo>,
+            ): Resolved<Foo> => {
+              expectedResult = instance;
+
+              return instance;
+            },
+          );
+
+        result = resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should return the activation result', () => {
+        expect(result).toBe(expectedResult);
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+
+    describe('when called, and setInstanceProperties() returns a promise', () => {
+      let expectedResult: unknown;
+      let result: unknown;
+
+      beforeAll(async () => {
+        vitest.mocked(setInstanceProperties).mockResolvedValueOnce(undefined);
+
+        const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+          buildZeroConstructorArgumentsResolverOnCsp(
+            nodeFixture,
+            (
+              _params: ResolutionParams,
+              instance: Resolved<Foo>,
+            ): Resolved<Foo> => {
+              expectedResult = instance;
+
+              return Promise.resolve(instance);
+            },
+          );
+
+        result = await resolveNode(paramsFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should return the resolved activation result', () => {
+        expect(result).toBe(expectedResult);
+      });
+
+      it('should call setInstanceProperties()', () => {
+        expect(setInstanceProperties).toHaveBeenCalledExactlyOnceWith(
+          paramsFixture,
+          expect.any(Foo),
+          nodeFixture,
+        );
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/planning/calculations/buildZeroConstructorArgumentsResolverOnCsp.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildZeroConstructorArgumentsResolverOnCsp.ts
@@ -1,0 +1,91 @@
+import { isPromise } from '@inversifyjs/common';
+
+import { type InstanceBinding } from '../../binding/models/InstanceBinding.js';
+import { setInstanceProperties } from '../../resolution/actions/setInstanceProperties.js';
+import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
+import {
+  type Resolved,
+  type SyncResolved,
+} from '../../resolution/models/Resolved.js';
+import { type InstanceBindingNode } from '../models/InstanceBindingNode.js';
+
+/**
+ * Builds a `resolveNode` for a zero-argument instance binding without
+ * relying on the `Function` constructor.
+ *
+ * `buildZeroConstructorArgumentsResolver` generates a brand new function
+ * from source text for every binding to keep the `new ctor()` call site
+ * monomorphic in V8's eyes. That approach requires `unsafe-eval` (or an
+ * equivalent CSP trusted types allowance), so it cannot be used in
+ * environments enforcing a strict Content Security Policy.
+ *
+ * This function provides the same behavior using a plain closure instead,
+ * so it works under CSP restrictions at the cost of the per-binding
+ * monomorphic optimization described above.
+ *
+ * When the bound class has no properties to inject,
+ * `node.classMetadata.properties` is empty and the returned `resolveNode`
+ * never performs any property related check, matching the zero-property
+ * fast path performance of `buildZeroConstructorArgumentsResolver`.
+ */
+export function buildZeroConstructorArgumentsResolverOnCsp<TActivated>(
+  node: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
+  resolveActivations?: (
+    params: ResolutionParams,
+    instance: Resolved<TActivated>,
+  ) => Resolved<TActivated>,
+): (params: ResolutionParams) => Resolved<TActivated> {
+  if (node.classMetadata.properties.size === 0) {
+    if (resolveActivations === undefined) {
+      return function resolveNode(
+        _params: ResolutionParams,
+      ): Resolved<TActivated> {
+        return new node.binding.implementationType();
+      };
+    }
+
+    return function resolveNode(
+      params: ResolutionParams,
+    ): Resolved<TActivated> {
+      return resolveActivations(params, new node.binding.implementationType());
+    };
+  }
+
+  if (resolveActivations === undefined) {
+    return function resolveNode(
+      params: ResolutionParams,
+    ): Resolved<TActivated> {
+      const instance: SyncResolved<TActivated> &
+        Record<string | symbol, unknown> =
+        new node.binding.implementationType() as SyncResolved<TActivated> &
+          Record<string | symbol, unknown>;
+
+      const propertiesAssignmentResult: void | Promise<void> =
+        setInstanceProperties(params, instance, node);
+
+      if (isPromise(propertiesAssignmentResult)) {
+        return propertiesAssignmentResult.then((): TActivated => instance);
+      }
+
+      return instance;
+    };
+  }
+
+  return function resolveNode(params: ResolutionParams): Resolved<TActivated> {
+    const instance: SyncResolved<TActivated> &
+      Record<string | symbol, unknown> =
+      new node.binding.implementationType() as SyncResolved<TActivated> &
+        Record<string | symbol, unknown>;
+
+    const propertiesAssignmentResult: void | Promise<void> =
+      setInstanceProperties(params, instance, node);
+
+    if (isPromise(propertiesAssignmentResult)) {
+      return propertiesAssignmentResult.then((): Resolved<TActivated> =>
+        resolveActivations(params, instance),
+      );
+    }
+
+    return resolveActivations(params, instance);
+  };
+}

--- a/packages/container/libraries/core/src/planning/calculations/resolveMany.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/resolveMany.spec.ts
@@ -1,0 +1,82 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { resolveMany } from './resolveMany.js';
+
+describe(resolveMany, () => {
+  describe('having five values', () => {
+    describe('when called, and all values are sync', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = resolveMany(
+          1,
+          2,
+          3,
+          4,
+          5,
+          (
+            value1: number,
+            value2: number,
+            value3: number,
+            value4: number,
+            value5: number,
+          ) => [value1, value2, value3, value4, value5],
+        );
+      });
+
+      it('should build with the resolved values', () => {
+        expect(result).toStrictEqual([1, 2, 3, 4, 5]);
+      });
+    });
+
+    describe('when called, and some values are promises', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = resolveMany(
+          1,
+          Promise.resolve(2),
+          3,
+          Promise.resolve(4),
+          5,
+          (
+            value1: number,
+            value2: number,
+            value3: number,
+            value4: number,
+            value5: number,
+          ) => [value1, value2, value3, value4, value5],
+        );
+      });
+
+      it('should build with the resolved values', () => {
+        expect(result).toStrictEqual(Promise.resolve([1, 2, 3, 4, 5]));
+      });
+    });
+
+    describe('when called, and all values are promises', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = resolveMany(
+          Promise.resolve(1),
+          Promise.resolve(2),
+          Promise.resolve(3),
+          Promise.resolve(4),
+          Promise.resolve(5),
+          (
+            value1: number,
+            value2: number,
+            value3: number,
+            value4: number,
+            value5: number,
+          ) => [value1, value2, value3, value4, value5],
+        );
+      });
+
+      it('should build with the resolved values', () => {
+        expect(result).toStrictEqual(Promise.resolve([1, 2, 3, 4, 5]));
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/planning/calculations/resolveMany.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/resolveMany.spec.ts
@@ -49,8 +49,8 @@ describe(resolveMany, () => {
         );
       });
 
-      it('should build with the resolved values', () => {
-        expect(result).toStrictEqual(Promise.resolve([1, 2, 3, 4, 5]));
+      it('should build with the resolved values', async () => {
+        await expect(result).resolves.toStrictEqual([1, 2, 3, 4, 5]);
       });
     });
 
@@ -74,8 +74,8 @@ describe(resolveMany, () => {
         );
       });
 
-      it('should build with the resolved values', () => {
-        expect(result).toStrictEqual(Promise.resolve([1, 2, 3, 4, 5]));
+      it('should build with the resolved values', async () => {
+        await expect(result).resolves.toStrictEqual([1, 2, 3, 4, 5]);
       });
     });
   });

--- a/packages/container/libraries/core/src/planning/calculations/resolveMany.ts
+++ b/packages/container/libraries/core/src/planning/calculations/resolveMany.ts
@@ -1,0 +1,30 @@
+import { isPromise } from '@inversifyjs/common';
+
+/**
+ * CSP-safe counterpart to `buildResolveMany`.
+ *
+ * `buildResolveMany` emits a fixed-arity helper with the `Function`
+ * constructor so it cannot run under a strict Content Security Policy.
+ * This helper accepts a variable number of resolved values followed by a
+ * `build` callback and uses `Promise.all` when any value is async.
+ */
+export function resolveMany(
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  ...args: [...unknown[], Function]
+): unknown {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  const build: Function = args[args.length - 1] as Function;
+  const values: unknown[] = args.slice(0, -1);
+
+  for (const value of values) {
+    if (isPromise(value)) {
+      return Promise.all(values).then(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+        (resolvedValues: unknown[]) => build(...resolvedValues),
+      );
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+  return build(...values);
+}

--- a/packages/container/libraries/core/src/planning/models/BasePlanParams.ts
+++ b/packages/container/libraries/core/src/planning/models/BasePlanParams.ts
@@ -5,6 +5,7 @@ import { type PlanParamsOperations } from './PlanParamsOperations.js';
 
 export interface BasePlanParams {
   autobindOptions: AutobindOptions | undefined;
+  jitEnabled: boolean;
   operations: PlanParamsOperations;
   servicesBranch: ServiceIdentifier[];
 }

--- a/packages/container/libraries/core/src/planning/models/InstanceBindingNodeImplementation.ts
+++ b/packages/container/libraries/core/src/planning/models/InstanceBindingNodeImplementation.ts
@@ -20,9 +20,10 @@ export class InstanceBindingNodeImplementation<
   constructor(
     public readonly binding: InstanceBinding<TActivated>,
     public readonly classMetadata: ClassMetadata,
+    jitEnabled: boolean,
   ) {
     this.constructorParams = [];
     this.propertyParams = new Map();
-    this.resolve = buildInstanceBindingNodeResolver(this);
+    this.resolve = buildInstanceBindingNodeResolver(this, jitEnabled);
   }
 }

--- a/packages/container/libraries/core/src/planning/services/PlanResultCacheService.spec.ts
+++ b/packages/container/libraries/core/src/planning/services/PlanResultCacheService.spec.ts
@@ -66,6 +66,7 @@ function buildExpectedPlanParamsFixture(
   const expectedPlanParamsFixture: PlanParams = optionsFixture.isMultiple
     ? {
         autobindOptions: undefined,
+        jitEnabled: true,
         operations: planResultCacheServiceInvalidationFixture.operations,
         rootConstraints: {
           chained: optionsFixture.chained,
@@ -77,6 +78,7 @@ function buildExpectedPlanParamsFixture(
       }
     : {
         autobindOptions: undefined,
+        jitEnabled: true,
         operations: planResultCacheServiceInvalidationFixture.operations,
         rootConstraints: {
           isMultiple: optionsFixture.isMultiple,
@@ -518,7 +520,7 @@ describe(PlanResultCacheService, () => {
                 shouldInvalidateServiceNode: true,
               };
 
-              planResultCacheService = new PlanResultCacheService();
+              planResultCacheService = new PlanResultCacheService(true);
               planResultCacheService.set(optionsFixture, planResultFixture);
 
               vitest
@@ -658,7 +660,7 @@ describe(PlanResultCacheService, () => {
                 planResultCacheServiceInvalidationFixture,
               );
 
-              planResultCacheService = new PlanResultCacheService();
+              planResultCacheService = new PlanResultCacheService(true);
               planResultCacheService.set(optionsFixture, planResultFixture);
 
               planServiceNodeBindingAddedResultFixture = {
@@ -854,7 +856,7 @@ describe(PlanResultCacheService, () => {
                 planResultCacheServiceInvalidationFixture,
               );
 
-              planResultCacheService = new PlanResultCacheService();
+              planResultCacheService = new PlanResultCacheService(true);
               planResultCacheService.set(
                 {
                   ...optionsFixture,
@@ -1073,7 +1075,7 @@ describe(PlanResultCacheService, () => {
                 planResultCacheServiceInvalidationFixture,
               );
 
-              planResultCacheService = new PlanResultCacheService();
+              planResultCacheService = new PlanResultCacheService(true);
               planResultCacheService.set(
                 {
                   ...optionsFixture,
@@ -1310,7 +1312,7 @@ describe(PlanResultCacheService, () => {
                 planResultCacheServiceInvalidationFixture,
               );
 
-              planResultCacheService = new PlanResultCacheService();
+              planResultCacheService = new PlanResultCacheService(true);
               planResultCacheService.set(
                 {
                   ...optionsFixture,
@@ -1529,7 +1531,7 @@ describe(PlanResultCacheService, () => {
                 planResultCacheServiceInvalidationFixture,
               );
 
-              planResultCacheService = new PlanResultCacheService();
+              planResultCacheService = new PlanResultCacheService(true);
               planResultCacheService.setNonCachedServiceNode(
                 childLazyPlanServiceNodeFixture,
                 {
@@ -1760,7 +1762,7 @@ describe(PlanResultCacheService, () => {
                 planResultCacheServiceInvalidationFixture,
               );
 
-              planResultCacheService = new PlanResultCacheService();
+              planResultCacheService = new PlanResultCacheService(true);
               planResultCacheService.setNonCachedServiceNode(
                 childLazyPlanServiceNodeFixture,
                 {
@@ -1996,7 +1998,7 @@ describe(PlanResultCacheService, () => {
                 planResultCacheServiceInvalidationFixture,
               );
 
-              planResultCacheService = new PlanResultCacheService();
+              planResultCacheService = new PlanResultCacheService(true);
               planResultCacheService.setNonCachedServiceNode(
                 childLazyPlanServiceNodeFixture,
                 {
@@ -2114,7 +2116,7 @@ describe(PlanResultCacheService, () => {
             shouldInvalidateServiceNode: true,
           };
 
-          planResultCacheService = new PlanResultCacheService();
+          planResultCacheService = new PlanResultCacheService(true);
           planResultCacheService.setNonCachedServiceNode(
             lazyPlanServiceNodeFixture,
             nonCachedServiceNodeContextFixture,
@@ -2136,6 +2138,7 @@ describe(PlanResultCacheService, () => {
         it('should call addServiceNodeBindingIfContextFree()', () => {
           const expectedBasePlanParams: BasePlanParams = {
             autobindOptions: undefined,
+            jitEnabled: true,
             operations: planResultCacheServiceInvalidationFixture.operations,
             servicesBranch: [],
           };
@@ -2189,8 +2192,8 @@ describe(PlanResultCacheService, () => {
             operations: Symbol() as unknown as PlanParamsOperations,
           };
 
-          parentPlanResultCacheService = new PlanResultCacheService();
-          planResultCacheService = new PlanResultCacheService();
+          parentPlanResultCacheService = new PlanResultCacheService(true);
+          planResultCacheService = new PlanResultCacheService(true);
 
           parentPlanResultCacheService.subscribe(planResultCacheService);
 
@@ -2212,7 +2215,7 @@ describe(PlanResultCacheService, () => {
             },
           };
 
-          planResultCacheService = new PlanResultCacheService();
+          planResultCacheService = new PlanResultCacheService(true);
           planResultCacheService.setNonCachedServiceNode(
             lazyPlanServiceNodeFixture,
             nonCachedServiceNodeContextFixture,
@@ -2234,6 +2237,7 @@ describe(PlanResultCacheService, () => {
         it('should call addServiceNodeBindingIfContextFree()', () => {
           const expectedBasePlanParams: BasePlanParams = {
             autobindOptions: undefined,
+            jitEnabled: true,
             operations: planResultCacheServiceInvalidationFixture.operations,
             servicesBranch: [],
           };
@@ -2269,7 +2273,7 @@ describe(PlanResultCacheService, () => {
 
       beforeAll(() => {
         serviceIdentifierFixture = 'service-id';
-        planService = new PlanResultCacheService();
+        planService = new PlanResultCacheService(true);
         planResultFixture = {} as PlanResult;
 
         planService.set(
@@ -2299,7 +2303,7 @@ describe(PlanResultCacheService, () => {
 
       beforeAll(() => {
         serviceIdentifierFixture = 'service-id';
-        planService = new PlanResultCacheService();
+        planService = new PlanResultCacheService(true);
 
         result = planService.getByServiceIdentifier(serviceIdentifierFixture);
       });
@@ -2317,7 +2321,7 @@ describe(PlanResultCacheService, () => {
 
       beforeAll(() => {
         serviceIdentifierFixture = 'service-id';
-        planService = new PlanResultCacheService();
+        planService = new PlanResultCacheService(true);
 
         planService.set(
           {
@@ -2351,7 +2355,7 @@ describe(PlanResultCacheService, () => {
           let planResultFixture: PlanResult;
 
           beforeAll(() => {
-            planService = new PlanResultCacheService();
+            planService = new PlanResultCacheService(true);
 
             planResultFixture = {} as PlanResult;
             planService.set(options, planResultFixture);
@@ -2390,7 +2394,7 @@ describe(PlanResultCacheService, () => {
       let planResult: PlanResult;
 
       beforeAll(() => {
-        planService = new PlanResultCacheService();
+        planService = new PlanResultCacheService(true);
 
         planResult = {} as PlanResult;
         planService.set(options, planResult);
@@ -2407,7 +2411,7 @@ describe(PlanResultCacheService, () => {
       let subscriberMock: Mocked<PlanResultCacheService>;
 
       beforeAll(() => {
-        planService = new PlanResultCacheService();
+        planService = new PlanResultCacheService(true);
         subscriberMock = {
           clearCache: vitest.fn(),
           // ...other mocked methods...

--- a/packages/container/libraries/core/src/planning/services/PlanResultCacheService.ts
+++ b/packages/container/libraries/core/src/planning/services/PlanResultCacheService.ts
@@ -45,6 +45,7 @@ const MAP_ARRAY_LENGTH: number = 0x8;
  * Ancestor binding constraints are the reason to avoid reusing plans from plan children nodes.
  */
 export class PlanResultCacheService {
+  readonly #jitEnabled: boolean;
   readonly #serviceIdToNonCachedServiceNodeMapMap: Map<
     ServiceIdentifier,
     Map<PlanServiceNode, NonCachedServiceNodeContext>
@@ -67,7 +68,8 @@ export class PlanResultCacheService {
 
   readonly #subscribers: WeakList<PlanResultCacheService>;
 
-  constructor() {
+  constructor(jitEnabled: boolean) {
+    this.#jitEnabled = jitEnabled;
     this.#serviceIdToNonCachedServiceNodeMapMap = new Map();
     this.#serviceIdToValuePlanMap = this.#buildInitializedMapArray();
     this.#namedServiceIdToValuePlanMap = this.#buildInitializedMapArray();
@@ -270,6 +272,7 @@ export class PlanResultCacheService {
 
     return {
       autobindOptions: undefined,
+      jitEnabled: this.#jitEnabled,
       operations: invalidation.operations,
       rootConstraints: planParamsConstraint,
       servicesBranch: [],
@@ -461,6 +464,7 @@ export class PlanResultCacheService {
               addServiceNodeBindingIfContextFree(
                 {
                   autobindOptions: undefined,
+                  jitEnabled: this.#jitEnabled,
                   operations: invalidation.operations,
                   servicesBranch: [],
                 },

--- a/packages/container/libraries/core/src/resolution/actions/resolve.int.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolve.int.spec.ts
@@ -261,7 +261,7 @@ describe(resolve, () => {
       getOwnReflectMetadata(type, classMetadataReflectKey) ??
       getDefaultClassMetadata();
 
-    planResultCacheService = new PlanResultCacheService();
+    planResultCacheService = new PlanResultCacheService(true);
 
     function buildPlanResult(
       isMultiple: boolean,
@@ -270,6 +270,7 @@ describe(resolve, () => {
     ): PlanResult {
       const planParams: PlanParams = {
         autobindOptions: undefined,
+        jitEnabled: true,
         operations: {
           getBindings: bindingService.get.bind(bindingService),
           getBindingsChained: bindingService.getChained.bind(bindingService),
@@ -522,6 +523,7 @@ describe(resolve, () => {
 
           const planResult: PlanResult = plan({
             autobindOptions: undefined,
+            jitEnabled: true,
             operations: {
               getBindings: bindingService.get.bind(bindingService),
               getBindingsChained:

--- a/packages/container/libraries/core/src/resolution/actions/resolveServiceActivations.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveServiceActivations.spec.ts
@@ -1,0 +1,222 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  type Mocked,
+  vitest,
+} from 'vitest';
+
+vitest.mock(import('./resolveBindingActivationsFromIterator.js'));
+vitest.mock(import('./resolveBindingActivationsFromIteratorAsync.js'));
+
+import { type ServiceIdentifier } from '@inversifyjs/common';
+
+import { type BindingActivation } from '../../binding/models/BindingActivation.js';
+import { type ResolutionParams } from '../models/ResolutionParams.js';
+import { resolveBindingActivationsFromIterator } from './resolveBindingActivationsFromIterator.js';
+import { resolveBindingActivationsFromIteratorAsync } from './resolveBindingActivationsFromIteratorAsync.js';
+import { resolveServiceActivations } from './resolveServiceActivations.js';
+
+describe(resolveServiceActivations, () => {
+  describe('having a non promise value', () => {
+    let paramsMock: Mocked<ResolutionParams>;
+    let serviceIdentifierFixture: ServiceIdentifier;
+    let valueFixture: unknown;
+
+    beforeAll(() => {
+      paramsMock = {
+        getActivations: vitest.fn(),
+      } as Partial<Mocked<ResolutionParams>> as Mocked<ResolutionParams>;
+      serviceIdentifierFixture = 'service-id';
+      valueFixture = Symbol();
+    });
+
+    describe('when called, and params.getActivations() returns undefined', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = resolveServiceActivations(serviceIdentifierFixture)(
+          paramsMock,
+          valueFixture,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call params.getActivations', () => {
+        expect(paramsMock.getActivations).toHaveBeenCalledExactlyOnceWith(
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should return value', () => {
+        expect(result).toBe(valueFixture);
+      });
+    });
+
+    describe('when called, and params.getActivations() returns activations', () => {
+      let activationsIteratorFixture: Iterator<BindingActivation<unknown>>;
+      let activationsIterableFixture: Iterable<BindingActivation<unknown>>;
+      let resolveBindingActivationsFromIteratorResultFixture: unknown;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        activationsIteratorFixture = Symbol(
+          'activations-iterator',
+        ) as unknown as Iterator<BindingActivation<unknown>>;
+        activationsIterableFixture = {
+          [Symbol.iterator]: () => activationsIteratorFixture,
+        };
+        resolveBindingActivationsFromIteratorResultFixture = Symbol(
+          'resolve-binding-activations-from-iterator-result',
+        );
+
+        paramsMock.getActivations.mockReturnValueOnce(
+          activationsIterableFixture,
+        );
+
+        vitest
+          .mocked(resolveBindingActivationsFromIterator)
+          .mockReturnValueOnce(
+            resolveBindingActivationsFromIteratorResultFixture,
+          );
+
+        result = resolveServiceActivations(serviceIdentifierFixture)(
+          paramsMock,
+          valueFixture,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call params.getActivations', () => {
+        expect(paramsMock.getActivations).toHaveBeenCalledExactlyOnceWith(
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should call resolveBindingActivationsFromIterator()', () => {
+        expect(
+          resolveBindingActivationsFromIterator,
+        ).toHaveBeenCalledExactlyOnceWith(
+          paramsMock,
+          valueFixture,
+          activationsIteratorFixture,
+        );
+      });
+
+      it('should return expected result', () => {
+        expect(result).toBe(resolveBindingActivationsFromIteratorResultFixture);
+      });
+    });
+  });
+
+  describe('having a promise value', () => {
+    let paramsMock: Mocked<ResolutionParams>;
+    let serviceIdentifierFixture: ServiceIdentifier;
+    let valueFixture: unknown;
+
+    beforeAll(() => {
+      paramsMock = {
+        getActivations: vitest.fn(),
+      } as Partial<Mocked<ResolutionParams>> as Mocked<ResolutionParams>;
+      serviceIdentifierFixture = 'service-id';
+      valueFixture = Symbol();
+    });
+
+    describe('when called, and params.getActivations() returns undefined', () => {
+      let result: unknown;
+
+      beforeAll(async () => {
+        result = await resolveServiceActivations(serviceIdentifierFixture)(
+          paramsMock,
+          Promise.resolve(valueFixture),
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call params.getActivations', () => {
+        expect(paramsMock.getActivations).toHaveBeenCalledExactlyOnceWith(
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should return value', () => {
+        expect(result).toBe(valueFixture);
+      });
+    });
+
+    describe('when called, and params.getActivations() returns activations', () => {
+      let activationsIteratorFixture: Iterator<BindingActivation<unknown>>;
+      let activationsIterableFixture: Iterable<BindingActivation<unknown>>;
+      let resolveBindingActivationsFromIteratorAsyncResultFixture: unknown;
+      let valuePromiseFixture: Promise<unknown>;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        activationsIteratorFixture = Symbol(
+          'activations-iterator',
+        ) as unknown as Iterator<BindingActivation<unknown>>;
+        activationsIterableFixture = {
+          [Symbol.iterator]: () => activationsIteratorFixture,
+        };
+        resolveBindingActivationsFromIteratorAsyncResultFixture = Symbol(
+          'resolve-binding-activations-from-iterator-async-result',
+        );
+        valuePromiseFixture = Promise.resolve(valueFixture);
+
+        paramsMock.getActivations.mockReturnValueOnce(
+          activationsIterableFixture,
+        );
+
+        vitest
+          .mocked(resolveBindingActivationsFromIteratorAsync)
+          .mockResolvedValueOnce(
+            resolveBindingActivationsFromIteratorAsyncResultFixture,
+          );
+
+        result = await resolveServiceActivations(serviceIdentifierFixture)(
+          paramsMock,
+          valuePromiseFixture,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call params.getActivations', () => {
+        expect(paramsMock.getActivations).toHaveBeenCalledExactlyOnceWith(
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should call resolveBindingActivationsFromIteratorAsync()', () => {
+        expect(
+          resolveBindingActivationsFromIteratorAsync,
+        ).toHaveBeenCalledExactlyOnceWith(
+          paramsMock,
+          valuePromiseFixture,
+          activationsIteratorFixture,
+        );
+      });
+
+      it('should return expected result', () => {
+        expect(result).toBe(
+          resolveBindingActivationsFromIteratorAsyncResultFixture,
+        );
+      });
+    });
+  });
+});

--- a/packages/container/libraries/core/src/resolution/actions/resolveServiceActivations.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveServiceActivations.ts
@@ -1,0 +1,40 @@
+import { isPromise, type ServiceIdentifier } from '@inversifyjs/common';
+
+import { type BindingActivation } from '../../binding/models/BindingActivation.js';
+import { type ResolutionParams } from '../models/ResolutionParams.js';
+import { type Resolved } from '../models/Resolved.js';
+import { resolveBindingActivationsFromIterator } from './resolveBindingActivationsFromIterator.js';
+import { resolveBindingActivationsFromIteratorAsync } from './resolveBindingActivationsFromIteratorAsync.js';
+
+export function resolveServiceActivations<TActivated>(
+  serviceIdentifier: ServiceIdentifier<TActivated>,
+): (
+  params: ResolutionParams,
+  value: Resolved<TActivated>,
+) => Resolved<TActivated> {
+  return (
+    params: ResolutionParams,
+    value: Resolved<TActivated>,
+  ): Resolved<TActivated> => {
+    const activations: Iterable<BindingActivation<TActivated>> | undefined =
+      params.getActivations(serviceIdentifier);
+
+    if (activations === undefined) {
+      return value;
+    }
+
+    if (isPromise(value)) {
+      return resolveBindingActivationsFromIteratorAsync(
+        params,
+        value,
+        activations[Symbol.iterator](),
+      );
+    }
+
+    return resolveBindingActivationsFromIterator(
+      params,
+      value,
+      activations[Symbol.iterator](),
+    );
+  };
+}

--- a/packages/container/libraries/inversify/src/test/container/container.int.spec.ts
+++ b/packages/container/libraries/inversify/src/test/container/container.int.spec.ts
@@ -221,9 +221,14 @@ function bindService(
 }
 
 describe(Container, () => {
-  describe.each(CONSTRUCTOR_ARITIES)(
+  describe.each(
+    CONSTRUCTOR_ARITIES.flatMap((arity: number) => [
+      [arity, true],
+      [arity, false],
+    ]),
+  )(
     'having a service with %s constructor/factory parameters',
-    (parameterCount: number) => {
+    (parameterCount: number, jitless: boolean) => {
       const dependencyIds: string[] =
         buildDependencyIdentifiers(parameterCount);
       const expectedArgs: string[] = buildExpectedArgs(parameterCount);
@@ -259,7 +264,9 @@ describe(Container, () => {
               bindDependencies,
               resolveService,
             }: ResolutionCase) => {
-              const container: Container = new Container();
+              const container: Container = new Container({
+                jitless,
+              });
 
               bindDependencies(container);
 

--- a/packages/container/tools/container-benchmarks/src/bin/run.ts
+++ b/packages/container/tools/container-benchmarks/src/bin/run.ts
@@ -42,6 +42,14 @@ import { InversifyCurrentGetComplexServiceWithPropertiesInTransientScope } from 
 import { InversifyCurrentGetServiceInSingletonScope } from '../scenario/inversifyCurrent/InversifyCurrentGetServiceInSingletonScope.js';
 import { InversifyCurrentGetServiceInTransientScope } from '../scenario/inversifyCurrent/InversifyCurrentGetServiceInTransientScope.js';
 import { InversifyCurrentGetWideServiceInTransientScope } from '../scenario/inversifyCurrent/InversifyCurrentGetWideServiceInTransientScope.js';
+import { InversifyCurrentJitlessGetComplexAsyncServiceInTransientScope } from '../scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetComplexAsyncServiceInTransientScope.js';
+import { InversifyCurrentJitlessGetComplexResolvedValueServiceInTranstientScope } from '../scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetComplexResolvedValueServiceInTranstientScope.js';
+import { InversifyCurrentJitlessGetComplexServiceInSingletonScope } from '../scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetComplexServiceInSingletonScope.js';
+import { InversifyCurrentJitlessGetComplexServiceInTransientScope } from '../scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetComplexServiceInTransientScope.js';
+import { InversifyCurrentJitlessGetComplexServiceWithPropertiesInTransientScope } from '../scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetComplexServiceWithPropertiesInTransientScope.js';
+import { InversifyCurrentJitlessGetServiceInSingletonScope } from '../scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetServiceInSingletonScope.js';
+import { InversifyCurrentJitlessGetServiceInTransientScope } from '../scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetServiceInTransientScope.js';
+import { InversifyCurrentJitlessGetWideServiceInTransientScope } from '../scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetWideServiceInTransientScope.js';
 import { NestCoreGetComplexServiceInSingletonScopeScenario } from '../scenario/nestCore/NestCoreGetComplexServiceInSingletonScopeScenario.js';
 import { NestCoreGetComplexServiceInTransientScopeScenario } from '../scenario/nestCore/NestCoreGetComplexServiceInTransientScopeScenario.js';
 import { NestCoreGetComplexServiceWithPropertiesInTransientScopeScenario } from '../scenario/nestCore/NestCoreGetComplexServiceWithPropertiesInTransientScopeScenario.js';
@@ -64,6 +72,7 @@ export async function run(): Promise<void> {
       },
       scenarios: [
         new InversifyCurrentGetServiceInSingletonScope(),
+        new InversifyCurrentJitlessGetServiceInSingletonScope(),
         new Inversify6GetServiceInSingletonScope(),
         new Inversify7GetServiceInSingletonScope(),
         new Inversify8GetServiceInSingletonScope(),
@@ -87,6 +96,7 @@ export async function run(): Promise<void> {
       },
       scenarios: [
         new InversifyCurrentGetServiceInTransientScope(),
+        new InversifyCurrentJitlessGetServiceInTransientScope(),
         new Inversify6GetServiceInTransientScope(),
         new Inversify7GetServiceInTransientScope(),
         new Inversify8GetServiceInTransientScope(),
@@ -110,6 +120,7 @@ export async function run(): Promise<void> {
       },
       scenarios: [
         new InversifyCurrentGetWideServiceInTransientScope(),
+        new InversifyCurrentJitlessGetWideServiceInTransientScope(),
         new Inversify6GetWideServiceInTransientScope(),
         new Inversify7GetWideServiceInTransientScope(),
         new Inversify8GetWideServiceInTransientScope(),
@@ -133,6 +144,7 @@ export async function run(): Promise<void> {
       },
       scenarios: [
         new InversifyCurrentGetComplexServiceInSingletonScope(),
+        new InversifyCurrentJitlessGetComplexServiceInSingletonScope(),
         new Inversify6GetComplexServiceInSingletonScope(),
         new Inversify7GetComplexServiceInSingletonScope(),
         new Inversify8GetComplexServiceInSingletonScope(),
@@ -156,7 +168,9 @@ export async function run(): Promise<void> {
       },
       scenarios: [
         new InversifyCurrentGetComplexServiceInTransientScope(),
+        new InversifyCurrentJitlessGetComplexServiceInTransientScope(),
         new InversifyCurrentGetComplexResolvedValueServiceInTransientScope(),
+        new InversifyCurrentJitlessGetComplexResolvedValueServiceInTranstientScope(),
         new Inversify6GetComplexServiceInTransientScope(),
         new Inversify7GetComplexServiceInTransientScope(),
         new Inversify8GetComplexServiceInTransientScope(),
@@ -180,6 +194,7 @@ export async function run(): Promise<void> {
       },
       scenarios: [
         new InversifyCurrentGetComplexServiceWithPropertiesInTransientScope(),
+        new InversifyCurrentJitlessGetComplexServiceWithPropertiesInTransientScope(),
         new Inversify6GetComplexServiceWithPropertiesInTransientScope(),
         new Inversify7GetComplexServiceWithPropertiesInTransientScope(),
         new Inversify8GetComplexServiceWithPropertiesInTransientScope(),
@@ -201,6 +216,7 @@ export async function run(): Promise<void> {
       },
       scenarios: [
         new InversifyCurrentGetComplexAsyncServiceInTransientScope(),
+        new InversifyCurrentJitlessGetComplexAsyncServiceInTransientScope(),
         new Inversify6GetComplexAsyncServiceInTransientScope(),
         new Inversify7GetComplexAsyncServiceInTransientScope(),
         new Inversify8GetComplexAsyncServiceInTransientScope(),

--- a/packages/container/tools/container-benchmarks/src/scenario/inversifyCurrentJitless/InversifyCurrentJitlessBaseScenario.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/inversifyCurrentJitless/InversifyCurrentJitlessBaseScenario.ts
@@ -3,16 +3,16 @@ import { Container } from '@inversifyjs/container';
 
 import { Platform } from '../models/Platform.js';
 
-export abstract class InversifyCurrentBaseScenario implements Scenario {
+export abstract class InversifyCurrentJitlessBaseScenario implements Scenario {
   public readonly name: string;
 
   protected readonly _container: Container;
 
   constructor(name?: string) {
     this._container = new Container({
-      jitless: false,
+      jitless: true,
     });
-    this.name = name ?? Platform.inversifyCurrent;
+    this.name = name ?? Platform.inversifyCurrentJitless;
   }
 
   public async setUp(): Promise<void> {

--- a/packages/container/tools/container-benchmarks/src/scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetComplexAsyncServiceInTransientScope.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetComplexAsyncServiceInTransientScope.ts
@@ -1,0 +1,187 @@
+import { injectable } from '@inversifyjs/core';
+
+import { InversifyCurrentJitlessBaseScenario } from './InversifyCurrentJitlessBaseScenario.js';
+
+@injectable()
+class FinalNode {
+  public log() {
+    return 'log!';
+  }
+}
+
+@injectable()
+class Node10 {
+  private readonly node1: FinalNode;
+  private readonly node2: FinalNode;
+
+  constructor(node1: FinalNode, node2: FinalNode) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node9 {
+  private readonly node1: Node10;
+  private readonly node2: Node10;
+
+  constructor(node1: Node10, node2: Node10) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node8 {
+  private readonly node1: Node9;
+  private readonly node2: Node9;
+
+  constructor(node1: Node9, node2: Node9) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node7 {
+  private readonly node1: Node8;
+  private readonly node2: Node8;
+
+  constructor(node1: Node8, node2: Node8) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node6 {
+  private readonly node1: Node7;
+  private readonly node2: Node7;
+
+  constructor(node1: Node7, node2: Node7) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node5 {
+  private readonly node1: Node6;
+  private readonly node2: Node6;
+
+  constructor(node1: Node6, node2: Node6) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node4 {
+  private readonly node1: Node5;
+  private readonly node2: Node5;
+
+  constructor(node1: Node5, node2: Node5) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node3 {
+  private readonly node1: Node4;
+  private readonly node2: Node4;
+
+  constructor(node1: Node4, node2: Node4) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node2 {
+  private readonly node1: Node3;
+  private readonly node2: Node3;
+
+  constructor(node1: Node3, node2: Node3) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node1 {
+  private readonly node1: Node2;
+  private readonly node2: Node2;
+
+  constructor(node1: Node2, node2: Node2) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+export class InversifyCurrentJitlessGetComplexAsyncServiceInTransientScope extends InversifyCurrentJitlessBaseScenario {
+  public override async setUp(): Promise<void> {
+    this._container
+      .bind(FinalNode)
+      .toResolvedValue(async () => new FinalNode())
+      .inTransientScope();
+    this._container.bind(Node1).toSelf().inTransientScope();
+    this._container.bind(Node2).toSelf().inTransientScope();
+    this._container.bind(Node3).toSelf().inTransientScope();
+    this._container.bind(Node4).toSelf().inTransientScope();
+    this._container.bind(Node5).toSelf().inTransientScope();
+    this._container.bind(Node6).toSelf().inTransientScope();
+    this._container.bind(Node7).toSelf().inTransientScope();
+    this._container.bind(Node8).toSelf().inTransientScope();
+    this._container.bind(Node9).toSelf().inTransientScope();
+    this._container.bind(Node10).toSelf().inTransientScope();
+  }
+
+  public async execute(): Promise<void> {
+    await this._container.getAsync(Node1);
+  }
+
+  public override async tearDown(): Promise<void> {
+    this._container.unbindAll();
+  }
+}

--- a/packages/container/tools/container-benchmarks/src/scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetComplexResolvedValueServiceInTranstientScope.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetComplexResolvedValueServiceInTranstientScope.ts
@@ -1,0 +1,262 @@
+import { injectable } from '@inversifyjs/core';
+
+import { Platform } from '../models/Platform.js';
+import { InversifyCurrentJitlessBaseScenario } from './InversifyCurrentJitlessBaseScenario.js';
+
+@injectable()
+class FinalNode {
+  public log() {
+    return 'log!';
+  }
+}
+
+@injectable()
+class Node10 {
+  private readonly node1: FinalNode;
+  private readonly node2: FinalNode;
+
+  constructor(node1: FinalNode, node2: FinalNode) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node9 {
+  private readonly node1: Node10;
+  private readonly node2: Node10;
+
+  constructor(node1: Node10, node2: Node10) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node8 {
+  private readonly node1: Node9;
+  private readonly node2: Node9;
+
+  constructor(node1: Node9, node2: Node9) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node7 {
+  private readonly node1: Node8;
+  private readonly node2: Node8;
+
+  constructor(node1: Node8, node2: Node8) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node6 {
+  private readonly node1: Node7;
+  private readonly node2: Node7;
+
+  constructor(node1: Node7, node2: Node7) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node5 {
+  private readonly node1: Node6;
+  private readonly node2: Node6;
+
+  constructor(node1: Node6, node2: Node6) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node4 {
+  private readonly node1: Node5;
+  private readonly node2: Node5;
+
+  constructor(node1: Node5, node2: Node5) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node3 {
+  private readonly node1: Node4;
+  private readonly node2: Node4;
+
+  constructor(node1: Node4, node2: Node4) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node2 {
+  private readonly node1: Node3;
+  private readonly node2: Node3;
+
+  constructor(node1: Node3, node2: Node3) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node1 {
+  private readonly node1: Node2;
+  private readonly node2: Node2;
+
+  constructor(node1: Node2, node2: Node2) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+export class InversifyCurrentJitlessGetComplexResolvedValueServiceInTranstientScope extends InversifyCurrentJitlessBaseScenario {
+  constructor() {
+    super(`${Platform.inversifyCurrentJitless} (Resolved Value)`);
+  }
+
+  public override async setUp(): Promise<void> {
+    this._container
+      .bind(FinalNode)
+      .toResolvedValue(() => new FinalNode())
+      .inTransientScope();
+    this._container
+      .bind(Node1)
+      .toResolvedValue(
+        (firstNode: Node2, secondNode: Node2) =>
+          new Node1(firstNode, secondNode),
+        [Node2, Node2],
+      )
+      .inTransientScope();
+    this._container
+      .bind(Node2)
+      .toResolvedValue(
+        (firstNode: Node3, secondNode: Node3) =>
+          new Node2(firstNode, secondNode),
+        [Node3, Node3],
+      )
+      .inTransientScope();
+    this._container
+      .bind(Node3)
+      .toResolvedValue(
+        (firstNode: Node4, secondNode: Node4) =>
+          new Node3(firstNode, secondNode),
+        [Node4, Node4],
+      )
+      .inTransientScope();
+    this._container
+      .bind(Node4)
+      .toResolvedValue(
+        (firstNode: Node5, secondNode: Node5) =>
+          new Node4(firstNode, secondNode),
+        [Node5, Node5],
+      )
+      .inTransientScope();
+    this._container
+      .bind(Node5)
+      .toResolvedValue(
+        (firstNode: Node6, secondNode: Node6) =>
+          new Node5(firstNode, secondNode),
+        [Node6, Node6],
+      )
+      .inTransientScope();
+    this._container
+      .bind(Node6)
+      .toResolvedValue(
+        (firstNode: Node7, secondNode: Node7) =>
+          new Node6(firstNode, secondNode),
+        [Node7, Node7],
+      )
+      .inTransientScope();
+    this._container
+      .bind(Node7)
+      .toResolvedValue(
+        (firstNode: Node8, secondNode: Node8) =>
+          new Node7(firstNode, secondNode),
+        [Node8, Node8],
+      )
+      .inTransientScope();
+    this._container
+      .bind(Node8)
+      .toResolvedValue(
+        (firstNode: Node9, secondNode: Node9) =>
+          new Node8(firstNode, secondNode),
+        [Node9, Node9],
+      )
+      .inTransientScope();
+    this._container
+      .bind(Node9)
+      .toResolvedValue(
+        (firstNode: Node10, secondNode: Node10) =>
+          new Node9(firstNode, secondNode),
+        [Node10, Node10],
+      )
+      .inTransientScope();
+    this._container
+      .bind(Node10)
+      .toResolvedValue(
+        (firstNode: FinalNode, secondNode: FinalNode) =>
+          new Node10(firstNode, secondNode),
+        [FinalNode, FinalNode],
+      )
+      .inTransientScope();
+  }
+
+  public async execute(): Promise<void> {
+    this._container.get(Node1);
+  }
+
+  public override async tearDown(): Promise<void> {
+    await this._container.unbindAllAsync();
+  }
+}

--- a/packages/container/tools/container-benchmarks/src/scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetComplexServiceInSingletonScope.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetComplexServiceInSingletonScope.ts
@@ -1,0 +1,184 @@
+import { injectable } from '@inversifyjs/core';
+
+import { InversifyCurrentJitlessBaseScenario } from './InversifyCurrentJitlessBaseScenario.js';
+
+@injectable()
+class FinalNode {
+  public log() {
+    return 'log!';
+  }
+}
+
+@injectable()
+class Node10 {
+  private readonly node1: FinalNode;
+  private readonly node2: FinalNode;
+
+  constructor(node1: FinalNode, node2: FinalNode) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node9 {
+  private readonly node1: Node10;
+  private readonly node2: Node10;
+
+  constructor(node1: Node10, node2: Node10) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node8 {
+  private readonly node1: Node9;
+  private readonly node2: Node9;
+
+  constructor(node1: Node9, node2: Node9) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node7 {
+  private readonly node1: Node8;
+  private readonly node2: Node8;
+
+  constructor(node1: Node8, node2: Node8) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node6 {
+  private readonly node1: Node7;
+  private readonly node2: Node7;
+
+  constructor(node1: Node7, node2: Node7) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node5 {
+  private readonly node1: Node6;
+  private readonly node2: Node6;
+
+  constructor(node1: Node6, node2: Node6) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node4 {
+  private readonly node1: Node5;
+  private readonly node2: Node5;
+
+  constructor(node1: Node5, node2: Node5) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node3 {
+  private readonly node1: Node4;
+  private readonly node2: Node4;
+
+  constructor(node1: Node4, node2: Node4) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node2 {
+  private readonly node1: Node3;
+  private readonly node2: Node3;
+
+  constructor(node1: Node3, node2: Node3) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node1 {
+  private readonly node1: Node2;
+  private readonly node2: Node2;
+
+  constructor(node1: Node2, node2: Node2) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+export class InversifyCurrentJitlessGetComplexServiceInSingletonScope extends InversifyCurrentJitlessBaseScenario {
+  public override async setUp(): Promise<void> {
+    this._container.bind(FinalNode).toSelf().inSingletonScope();
+    this._container.bind(Node1).toSelf().inSingletonScope();
+    this._container.bind(Node2).toSelf().inSingletonScope();
+    this._container.bind(Node3).toSelf().inSingletonScope();
+    this._container.bind(Node4).toSelf().inSingletonScope();
+    this._container.bind(Node5).toSelf().inSingletonScope();
+    this._container.bind(Node6).toSelf().inSingletonScope();
+    this._container.bind(Node7).toSelf().inSingletonScope();
+    this._container.bind(Node8).toSelf().inSingletonScope();
+    this._container.bind(Node9).toSelf().inSingletonScope();
+    this._container.bind(Node10).toSelf().inSingletonScope();
+  }
+
+  public async execute(): Promise<void> {
+    this._container.get(Node1);
+  }
+
+  public override async tearDown(): Promise<void> {
+    await this._container.unbindAllAsync();
+  }
+}

--- a/packages/container/tools/container-benchmarks/src/scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetComplexServiceInTransientScope.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetComplexServiceInTransientScope.ts
@@ -1,0 +1,184 @@
+import { injectable } from '@inversifyjs/core';
+
+import { InversifyCurrentJitlessBaseScenario } from './InversifyCurrentJitlessBaseScenario.js';
+
+@injectable()
+class FinalNode {
+  public log() {
+    return 'log!';
+  }
+}
+
+@injectable()
+class Node10 {
+  private readonly node1: FinalNode;
+  private readonly node2: FinalNode;
+
+  constructor(node1: FinalNode, node2: FinalNode) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node9 {
+  private readonly node1: Node10;
+  private readonly node2: Node10;
+
+  constructor(node1: Node10, node2: Node10) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node8 {
+  private readonly node1: Node9;
+  private readonly node2: Node9;
+
+  constructor(node1: Node9, node2: Node9) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node7 {
+  private readonly node1: Node8;
+  private readonly node2: Node8;
+
+  constructor(node1: Node8, node2: Node8) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node6 {
+  private readonly node1: Node7;
+  private readonly node2: Node7;
+
+  constructor(node1: Node7, node2: Node7) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node5 {
+  private readonly node1: Node6;
+  private readonly node2: Node6;
+
+  constructor(node1: Node6, node2: Node6) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node4 {
+  private readonly node1: Node5;
+  private readonly node2: Node5;
+
+  constructor(node1: Node5, node2: Node5) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node3 {
+  private readonly node1: Node4;
+  private readonly node2: Node4;
+
+  constructor(node1: Node4, node2: Node4) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node2 {
+  private readonly node1: Node3;
+  private readonly node2: Node3;
+
+  constructor(node1: Node3, node2: Node3) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node1 {
+  private readonly node1: Node2;
+  private readonly node2: Node2;
+
+  constructor(node1: Node2, node2: Node2) {
+    this.node1 = node1;
+    this.node2 = node2;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+export class InversifyCurrentJitlessGetComplexServiceInTransientScope extends InversifyCurrentJitlessBaseScenario {
+  public override async setUp(): Promise<void> {
+    this._container.bind(FinalNode).toSelf().inTransientScope();
+    this._container.bind(Node1).toSelf().inTransientScope();
+    this._container.bind(Node2).toSelf().inTransientScope();
+    this._container.bind(Node3).toSelf().inTransientScope();
+    this._container.bind(Node4).toSelf().inTransientScope();
+    this._container.bind(Node5).toSelf().inTransientScope();
+    this._container.bind(Node6).toSelf().inTransientScope();
+    this._container.bind(Node7).toSelf().inTransientScope();
+    this._container.bind(Node8).toSelf().inTransientScope();
+    this._container.bind(Node9).toSelf().inTransientScope();
+    this._container.bind(Node10).toSelf().inTransientScope();
+  }
+
+  public async execute(): Promise<void> {
+    this._container.get(Node1);
+  }
+
+  public override async tearDown(): Promise<void> {
+    await this._container.unbindAllAsync();
+  }
+}

--- a/packages/container/tools/container-benchmarks/src/scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetComplexServiceWithPropertiesInTransientScope.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetComplexServiceWithPropertiesInTransientScope.ts
@@ -1,0 +1,194 @@
+import { inject, injectable } from '@inversifyjs/core';
+
+import { InversifyCurrentJitlessBaseScenario } from './InversifyCurrentJitlessBaseScenario.js';
+
+@injectable()
+class FinalNode {
+  public log() {
+    return 'log!';
+  }
+}
+
+@injectable()
+class Node10 {
+  @inject(FinalNode)
+  private readonly node2!: FinalNode;
+
+  private readonly node1: FinalNode;
+
+  constructor(node1: FinalNode) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node9 {
+  @inject(Node10)
+  private readonly node2!: Node10;
+
+  private readonly node1: Node10;
+
+  constructor(node1: Node10) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node8 {
+  @inject(Node9)
+  private readonly node2!: Node9;
+
+  private readonly node1: Node9;
+
+  constructor(node1: Node9) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node7 {
+  @inject(Node8)
+  private readonly node2!: Node8;
+
+  private readonly node1: Node8;
+
+  constructor(node1: Node8) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node6 {
+  @inject(Node7)
+  private readonly node2!: Node7;
+
+  private readonly node1: Node7;
+
+  constructor(node1: Node7) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node5 {
+  @inject(Node6)
+  private readonly node2!: Node6;
+
+  private readonly node1: Node6;
+
+  constructor(node1: Node6) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node4 {
+  @inject(Node5)
+  private readonly node2!: Node5;
+
+  private readonly node1: Node5;
+
+  constructor(node1: Node5) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node3 {
+  @inject(Node4)
+  private readonly node2!: Node4;
+
+  private readonly node1: Node4;
+
+  constructor(node1: Node4) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node2 {
+  @inject(Node3)
+  private readonly node2!: Node3;
+
+  private readonly node1: Node3;
+
+  constructor(node1: Node3) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+@injectable()
+class Node1 {
+  @inject(Node2)
+  private readonly node2!: Node2;
+
+  private readonly node1: Node2;
+
+  constructor(node1: Node2) {
+    this.node1 = node1;
+  }
+
+  public log() {
+    return `${this.node1.log()} ${this.node2.log()}`;
+  }
+}
+
+export class InversifyCurrentJitlessGetComplexServiceWithPropertiesInTransientScope extends InversifyCurrentJitlessBaseScenario {
+  public override async setUp(): Promise<void> {
+    this._container.bind(FinalNode).toSelf().inTransientScope();
+    this._container.bind(Node1).toSelf().inTransientScope();
+    this._container.bind(Node2).toSelf().inTransientScope();
+    this._container.bind(Node3).toSelf().inTransientScope();
+    this._container.bind(Node4).toSelf().inTransientScope();
+    this._container.bind(Node5).toSelf().inTransientScope();
+    this._container.bind(Node6).toSelf().inTransientScope();
+    this._container.bind(Node7).toSelf().inTransientScope();
+    this._container.bind(Node8).toSelf().inTransientScope();
+    this._container.bind(Node9).toSelf().inTransientScope();
+    this._container.bind(Node10).toSelf().inTransientScope();
+  }
+
+  public async execute(): Promise<void> {
+    this._container.get(Node1);
+  }
+
+  public override async tearDown(): Promise<void> {
+    await this._container.unbindAllAsync();
+  }
+}

--- a/packages/container/tools/container-benchmarks/src/scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetServiceInSingletonScope.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetServiceInSingletonScope.ts
@@ -1,0 +1,38 @@
+import { injectable } from '@inversifyjs/core';
+
+import { InversifyCurrentJitlessBaseScenario } from './InversifyCurrentJitlessBaseScenario.js';
+
+@injectable()
+class Katana {
+  public hit() {
+    return 'cut!';
+  }
+}
+
+@injectable()
+class Samurai {
+  readonly #katana: Katana;
+
+  constructor(katana: Katana) {
+    this.#katana = katana;
+  }
+
+  public attack() {
+    return this.#katana.hit();
+  }
+}
+
+export class InversifyCurrentJitlessGetServiceInSingletonScope extends InversifyCurrentJitlessBaseScenario {
+  public override async setUp(): Promise<void> {
+    this._container.bind(Katana).toSelf().inSingletonScope();
+    this._container.bind(Samurai).toSelf().inSingletonScope();
+  }
+
+  public async execute(): Promise<void> {
+    this._container.get(Samurai);
+  }
+
+  public override async tearDown(): Promise<void> {
+    await this._container.unbindAllAsync();
+  }
+}

--- a/packages/container/tools/container-benchmarks/src/scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetServiceInTransientScope.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetServiceInTransientScope.ts
@@ -1,0 +1,38 @@
+import { injectable } from '@inversifyjs/core';
+
+import { InversifyCurrentJitlessBaseScenario } from './InversifyCurrentJitlessBaseScenario.js';
+
+@injectable()
+class Katana {
+  public hit() {
+    return 'cut!';
+  }
+}
+
+@injectable()
+class Samurai {
+  readonly #katana: Katana;
+
+  constructor(katana: Katana) {
+    this.#katana = katana;
+  }
+
+  public attack() {
+    return this.#katana.hit();
+  }
+}
+
+export class InversifyCurrentJitlessGetServiceInTransientScope extends InversifyCurrentJitlessBaseScenario {
+  public override async setUp(): Promise<void> {
+    this._container.bind(Katana).toSelf().inTransientScope();
+    this._container.bind(Samurai).toSelf().inTransientScope();
+  }
+
+  public async execute(): Promise<void> {
+    this._container.get(Samurai);
+  }
+
+  public override async tearDown(): Promise<void> {
+    await this._container.unbindAllAsync();
+  }
+}

--- a/packages/container/tools/container-benchmarks/src/scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetWideServiceInTransientScope.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/inversifyCurrentJitless/InversifyCurrentJitlessGetWideServiceInTransientScope.ts
@@ -1,0 +1,78 @@
+import { injectable } from '@inversifyjs/core';
+
+import { InversifyCurrentJitlessBaseScenario } from './InversifyCurrentJitlessBaseScenario.js';
+
+@injectable()
+class Parameter {
+  public value() {
+    return 'value';
+  }
+}
+
+@injectable()
+class WideService {
+  private readonly param1: Parameter;
+  private readonly param2: Parameter;
+  private readonly param3: Parameter;
+  private readonly param4: Parameter;
+  private readonly param5: Parameter;
+  private readonly param6: Parameter;
+  private readonly param7: Parameter;
+  private readonly param8: Parameter;
+  private readonly param9: Parameter;
+  private readonly param10: Parameter;
+
+  constructor(
+    param1: Parameter,
+    param2: Parameter,
+    param3: Parameter,
+    param4: Parameter,
+    param5: Parameter,
+    param6: Parameter,
+    param7: Parameter,
+    param8: Parameter,
+    param9: Parameter,
+    param10: Parameter,
+  ) {
+    this.param1 = param1;
+    this.param2 = param2;
+    this.param3 = param3;
+    this.param4 = param4;
+    this.param5 = param5;
+    this.param6 = param6;
+    this.param7 = param7;
+    this.param8 = param8;
+    this.param9 = param9;
+    this.param10 = param10;
+  }
+
+  public run() {
+    return [
+      this.param1.value(),
+      this.param2.value(),
+      this.param3.value(),
+      this.param4.value(),
+      this.param5.value(),
+      this.param6.value(),
+      this.param7.value(),
+      this.param8.value(),
+      this.param9.value(),
+      this.param10.value(),
+    ].join(' ');
+  }
+}
+
+export class InversifyCurrentJitlessGetWideServiceInTransientScope extends InversifyCurrentJitlessBaseScenario {
+  public override async setUp(): Promise<void> {
+    this._container.bind(Parameter).toSelf().inTransientScope();
+    this._container.bind(WideService).toSelf().inTransientScope();
+  }
+
+  public async execute(): Promise<void> {
+    this._container.get(WideService);
+  }
+
+  public override async tearDown(): Promise<void> {
+    await this._container.unbindAllAsync();
+  }
+}

--- a/packages/container/tools/container-benchmarks/src/scenario/models/Platform.ts
+++ b/packages/container/tools/container-benchmarks/src/scenario/models/Platform.ts
@@ -4,6 +4,7 @@ export enum Platform {
   inversify7 = 'inversify7',
   inversify8 = 'inversify8',
   inversifyCurrent = 'inversifyCurrent',
+  inversifyCurrentJitless = 'inversifyCurrent (Jitless)',
   nestJs = 'NestJS',
   tsyringe = 'tsyringe',
 }

--- a/packages/docs/services/inversify-site/blog/2026-07-15-announcing-inversify-8-2-0/index.mdx
+++ b/packages/docs/services/inversify-site/blog/2026-07-15-announcing-inversify-8-2-0/index.mdx
@@ -1,0 +1,79 @@
+---
+slug: announcing-inversify-8-2-0
+title: Announcing InversifyJS 8.2.0
+authors: [notaphplover]
+tags: [releases]
+---
+
+We're happy to announce **InversifyJS 8.2.0**, a release focused on making the container work reliably in environments that enforce a strict Content Security Policy (CSP).
+
+{/* truncate */}
+
+## The problem
+
+InversifyJS has long used just-in-time (JIT) resolution optimizations that generate specialized resolver functions at runtime via the `Function` constructor. This approach keeps constructor call sites monomorphic in V8 and delivers strong performance, especially when resolving complex transient object graphs.
+
+The trade-off is that `Function` constructor usage requires `unsafe-eval` (or an equivalent CSP trusted-types allowance). In browser extensions, embedded web views, and other CSP-restricted environments, that can cause resolution to fail at runtime with errors like:
+
+```
+EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script
+```
+
+## The `jitless` option
+
+InversifyJS 8.2.0 introduces a new container option:
+
+```ts
+const container = new Container({ jitless: true });
+```
+
+When `jitless` is `true`, the container uses CSP-compatible resolution paths built from plain closures instead of dynamically generated functions. The behavior is the same — constructor injection, property injection, activations, scopes, and async resolution all continue to work — but without relying on `unsafe-eval`.
+
+**`jitless` defaults to `true` in 8.2.0**, so existing applications that upgrade without changing their container options will automatically use the CSP-safe path. If your environment allows `unsafe-eval` and you want the previous JIT performance profile, opt in explicitly:
+
+```ts
+const container = new Container({ jitless: false });
+```
+
+In the next major release, `jitless` is planned to default to `false`, restoring JIT optimizations as the out-of-the-box behavior for environments that permit them. Applications deployed under strict CSP will be able to set `jitless: true` explicitly.
+
+Refer to the [Container API docs](/docs/api/container#jitless) for the full option reference.
+
+## Performance trade-offs
+
+The CSP-compatible path avoids per-binding monomorphic optimizations, so the performance impact depends on your workload. Simple resolutions are largely unaffected; complex transient graphs see a more noticeable difference.
+
+The benchmarks below were taken from `packages/container/tools/container-benchmarks/src/bin/run.ts` and compare JIT-enabled (`jitless: false`) against the new default (`jitless: true`).
+
+```
+Get service in singleton scope
+inversifyCurrent vs inversifyCurrent (Jitless) Speedup: 1.029x
+
+Get service in transient scope
+inversifyCurrent vs inversifyCurrent (Jitless) Speedup: 1.005x
+
+Get complex service in transient scope
+inversifyCurrent vs inversifyCurrent (Jitless) Speedup: 1.322x
+
+Get complex service with properties in transient scope
+inversifyCurrent vs inversifyCurrent (Jitless) Speedup: 1.263x
+
+Get complex async service in transient scope
+inversifyCurrent vs inversifyCurrent (Jitless) Speedup: 1.009x
+```
+
+In practice:
+
+- **Simple singleton and transient resolutions** are within ~3% of the JIT path.
+- **Complex transient object graphs** are roughly **1.2x–1.3x slower** with `jitless: true`, which is still significantly faster than InversifyJS 7 and 8.0 in the same scenarios.
+- **Resolved value bindings** show negligible difference between the two paths.
+
+If your application does not run under CSP restrictions and resolves large transient graphs frequently, setting `jitless: false` remains the best choice for raw container throughput. If you deploy to CSP-restricted environments — or simply want to avoid `unsafe-eval` as a matter of policy — the default `jitless: true` gives you correct behavior with a modest performance cost in the workloads where JIT mattered most.
+
+## What this means for you
+
+- **Upgrading from 8.1.x**: No code changes are required. The container will use CSP-compatible resolution by default.
+- **CSP-restricted environments**: InversifyJS should now work without relaxing your content security policy.
+- **Performance-sensitive, non-CSP environments**: Pass `{ jitless: false }` to the container constructor to restore the JIT resolution path from previous releases.
+
+Thanks for trying out InversifyJS 8.2.0, and please let us know if you run into any issues.

--- a/packages/docs/services/inversify-site/blog/2026-07-15-announcing-inversify-8-2-0/index.mdx
+++ b/packages/docs/services/inversify-site/blog/2026-07-15-announcing-inversify-8-2-0/index.mdx
@@ -47,25 +47,25 @@ The benchmarks below were taken from `packages/container/tools/container-benchma
 
 ```
 Get service in singleton scope
-inversifyCurrent vs inversifyCurrent (Jitless) Speedup: 1.029x
+inversifyCurrent vs inversifyCurrent (Jitless) Speedup: 0.996x
 
 Get service in transient scope
-inversifyCurrent vs inversifyCurrent (Jitless) Speedup: 1.005x
+inversifyCurrent vs inversifyCurrent (Jitless) Speedup: 1.065x
 
 Get complex service in transient scope
-inversifyCurrent vs inversifyCurrent (Jitless) Speedup: 1.322x
+inversifyCurrent vs inversifyCurrent (Jitless) Speedup: 1.748x
 
 Get complex service with properties in transient scope
-inversifyCurrent vs inversifyCurrent (Jitless) Speedup: 1.263x
+inversifyCurrent vs inversifyCurrent (Jitless) Speedup: 2.085x
 
 Get complex async service in transient scope
-inversifyCurrent vs inversifyCurrent (Jitless) Speedup: 1.009x
+inversifyCurrent vs inversifyCurrent (Jitless) Speedup: 1.058x
 ```
 
 In practice:
 
-- **Simple singleton and transient resolutions** are within ~3% of the JIT path.
-- **Complex transient object graphs** are roughly **1.2x–1.3x slower** with `jitless: true`, which is still significantly faster than InversifyJS 7 and 8.0 in the same scenarios.
+- **Simple singleton and transient resolutions** are within noise or a few percent of the JIT path.
+- **Complex transient object graphs** are roughly **1.7x–2.1x slower** with `jitless: true`, while remaining competitive with recent InversifyJS releases in the same scenarios.
 - **Resolved value bindings** show negligible difference between the two paths.
 
 If your application does not run under CSP restrictions and resolves large transient graphs frequently, setting `jitless: false` remains the best choice for raw container throughput. If you deploy to CSP-restricted environments — or simply want to avoid `unsafe-eval` as a matter of policy — the default `jitless: true` gives you correct behavior with a modest performance cost in the workloads where JIT mattered most.

--- a/packages/docs/services/inversify-site/docs/api/container.mdx
+++ b/packages/docs/services/inversify-site/docs/api/container.mdx
@@ -53,6 +53,16 @@ defaultScope?: BindingScope | undefined;
 
 The default scope for bindings.
 
+### jitless
+
+```ts
+jitless?: boolean | undefined;
+```
+
+Option to disable just-in-time resolution optimizations that rely on the `Function` constructor. When `true` (the default), the container uses CSP-compatible resolution paths that work in environments enforcing a strict Content Security Policy without `unsafe-eval`.
+
+Set `jitless` to `false` to enable JIT optimizations for better performance in environments where `unsafe-eval` is permitted. In the next major release, `jitless` is planned to default to `false`.
+
 ## bind
 
 ```ts

--- a/packages/docs/services/inversify-site/i18n/zh/docusaurus-plugin-content-docs/current/api/container.mdx
+++ b/packages/docs/services/inversify-site/i18n/zh/docusaurus-plugin-content-docs/current/api/container.mdx
@@ -53,6 +53,16 @@ defaultScope?: BindingScope | undefined;
 
 绑定的默认作用域。
 
+### jitless
+
+```ts
+jitless?: boolean | undefined;
+```
+
+用于禁用依赖 `Function` 构造函数的即时（JIT）解析优化的选项。当为 `true`（默认值）时，容器使用与 CSP 兼容的解析路径，可在强制执行严格内容安全策略（不允许 `unsafe-eval`）的环境中正常工作。
+
+在允许 `unsafe-eval` 的环境中，将 `jitless` 设置为 `false` 可启用 JIT 优化以获得更好的性能。在下一个主要版本中，`jitless` 计划默认值为 `false`。
+
 ## bind
 
 ```ts

--- a/packages/docs/services/inversify-site/i18n/zh/docusaurus-plugin-content-docs/version-8.x/api/container.mdx
+++ b/packages/docs/services/inversify-site/i18n/zh/docusaurus-plugin-content-docs/version-8.x/api/container.mdx
@@ -53,6 +53,16 @@ defaultScope?: BindingScope | undefined;
 
 绑定的默认作用域。
 
+### jitless
+
+```ts
+jitless?: boolean | undefined;
+```
+
+用于禁用依赖 `Function` 构造函数的即时（JIT）解析优化的选项。当为 `true`（默认值）时，容器使用与 CSP 兼容的解析路径，可在强制执行严格内容安全策略（不允许 `unsafe-eval`）的环境中正常工作。
+
+在允许 `unsafe-eval` 的环境中，将 `jitless` 设置为 `false` 可启用 JIT 优化以获得更好的性能。在下一个主要版本中，`jitless` 计划默认值为 `false`。
+
 ## bind
 
 ```ts

--- a/packages/docs/services/inversify-site/versioned_docs/version-8.x/api/container.mdx
+++ b/packages/docs/services/inversify-site/versioned_docs/version-8.x/api/container.mdx
@@ -53,6 +53,16 @@ defaultScope?: BindingScope | undefined;
 
 The default scope for bindings.
 
+### jitless
+
+```ts
+jitless?: boolean | undefined;
+```
+
+Option to disable just-in-time resolution optimizations that rely on the `Function` constructor. When `true` (the default), the container uses CSP-compatible resolution paths that work in environments enforcing a strict Content Security Policy without `unsafe-eval`.
+
+Set `jitless` to `false` to enable JIT optimizations for better performance in environments where `unsafe-eval` is permitted. In the next major release, `jitless` is planned to default to `false`.
+
 ## bind
 
 ```ts


### PR DESCRIPTION
### Context
- Fixes #1994.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `jitless` container option (defaults to enabled) for CSP-compatible dependency resolution without runtime code generation.
  * Resolution planning now consistently respects the configured JIT/JITless mode.
* **Bug Fixes**
  * Improved CSP behavior by aligning resolution, caching, and activation handling with the JIT settings.
* **Documentation**
  * Updated Container API docs and added an InversifyJS 8.2.0 release announcement with upgrade guidance and performance trade-offs.
* **Tests**
  * Expanded coverage for both JIT and JITless modes, including CSP-safe constructor/property resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->