### PR TITLE
[Perf]: No service activation resolution flow

### DIFF
--- a/.changeset/tidy-mirrors-glow.md
+++ b/.changeset/tidy-mirrors-glow.md
@@ -1,0 +1,6 @@
+---
+"@inversifyjs/core": major
+"@inversifyjs/container": patch
+---
+
+- Updated `PlanParamsOperations` with `getActivations`.

--- a/packages/container/libraries/container/src/container/services/Container.spec.ts
+++ b/packages/container/libraries/container/src/container/services/Container.spec.ts
@@ -178,6 +178,7 @@ describe(Container, () => {
     } as Partial<Mocked<DeactivationsService>> as Mocked<DeactivationsService>;
     planParamsOperationsManagerMock = {
       planParamsOperations: {
+        getActivations: vitest.fn(),
         getBindings: vitest.fn(),
         getBindingsChained: vitest.fn(),
         getClassMetadata: vitest.fn(),
@@ -185,6 +186,7 @@ describe(Container, () => {
         setBinding: vitest.fn(),
         setNonCachedServiceNode: vitest.fn(),
         setPlan: vitest.fn(),
+        subscribeActivationAddedOnce: vitest.fn(),
       },
     } as Partial<
       Mocked<PlanParamsOperationsManager>

--- a/packages/container/libraries/container/src/container/services/PlanParamsOperationsManager.spec.ts
+++ b/packages/container/libraries/container/src/container/services/PlanParamsOperationsManager.spec.ts
@@ -1,0 +1,228 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  type Mocked,
+  vitest,
+} from 'vitest';
+
+import { type ServiceIdentifier } from '@inversifyjs/common';
+import {
+  type ActivationsService,
+  type Binding,
+  type BindingActivation,
+  type BindingService,
+  CacheBindingInvalidationKind,
+  getClassMetadata,
+  type PlanResultCacheService,
+} from '@inversifyjs/core';
+
+import { PlanParamsOperationsManager } from './PlanParamsOperationsManager.js';
+import { type ServiceReferenceManager } from './ServiceReferenceManager.js';
+
+describe(PlanParamsOperationsManager, () => {
+  let activationServiceMock: Mocked<ActivationsService>;
+  let bindingServiceMock: Mocked<BindingService>;
+  let planResultCacheServiceMock: Mocked<PlanResultCacheService>;
+  let serviceReferenceManagerMock: Mocked<ServiceReferenceManager>;
+  let onResetListener: (() => void) | undefined;
+
+  let planParamsOperationsManager: PlanParamsOperationsManager;
+
+  beforeAll(() => {
+    activationServiceMock = {
+      get: vitest.fn(),
+    } as Partial<Mocked<ActivationsService>> as Mocked<ActivationsService>;
+
+    bindingServiceMock = {
+      get: vitest.fn(),
+      getChained: vitest.fn(),
+      set: vitest.fn(),
+    } as Partial<Mocked<BindingService>> as Mocked<BindingService>;
+
+    planResultCacheServiceMock = {
+      get: vitest.fn(),
+      invalidateServiceBinding: vitest.fn(),
+      set: vitest.fn(),
+      setNonCachedServiceNode: vitest.fn(),
+    } as Partial<
+      Mocked<PlanResultCacheService>
+    > as Mocked<PlanResultCacheService>;
+
+    onResetListener = undefined;
+
+    serviceReferenceManagerMock = {
+      activationService: activationServiceMock,
+      bindingService: bindingServiceMock,
+      onReset: vitest.fn((listener: () => void): void => {
+        onResetListener = listener;
+      }),
+      planResultCacheService: planResultCacheServiceMock,
+    } as Partial<
+      Mocked<ServiceReferenceManager>
+    > as Mocked<ServiceReferenceManager>;
+
+    planParamsOperationsManager = new PlanParamsOperationsManager(
+      serviceReferenceManagerMock,
+    );
+  });
+
+  describe('constructor', () => {
+    describe('when called', () => {
+      it('should call serviceReferenceManager.onReset()', () => {
+        expect(
+          serviceReferenceManagerMock.onReset,
+        ).toHaveBeenCalledExactlyOnceWith(expect.any(Function));
+      });
+
+      it('should set planParamsOperations.getClassMetadata', () => {
+        expect(
+          planParamsOperationsManager.planParamsOperations.getClassMetadata,
+        ).toBe(getClassMetadata);
+      });
+    });
+  });
+
+  describe('.planParamsOperations.getActivations', () => {
+    describe('when called', () => {
+      let serviceIdentifierFixture: ServiceIdentifier;
+      let activationsFixture: Iterable<BindingActivation>;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        serviceIdentifierFixture = 'service-id';
+        activationsFixture = [vitest.fn() as BindingActivation];
+
+        vitest
+          .mocked(activationServiceMock.get)
+          .mockReturnValueOnce(activationsFixture);
+
+        result =
+          planParamsOperationsManager.planParamsOperations.getActivations(
+            serviceIdentifierFixture,
+          );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call activationService.get()', () => {
+        expect(activationServiceMock.get).toHaveBeenCalledExactlyOnceWith(
+          serviceIdentifierFixture,
+        );
+      });
+
+      it('should return expected result', () => {
+        expect(result).toBe(activationsFixture);
+      });
+    });
+  });
+
+  describe('.planParamsOperations.setBinding', () => {
+    describe('when called', () => {
+      let bindingFixture: Binding;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        bindingFixture = Symbol() as unknown as Binding;
+
+        result =
+          planParamsOperationsManager.planParamsOperations.setBinding(
+            bindingFixture,
+          );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call bindingService.set()', () => {
+        expect(bindingServiceMock.set).toHaveBeenCalledExactlyOnceWith(
+          bindingFixture,
+        );
+      });
+
+      it('should call planResultCacheService.invalidateServiceBinding()', () => {
+        expect(
+          planResultCacheServiceMock.invalidateServiceBinding,
+        ).toHaveBeenCalledExactlyOnceWith({
+          binding: bindingFixture,
+          kind: CacheBindingInvalidationKind.bindingAdded,
+          operations: planParamsOperationsManager.planParamsOperations,
+        });
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('when serviceReferenceManager.onReset() listener is called', () => {
+    let newActivationServiceMock: Mocked<ActivationsService>;
+    let newBindingServiceMock: Mocked<BindingService>;
+
+    beforeAll(() => {
+      newActivationServiceMock = {
+        get: vitest.fn(),
+      } as Partial<Mocked<ActivationsService>> as Mocked<ActivationsService>;
+
+      newBindingServiceMock = {
+        get: vitest.fn(),
+        getChained: vitest.fn(),
+        set: vitest.fn(),
+      } as Partial<Mocked<BindingService>> as Mocked<BindingService>;
+
+      serviceReferenceManagerMock.activationService = newActivationServiceMock;
+      serviceReferenceManagerMock.bindingService = newBindingServiceMock;
+
+      onResetListener?.();
+    });
+
+    describe('.planParamsOperations.getActivations', () => {
+      describe('when called', () => {
+        let serviceIdentifierFixture: ServiceIdentifier;
+        let activationsFixture: Iterable<BindingActivation>;
+
+        let result: unknown;
+
+        beforeAll(() => {
+          serviceIdentifierFixture = 'service-id';
+          activationsFixture = [vitest.fn() as BindingActivation];
+
+          vitest
+            .mocked(newActivationServiceMock.get)
+            .mockReturnValueOnce(activationsFixture);
+
+          result =
+            planParamsOperationsManager.planParamsOperations.getActivations(
+              serviceIdentifierFixture,
+            );
+        });
+
+        afterAll(() => {
+          vitest.clearAllMocks();
+        });
+
+        it('should call new activationService.get()', () => {
+          expect(newActivationServiceMock.get).toHaveBeenCalledExactlyOnceWith(
+            serviceIdentifierFixture,
+          );
+        });
+
+        it('should not call previous activationService.get()', () => {
+          expect(activationServiceMock.get).not.toHaveBeenCalled();
+        });
+
+        it('should return expected result', () => {
+          expect(result).toBe(activationsFixture);
+        });
+      });
+    });
+  });
+});

--- a/packages/container/libraries/container/src/container/services/PlanParamsOperationsManager.ts
+++ b/packages/container/libraries/container/src/container/services/PlanParamsOperationsManager.ts
@@ -1,10 +1,13 @@
+import { type ServiceIdentifier } from '@inversifyjs/common';
 import {
   type Binding,
+  type BindingActivation,
   CacheBindingInvalidationKind,
   getClassMetadata,
   type PlanParamsOperations,
 } from '@inversifyjs/core';
 
+import { type ActivationSubscriber } from '../../../../core/lib/binding/models/ActivationSubscriber.js';
 import { type ServiceReferenceManager } from './ServiceReferenceManager.js';
 
 export class PlanParamsOperationsManager {
@@ -15,6 +18,7 @@ export class PlanParamsOperationsManager {
     this.#serviceReferenceManager = serviceReferenceManager;
 
     this.planParamsOperations = {
+      getActivations: this.#getActivations.bind(this),
       getBindings: this.#serviceReferenceManager.bindingService.get.bind(
         this.#serviceReferenceManager.bindingService,
       ),
@@ -34,11 +38,31 @@ export class PlanParamsOperationsManager {
       setPlan: this.#serviceReferenceManager.planResultCacheService.set.bind(
         this.#serviceReferenceManager.planResultCacheService,
       ),
+      subscribeActivationAddedOnce:
+        this.#subscribeActivationAddedOnce.bind(this),
     };
 
     this.#serviceReferenceManager.onReset(() => {
       this.#resetComputedProperties();
     });
+  }
+
+  #getActivations<TActivated>(
+    serviceIdentifier: ServiceIdentifier<TActivated>,
+  ): Iterable<BindingActivation<TActivated>> | undefined {
+    return this.#serviceReferenceManager.activationService.get(
+      serviceIdentifier,
+    ) as Iterable<BindingActivation<TActivated>> | undefined;
+  }
+
+  #subscribeActivationAddedOnce(
+    serviceIdentifier: ServiceIdentifier,
+    subscriber: ActivationSubscriber,
+  ): void {
+    this.#serviceReferenceManager.activationService.subscribeOnce(
+      serviceIdentifier,
+      subscriber,
+    );
   }
 
   #resetComputedProperties(): void {

