### PR TITLE
fix: preload reflect-metadata in container e2e tests

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -55,6 +55,7 @@ export default {
         "src/*/parameters/*.ts",
         "src/*/step-definitions/*.ts",
         "src/app/hooks/*.ts",
+        "src/app/setup/*.ts",
       ],
       ignoreDependencies: [
         ...defaultWorkspaceProjectConfig.ignoreDependencies,

--- a/packages/container/tools/e2e-tests/config/cucumber.cjs.config.mjs
+++ b/packages/container/tools/e2e-tests/config/cucumber.cjs.config.mjs
@@ -9,6 +9,8 @@ function getConfiguration(parallel) {
   const config = {
     ...getBaseConfiguration(parallel),
     require: [
+      // Must run before decorated support code (Cucumber 13.1+ no longer loads it).
+      'lib/cjs/app/setup/reflectMetadata.js',
       'lib/cjs/*/parameters/*.js',
       'lib/cjs/*/step-definitions/*.js',
       'lib/cjs/app/hooks/*.js',

--- a/packages/container/tools/e2e-tests/config/cucumber.ts.config.mjs
+++ b/packages/container/tools/e2e-tests/config/cucumber.ts.config.mjs
@@ -9,6 +9,8 @@ function getConfiguration(parallel) {
   const config = {
     ...getBaseConfiguration(parallel),
     require: [
+      // Must run before decorated support code (Cucumber 13.1+ no longer loads it).
+      'src/app/setup/reflectMetadata.ts',
       'src/*/parameters/*.ts',
       'src/*/step-definitions/*.ts',
       'src/app/hooks/*.ts',

--- a/packages/container/tools/e2e-tests/package.json
+++ b/packages/container/tools/e2e-tests/package.json
@@ -8,7 +8,8 @@
     "@cucumber/cucumber": "13.1.1",
     "@inversifyjs/common": "workspace:*",
     "@inversifyjs/container": "workspace:*",
-    "@inversifyjs/core": "workspace:*"
+    "@inversifyjs/core": "workspace:*",
+    "reflect-metadata": "0.2.2"
   },
   "devDependencies": {
     "@types/node": "24.13.3",

--- a/packages/container/tools/e2e-tests/src/app/setup/reflectMetadata.ts
+++ b/packages/container/tools/e2e-tests/src/app/setup/reflectMetadata.ts
@@ -1,0 +1,1 @@
+import 'reflect-metadata/lite';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes container e2e CJS failures (`Reflect.getOwnMetadata is not a function`) on #2004.

### Root cause

`@cucumber/cucumber` `13.0.0` → `13.1.1` upgraded `@cucumber/messages` from `32.3.1` to `34.0.1`.

- `messages@32.3.1` had a side-effect `import 'reflect-metadata'`
- `messages@33+` / `34` removed that dependency entirely

Container e2e CJS support code loads `parameters` first (including decorated warrior models that import `@injectable` from `@inversifyjs/core`). `@inversifyjs/core` does **not** import `reflect-metadata`; only `@inversifyjs/container` does. Previously cucumber’s transitive import accidentally polyfilled `Reflect` before those modules loaded. After the upgrade, CI can resolve `@cucumber/gherkin@41` against `messages@33.x` (range `>=31 <34`) with no polyfill, so decorator evaluation fails.

HTTP e2e stayed green because those tests import decorators from `inversify`, which pulls in `@inversifyjs/container` and its `reflect-metadata/lite` side effect.

### Fix

- Add an explicit `reflect-metadata/lite` bootstrap loaded first in the CJS/TS cucumber configs
- Declare `reflect-metadata` as a direct dependency of `@inversifyjs/container-e2e-tests`
- Register `src/app/setup/*.ts` as a knip entry so the bootstrap is not reported unused

### Test plan

- [x] `pnpm run --filter @inversifyjs/container-e2e-tests test:e2e:cjs`
- [x] `pnpm run --filter @inversifyjs/container-e2e-tests test:e2e:esm`
- [x] Isolated repro: loading `Bow.js` without the bootstrap fails; with bootstrap succeeds
- [x] `pnpm run unused` no longer flags the setup script
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d523022-a42f-470a-adc1-02224c94e577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d523022-a42f-470a-adc1-02224c94e577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

