### PR TITLE
Fix JIT related resolution for big arities

### DIFF
--- a/.changeset/fix-jit-resolve-many-arity.md
+++ b/.changeset/fix-jit-resolve-many-arity.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/core": patch
+---
+
+- Fixed JIT resolution for transient instance bindings with more than four constructor and property injections combined, which could throw a `SyntaxError` or resolve with the wrong arity when `jitless` was `false`.

--- a/packages/container/libraries/core/src/planning/calculations/buildConstructorArgumentsResolverJit.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildConstructorArgumentsResolverJit.spec.ts
@@ -7,6 +7,7 @@ import { type Resolved } from '../../resolution/models/Resolved.js';
 import { type InstanceBindingNode } from '../models/InstanceBindingNode.js';
 import { type PlanServiceNode } from '../models/PlanServiceNode.js';
 import { buildConstructorArgumentsResolverJit } from './buildConstructorArgumentsResolverJit.js';
+import { buildResolveMany } from './buildResolveMany.js';
 import { resolveFour } from './resolveFour.js';
 import { resolveThree } from './resolveThree.js';
 import { resolveTwo } from './resolveTwo.js';
@@ -594,4 +595,104 @@ describe(buildConstructorArgumentsResolverJit, () => {
       });
     });
   });
+
+  describe.each<[string, number, string[], PropertyFixture[]]>([
+    [
+      'zero constructor arguments and five properties',
+      0,
+      [],
+      [
+        { key: 'propertyA', value: 'property-0' },
+        { key: 'propertyB', value: 'property-1' },
+        { key: 'propertyC', value: 'property-2' },
+        { key: 'propertyD', value: 'property-3' },
+        { key: 'propertyE', value: 'property-4' },
+      ],
+    ],
+    [
+      'two constructor arguments and three properties',
+      2,
+      ['value-0', 'value-1'],
+      [
+        { key: 'propertyA', value: 'property-0' },
+        { key: 'propertyB', value: 'property-1' },
+        { key: 'propertyC', value: 'property-2' },
+      ],
+    ],
+  ])(
+    'having %s',
+    (
+      _description: string,
+      paramsCount: number,
+      valueFixtures: string[],
+      propertyFixtures: PropertyFixture[],
+    ) => {
+      let paramsFixture: ResolutionParams;
+
+      beforeAll(() => {
+        paramsFixture = Symbol() as unknown as ResolutionParams;
+      });
+
+      function populatePropertyResolvers(
+        nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>,
+      ): void {
+        for (const propertyFixture of propertyFixtures) {
+          nodeFixture.propertyParams.set(propertyFixture.key, {
+            bindings: [],
+            resolve: (resolveParams: ResolutionParams): string => {
+              expect(resolveParams).toBe(paramsFixture);
+
+              return propertyFixture.value;
+            },
+          } as Partial<PlanServiceNode> as PlanServiceNode);
+        }
+      }
+
+      describe('when called, and resolveActivations is not provided', () => {
+        describe('when called, and node params are populated after the resolveNode is built', () => {
+          let nodeFixture: InstanceBindingNode<Foo, InstanceBinding<Foo>>;
+
+          let result: unknown;
+
+          beforeAll(() => {
+            nodeFixture = buildNodeFixtureForArguments(
+              paramsCount,
+              propertyFixtures,
+            );
+
+            const resolveNode: (params: ResolutionParams) => Resolved<Foo> =
+              buildConstructorArgumentsResolverJit(
+                nodeFixture,
+                Foo,
+                buildResolveMany(nodeFixture),
+              );
+
+            nodeFixture.constructorParams.push(
+              ...valueFixtures.map(
+                (value: string): PlanServiceNode =>
+                  ({
+                    resolve: (): string => value,
+                  }) as Partial<PlanServiceNode> as PlanServiceNode,
+              ),
+            );
+
+            populatePropertyResolvers(nodeFixture);
+
+            result = resolveNode(paramsFixture);
+          });
+
+          it('should build an instance with the resolved constructor arguments and properties in order', () => {
+            expect(result).toBeInstanceOf(Foo);
+            expect((result as Foo).args).toStrictEqual(valueFixtures);
+
+            for (const propertyFixture of propertyFixtures) {
+              expect(
+                (result as FooWithProperties)[propertyFixture.key],
+              ).toStrictEqual(propertyFixture.value);
+            }
+          });
+        });
+      });
+    },
+  );
 });

