### PR TITLE
Move getActivations to ResolutionContext

### DIFF
--- a/.changeset/cyan-groups-spend.md
+++ b/.changeset/cyan-groups-spend.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": major
+---
+
+- Moved `getActivations` from `ResolutionParams` to `ResolutionContext`.

--- a/packages/container/libraries/container/src/container/services/ServiceResolutionManager.spec.ts
+++ b/packages/container/libraries/container/src/container/services/ServiceResolutionManager.spec.ts
@@ -157,11 +157,11 @@ describe(ServiceResolutionManager, () => {
           const expectedResolveParams: ResolutionParams = {
             context: {
               get: expect.any(Function),
+              getActivations: expect.any(Function),
               getAll: expect.any(Function),
               getAllAsync: expect.any(Function),
               getAsync: expect.any(Function),
             },
-            getActivations: expect.any(Function),
             planResult: planResultFixture,
             requestScopeCache: undefined,
           };
@@ -255,11 +255,11 @@ describe(ServiceResolutionManager, () => {
           const expectedResolveParams: ResolutionParams = {
             context: {
               get: expect.any(Function),
+              getActivations: expect.any(Function),
               getAll: expect.any(Function),
               getAllAsync: expect.any(Function),
               getAsync: expect.any(Function),
             },
-            getActivations: expect.any(Function),
             planResult: planResultFixture,
             requestScopeCache: undefined,
           };
@@ -376,11 +376,11 @@ describe(ServiceResolutionManager, () => {
           const expectedResolveParams: ResolutionParams = {
             context: {
               get: expect.any(Function),
+              getActivations: expect.any(Function),
               getAll: expect.any(Function),
               getAllAsync: expect.any(Function),
               getAsync: expect.any(Function),
             },
-            getActivations: expect.any(Function),
             planResult: planResultFixture,
             requestScopeCache: undefined,
           };
@@ -488,11 +488,11 @@ describe(ServiceResolutionManager, () => {
           const expectedResolveParams: ResolutionParams = {
             context: {
               get: expect.any(Function),
+              getActivations: expect.any(Function),
               getAll: expect.any(Function),
               getAllAsync: expect.any(Function),
               getAsync: expect.any(Function),
             },
-            getActivations: expect.any(Function),
             planResult: planResultFixture,
             requestScopeCache: undefined,
           };
@@ -601,11 +601,11 @@ describe(ServiceResolutionManager, () => {
           const expectedResolveParams: ResolutionParams = {
             context: {
               get: expect.any(Function),
+              getActivations: expect.any(Function),
               getAll: expect.any(Function),
               getAllAsync: expect.any(Function),
               getAsync: expect.any(Function),
             },
-            getActivations: expect.any(Function),
             planResult: planResultFixture,
             requestScopeCache: undefined,
           };
@@ -696,11 +696,11 @@ describe(ServiceResolutionManager, () => {
         const expectedResolveParams: ResolutionParams = {
           context: {
             get: expect.any(Function),
+            getActivations: expect.any(Function),
             getAll: expect.any(Function),
             getAllAsync: expect.any(Function),
             getAsync: expect.any(Function),
           },
-          getActivations: expect.any(Function),
           planResult: planResultFixture,
           requestScopeCache: undefined,
         };
@@ -779,11 +779,11 @@ describe(ServiceResolutionManager, () => {
           const expectedResolveParams: ResolutionParams = {
             context: {
               get: expect.any(Function),
+              getActivations: expect.any(Function),
               getAll: expect.any(Function),
               getAllAsync: expect.any(Function),
               getAsync: expect.any(Function),
             },
-            getActivations: expect.any(Function),
             planResult: planResultFixture,
             requestScopeCache: undefined,
           };
@@ -949,11 +949,11 @@ describe(ServiceResolutionManager, () => {
           const expectedResolveParams: ResolutionParams = {
             context: {
               get: expect.any(Function),
+              getActivations: expect.any(Function),
               getAll: expect.any(Function),
               getAllAsync: expect.any(Function),
               getAsync: expect.any(Function),
             },
-            getActivations: expect.any(Function),
             planResult: planResultFixture,
             requestScopeCache: undefined,
           };
@@ -1049,11 +1049,11 @@ describe(ServiceResolutionManager, () => {
         const expectedResolveParams: ResolutionParams = {
           context: {
             get: expect.any(Function),
+            getActivations: expect.any(Function),
             getAll: expect.any(Function),
             getAllAsync: expect.any(Function),
             getAsync: expect.any(Function),
           },
-          getActivations: expect.any(Function),
           planResult: planResultFixture,
           requestScopeCache: undefined,
         };
@@ -1150,11 +1150,11 @@ describe(ServiceResolutionManager, () => {
         const expectedResolveParams: ResolutionParams = {
           context: {
             get: expect.any(Function),
+            getActivations: expect.any(Function),
             getAll: expect.any(Function),
             getAllAsync: expect.any(Function),
             getAsync: expect.any(Function),
           },
-          getActivations: expect.any(Function),
           planResult: planResultFixture,
           requestScopeCache: undefined,
         };
@@ -1257,11 +1257,11 @@ describe(ServiceResolutionManager, () => {
         const expectedResolveParams: ResolutionParams = {
           context: {
             get: expect.any(Function),
+            getActivations: expect.any(Function),
             getAll: expect.any(Function),
             getAllAsync: expect.any(Function),
             getAsync: expect.any(Function),
           },
-          getActivations: expect.any(Function),
           planResult: planResultFixture,
           requestScopeCache: undefined,
         };
@@ -1354,11 +1354,11 @@ describe(ServiceResolutionManager, () => {
         const expectedResolveParams: ResolutionParams = {
           context: {
             get: expect.any(Function),
+            getActivations: expect.any(Function),
             getAll: expect.any(Function),
             getAllAsync: expect.any(Function),
             getAsync: expect.any(Function),
           },
-          getActivations: expect.any(Function),
           planResult: planResultFixture,
           requestScopeCache: undefined,
         };

--- a/packages/container/libraries/container/src/container/services/ServiceResolutionManager.ts
+++ b/packages/container/libraries/container/src/container/services/ServiceResolutionManager.ts
@@ -49,15 +49,17 @@ export class ServiceResolutionManager {
   ) {
     this.#planParamsOperationsManager = planParamsOperationsManager;
     this.#serviceReferenceManager = serviceReferenceManager;
-    this.#resolutionContext = this.#buildResolutionContext();
-    this.#autobind = autobind;
-    this.#defaultScope = defaultScope;
-    this.#jitEnabled = jitEnabled;
+
     this.#getActivationsResolutionParam = <TActivated>(
       serviceIdentifier: ServiceIdentifier<TActivated>,
     ): Iterable<BindingActivation<TActivated>> | undefined =>
       this.#serviceReferenceManager.activationService.get(serviceIdentifier) as
         Iterable<BindingActivation<TActivated>> | undefined;
+
+    this.#resolutionContext = this.#buildResolutionContext();
+    this.#autobind = autobind;
+    this.#defaultScope = defaultScope;
+    this.#jitEnabled = jitEnabled;
 
     this.#onPlanHandlers = [];
 
@@ -286,6 +288,7 @@ export class ServiceResolutionManager {
   #buildResolutionContext(): ResolutionContext {
     return {
       get: this.get.bind(this),
+      getActivations: this.#getActivationsResolutionParam,
       getAll: this.getAll.bind(this),
       getAllAsync: this.getAllAsync.bind(this),
       getAsync: this.getAsync.bind(this),
@@ -296,7 +299,6 @@ export class ServiceResolutionManager {
   #getFromPlanResult<T>(planResult: PlanResult): T {
     return resolve({
       context: this.#resolutionContext,
-      getActivations: this.#getActivationsResolutionParam,
       planResult,
       requestScopeCache: undefined,
     }) as T;

--- a/packages/container/libraries/core/src/planning/calculations/handleResolveError.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/handleResolveError.spec.ts
@@ -63,7 +63,6 @@ function buildParams(root: PlanServiceNode): ResolutionParams {
   const planResult: PlanResult = { tree: { root } };
   return {
     context: {} as unknown,
-    getActivations: vitest.fn(),
     planResult,
     requestScopeCache: new Map(),
   } as unknown as ResolutionParams;

--- a/packages/container/libraries/core/src/resolution/actions/resolve.int.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolve.int.spec.ts
@@ -337,11 +337,6 @@ describe(resolve, () => {
 
       return resolve({
         context: resolutionContext,
-        getActivations: <TActivated>(
-          serviceIdentifier: ServiceIdentifier,
-        ): BindingActivation<TActivated>[] | undefined =>
-          activationService.get(serviceIdentifier) as
-            BindingActivation<TActivated>[] | undefined,
         planResult,
         requestScopeCache: new Map(),
       }) as TMultiple extends false
@@ -402,6 +397,11 @@ describe(resolve, () => {
 
     resolutionContext = {
       get: handleGet,
+      getActivations: <TActivated>(
+        serviceIdentifier: ServiceIdentifier,
+      ): BindingActivation<TActivated>[] | undefined =>
+        activationService.get(serviceIdentifier) as
+          BindingActivation<TActivated>[] | undefined,
       getAll: <TActivated>(
         serviceIdentifier: ServiceIdentifier<TActivated>,
         options?: GetOptions,
@@ -543,11 +543,6 @@ describe(resolve, () => {
 
           result = resolve({
             context: resolutionContext,
-            getActivations: <TActivated>(
-              serviceIdentifier: ServiceIdentifier,
-            ): BindingActivation<TActivated>[] | undefined =>
-              activationService.get(serviceIdentifier) as
-                BindingActivation<TActivated>[] | undefined,
             planResult,
             requestScopeCache: new Map(),
           });

--- a/packages/container/libraries/core/src/resolution/actions/resolveBindingActivations.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveBindingActivations.spec.ts
@@ -13,7 +13,6 @@ vitest.mock(import('./resolveBindingServiceActivations.js'));
 
 import { ConstantValueBindingFixtures } from '../../binding/fixtures/ConstantValueBindingFixtures.js';
 import { type ConstantValueBinding } from '../../binding/models/ConstantValueBinding.js';
-import { type ResolutionContext } from '../models/ResolutionContext.js';
 import { type ResolutionParams } from '../models/ResolutionParams.js';
 import { resolveBindingActivations } from './resolveBindingActivations.js';
 import { resolveBindingServiceActivations } from './resolveBindingServiceActivations.js';
@@ -26,7 +25,6 @@ describe(resolveBindingActivations, () => {
 
     beforeAll(() => {
       paramsMock = {
-        getActivations: vitest.fn(),
         getBindings: vitest.fn(),
       } as Partial<Mocked<ResolutionParams>> as Mocked<ResolutionParams>;
       bindingFixture = ConstantValueBindingFixtures.withOnActivationUndefined;
@@ -80,8 +78,6 @@ describe(resolveBindingActivations, () => {
     beforeAll(() => {
       onActivationMock = vitest.fn();
       paramsMock = {
-        context: Symbol() as unknown as Mocked<ResolutionContext>,
-        getActivations: vitest.fn(),
         getBindings: vitest.fn(),
       } as Partial<Mocked<ResolutionParams>> as Mocked<ResolutionParams>;
       bindingFixture = {

--- a/packages/container/libraries/core/src/resolution/actions/resolveBindingServiceActivations.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveBindingServiceActivations.spec.ts
@@ -14,6 +14,7 @@ vitest.mock(import('./resolveBindingActivationsFromIteratorAsync.js'));
 import { type ServiceIdentifier } from '@inversifyjs/common';
 
 import { type BindingActivation } from '../../binding/models/BindingActivation.js';
+import { type ResolutionContext } from '../models/ResolutionContext.js';
 import { type ResolutionParams } from '../models/ResolutionParams.js';
 import { resolveBindingActivationsFromIterator } from './resolveBindingActivationsFromIterator.js';
 import { resolveBindingActivationsFromIteratorAsync } from './resolveBindingActivationsFromIteratorAsync.js';
@@ -27,13 +28,15 @@ describe(resolveBindingServiceActivations, () => {
 
     beforeAll(() => {
       paramsMock = {
-        getActivations: vitest.fn(),
+        context: {
+          getActivations: vitest.fn(),
+        } as Partial<Mocked<ResolutionContext>> as Mocked<ResolutionContext>,
       } as Partial<Mocked<ResolutionParams>> as Mocked<ResolutionParams>;
       serviceIdentifierFixture = 'service-id';
       valueFixture = Symbol();
     });
 
-    describe('when called, and params.getActivations() returns undefined', () => {
+    describe('when called, and params.context.getActivations() returns undefined', () => {
       let result: unknown;
 
       beforeAll(() => {
@@ -48,10 +51,10 @@ describe(resolveBindingServiceActivations, () => {
         vitest.clearAllMocks();
       });
 
-      it('should call params.getActivations', () => {
-        expect(paramsMock.getActivations).toHaveBeenCalledExactlyOnceWith(
-          serviceIdentifierFixture,
-        );
+      it('should call params.context.getActivations', () => {
+        expect(
+          paramsMock.context.getActivations,
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
       });
 
       it('should return value', () => {
@@ -59,7 +62,7 @@ describe(resolveBindingServiceActivations, () => {
       });
     });
 
-    describe('when called, and params.getActivations() returns activations', () => {
+    describe('when called, and params.context.getActivations() returns activations', () => {
       let activationsIteratorFixture: Iterator<BindingActivation<unknown>>;
       let activationsIterableFixture: Iterable<BindingActivation<unknown>>;
       let resolveBindingActivationsFromIteratorResultFixture: unknown;
@@ -77,9 +80,9 @@ describe(resolveBindingServiceActivations, () => {
           'resolve-binding-activations-from-iterator-result',
         );
 
-        paramsMock.getActivations.mockReturnValueOnce(
-          activationsIterableFixture,
-        );
+        vitest
+          .mocked(paramsMock.context.getActivations)
+          .mockReturnValueOnce(activationsIterableFixture);
 
         vitest
           .mocked(resolveBindingActivationsFromIterator)
@@ -98,10 +101,10 @@ describe(resolveBindingServiceActivations, () => {
         vitest.clearAllMocks();
       });
 
-      it('should call params.getActivations', () => {
-        expect(paramsMock.getActivations).toHaveBeenCalledExactlyOnceWith(
-          serviceIdentifierFixture,
-        );
+      it('should call params.context.getActivations', () => {
+        expect(
+          paramsMock.context.getActivations,
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
       });
 
       it('should call resolveBindingActivationsFromIterator()', () => {
@@ -127,13 +130,15 @@ describe(resolveBindingServiceActivations, () => {
 
     beforeAll(() => {
       paramsMock = {
-        getActivations: vitest.fn(),
+        context: {
+          getActivations: vitest.fn(),
+        } as Partial<Mocked<ResolutionContext>> as Mocked<ResolutionContext>,
       } as Partial<Mocked<ResolutionParams>> as Mocked<ResolutionParams>;
       serviceIdentifierFixture = 'service-id';
       valueFixture = Symbol();
     });
 
-    describe('when called, and params.getActivations() returns undefined', () => {
+    describe('when called, and params.context.getActivations() returns undefined', () => {
       let result: unknown;
 
       beforeAll(async () => {
@@ -148,10 +153,10 @@ describe(resolveBindingServiceActivations, () => {
         vitest.clearAllMocks();
       });
 
-      it('should call params.getActivations', () => {
-        expect(paramsMock.getActivations).toHaveBeenCalledExactlyOnceWith(
-          serviceIdentifierFixture,
-        );
+      it('should call params.context.getActivations', () => {
+        expect(
+          paramsMock.context.getActivations,
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
       });
 
       it('should return value', () => {
@@ -159,7 +164,7 @@ describe(resolveBindingServiceActivations, () => {
       });
     });
 
-    describe('when called, and params.getActivations() returns activations', () => {
+    describe('when called, and params.context.getActivations() returns activations', () => {
       let activationsIteratorFixture: Iterator<BindingActivation<unknown>>;
       let activationsIterableFixture: Iterable<BindingActivation<unknown>>;
       let resolveBindingActivationsFromIteratorAsyncResultFixture: unknown;
@@ -179,9 +184,9 @@ describe(resolveBindingServiceActivations, () => {
         );
         valuePromiseFixture = Promise.resolve(valueFixture);
 
-        paramsMock.getActivations.mockReturnValueOnce(
-          activationsIterableFixture,
-        );
+        vitest
+          .mocked(paramsMock.context.getActivations)
+          .mockReturnValueOnce(activationsIterableFixture);
 
         vitest
           .mocked(resolveBindingActivationsFromIteratorAsync)
@@ -200,10 +205,10 @@ describe(resolveBindingServiceActivations, () => {
         vitest.clearAllMocks();
       });
 
-      it('should call params.getActivations', () => {
-        expect(paramsMock.getActivations).toHaveBeenCalledExactlyOnceWith(
-          serviceIdentifierFixture,
-        );
+      it('should call params.context.getActivations', () => {
+        expect(
+          paramsMock.context.getActivations,
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
       });
 
       it('should call resolveBindingActivationsFromIteratorAsync()', () => {

--- a/packages/container/libraries/core/src/resolution/actions/resolveBindingServiceActivations.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveBindingServiceActivations.ts
@@ -12,7 +12,7 @@ export function resolveBindingServiceActivations<TActivated>(
   value: Resolved<TActivated>,
 ): Resolved<TActivated> {
   const activations: Iterable<BindingActivation<TActivated>> | undefined =
-    params.getActivations(serviceIdentifier);
+    params.context.getActivations(serviceIdentifier);
 
   if (activations === undefined) {
     return value;

--- a/packages/container/libraries/core/src/resolution/actions/resolveServiceActivations.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveServiceActivations.spec.ts
@@ -14,6 +14,7 @@ vitest.mock(import('./resolveBindingActivationsFromIteratorAsync.js'));
 import { type ServiceIdentifier } from '@inversifyjs/common';
 
 import { type BindingActivation } from '../../binding/models/BindingActivation.js';
+import { type ResolutionContext } from '../models/ResolutionContext.js';
 import { type ResolutionParams } from '../models/ResolutionParams.js';
 import { resolveBindingActivationsFromIterator } from './resolveBindingActivationsFromIterator.js';
 import { resolveBindingActivationsFromIteratorAsync } from './resolveBindingActivationsFromIteratorAsync.js';
@@ -27,13 +28,15 @@ describe(resolveServiceActivations, () => {
 
     beforeAll(() => {
       paramsMock = {
-        getActivations: vitest.fn(),
+        context: {
+          getActivations: vitest.fn(),
+        } as Partial<Mocked<ResolutionContext>> as Mocked<ResolutionContext>,
       } as Partial<Mocked<ResolutionParams>> as Mocked<ResolutionParams>;
       serviceIdentifierFixture = 'service-id';
       valueFixture = Symbol();
     });
 
-    describe('when called, and params.getActivations() returns undefined', () => {
+    describe('when called, and params.context.getActivations() returns undefined', () => {
       let result: unknown;
 
       beforeAll(() => {
@@ -47,10 +50,10 @@ describe(resolveServiceActivations, () => {
         vitest.clearAllMocks();
       });
 
-      it('should call params.getActivations', () => {
-        expect(paramsMock.getActivations).toHaveBeenCalledExactlyOnceWith(
-          serviceIdentifierFixture,
-        );
+      it('should call params.context.getActivations', () => {
+        expect(
+          paramsMock.context.getActivations,
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
       });
 
       it('should return value', () => {
@@ -58,7 +61,7 @@ describe(resolveServiceActivations, () => {
       });
     });
 
-    describe('when called, and params.getActivations() returns activations', () => {
+    describe('when called, and params.context.getActivations() returns activations', () => {
       let activationsIteratorFixture: Iterator<BindingActivation<unknown>>;
       let activationsIterableFixture: Iterable<BindingActivation<unknown>>;
       let resolveBindingActivationsFromIteratorResultFixture: unknown;
@@ -76,9 +79,9 @@ describe(resolveServiceActivations, () => {
           'resolve-binding-activations-from-iterator-result',
         );
 
-        paramsMock.getActivations.mockReturnValueOnce(
-          activationsIterableFixture,
-        );
+        vitest
+          .mocked(paramsMock.context.getActivations)
+          .mockReturnValueOnce(activationsIterableFixture);
 
         vitest
           .mocked(resolveBindingActivationsFromIterator)
@@ -96,10 +99,10 @@ describe(resolveServiceActivations, () => {
         vitest.clearAllMocks();
       });
 
-      it('should call params.getActivations', () => {
-        expect(paramsMock.getActivations).toHaveBeenCalledExactlyOnceWith(
-          serviceIdentifierFixture,
-        );
+      it('should call params.context.getActivations', () => {
+        expect(
+          paramsMock.context.getActivations,
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
       });
 
       it('should call resolveBindingActivationsFromIterator()', () => {
@@ -125,13 +128,15 @@ describe(resolveServiceActivations, () => {
 
     beforeAll(() => {
       paramsMock = {
-        getActivations: vitest.fn(),
+        context: {
+          getActivations: vitest.fn(),
+        } as Partial<Mocked<ResolutionContext>> as Mocked<ResolutionContext>,
       } as Partial<Mocked<ResolutionParams>> as Mocked<ResolutionParams>;
       serviceIdentifierFixture = 'service-id';
       valueFixture = Symbol();
     });
 
-    describe('when called, and params.getActivations() returns undefined', () => {
+    describe('when called, and params.context.getActivations() returns undefined', () => {
       let result: unknown;
 
       beforeAll(async () => {
@@ -145,10 +150,10 @@ describe(resolveServiceActivations, () => {
         vitest.clearAllMocks();
       });
 
-      it('should call params.getActivations', () => {
-        expect(paramsMock.getActivations).toHaveBeenCalledExactlyOnceWith(
-          serviceIdentifierFixture,
-        );
+      it('should call params.context.getActivations', () => {
+        expect(
+          paramsMock.context.getActivations,
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
       });
 
       it('should return value', () => {
@@ -156,7 +161,7 @@ describe(resolveServiceActivations, () => {
       });
     });
 
-    describe('when called, and params.getActivations() returns activations', () => {
+    describe('when called, and params.context.getActivations() returns activations', () => {
       let activationsIteratorFixture: Iterator<BindingActivation<unknown>>;
       let activationsIterableFixture: Iterable<BindingActivation<unknown>>;
       let resolveBindingActivationsFromIteratorAsyncResultFixture: unknown;
@@ -176,9 +181,9 @@ describe(resolveServiceActivations, () => {
         );
         valuePromiseFixture = Promise.resolve(valueFixture);
 
-        paramsMock.getActivations.mockReturnValueOnce(
-          activationsIterableFixture,
-        );
+        vitest
+          .mocked(paramsMock.context.getActivations)
+          .mockReturnValueOnce(activationsIterableFixture);
 
         vitest
           .mocked(resolveBindingActivationsFromIteratorAsync)
@@ -196,10 +201,10 @@ describe(resolveServiceActivations, () => {
         vitest.clearAllMocks();
       });
 
-      it('should call params.getActivations', () => {
-        expect(paramsMock.getActivations).toHaveBeenCalledExactlyOnceWith(
-          serviceIdentifierFixture,
-        );
+      it('should call params.context.getActivations', () => {
+        expect(
+          paramsMock.context.getActivations,
+        ).toHaveBeenCalledExactlyOnceWith(serviceIdentifierFixture);
       });
 
       it('should call resolveBindingActivationsFromIteratorAsync()', () => {

--- a/packages/container/libraries/core/src/resolution/actions/resolveServiceActivations.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolveServiceActivations.ts
@@ -17,7 +17,7 @@ export function resolveServiceActivations<TActivated>(
     value: Resolved<TActivated>,
   ): Resolved<TActivated> => {
     const activations: Iterable<BindingActivation<TActivated>> | undefined =
-      params.getActivations(serviceIdentifier);
+      params.context.getActivations(serviceIdentifier);
 
     if (activations === undefined) {
       return value;

--- a/packages/container/libraries/core/src/resolution/models/ResolutionContext.ts
+++ b/packages/container/libraries/core/src/resolution/models/ResolutionContext.ts
@@ -1,5 +1,6 @@
 import { type ServiceIdentifier } from '@inversifyjs/common';
 
+import { type BindingActivation } from '../../binding/models/BindingActivation.js';
 import { type GetOptions } from './GetOptions.js';
 import { type OptionalGetOptions } from './OptionalGetOptions.js';
 
@@ -12,6 +13,10 @@ export interface ResolutionContext {
     serviceIdentifier: ServiceIdentifier<TActivated>,
     options?: GetOptions,
   ): TActivated;
+
+  getActivations<TActivated>(
+    serviceIdentifier: ServiceIdentifier<TActivated>,
+  ): Iterable<BindingActivation<TActivated>> | undefined;
 
   getAll<TActivated>(
     serviceIdentifier: ServiceIdentifier<TActivated>,

--- a/packages/container/libraries/core/src/resolution/models/ResolutionParams.ts
+++ b/packages/container/libraries/core/src/resolution/models/ResolutionParams.ts
@@ -1,14 +1,8 @@
-import { type ServiceIdentifier } from '@inversifyjs/common';
-
-import { type BindingActivation } from '../../binding/models/BindingActivation.js';
 import { type PlanResult } from '../../planning/models/PlanResult.js';
 import { type ResolutionContext } from './ResolutionContext.js';
 
 export interface ResolutionParams {
   context: ResolutionContext;
-  getActivations: <TActivated>(
-    serviceIdentifier: ServiceIdentifier<TActivated>,
-  ) => Iterable<BindingActivation<TActivated>> | undefined;
   planResult: PlanResult;
   requestScopeCache: Map<number, unknown> | undefined;
 }


### PR DESCRIPTION
### Changed
- Moved `getActivations` to `ResolutionContext`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Moved `getActivations` from `ResolutionParams` to `ResolutionContext`.
  * Updated the package with a major version release to reflect this API change.

* **Bug Fixes**
  * Updated activation resolution to consistently use the new context-based API for synchronous and asynchronous services.

* **Tests**
  * Expanded coverage for activation lookup, including undefined results and promise-based resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->