### PR TITLE
docs: add Cursor Cloud environment setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,3 +192,11 @@ Docusaurus-based documentation sites:
 - Use `workspace:*` protocol for internal dependencies
 - Run `pnpm install` after adding new dependencies
 - Check `knip` output for unused dependencies: `pnpm run unused`
+
+## Cursor Cloud specific instructions
+
+- **Node version gotcha (important):** the default `node` on the PATH is `/exec-daemon/node` (v22), which is re-prepended after `~/.bashrc`/`nvm` run, so `nvm use` and `.bashrc` edits do NOT change what bare `node`/`pnpm` resolve to. The repo pins Node `24.18.0` (`.nvmrc`), which is installed via nvm. Select it per-command by prepending PATH: `export PATH="$HOME/.nvm/versions/node/v24.18.0/bin:$PATH"`. The startup update script already does this before `pnpm install`. Run/build/test commands under Node 24 too, because native modules (`lmdb`, `better-sqlite3`, `@swc/core`, `sharp`) are compiled against the install-time ABI — mixing Node 22 and 24 causes native module load errors.
+- Standard build/lint/test/format commands live in the root `package.json` and this file's "Build and Test Commands" section (`pnpm run build`, `pnpm run lint`, `pnpm test`, `pnpm run test:e2e`). Turbo caches results, so re-runs are fast.
+- This is a library monorepo — there is no long-running backend/database to boot for end-to-end validation; `build` + `test` + `test:e2e` are the primary verification.
+- Runnable example app for manual verification: `@inversifyjs/http-openapi-example` (Express + InversifyJS DI + OpenAPI). Build it first, then serve on port 3000: `pnpm run --filter "@inversifyjs/http-openapi-example" build` then `pnpm run --filter "@inversifyjs/http-openapi-example" serve`. Swagger UI is at `http://localhost:3000/docs`; `POST /users` (body `{"email","name","surname"}`) creates a user (persisted via LMDB) and returns it with a generated `id`.
+- Optional Docusaurus docs sites (`packages/docs/services/*`) run via their `start` scripts (ports 3000 / 3001); not required for verifying the libraries.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for this InversifyJS monorepo in Cursor Cloud, and documents a non-obvious Node version gotcha for future agents.

This PR is documentation-only: it appends a `## Cursor Cloud specific instructions` section to `AGENTS.md`. No source code was modified.

## Environment setup performed

- Installed Node `24.18.0` (per `.nvmrc`) via nvm; `pnpm@11.11.0` via corepack.
- `pnpm install` — all 62 workspace projects.
- `pnpm run build` — 54/54 tasks successful.
- `pnpm run lint` — 95/95 tasks successful (0 errors).
- `pnpm test` — 77/77 tasks successful.
- `pnpm run test:e2e` — 43/43 tasks successful (829 scenarios / 7260 steps passed).

## Key finding documented

The default `node` on PATH is `/exec-daemon/node` (v22), re-prepended after `~/.bashrc`/`nvm`, so bare `node`/`pnpm` don't pick up the repo's required Node 24. Commands must select Node 24 via `export PATH="$HOME/.nvm/versions/node/v24.18.0/bin:$PATH"` (the startup update script does this). This matters for native modules (`lmdb`, `better-sqlite3`, `@swc/core`) whose ABI must match the runtime.

## Hello-world verification

Built and ran the `@inversifyjs/http-openapi-example` Express + InversifyJS DI + OpenAPI server on port 3000, then created a user through the Swagger UI (`POST /users`) and got a `200` with a generated `id`.

[inversify_openapi_example_create_user.mp4](https://cursor.com/agents/bc-517b611f-f953-4f3c-9d30-883cfacec11f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finversify_openapi_example_create_user.mp4)

[Swagger UI 200 response after creating a user](https://cursor.com/agents/bc-517b611f-f953-4f3c-9d30-883cfacec11f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fswagger_create_user_200_response.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-517b611f-f953-4f3c-9d30-883cfacec11f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-517b611f-f953-4f3c-9d30-883cfacec11f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