--- a/packages/container/libraries/core/src/planning/calculations/buildFourConstructorArgumentResolver.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildFourConstructorArgumentResolver.spec.ts
@@ -380,8 +380,8 @@ describe(buildFourConstructorArgumentResolver, () => {
         vitest.clearAllMocks();
       });
 
-      it('should build an instance with the resolved constructor arguments', () => {
-        expect(result).toStrictEqual(Promise.resolve(expect.any(Foo)));
+      it('should build an instance with the resolved constructor arguments', async () => {
+        await expect(result).resolves.toStrictEqual(expect.any(Foo));
       });
 
       it('should call setInstanceProperties()', () => {

--- a/packages/container/libraries/core/src/planning/calculations/buildOneConstructorArgumentResolver.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildOneConstructorArgumentResolver.spec.ts
@@ -272,8 +272,8 @@ describe(buildOneConstructorArgumentResolver, () => {
         vitest.clearAllMocks();
       });
 
-      it('should build an instance with the resolved constructor argument', () => {
-        expect(result).toStrictEqual(Promise.resolve(expect.any(Foo)));
+      it('should build an instance with the resolved constructor argument', async () => {
+        await expect(result).resolves.toStrictEqual(expect.any(Foo));
       });
 
       it('should call setInstanceProperties()', () => {

--- a/packages/container/libraries/core/src/planning/calculations/buildResolveMany.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildResolveMany.spec.ts
@@ -7,18 +7,28 @@ import { type PlanServiceNode } from '../models/PlanServiceNode.js';
 import { buildResolveMany } from './buildResolveMany.js';
 
 function buildNodeFixture(
-  length: number,
+  constructorArgumentsLength: number,
+  propertiesSize: number = 0,
 ): InstanceBindingNode<unknown, InstanceBinding<unknown>> {
+  const properties: Map<string | symbol, ClassElementMetadata> = new Map();
+
+  for (let index: number = 0; index < propertiesSize; ++index) {
+    properties.set(
+      `property-${index.toString()}`,
+      Symbol() as unknown as ClassElementMetadata,
+    );
+  }
+
   return {
     classMetadata: {
-      constructorArguments: new Array<ClassElementMetadata>(length).fill(
-        Symbol() as unknown as ClassElementMetadata,
-      ),
+      constructorArguments: new Array<ClassElementMetadata>(
+        constructorArgumentsLength,
+      ).fill(Symbol() as unknown as ClassElementMetadata),
       lifecycle: {
         postConstructMethodNames: new Set(),
         preDestroyMethodNames: new Set(),
       },
-      properties: new Map<string | symbol, unknown>(),
+      properties,
       scope: undefined,
     },
     constructorParams: [] as PlanServiceNode[],
@@ -31,6 +41,115 @@ function buildNodeFixture(
 type ResolveManyFunction = (...args: any[]) => any;
 
 describe(buildResolveMany, () => {
+  describe('having zero constructor arguments', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        const resolveMany: ResolveManyFunction = buildResolveMany(
+          buildNodeFixture(0),
+        ) as ResolveManyFunction;
+
+        result = resolveMany(() => []);
+      });
+
+      it('should build with no resolved values', () => {
+        expect(result).toStrictEqual([]);
+      });
+    });
+  });
+
+  describe('having zero constructor arguments and five properties', () => {
+    describe('when called, and all values are sync', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        const resolveMany: ResolveManyFunction = buildResolveMany(
+          buildNodeFixture(0, 5),
+        ) as ResolveManyFunction;
+
+        result = resolveMany(
+          1,
+          2,
+          3,
+          4,
+          5,
+          (
+            value1: number,
+            value2: number,
+            value3: number,
+            value4: number,
+            value5: number,
+          ) => [value1, value2, value3, value4, value5],
+        );
+      });
+
+      it('should build with resolved values in order', () => {
+        expect(result).toStrictEqual([1, 2, 3, 4, 5]);
+      });
+    });
+
+    describe('when called, and a value is a promise', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        const resolveMany: ResolveManyFunction = buildResolveMany(
+          buildNodeFixture(0, 5),
+        ) as ResolveManyFunction;
+
+        result = resolveMany(
+          1,
+          2,
+          Promise.resolve(3),
+          4,
+          5,
+          (
+            value1: number,
+            value2: number,
+            value3: number,
+            value4: number,
+            value5: number,
+          ) => [value1, value2, value3, value4, value5],
+        );
+      });
+
+      it('should build with resolved values in order', () => {
+        expect(result).toStrictEqual(Promise.resolve([1, 2, 3, 4, 5]));
+      });
+    });
+  });
+
+  describe('having two constructor arguments and three properties', () => {
+    describe('when called, and all values are sync', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        const resolveMany: ResolveManyFunction = buildResolveMany(
+          buildNodeFixture(2, 3),
+        ) as ResolveManyFunction;
+
+        result = resolveMany(
+          1,
+          2,
+          3,
+          4,
+          5,
+          (
+            value1: number,
+            value2: number,
+            value3: number,
+            value4: number,
+            value5: number,
+          ) => [value1, value2, value3, value4, value5],
+        );
+      });
+
+      it('should build with resolved values in order', () => {
+        expect(result).toStrictEqual([1, 2, 3, 4, 5]);
+      });
+    });
+  });
+
   describe('having one constructor argument', () => {
     describe('when called, and the value is sync', () => {
       let result: unknown;

--- a/packages/container/libraries/core/src/planning/calculations/buildResolveMany.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildResolveMany.spec.ts
@@ -113,8 +113,8 @@ describe(buildResolveMany, () => {
         );
       });
 
-      it('should build with resolved values in order', () => {
-        expect(result).toStrictEqual(Promise.resolve([1, 2, 3, 4, 5]));
+      it('should build with resolved values in order', async () => {
+        await expect(result).resolves.toStrictEqual([1, 2, 3, 4, 5]);
       });
     });
   });
@@ -178,8 +178,8 @@ describe(buildResolveMany, () => {
         result = resolveMany(Promise.resolve(1), (value: number) => [value]);
       });
 
-      it('should build with the resolved value', () => {
-        expect(result).toStrictEqual(Promise.resolve([1]));
+      it('should build with the resolved value', async () => {
+        await expect(result).resolves.toStrictEqual([1]);
       });
     });
   });