--- a/packages/container/libraries/core/src/binding/models/ActivationSubscriber.ts
+++ b/packages/container/libraries/core/src/binding/models/ActivationSubscriber.ts
@@ -1,0 +1,10 @@
+import { type ServiceIdentifier } from '@inversifyjs/common';
+
+import { type BindingActivation } from './BindingActivation.js';
+
+export interface ActivationSubscriber {
+  onActivationAdded(
+    serviceIdentifier: ServiceIdentifier,
+    activation: BindingActivation,
+  ): void;
+}

--- a/packages/container/libraries/core/src/binding/services/ActivationsService.spec.ts
+++ b/packages/container/libraries/core/src/binding/services/ActivationsService.spec.ts
@@ -16,6 +16,7 @@ vitest.mock(import('../../common/calculations/chain.js'));
 
 import { chain } from '../../common/calculations/chain.js';
 import { OneToManyMapStar } from '../../common/models/OneToManyMapStar.js';
+import { type ActivationSubscriber } from '../models/ActivationSubscriber.js';
 import { type BindingActivation } from '../models/BindingActivation.js';
 import {
   ActivationsService,
@@ -273,6 +274,202 @@ describe(ActivationsService, () => {
 
       it('should return undefined', () => {
         expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('.subscribeOnce', () => {
+    describe('when called', () => {
+      let serviceIdentifierFixture: ServiceIdentifier;
+      let subscriberMock: Mocked<ActivationSubscriber>;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        serviceIdentifierFixture = 'subscribe-once-service-id';
+        subscriberMock = {
+          onActivationAdded: vitest.fn(),
+        };
+
+        result = activationsService.subscribeOnce(
+          serviceIdentifierFixture,
+          subscriberMock,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when called, and activationsService.add() is called for the same serviceId', () => {
+      let serviceIdentifierFixture: ServiceIdentifier;
+      let activationFixture: BindingActivation;
+      let relationFixture: BindingActivationRelation;
+      let subscriberMock: Mocked<ActivationSubscriber>;
+
+      beforeAll(() => {
+        serviceIdentifierFixture = 'subscribe-once-same-service-id';
+        activationFixture = () => undefined;
+        relationFixture = {
+          serviceId: serviceIdentifierFixture,
+        };
+        subscriberMock = {
+          onActivationAdded: vitest.fn(),
+        };
+
+        activationsService.subscribeOnce(
+          serviceIdentifierFixture,
+          subscriberMock,
+        );
+        activationsService.add(activationFixture, relationFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call subscriber.onActivationAdded()', () => {
+        expect(
+          subscriberMock.onActivationAdded,
+        ).toHaveBeenCalledExactlyOnceWith(
+          serviceIdentifierFixture,
+          activationFixture,
+        );
+      });
+    });
+
+    describe('when called, and activationsService.add() is called twice for the same serviceId', () => {
+      let serviceIdentifierFixture: ServiceIdentifier;
+      let firstActivationFixture: BindingActivation;
+      let secondActivationFixture: BindingActivation;
+      let firstRelationFixture: BindingActivationRelation;
+      let secondRelationFixture: BindingActivationRelation;
+      let subscriberMock: Mocked<ActivationSubscriber>;
+
+      beforeAll(() => {
+        serviceIdentifierFixture = 'subscribe-once-twice-service-id';
+        firstActivationFixture = () => undefined;
+        secondActivationFixture = () => undefined;
+        firstRelationFixture = {
+          serviceId: serviceIdentifierFixture,
+        };
+        secondRelationFixture = {
+          serviceId: serviceIdentifierFixture,
+        };
+        subscriberMock = {
+          onActivationAdded: vitest.fn(),
+        };
+
+        activationsService.subscribeOnce(
+          serviceIdentifierFixture,
+          subscriberMock,
+        );
+        activationsService.add(firstActivationFixture, firstRelationFixture);
+        activationsService.add(secondActivationFixture, secondRelationFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call subscriber.onActivationAdded() once', () => {
+        expect(
+          subscriberMock.onActivationAdded,
+        ).toHaveBeenCalledExactlyOnceWith(
+          serviceIdentifierFixture,
+          firstActivationFixture,
+        );
+      });
+    });
+
+    describe('when called, and activationsService.add() is called for a different serviceId', () => {
+      let serviceIdentifierFixture: ServiceIdentifier;
+      let activationFixture: BindingActivation;
+      let relationFixture: BindingActivationRelation;
+      let subscriberMock: Mocked<ActivationSubscriber>;
+
+      beforeAll(() => {
+        serviceIdentifierFixture = 'subscribe-once-different-service-id';
+        activationFixture = () => undefined;
+        relationFixture = {
+          serviceId: 'other-service-id',
+        };
+        subscriberMock = {
+          onActivationAdded: vitest.fn(),
+        };
+
+        activationsService.subscribeOnce(
+          serviceIdentifierFixture,
+          subscriberMock,
+        );
+        activationsService.add(activationFixture, relationFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should not call subscriber.onActivationAdded()', () => {
+        expect(subscriberMock.onActivationAdded).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when called twice with different subscribers, and activationsService.add() is called for the same serviceId', () => {
+      let serviceIdentifierFixture: ServiceIdentifier;
+      let activationFixture: BindingActivation;
+      let relationFixture: BindingActivationRelation;
+      let firstSubscriberMock: Mocked<ActivationSubscriber>;
+      let secondSubscriberMock: Mocked<ActivationSubscriber>;
+
+      beforeAll(() => {
+        serviceIdentifierFixture = 'subscribe-once-multiple-subscribers-id';
+        activationFixture = () => undefined;
+        relationFixture = {
+          serviceId: serviceIdentifierFixture,
+        };
+        firstSubscriberMock = {
+          onActivationAdded: vitest.fn(),
+        };
+        secondSubscriberMock = {
+          onActivationAdded: vitest.fn(),
+        };
+
+        activationsService.subscribeOnce(
+          serviceIdentifierFixture,
+          firstSubscriberMock,
+        );
+        activationsService.subscribeOnce(
+          serviceIdentifierFixture,
+          secondSubscriberMock,
+        );
+        activationsService.add(activationFixture, relationFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call firstSubscriber.onActivationAdded()', () => {
+        expect(
+          firstSubscriberMock.onActivationAdded,
+        ).toHaveBeenCalledExactlyOnceWith(
+          serviceIdentifierFixture,
+          activationFixture,
+        );
+      });
+
+      it('should call secondSubscriber.onActivationAdded()', () => {
+        expect(
+          secondSubscriberMock.onActivationAdded,
+        ).toHaveBeenCalledExactlyOnceWith(
+          serviceIdentifierFixture,
+          activationFixture,
+        );
       });
     });
   });

--- a/packages/container/libraries/core/src/binding/services/ActivationsService.ts
+++ b/packages/container/libraries/core/src/binding/services/ActivationsService.ts
@@ -3,6 +3,8 @@ import { type ServiceIdentifier } from '@inversifyjs/common';
 import { chain } from '../../common/calculations/chain.js';
 import { type Cloneable } from '../../common/models/Cloneable.js';
 import { OneToManyMapStar } from '../../common/models/OneToManyMapStar.js';
+import { WeakList } from '../../common/models/WeakList.js';
+import { type ActivationSubscriber } from '../models/ActivationSubscriber.js';
 import { type BindingActivation } from '../models/BindingActivation.js';
 
 enum ActivationRelationKind {
@@ -21,6 +23,10 @@ export class ActivationsService implements Cloneable<ActivationsService> {
     BindingActivationRelation
   >;
   readonly #getParent: () => ActivationsService | undefined;
+  readonly #serviceToActivationSubscribersOnceMap: Map<
+    ServiceIdentifier,
+    WeakList<ActivationSubscriber>
+  >;
 
   private constructor(
     getParent: () => ActivationsService | undefined,
@@ -41,6 +47,8 @@ export class ActivationsService implements Cloneable<ActivationsService> {
       });
 
     this.#getParent = getParent;
+    // We don't want to clone subscribers
+    this.#serviceToActivationSubscribersOnceMap = new Map();
   }
 
   public static build(
@@ -54,6 +62,29 @@ export class ActivationsService implements Cloneable<ActivationsService> {
     relation: BindingActivationRelation,
   ): void {
     this.#activationMaps.add(activation, relation);
+
+    this.#triggerActivationAdded(
+      relation[ActivationRelationKind.serviceId],
+      activation,
+    );
+  }
+
+  public subscribeOnce(
+    serviceIdentifier: ServiceIdentifier,
+    subscriber: ActivationSubscriber,
+  ): void {
+    let subscribersOnce: WeakList<ActivationSubscriber> | undefined =
+      this.#serviceToActivationSubscribersOnceMap.get(serviceIdentifier);
+
+    if (subscribersOnce === undefined) {
+      subscribersOnce = new WeakList();
+      this.#serviceToActivationSubscribersOnceMap.set(
+        serviceIdentifier,
+        subscribersOnce,
+      );
+    }
+
+    subscribersOnce.push(subscriber);
   }
 
   public clone(): ActivationsService {
@@ -100,5 +131,21 @@ export class ActivationsService implements Cloneable<ActivationsService> {
       ActivationRelationKind.serviceId,
       serviceId,
     );
+  }
+
+  #triggerActivationAdded(
+    serviceId: ServiceIdentifier,
+    activation: BindingActivation,
+  ): void {
+    const subscribersOnce: WeakList<ActivationSubscriber> | undefined =
+      this.#serviceToActivationSubscribersOnceMap.get(serviceId);
+
+    if (subscribersOnce !== undefined) {
+      for (const subscriber of subscribersOnce) {
+        subscriber.onActivationAdded(serviceId, activation);
+      }
+
+      this.#serviceToActivationSubscribersOnceMap.delete(serviceId);
+    }
   }
 }

--- a/packages/container/libraries/core/src/planning/actions/curryBuildServiceNodeBindings.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildServiceNodeBindings.spec.ts
@@ -9,6 +9,10 @@ import {
   vitest,
 } from 'vitest';
 
+vitest.mock(import('../models/InstanceBindingNodeImplementation.js'));
+
+import { type Newable } from '@inversifyjs/common';
+
 import { InstanceBindingFixtures } from '../../binding/fixtures/InstanceBindingFixtures.js';
 import { ResolvedValueBindingFixtures } from '../../binding/fixtures/ResolvedValueBindingFixtures.js';
 import { ServiceRedirectionBindingFixtures } from '../../binding/fixtures/ServiceRedirectionBindingFixtures.js';
@@ -20,9 +24,13 @@ import { type ServiceRedirectionBinding } from '../../binding/models/ServiceRedi
 import { SingleImmutableLinkedList } from '../../common/models/SingleImmutableLinkedList.js';
 import { ClassMetadataFixtures } from '../../metadata/fixtures/ClassMetadataFixtures.js';
 import { type ClassMetadata } from '../../metadata/models/ClassMetadata.js';
+import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
+import { type Resolved } from '../../resolution/models/Resolved.js';
 import { PlanMultipleBindingServiceNodeFixtures } from '../fixtures/PlanMultipleBindingServiceNodeFixtures.js';
 import { type BasePlanParams } from '../models/BasePlanParams.js';
 import { type BuildServiceNodeOptions } from '../models/BuildServiceNodeOptions.js';
+import { type ConstructorNoParamNode } from '../models/ConstructorNoParamNode.js';
+import { InstanceBindingNodeImplementation } from '../models/InstanceBindingNodeImplementation.js';
 import { type PlanBindingNode } from '../models/PlanBindingNode.js';
 import { type PlanParamsOperations } from '../models/PlanParamsOperations.js';
 import { type PlanServiceNode } from '../models/PlanServiceNode.js';
@@ -31,6 +39,10 @@ import { type SubplanParams } from '../models/SubplanParams.js';
 import { curryBuildServiceNodeBindings } from './curryBuildServiceNodeBindings.js';
 
 describe(curryBuildServiceNodeBindings, () => {
+  let instanceBindingNodeImplementationClassMock: Newable<
+    Mocked<InstanceBindingNodeImplementation>
+  >;
+
   let subplanMock: Mock<
     (
       params: SubplanParams,
@@ -39,7 +51,34 @@ describe(curryBuildServiceNodeBindings, () => {
   >;
 
   beforeAll(() => {
+    instanceBindingNodeImplementationClassMock = class<
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      TActivated = any,
+    > implements Partial<Mocked<InstanceBindingNodeImplementation>> {
+      public readonly constructorParams: (
+        PlanServiceNode | ConstructorNoParamNode
+      )[];
+      public readonly propertyParams: Map<string | symbol, PlanServiceNode>;
+      public resolve: Mock<(params: ResolutionParams) => Resolved<TActivated>>;
+
+      constructor(
+        public readonly binding: InstanceBinding<TActivated>,
+        public readonly classMetadata: ClassMetadata,
+        _params: BasePlanParams,
+      ) {
+        this.constructorParams = [];
+        this.propertyParams = new Map();
+        this.resolve = vitest.fn();
+      }
+    } as Newable<Partial<Mocked<InstanceBindingNodeImplementation>>> as Newable<
+      Mocked<InstanceBindingNodeImplementation>
+    >;
+
     subplanMock = vitest.fn();
+
+    vitest
+      .mocked(InstanceBindingNodeImplementation)
+      .mockImplementation(instanceBindingNodeImplementationClassMock);
   });
 
   describe('having serviceBindings with InstanceBinding and PlanServiceNode parent node', () => {
@@ -125,13 +164,13 @@ describe(curryBuildServiceNodeBindings, () => {
         const expectedSubplanParams: SubplanParams = {
           autobindOptions: basePlanParamsMock.autobindOptions,
           jitEnabled: true,
-          node: {
+          node: expect.objectContaining({
             binding: instanceBindingFixture,
             classMetadata: classMetadataFixture,
             constructorParams: [],
             propertyParams: new Map(),
             resolve: expect.any(Function),
-          },
+          }),
           operations: basePlanParamsMock.operations,
           servicesBranch: basePlanParamsMock.servicesBranch,
         };

--- a/packages/container/libraries/core/src/planning/actions/curryBuildServiceNodeBindings.ts
+++ b/packages/container/libraries/core/src/planning/actions/curryBuildServiceNodeBindings.ts
@@ -167,11 +167,7 @@ function curryBuildInstancePlanBindingNode(
     );
 
     const childNode: InstanceBindingNode =
-      new InstanceBindingNodeImplementation(
-        binding,
-        classMetadata,
-        params.jitEnabled,
-      );
+      new InstanceBindingNodeImplementation(binding, classMetadata, params);
 
     const subplanParams: SubplanParams = {
       autobindOptions: params.autobindOptions,

--- a/packages/container/libraries/core/src/planning/actions/plan.int.spec.ts
+++ b/packages/container/libraries/core/src/planning/actions/plan.int.spec.ts
@@ -473,6 +473,7 @@ describe(plan, () => {
             autobindOptions: undefined,
             jitEnabled: true,
             operations: {
+              getActivations: () => undefined,
               getBindings: bindingService.get.bind(bindingService),
               getBindingsChained:
                 bindingService.getChained.bind(bindingService),
@@ -484,6 +485,7 @@ describe(plan, () => {
                   planResultCacheService,
                 ),
               setPlan: planResultCacheService.set.bind(planResultCacheService),
+              subscribeActivationAddedOnce: () => undefined,
             },
             rootConstraints: planParamsConstraint,
             servicesBranch: [],
@@ -548,6 +550,7 @@ Binding constraints:
               autobindOptions: undefined,
               jitEnabled: true,
               operations: {
+                getActivations: () => undefined,
                 getBindings: bindingService.get.bind(bindingService),
                 getBindingsChained:
                   bindingService.getChained.bind(bindingService),
@@ -563,6 +566,7 @@ Binding constraints:
                 setPlan: planResultCacheService.set.bind(
                   planResultCacheService,
                 ),
+                subscribeActivationAddedOnce: () => undefined,
               },
               rootConstraints: planParamsConstraint,
               servicesBranch: [],

--- a/packages/container/libraries/core/src/planning/calculations/buildInstanceBindingNodeResolver.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildInstanceBindingNodeResolver.ts
@@ -38,6 +38,7 @@ const resolveScopedInstanceBindingNode: <TActivated>(
 
 export function buildInstanceBindingNodeResolver<TActivated>(
   node: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
+  areServiceActivations: boolean,
   jitEnabled: boolean,
 ): (params: ResolutionParams) => Resolved<TActivated> {
   if (
@@ -45,9 +46,15 @@ export function buildInstanceBindingNodeResolver<TActivated>(
     node.binding.onActivation === undefined
   ) {
     if (jitEnabled) {
-      return buildNoActivationsInstanceBindingNodeResolver(node);
+      return buildNoActivationsInstanceBindingNodeResolver(
+        node,
+        areServiceActivations,
+      );
     } else {
-      return buildNoActivationsInstanceBindingNodeResolverOnCsp(node);
+      return buildNoActivationsInstanceBindingNodeResolverOnCsp(
+        node,
+        areServiceActivations,
+      );
     }
   }
 

--- a/packages/container/libraries/core/src/planning/calculations/buildNoActivationsInstanceBindingNodeResolver.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildNoActivationsInstanceBindingNodeResolver.ts
@@ -32,16 +32,21 @@ const FOUR_CONSTRUCTOR_ARGUMENTS: number = 4;
  */
 export function buildNoActivationsInstanceBindingNodeResolver<TActivated>(
   node: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
+  areServiceActivations: boolean,
 ): (params: ResolutionParams) => Resolved<TActivated> {
   const implementationType: Newable<TActivated> =
     node.binding.implementationType;
   const serviceIdentifier: ServiceIdentifier<TActivated> =
     node.binding.serviceIdentifier;
 
-  const resolveActivations: (
-    params: ResolutionParams,
-    value: Resolved<TActivated>,
-  ) => Resolved<TActivated> = resolveServiceActivations(serviceIdentifier);
+  const resolveActivations:
+    | ((
+        params: ResolutionParams,
+        value: Resolved<TActivated>,
+      ) => Resolved<TActivated>)
+    | undefined = areServiceActivations
+    ? resolveServiceActivations(serviceIdentifier)
+    : undefined;
 
   let resolveNode: (params: ResolutionParams) => Resolved<TActivated>;
 

--- a/packages/container/libraries/core/src/planning/calculations/buildNoActivationsInstanceBindingNodeResolverOnCsp.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildNoActivationsInstanceBindingNodeResolverOnCsp.ts
@@ -31,14 +31,19 @@ const FOUR_CONSTRUCTOR_ARGUMENTS: number = 4;
  */
 export function buildNoActivationsInstanceBindingNodeResolverOnCsp<TActivated>(
   node: InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
+  areServiceActivations: boolean,
 ): (params: ResolutionParams) => Resolved<TActivated> {
   const serviceIdentifier: ServiceIdentifier<TActivated> =
     node.binding.serviceIdentifier;
 
-  const resolveActivations: (
-    params: ResolutionParams,
-    value: Resolved<TActivated>,
-  ) => Resolved<TActivated> = resolveServiceActivations(serviceIdentifier);
+  const resolveActivations:
+    | ((
+        params: ResolutionParams,
+        value: Resolved<TActivated>,
+      ) => Resolved<TActivated>)
+    | undefined = areServiceActivations
+    ? resolveServiceActivations(serviceIdentifier)
+    : undefined;
 
   let resolveNode: (params: ResolutionParams) => Resolved<TActivated>;
 

--- a/packages/container/libraries/core/src/planning/calculations/isDynamicallyResolvableBindingNode.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/isDynamicallyResolvableBindingNode.spec.ts
@@ -1,0 +1,53 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  type DynamicallyResolvableBindingNode,
+  isDynamicallyResolvableBindingNodeSymbol,
+} from '../models/DynamicallyResolvableBindingNode.js';
+import { type ResolvableBindingNode } from '../models/ResolvableBindingNode.js';
+import { isDynamicallyResolvableBindingNode } from './isDynamicallyResolvableBindingNode.js';
+
+describe(isDynamicallyResolvableBindingNode, () => {
+  describe.each<
+    [string, ResolvableBindingNode | DynamicallyResolvableBindingNode, boolean]
+  >([
+    [
+      'a ResolvableBindingNode',
+      {
+        binding: Symbol() as unknown as ResolvableBindingNode['binding'],
+        resolve: () => undefined,
+      },
+      false,
+    ],
+    [
+      'a DynamicallyResolvableBindingNode',
+      {
+        addOnResolverChangedHandler: () => undefined,
+        binding:
+          Symbol() as unknown as DynamicallyResolvableBindingNode['binding'],
+        [isDynamicallyResolvableBindingNodeSymbol]: true,
+        resolve: () => undefined,
+      },
+      true,
+    ],
+  ])(
+    'having %s',
+    (
+      _: string,
+      node: ResolvableBindingNode | DynamicallyResolvableBindingNode,
+      expected: boolean,
+    ) => {
+      describe('when called', () => {
+        let result: boolean;
+
+        beforeAll(() => {
+          result = isDynamicallyResolvableBindingNode(node);
+        });
+
+        it('should return the expected result', () => {
+          expect(result).toBe(expected);
+        });
+      });
+    },
+  );
+});

--- a/packages/container/libraries/core/src/planning/calculations/isDynamicallyResolvableBindingNode.ts
+++ b/packages/container/libraries/core/src/planning/calculations/isDynamicallyResolvableBindingNode.ts
@@ -1,0 +1,20 @@
+import { type Binding } from '../../binding/models/Binding.js';
+import {
+  type DynamicallyResolvableBindingNode,
+  isDynamicallyResolvableBindingNodeSymbol,
+} from '../models/DynamicallyResolvableBindingNode.js';
+import { type ResolvableBindingNode } from '../models/ResolvableBindingNode.js';
+
+export function isDynamicallyResolvableBindingNode<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TActivated = any,
+  TBinding extends Binding<TActivated> = Binding<TActivated>,
+>(
+  node: ResolvableBindingNode<TActivated, TBinding>,
+): node is DynamicallyResolvableBindingNode<TActivated, TBinding> {
+  return (
+    (node as Partial<DynamicallyResolvableBindingNode<TActivated, TBinding>>)[
+      isDynamicallyResolvableBindingNodeSymbol
+    ] === true
+  );
+}

--- a/packages/container/libraries/core/src/planning/models/DynamicallyResolvableBindingNode.ts
+++ b/packages/container/libraries/core/src/planning/models/DynamicallyResolvableBindingNode.ts
@@ -1,0 +1,20 @@
+import { type Binding } from '../../binding/models/Binding.js';
+import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
+import { type Resolved } from '../../resolution/models/Resolved.js';
+import { type ResolvableBindingNode } from './ResolvableBindingNode.js';
+
+export const isDynamicallyResolvableBindingNodeSymbol: unique symbol =
+  Symbol.for('@inversifyjs/core/DynamicallyResolvableBindingNode');
+
+export interface DynamicallyResolvableBindingNode<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TActivated = any,
+  TBinding extends Binding<TActivated> = Binding<TActivated>,
+> extends ResolvableBindingNode<TActivated, TBinding> {
+  [isDynamicallyResolvableBindingNodeSymbol]: true;
+  addOnResolverChangedHandler(
+    callback: (
+      newResolver: (params: ResolutionParams) => Resolved<TActivated>,
+    ) => void,
+  ): void;
+}

--- a/packages/container/libraries/core/src/planning/models/InstanceBindingNodeImplementation.ts
+++ b/packages/container/libraries/core/src/planning/models/InstanceBindingNodeImplementation.ts
@@ -1,29 +1,96 @@
+import { type ActivationSubscriber } from '../../binding/models/ActivationSubscriber.js';
 import { type InstanceBinding } from '../../binding/models/InstanceBinding.js';
 import { type ClassMetadata } from '../../metadata/models/ClassMetadata.js';
 import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
 import { type Resolved } from '../../resolution/models/Resolved.js';
 import { buildInstanceBindingNodeResolver } from '../calculations/buildInstanceBindingNodeResolver.js';
+import { type BasePlanParams } from './BasePlanParams.js';
 import { type ConstructorNoParamNode } from './ConstructorNoParamNode.js';
+import {
+  type DynamicallyResolvableBindingNode,
+  isDynamicallyResolvableBindingNodeSymbol,
+} from './DynamicallyResolvableBindingNode.js';
 import { type InstanceBindingNode } from './InstanceBindingNode.js';
 import { type PlanServiceNode } from './PlanServiceNode.js';
 
 export class InstanceBindingNodeImplementation<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TActivated = any,
-> implements InstanceBindingNode<TActivated, InstanceBinding<TActivated>> {
+>
+  implements
+    InstanceBindingNode<TActivated, InstanceBinding<TActivated>>,
+    DynamicallyResolvableBindingNode<TActivated, InstanceBinding<TActivated>>,
+    ActivationSubscriber
+{
+  public readonly [isDynamicallyResolvableBindingNodeSymbol]: true;
   public readonly constructorParams: (
     PlanServiceNode | ConstructorNoParamNode
   )[];
   public readonly propertyParams: Map<string | symbol, PlanServiceNode>;
-  public readonly resolve: (params: ResolutionParams) => Resolved<TActivated>;
+  public resolve: (params: ResolutionParams) => Resolved<TActivated>;
+
+  readonly #jitEnabled: boolean;
+  #onResolverChangedHandlers:
+    | ((
+        newResolver: (params: ResolutionParams) => Resolved<TActivated>,
+      ) => void)[]
+    | undefined;
+  #resolveImpl: (params: ResolutionParams) => Resolved<TActivated>;
 
   constructor(
     public readonly binding: InstanceBinding<TActivated>,
     public readonly classMetadata: ClassMetadata,
-    jitEnabled: boolean,
+    params: BasePlanParams,
   ) {
+    this[isDynamicallyResolvableBindingNodeSymbol] = true;
     this.constructorParams = [];
     this.propertyParams = new Map();
-    this.resolve = buildInstanceBindingNodeResolver(this, jitEnabled);
+
+    this.#jitEnabled = params.jitEnabled;
+    const areServiceActivations: boolean =
+      params.operations.getActivations(binding.serviceIdentifier) !== undefined;
+
+    this.#onResolverChangedHandlers = undefined;
+
+    this.#resolveImpl = buildInstanceBindingNodeResolver(
+      this,
+      areServiceActivations,
+      this.#jitEnabled,
+    );
+
+    this.resolve = this.#resolveImpl;
+
+    if (!areServiceActivations) {
+      params.operations.subscribeActivationAddedOnce(
+        binding.serviceIdentifier,
+        this,
+      );
+    }
+  }
+
+  public onActivationAdded(): void {
+    this.#resolveImpl = buildInstanceBindingNodeResolver(
+      this,
+      true,
+      this.#jitEnabled,
+    );
+
+    if (this.#onResolverChangedHandlers !== undefined) {
+      for (const handler of this.#onResolverChangedHandlers) {
+        handler(this.#resolveImpl);
+      }
+    }
+  }
+
+  public addOnResolverChangedHandler(
+    callback: (
+      newResolver: (params: ResolutionParams) => Resolved<TActivated>,
+    ) => void,
+  ): void {
+    if (this.#onResolverChangedHandlers === undefined) {
+      this.#onResolverChangedHandlers = [];
+    }
+
+    this.#onResolverChangedHandlers.push(callback);
   }
 }

--- a/packages/container/libraries/core/src/planning/models/InstanceBindingNodeImplementation.ts
+++ b/packages/container/libraries/core/src/planning/models/InstanceBindingNodeImplementation.ts
@@ -35,7 +35,6 @@ export class InstanceBindingNodeImplementation<
         newResolver: (params: ResolutionParams) => Resolved<TActivated>,
       ) => void)[]
     | undefined;
-  #resolveImpl: (params: ResolutionParams) => Resolved<TActivated>;
 
   constructor(
     public readonly binding: InstanceBinding<TActivated>,
@@ -52,13 +51,11 @@ export class InstanceBindingNodeImplementation<
 
     this.#onResolverChangedHandlers = undefined;
 
-    this.#resolveImpl = buildInstanceBindingNodeResolver(
+    this.resolve = buildInstanceBindingNodeResolver(
       this,
       areServiceActivations,
       this.#jitEnabled,
     );
-
-    this.resolve = this.#resolveImpl;
 
     if (!areServiceActivations) {
       params.operations.subscribeActivationAddedOnce(
@@ -69,7 +66,7 @@ export class InstanceBindingNodeImplementation<
   }
 
   public onActivationAdded(): void {
-    this.#resolveImpl = buildInstanceBindingNodeResolver(
+    this.resolve = buildInstanceBindingNodeResolver(
       this,
       true,
       this.#jitEnabled,
@@ -77,7 +74,7 @@ export class InstanceBindingNodeImplementation<
 
     if (this.#onResolverChangedHandlers !== undefined) {
       for (const handler of this.#onResolverChangedHandlers) {
-        handler(this.#resolveImpl);
+        handler(this.resolve);
       }
     }
   }

--- a/packages/container/libraries/core/src/planning/models/PlanParamsOperations.ts
+++ b/packages/container/libraries/core/src/planning/models/PlanParamsOperations.ts
@@ -1,6 +1,8 @@
 import { type Newable, type ServiceIdentifier } from '@inversifyjs/common';
 
+import { type ActivationSubscriber } from '../../binding/models/ActivationSubscriber.js';
 import { type Binding } from '../../binding/models/Binding.js';
+import { type BindingActivation } from '../../binding/models/BindingActivation.js';
 import { type ClassMetadata } from '../../metadata/models/ClassMetadata.js';
 import { type GetPlanOptions } from './GetPlanOptions.js';
 import { type NonCachedServiceNodeContext } from './NonCachedServiceNodeContext.js';
@@ -8,6 +10,9 @@ import { type PlanResult } from './PlanResult.js';
 import { type PlanServiceNode } from './PlanServiceNode.js';
 
 export interface PlanParamsOperations {
+  readonly getActivations: <TActivated>(
+    serviceIdentifier: ServiceIdentifier<TActivated>,
+  ) => Iterable<BindingActivation<TActivated>> | undefined;
   getBindings: <TInstance>(
     serviceIdentifier: ServiceIdentifier<TInstance>,
   ) => Iterable<Binding<TInstance>> | undefined;
@@ -22,4 +27,8 @@ export interface PlanParamsOperations {
     context: NonCachedServiceNodeContext,
   ) => void;
   readonly setPlan: (options: GetPlanOptions, planResult: PlanResult) => void;
+  readonly subscribeActivationAddedOnce: (
+    serviceIdentifier: ServiceIdentifier,
+    subscriber: ActivationSubscriber,
+  ) => void;
 }

--- a/packages/container/libraries/core/src/planning/models/PlanSingleBindingServiceNode.ts
+++ b/packages/container/libraries/core/src/planning/models/PlanSingleBindingServiceNode.ts
@@ -1,6 +1,8 @@
 import { type ServiceIdentifier } from '@inversifyjs/common';
 
+import { type Binding } from '../../binding/models/Binding.js';
 import { type ResolutionParams } from '../../resolution/models/ResolutionParams.js';
+import { isDynamicallyResolvableBindingNode } from '../calculations/isDynamicallyResolvableBindingNode.js';
 import { type PlanBindingNode } from './PlanBindingNode.js';
 import { type PlanServiceNode } from './PlanServiceNode.js';
 
@@ -41,6 +43,25 @@ export class PlanSingleBindingServiceNodeImplementation implements PlanServiceNo
       this.resolve = Object.hasOwn(value, RESOLVE_KEY)
         ? value.resolve
         : value.resolve.bind(value);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if (isDynamicallyResolvableBindingNode<any, Binding<any>>(value)) {
+        // Weak reference to avoid memory leaks. A strong reference would prevent the service node from being garbage collected.
+
+        const serviceNodeWeakReference: WeakRef<PlanSingleBindingServiceNodeImplementation> =
+          new WeakRef<PlanSingleBindingServiceNodeImplementation>(this);
+
+        value.addOnResolverChangedHandler(
+          (newResolver: (params: ResolutionParams) => unknown) => {
+            const serviceNode:
+              PlanSingleBindingServiceNodeImplementation | undefined =
+              serviceNodeWeakReference.deref();
+            if (serviceNode !== undefined) {
+              serviceNode.resolve = newResolver;
+            }
+          },
+        );
+      }
     }
   }
 }

--- a/packages/container/libraries/core/src/resolution/actions/resolve.int.spec.ts
+++ b/packages/container/libraries/core/src/resolution/actions/resolve.int.spec.ts
@@ -272,6 +272,11 @@ describe(resolve, () => {
         autobindOptions: undefined,
         jitEnabled: true,
         operations: {
+          getActivations: <TActivated>(
+            serviceIdentifier: ServiceIdentifier<TActivated>,
+          ) =>
+            activationService.get(serviceIdentifier) as
+              Iterable<BindingActivation<TActivated>> | undefined,
           getBindings: bindingService.get.bind(bindingService),
           getBindingsChained: bindingService.getChained.bind(bindingService),
           getClassMetadata: getClassMetadataFunction,
@@ -282,6 +287,8 @@ describe(resolve, () => {
               planResultCacheService,
             ),
           setPlan: planResultCacheService.set.bind(planResultCacheService),
+          subscribeActivationAddedOnce:
+            activationService.subscribeOnce.bind(activationService),
         },
         rootConstraints: {
           chained: false,
@@ -525,6 +532,11 @@ describe(resolve, () => {
             autobindOptions: undefined,
             jitEnabled: true,
             operations: {
+              getActivations: <TActivated>(
+                serviceIdentifier: ServiceIdentifier<TActivated>,
+              ) =>
+                activationService.get(serviceIdentifier) as
+                  Iterable<BindingActivation<TActivated>> | undefined,
               getBindings: bindingService.get.bind(bindingService),
               getBindingsChained:
                 bindingService.getChained.bind(bindingService),
@@ -536,6 +548,8 @@ describe(resolve, () => {
                   planResultCacheService,
                 ),
               setPlan: planResultCacheService.set.bind(planResultCacheService),
+              subscribeActivationAddedOnce:
+                activationService.subscribeOnce.bind(activationService),
             },
             rootConstraints: planParamsConstraint(),
             servicesBranch: [],

--- a/packages/container/libraries/inversify/src/test/bugs/issue_1810.int.spec.ts
+++ b/packages/container/libraries/inversify/src/test/bugs/issue_1810.int.spec.ts
@@ -1,0 +1,153 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { Container, inject, injectable } from '../../index.js';
+
+const CHILD_CONTAINER_ITERATIONS: number = 50_000;
+/*
+ * A retained PlanResultCacheService / plan graph per child grows into the
+ * hundreds of MB at this iteration count (see issue #1810). Allow some V8
+ * heap noise, but fail well below a real subscriber leak.
+ */
+const MAX_HEAP_GROWTH_MB: number = 32;
+
+async function collectGarbage(): Promise<void> {
+  /*
+   * Child plan-cache subscribers are weakly held. Yielding to the event loop
+   * before GC matches the collection conditions described when fixing #1810.
+   */
+  await new Promise<void>((resolve: () => void) => {
+    setImmediate(resolve);
+  });
+
+  if (globalThis.gc === undefined) {
+    throw new Error(
+      'Garbage collector is not exposed. Run the tests with the --expose-gc flag.',
+    );
+  }
+
+  globalThis.gc();
+}
+
+function getHeapUsedMb(): number {
+  return Math.round(process.memoryUsage().heapUsed / 1e6);
+}
+
+describe('Issue 1810', () => {
+  describe('when many temporary child containers resolve instance bindings', () => {
+    @injectable()
+    class Dependency {}
+
+    @injectable()
+    class Service {
+      constructor(
+        @inject(Dependency)
+        public readonly dependency: Dependency,
+      ) {}
+    }
+
+    let parentContainer: Container;
+    let heapUsedAfterChildrenMb: number;
+    let heapUsedBaselineMb: number;
+
+    beforeAll(async () => {
+      parentContainer = new Container();
+      parentContainer.bind(Dependency).toSelf();
+      parentContainer.bind(Service).toSelf();
+
+      {
+        const warmupChild: Container = new Container({
+          parent: parentContainer,
+        });
+        warmupChild.get(Service);
+      }
+
+      await collectGarbage();
+
+      heapUsedBaselineMb = getHeapUsedMb();
+
+      for (let i: number = 0; i < CHILD_CONTAINER_ITERATIONS; ++i) {
+        const childContainer: Container = new Container({
+          parent: parentContainer,
+        });
+
+        /*
+         * Resolving an instance binding builds PlanSingleBindingServiceNode
+         * handlers over dynamically resolvable binding nodes (WeakRef-based).
+         */
+        childContainer.get(Service);
+      }
+
+      await collectGarbage();
+
+      heapUsedAfterChildrenMb = getHeapUsedMb();
+    }, 120_000);
+
+    afterAll(() => {
+      parentContainer = undefined as unknown as Container;
+    });
+
+    it('should not retain a large amount of heap after child containers are discarded', () => {
+      const heapGrowthMb: number = heapUsedAfterChildrenMb - heapUsedBaselineMb;
+
+      expect(
+        heapGrowthMb,
+        `heap grew by ${String(heapGrowthMb)}MB (baseline=${String(heapUsedBaselineMb)}MB, after=${String(heapUsedAfterChildrenMb)}MB)`,
+      ).toBeLessThan(MAX_HEAP_GROWTH_MB);
+    });
+  });
+
+  describe('when cache plans are regenerated over time', () => {
+    @injectable()
+    class Dependency {}
+
+    @injectable()
+    class Service {
+      constructor(
+        @inject(Dependency)
+        public readonly dependency: Dependency,
+      ) {}
+    }
+
+    let container: Container;
+    let heapUsedAfterChildrenMb: number;
+    let heapUsedBaselineMb: number;
+
+    beforeAll(async () => {
+      container = new Container();
+
+      await collectGarbage();
+
+      heapUsedBaselineMb = getHeapUsedMb();
+
+      for (let i: number = 0; i < CHILD_CONTAINER_ITERATIONS; ++i) {
+        container.bind(Dependency).toSelf();
+        container.bind(Service).toSelf();
+        /*
+         * Resolving an instance binding builds PlanSingleBindingServiceNode
+         * handlers over dynamically resolvable binding nodes (WeakRef-based).
+         */
+        container.get(Service);
+
+        container.unbind(Dependency);
+        container.unbind(Service);
+      }
+
+      await collectGarbage();
+
+      heapUsedAfterChildrenMb = getHeapUsedMb();
+    }, 120_000);
+
+    afterAll(() => {
+      container = undefined as unknown as Container;
+    });
+
+    it('should not retain a large amount of heap after child containers are discarded', () => {
+      const heapGrowthMb: number = heapUsedAfterChildrenMb - heapUsedBaselineMb;
+
+      expect(
+        heapGrowthMb,
+        `heap grew by ${String(heapGrowthMb)}MB (baseline=${String(heapUsedBaselineMb)}MB, after=${String(heapUsedAfterChildrenMb)}MB)`,
+      ).toBeLessThan(MAX_HEAP_GROWTH_MB);
+    });
+  });
+});

--- a/packages/container/libraries/inversify/src/test/container/container.int.spec.ts
+++ b/packages/container/libraries/inversify/src/test/container/container.int.spec.ts
@@ -295,6 +295,54 @@ describe(Container, () => {
           );
         },
       );
+
+      describe('with activation added after binding', () => {
+        it.each(
+          buildResolutionCases(bindSyncDependencies, bindAsyncDependencies),
+        )(
+          'should activate a $description binding when called, and a service activation is added after the plan is cached',
+          async ({
+            kind,
+            bindDependencies,
+            resolveService,
+          }: ResolutionCase) => {
+            const container: Container = new Container({
+              jitless,
+            });
+
+            bindDependencies(container);
+
+            const serviceIdentifier: ServiceIdentifier<ArgsCapturingInstance> =
+              bindService(
+                container,
+                kind,
+                dependencyIds,
+                resolvedValueServiceId,
+                {
+                  description: 'without a binding or a service activation',
+                  useBindingActivation: false,
+                  useServiceActivation: false,
+                },
+              );
+
+            const instanceBeforeActivation: ArgsCapturingInstance =
+              await resolveService(container, serviceIdentifier);
+
+            expect(instanceBeforeActivation.args).toStrictEqual(expectedArgs);
+            expect(instanceBeforeActivation.activatedByBinding).toBe(false);
+            expect(instanceBeforeActivation.activatedByService).toBe(false);
+
+            container.onActivation(serviceIdentifier, buildServiceActivation());
+
+            const instanceAfterActivation: ArgsCapturingInstance =
+              await resolveService(container, serviceIdentifier);
+
+            expect(instanceAfterActivation.args).toStrictEqual(expectedArgs);
+            expect(instanceAfterActivation.activatedByBinding).toBe(false);
+            expect(instanceAfterActivation.activatedByService).toBe(true);
+          },
+        );
+      });
     },
   );
 

--- a/packages/container/libraries/inversify/vitest.config.mjs
+++ b/packages/container/libraries/inversify/vitest.config.mjs
@@ -1,3 +1,16 @@
 import { defaultConfig } from '@inversifyjs/foundation-vitest-config';
 
-export default defaultConfig;
+export default {
+  ...defaultConfig,
+  test: {
+    ...defaultConfig.test,
+    execArgv: ['--expose-gc'],
+    projects: defaultConfig.test.projects.map((project) => ({
+      ...project,
+      test: {
+        ...project.test,
+        execArgv: ['--expose-gc'],
+      },
+    })),
+  },
+};

--- a/packages/docs/services/inversify-site/blog/2026-07-15-announcing-inversify-8-2/index.mdx
+++ b/packages/docs/services/inversify-site/blog/2026-07-15-announcing-inversify-8-2/index.mdx
@@ -1,17 +1,17 @@
 ---
-slug: announcing-inversify-8-2-0
-title: Announcing InversifyJS 8.2.0
+slug: announcing-inversify-8-2
+title: Announcing InversifyJS 8.2
 authors: [notaphplover]
 tags: [releases]
 ---
 
-We're happy to announce **InversifyJS 8.2.0**, a release focused on making the container work reliably in environments that enforce a strict Content Security Policy (CSP).
+We're happy to announce **InversifyJS 8.2**, a release focused on making the container work reliably in environments that enforce a strict Content Security Policy (CSP).
 
 {/* truncate */}
 
 ## The problem
 
-InversifyJS has long used just-in-time (JIT) resolution optimizations that generate specialized resolver functions at runtime via the `Function` constructor. This approach keeps constructor call sites monomorphic in V8 and delivers strong performance, especially when resolving complex transient object graphs.
+InversifyJS has used just-in-time (JIT) resolution optimizations that generate specialized resolver functions at runtime via the `Function` constructor. This approach keeps constructor call sites monomorphic in V8 and delivers strong performance, especially when resolving complex transient object graphs.
 
 The trade-off is that `Function` constructor usage requires `unsafe-eval` (or an equivalent CSP trusted-types allowance). In browser extensions, embedded web views, and other CSP-restricted environments, that can cause resolution to fail at runtime with errors like:
 
@@ -21,7 +21,7 @@ EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is n
 
 ## The `jitless` option
 
-InversifyJS 8.2.0 introduces a new container option:
+InversifyJS 8.2 introduces a new container option:
 
 ```ts
 const container = new Container({ jitless: true });
@@ -29,7 +29,7 @@ const container = new Container({ jitless: true });
 
 When `jitless` is `true`, the container uses CSP-compatible resolution paths built from plain closures instead of dynamically generated functions. The behavior is the same — constructor injection, property injection, activations, scopes, and async resolution all continue to work — but without relying on `unsafe-eval`.
 
-**`jitless` defaults to `true` in 8.2.0**, so existing applications that upgrade without changing their container options will automatically use the CSP-safe path. If your environment allows `unsafe-eval` and you want the previous JIT performance profile, opt in explicitly:
+**`jitless` defaults to `true` in 8.2**, so existing applications that upgrade without changing their container options will automatically use the CSP-safe path. If your environment allows `unsafe-eval` and you want the previous JIT performance profile, opt in explicitly:
 
 ```ts
 const container = new Container({ jitless: false });
@@ -76,4 +76,4 @@ If your application does not run under CSP restrictions and resolves large trans
 - **CSP-restricted environments**: InversifyJS should now work without relaxing your content security policy.
 - **Performance-sensitive, non-CSP environments**: Pass `{ jitless: false }` to the container constructor to restore the JIT resolution path from previous releases.
 
-Thanks for trying out InversifyJS 8.2.0, and please let us know if you run into any issues.
+Thanks for trying out InversifyJS 8.2, and please let us know if you run into any issues.

--- a/packages/docs/services/inversify-site/docusaurus.config.ts
+++ b/packages/docs/services/inversify-site/docusaurus.config.ts
@@ -105,8 +105,8 @@ const config: Config = {
     },
     announcementBar: {
       content:
-        '<a target="_blank" rel="noopener noreferrer" href="/blog/announcing-inversify-8-1-3/">InversifyJS 8.1.3 is out! 🎉️</a>',
-      id: 'announcing_v8_1_3',
+        '<a target="_blank" rel="noopener noreferrer" href="/blog/announcing-inversify-8-2/">InversifyJS 8.2 is out! 🎉️</a>',
+      id: 'announcing_v8_2',
       isCloseable: true,
     },
     footer: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added activation-aware planning so activations registered after a service is created are picked up automatically on the next resolution.
  * Introduced one-time activation subscription support to enable dynamic resolver updates when activations become available.

* **Bug Fixes**
  * Improved resolution correctness when activation handlers are registered after initial service resolution.
  * Strengthened memory cleanup behavior for repeated binding changes and temporary container lifecycles.

* **Documentation**
  * Updated InversifyJS 8.2 release announcement text and links, including clearer `jitless` (CSP-friendly) guidance and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->