@@ -219,8 +219,8 @@ describe(buildResolveMany, () => {
         );
       });
 
-      it('should build with resolved values in order', () => {
-        expect(result).toStrictEqual(Promise.resolve([1, 2]));
+      it('should build with resolved values in order', async () => {
+        await expect(result).resolves.toStrictEqual([1, 2]);
       });
     });
 
@@ -239,8 +239,8 @@ describe(buildResolveMany, () => {
         );
       });
 
-      it('should build with resolved values in order', () => {
-        expect(result).toStrictEqual(Promise.resolve([1, 2]));
+      it('should build with resolved values in order', async () => {
+        await expect(result).resolves.toStrictEqual([1, 2]);
       });
     });
 
@@ -259,8 +259,8 @@ describe(buildResolveMany, () => {
         );
       });
 
-      it('should build with resolved values in order', () => {
-        expect(result).toStrictEqual(Promise.resolve([1, 2]));
+      it('should build with resolved values in order', async () => {
+        await expect(result).resolves.toStrictEqual([1, 2]);
       });
     });
   });
@@ -311,8 +311,8 @@ describe(buildResolveMany, () => {
         );
       });
 
-      it('should build with resolved values in order', () => {
-        expect(result).toStrictEqual(Promise.resolve([1, 2, 3]));
+      it('should build with resolved values in order', async () => {
+        await expect(result).resolves.toStrictEqual([1, 2, 3]);
       });
     });
 
@@ -336,8 +336,8 @@ describe(buildResolveMany, () => {
         );
       });
 
-      it('should build with resolved values in order', () => {
-        expect(result).toStrictEqual(Promise.resolve([1, 2, 3]));
+      it('should build with resolved values in order', async () => {
+        await expect(result).resolves.toStrictEqual([1, 2, 3]);
       });
     });
 
@@ -361,8 +361,8 @@ describe(buildResolveMany, () => {
         );
       });
 
-      it('should build with resolved values in order', () => {
-        expect(result).toStrictEqual(Promise.resolve([1, 2, 3]));
+      it('should build with resolved values in order', async () => {
+        await expect(result).resolves.toStrictEqual([1, 2, 3]);
       });
     });
 
@@ -386,8 +386,8 @@ describe(buildResolveMany, () => {
         );
       });
 
-      it('should build with resolved values in order', () => {
-        expect(result).toStrictEqual(Promise.resolve([1, 2, 3]));
+      it('should build with resolved values in order', async () => {
+        await expect(result).resolves.toStrictEqual([1, 2, 3]);
       });
     });
 
@@ -411,8 +411,8 @@ describe(buildResolveMany, () => {
         );
       });
 
-      it('should build with resolved values in order', () => {
-        expect(result).toStrictEqual(Promise.resolve([1, 2, 3]));
+      it('should build with resolved values in order', async () => {
+        await expect(result).resolves.toStrictEqual([1, 2, 3]);
       });
     });
 
@@ -436,8 +436,8 @@ describe(buildResolveMany, () => {
         );
       });
 
-      it('should build with resolved values in order', () => {
-        expect(result).toStrictEqual(Promise.resolve([1, 2, 3]));
+      it('should build with resolved values in order', async () => {
+        await expect(result).resolves.toStrictEqual([1, 2, 3]);
       });
     });
 
@@ -461,8 +461,8 @@ describe(buildResolveMany, () => {
         );
       });
 
-      it('should build with resolved values in order', () => {
-        expect(result).toStrictEqual(Promise.resolve([1, 2, 3]));
+      it('should build with resolved values in order', async () => {
+        await expect(result).resolves.toStrictEqual([1, 2, 3]);
       });
     });
   });
@@ -521,8 +521,8 @@ describe(buildResolveMany, () => {
         );
       });
 
-      it('should build with resolved values in order', () => {
-        expect(result).toStrictEqual(Promise.resolve([1, 2, 3, 4, 5]));
+      it('should build with resolved values in order', async () => {
+        await expect(result).resolves.toStrictEqual([1, 2, 3, 4, 5]);
       });
     });
 
@@ -550,8 +550,8 @@ describe(buildResolveMany, () => {
         );
       });
 
-      it('should build with resolved values in order', () => {
-        expect(result).toStrictEqual(Promise.resolve([1, 2, 3, 4, 5]));
+      it('should build with resolved values in order', async () => {
+        await expect(result).resolves.toStrictEqual([1, 2, 3, 4, 5]);
       });
     });
 
@@ -579,8 +579,8 @@ describe(buildResolveMany, () => {
         );
       });
 
-      it('should build with resolved values in order', () => {
-        expect(result).toStrictEqual(Promise.resolve([1, 2, 3, 4, 5]));
+      it('should build with resolved values in order', async () => {
+        await expect(result).resolves.toStrictEqual([1, 2, 3, 4, 5]);
       });
     });
 
@@ -608,8 +608,8 @@ describe(buildResolveMany, () => {
         );
       });
 
-      it('should build with resolved values in order', () => {
-        expect(result).toStrictEqual(Promise.resolve([1, 2, 3, 4, 5]));
+      it('should build with resolved values in order', async () => {
+        await expect(result).resolves.toStrictEqual([1, 2, 3, 4, 5]);
       });
     });
   });

--- a/packages/container/libraries/core/src/planning/calculations/buildResolveMany.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildResolveMany.ts
@@ -10,32 +10,38 @@ export function buildResolveMany<TActivated>(
 ): Function {
   const id: string = getGeneratedResolverId().toString();
 
-  const constructorArgumentsCount: number =
-    node.classMetadata.constructorArguments.length;
+  const argumentsCount: number =
+    node.classMetadata.constructorArguments.length +
+    node.classMetadata.properties.size;
 
-  const constructorArgumentIndexes: number[] = Array.from(
-    { length: constructorArgumentsCount },
+  const argumentIndexes: number[] = Array.from(
+    { length: argumentsCount },
     (_: unknown, index: number) => index,
   );
 
-  const valueConcatenation: string = constructorArgumentIndexes
+  const valueConcatenation: string = argumentIndexes
     .map((index: number) => `value$${index.toString()}`)
     .join(', ');
 
-  const resolvedValueConcatenation: string = constructorArgumentIndexes
+  const resolvedValueConcatenation: string = argumentIndexes
     .map((index: number) => `resolvedValue$${index.toString()}`)
     .join(', ');
 
-  const isPromiseChecks: string = constructorArgumentIndexes
-    .map((index: number) => `isPromise$${id}(value$${index.toString()})`)
-    .join(' || ');
+  const parametersConcatenation: string = [valueConcatenation, `build$${id}`]
+    .filter((value: string) => value.length > 0)
+    .join(', ');
+
+  const isPromiseChecks: string =
+    argumentIndexes
+      .map((index: number) => `isPromise$${id}(value$${index.toString()})`)
+      .join(' || ') || 'false';
 
   const buildResolveManyFunction: (
     isPromiseFunction: typeof isPromise,
     // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type, @typescript-eslint/no-implied-eval
   ) => Function = new Function(
     `isPromise$${id}`,
-    `return function resolveMany$${id}(${valueConcatenation}, build$${id}) {
+    `return function resolveMany$${id}(${parametersConcatenation}) {
   if (${isPromiseChecks}) {
     return Promise.all([${valueConcatenation}]).then(
       function ([${resolvedValueConcatenation}]) {

--- a/packages/container/libraries/core/src/planning/calculations/buildThreeConstructorArgumentResolver.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildThreeConstructorArgumentResolver.spec.ts
@@ -364,8 +364,8 @@ describe(buildThreeConstructorArgumentResolver, () => {
         vitest.clearAllMocks();
       });
 
-      it('should build an instance with the resolved constructor arguments', () => {
-        expect(result).toStrictEqual(Promise.resolve(expect.any(Foo)));
+      it('should build an instance with the resolved constructor arguments', async () => {
+        await expect(result).resolves.toStrictEqual(expect.any(Foo));
       });
 
       it('should call setInstanceProperties()', () => {

--- a/packages/container/libraries/core/src/planning/calculations/buildTwoConstructorArgumentResolver.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildTwoConstructorArgumentResolver.spec.ts
@@ -328,8 +328,8 @@ describe(buildTwoConstructorArgumentResolver, () => {
         vitest.clearAllMocks();
       });
 
-      it('should build an instance with the resolved constructor arguments', () => {
-        expect(result).toStrictEqual(Promise.resolve(expect.any(Foo)));
+      it('should build an instance with the resolved constructor arguments', async () => {
+        await expect(result).resolves.toStrictEqual(expect.any(Foo));
       });
 
       it('should call setInstanceProperties()', () => {

--- a/packages/container/libraries/core/src/planning/calculations/buildZeroConstructorArgumentsResolver.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildZeroConstructorArgumentsResolver.spec.ts
@@ -193,8 +193,8 @@ describe(buildZeroConstructorArgumentsResolver, () => {
         vitest.clearAllMocks();
       });
 
-      it('should build an instance with no constructor arguments', () => {
-        expect(result).toStrictEqual(Promise.resolve(expect.any(Foo)));
+      it('should build an instance with no constructor arguments', async () => {
+        await expect(result).resolves.toStrictEqual(expect.any(Foo));
       });
 
       it('should call setInstanceProperties()', () => {

--- a/packages/container/libraries/inversify/src/test/container/container.int.spec.ts
+++ b/packages/container/libraries/inversify/src/test/container/container.int.spec.ts
@@ -14,6 +14,7 @@ import {
 } from '../../index.js';
 
 const CONSTRUCTOR_ARITIES: number[] = [0, 1, 2, 3, 4, 5];
+const PROPERTY_ARITIES: number[] = [0, 1, 2, 3, 4, 5];
 
 function buildDependencyIdentifiers(parameterCount: number): string[] {
   return Array.from(
@@ -30,10 +31,21 @@ function buildExpectedArgs(parameterCount: number): string[] {
   );
 }
 
+function buildPropertyKey(index: number): string {
+  return `property${index.toString()}`;
+}
+
 interface ArgsCapturingInstance {
   activatedByBinding: boolean;
   activatedByService: boolean;
   args: unknown[];
+}
+
+interface PropertiesCapturingInstance {
+  [propertyKey: string]: unknown;
+
+  activatedByBinding: boolean;
+  activatedByService: boolean;
 }
 
 function buildArgsCapturingClass(
@@ -56,6 +68,64 @@ function buildArgsCapturingClass(
   });
 
   return ArgsCapturingService;
+}
+
+function buildPropertiesCapturingClass(
+  dependencyIds: string[],
+): Newable<PropertiesCapturingInstance> {
+  class PropertiesCapturingService implements PropertiesCapturingInstance {
+    [propertyKey: string]: unknown;
+
+    public activatedByBinding: boolean = false;
+    public activatedByService: boolean = false;
+  }
+
+  injectable()(PropertiesCapturingService);
+
+  dependencyIds.forEach((dependencyId: string, index: number): void => {
+    inject(dependencyId)(
+      PropertiesCapturingService.prototype,
+      buildPropertyKey(index),
+    );
+  });
+
+  return PropertiesCapturingService;
+}
+
+function buildArgsAndPropertiesCapturingClass(
+  constructorDependencyIds: string[],
+  propertyDependencyIds: string[],
+): Newable<ArgsCapturingInstance & PropertiesCapturingInstance> {
+  class ArgsAndPropertiesCapturingService
+    implements ArgsCapturingInstance, PropertiesCapturingInstance
+  {
+    [propertyKey: string]: unknown;
+
+    public activatedByBinding: boolean = false;
+    public activatedByService: boolean = false;
+    public readonly args: unknown[];
+
+    constructor(...args: unknown[]) {
+      this.args = args;
+    }
+  }
+
+  injectable()(ArgsAndPropertiesCapturingService);
+
+  constructorDependencyIds.forEach(
+    (dependencyId: string, index: number): void => {
+      inject(dependencyId)(ArgsAndPropertiesCapturingService, undefined, index);
+    },
+  );
+
+  propertyDependencyIds.forEach((dependencyId: string, index: number): void => {
+    inject(dependencyId)(
+      ArgsAndPropertiesCapturingService.prototype,
+      buildPropertyKey(index),
+    );
+  });
+
+  return ArgsAndPropertiesCapturingService;
 }
 
 function buildArgsCapturingResolvedValueFactory(): (
@@ -340,6 +410,105 @@ describe(Container, () => {
             expect(instanceAfterActivation.args).toStrictEqual(expectedArgs);
             expect(instanceAfterActivation.activatedByBinding).toBe(false);
             expect(instanceAfterActivation.activatedByService).toBe(true);
+          },
+        );
+      });
+    },
+  );
+
+  describe.each(
+    PROPERTY_ARITIES.flatMap((arity: number) => [
+      [arity, true],
+      [arity, false],
+    ]),
+  )(
+    'having a transient instance service with %s property injections and no constructor parameters',
+    (propertyCount: number, jitless: boolean) => {
+      const dependencyIds: string[] = buildDependencyIdentifiers(propertyCount);
+      const expectedValues: string[] = buildExpectedArgs(propertyCount);
+
+      it('should resolve property injections when called', () => {
+        const container: Container = new Container({
+          jitless,
+        });
+
+        dependencyIds.forEach((dependencyId: string, index: number): void => {
+          container
+            .bind<string>(dependencyId)
+            .toConstantValue(expectedValues[index] as string);
+        });
+
+        const serviceClass: Newable<PropertiesCapturingInstance> =
+          buildPropertiesCapturingClass(dependencyIds);
+
+        container.bind(serviceClass).toSelf().inTransientScope();
+
+        const instance: PropertiesCapturingInstance =
+          container.get(serviceClass);
+
+        dependencyIds.forEach((_dependencyId: string, index: number): void => {
+          expect(instance[buildPropertyKey(index)]).toBe(expectedValues[index]);
+        });
+      });
+    },
+  );
+
+  describe.each([[true], [false]])(
+    'having a transient instance service with two constructor parameters and three property injections (jitless %s)',
+    (jitless: boolean) => {
+      const constructorDependencyIds: string[] = buildDependencyIdentifiers(2);
+      const propertyDependencyIds: string[] = [
+        'property-dependency-0',
+        'property-dependency-1',
+        'property-dependency-2',
+      ];
+      const expectedConstructorArgs: string[] = buildExpectedArgs(2);
+      const expectedPropertyValues: string[] = [
+        'property-value-0',
+        'property-value-1',
+        'property-value-2',
+      ];
+
+      it('should resolve constructor and property injections when called', () => {
+        const container: Container = new Container({
+          jitless,
+        });
+
+        constructorDependencyIds.forEach(
+          (dependencyId: string, index: number): void => {
+            container
+              .bind<string>(dependencyId)
+              .toConstantValue(expectedConstructorArgs[index] as string);
+          },
+        );
+
+        propertyDependencyIds.forEach(
+          (dependencyId: string, index: number): void => {
+            container
+              .bind<string>(dependencyId)
+              .toConstantValue(expectedPropertyValues[index] as string);
+          },
+        );
+
+        const serviceClass: Newable<
+          ArgsCapturingInstance & PropertiesCapturingInstance
+        > = buildArgsAndPropertiesCapturingClass(
+          constructorDependencyIds,
+          propertyDependencyIds,
+        );
+
+        container.bind(serviceClass).toSelf().inTransientScope();
+
+        const instance: ArgsCapturingInstance & PropertiesCapturingInstance =
+          container.get(serviceClass);
+
+        expect(instance.args).toStrictEqual(expectedConstructorArgs);
+
+        propertyDependencyIds.forEach(
+          (_dependencyId: string, index: number): void => {
+            expect(instance[buildPropertyKey(index)]).toBe(
+              expectedPropertyValues[index],
+            );
           },
         );
       });

--- a/packages/container/libraries/inversify/src/test/container/container.no-eval.int.spec.ts
+++ b/packages/container/libraries/inversify/src/test/container/container.no-eval.int.spec.ts
@@ -13,6 +13,7 @@ import {
 } from '@inversifyjs/core';
 
 const CONSTRUCTOR_ARITIES: number[] = [0, 1, 2, 3, 4, 5];
+const PROPERTY_ARITIES: number[] = [0, 1, 2, 3, 4, 5];
 
 function buildDependencyIdentifiers(parameterCount: number): string[] {
   return Array.from(
@@ -29,10 +30,20 @@ function buildExpectedArgs(parameterCount: number): string[] {
   );
 }
 
+function buildPropertyKey(index: number): string {
+  return `property${index.toString()}`;
+}
+
 interface ArgsCapturingInstance {
   activatedByBinding: boolean;
   activatedByService: boolean;
   args: unknown[];
+}
+
+interface PropertiesCapturingInstance {
+  [propertyKey: string]: unknown;
+  activatedByBinding: boolean;
+  activatedByService: boolean;
 }
 
 function buildArgsCapturingClass(
@@ -55,6 +66,64 @@ function buildArgsCapturingClass(
   });
 
   return ArgsCapturingService;
+}
+
+function buildPropertiesCapturingClass(
+  dependencyIds: string[],
+): Newable<PropertiesCapturingInstance> {
+  class PropertiesCapturingService implements PropertiesCapturingInstance {
+    [propertyKey: string]: unknown;
+
+    public activatedByBinding: boolean = false;
+    public activatedByService: boolean = false;
+  }
+
+  injectable()(PropertiesCapturingService);
+
+  dependencyIds.forEach((dependencyId: string, index: number): void => {
+    inject(dependencyId)(
+      PropertiesCapturingService.prototype,
+      buildPropertyKey(index),
+    );
+  });
+
+  return PropertiesCapturingService;
+}
+
+function buildArgsAndPropertiesCapturingClass(
+  constructorDependencyIds: string[],
+  propertyDependencyIds: string[],
+): Newable<ArgsCapturingInstance & PropertiesCapturingInstance> {
+  class ArgsAndPropertiesCapturingService
+    implements ArgsCapturingInstance, PropertiesCapturingInstance
+  {
+    [propertyKey: string]: unknown;
+
+    public activatedByBinding: boolean = false;
+    public activatedByService: boolean = false;
+    public readonly args: unknown[];
+
+    constructor(...args: unknown[]) {
+      this.args = args;
+    }
+  }
+
+  injectable()(ArgsAndPropertiesCapturingService);
+
+  constructorDependencyIds.forEach(
+    (dependencyId: string, index: number): void => {
+      inject(dependencyId)(ArgsAndPropertiesCapturingService, undefined, index);
+    },
+  );
+
+  propertyDependencyIds.forEach((dependencyId: string, index: number): void => {
+    inject(dependencyId)(
+      ArgsAndPropertiesCapturingService.prototype,
+      buildPropertyKey(index),
+    );
+  });
+
+  return ArgsAndPropertiesCapturingService;
 }
 
 function buildArgsCapturingResolvedValueFactory(): (
@@ -339,4 +408,93 @@ describe(Container, () => {
       });
     },
   );
+
+  describe.each(PROPERTY_ARITIES)(
+    'having a transient instance service with %s property injections and no constructor parameters',
+    (propertyCount: number) => {
+      const dependencyIds: string[] = buildDependencyIdentifiers(propertyCount);
+      const expectedValues: string[] = buildExpectedArgs(propertyCount);
+
+      it('should resolve property injections when called', () => {
+        const container: Container = new Container({
+          jitless: true,
+        });
+
+        dependencyIds.forEach((dependencyId: string, index: number): void => {
+          container
+            .bind<string>(dependencyId)
+            .toConstantValue(expectedValues[index] as string);
+        });
+
+        const serviceClass: Newable<PropertiesCapturingInstance> =
+          buildPropertiesCapturingClass(dependencyIds);
+
+        container.bind(serviceClass).toSelf().inTransientScope();
+
+        const instance: PropertiesCapturingInstance =
+          container.get(serviceClass);
+
+        dependencyIds.forEach((_dependencyId: string, index: number): void => {
+          expect(instance[buildPropertyKey(index)]).toBe(expectedValues[index]);
+        });
+      });
+    },
+  );
+
+  it('should resolve a transient instance service with two constructor parameters and three property injections when called', () => {
+    const constructorDependencyIds: string[] = buildDependencyIdentifiers(2);
+    const propertyDependencyIds: string[] = [
+      'property-dependency-0',
+      'property-dependency-1',
+      'property-dependency-2',
+    ];
+    const expectedConstructorArgs: string[] = buildExpectedArgs(2);
+    const expectedPropertyValues: string[] = [
+      'property-value-0',
+      'property-value-1',
+      'property-value-2',
+    ];
+
+    const container: Container = new Container({
+      jitless: true,
+    });
+
+    constructorDependencyIds.forEach(
+      (dependencyId: string, index: number): void => {
+        container
+          .bind<string>(dependencyId)
+          .toConstantValue(expectedConstructorArgs[index] as string);
+      },
+    );
+
+    propertyDependencyIds.forEach(
+      (dependencyId: string, index: number): void => {
+        container
+          .bind<string>(dependencyId)
+          .toConstantValue(expectedPropertyValues[index] as string);
+      },
+    );
+
+    const serviceClass: Newable<
+      ArgsCapturingInstance & PropertiesCapturingInstance
+    > = buildArgsAndPropertiesCapturingClass(
+      constructorDependencyIds,
+      propertyDependencyIds,
+    );
+
+    container.bind(serviceClass).toSelf().inTransientScope();
+
+    const instance: ArgsCapturingInstance & PropertiesCapturingInstance =
+      container.get(serviceClass);
+
+    expect(instance.args).toStrictEqual(expectedConstructorArgs);
+
+    propertyDependencyIds.forEach(
+      (_dependencyId: string, index: number): void => {
+        expect(instance[buildPropertyKey(index)]).toBe(
+          expectedPropertyValues[index],
+        );
+      },
+    );
+  });
 });


### PR DESCRIPTION
### Context
- See [this comment](https://github.com/inversify/monorepo/issues/2020#issuecomment-5061168619)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed just-in-time resolution for transient bindings with more than four combined constructor and property injections, preventing resolution errors and incorrect arity during instantiation.
  - Improved resolver generation to correctly handle mixed constructor/property cases and promise detection.

- **Tests**
  - Expanded coverage for property-only and combined constructor/property injection scenarios, including async property resolution.
  - Updated assertions to consistently use async expectations for resolved results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->