### PR TITLE
Add validation specific errors with original errors

### DIFF
--- a/.changeset/calm-ajv-errors.md
+++ b/.changeset/calm-ajv-errors.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/ajv-validation": minor
+---
+
+- Added `InversifyAjvValidationError` with Ajv `ErrorObject[]` on validation failure.

--- a/.changeset/keen-standard-errors.md
+++ b/.changeset/keen-standard-errors.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/standard-schema-validation": minor
+---
+
+- Added `InversifyStandardSchemaValidationError` with Standard Schema `Issue[]` on validation failure.

--- a/.changeset/open-api-errors.md
+++ b/.changeset/open-api-errors.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/open-api-validation": minor
+---
+
+- Added `InversifyOpenApiValidationError` with Ajv `ErrorObject[]` on schema validation failure.

--- a/.changeset/tidy-errors-common.md
+++ b/.changeset/tidy-errors-common.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/validation-common": minor
+---
+
+- Added an optional typed `errors` field to `InversifyValidationError`.

--- a/.changeset/warm-class-errors.md
+++ b/.changeset/warm-class-errors.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/class-validation": minor
+---
+
+- Added `InversifyClassValidationError` with class-validator `ValidationError[]` on validation failure.

--- a/packages/container/libraries/core/src/planning/calculations/resolveMany.ts
+++ b/packages/container/libraries/core/src/planning/calculations/resolveMany.ts
@@ -25,6 +25,6 @@ export function resolveMany(
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
   return build(...values);
 }

--- a/packages/docs/services/inversify-framework-site/validation-docs/ajv/api.mdx
+++ b/packages/docs/services/inversify-framework-site/validation-docs/ajv/api.mdx
@@ -5,6 +5,7 @@ title: API
 import apiAjvValidationPipeSource from '@inversifyjs/validation-code-examples/generated/examples/v1/ajv/apiAjvValidationPipe.ts.txt';
 import apiAjvCompiledValidationPipeSource from '@inversifyjs/validation-code-examples/generated/examples/v1/ajv/apiAjvCompiledValidationPipe.ts.txt';
 import apiValidateAjvSchemaSource from '@inversifyjs/validation-code-examples/generated/examples/v1/ajv/apiValidateAjvSchema.ts.txt';
+import customValidationErrorFilterSource from '@inversifyjs/validation-code-examples/generated/examples/v1/ajv/customValidationErrorFilter.ts.txt';
 import CodeBlock from '@theme/CodeBlock';
 
 ## AjvValidationPipe
@@ -60,7 +61,7 @@ Parameters
 
 When multiple schemas are provided, they run in sequence. The value must pass all schema validations. Any schemas provided to `AjvValidationPipe` run first; parameter-level schemas run afterwards.
 
-On validation failure, an `InversifyValidationError` is thrown and can be converted to a Bad Request HTTP response by `ValidationErrorFilter`.
+On validation failure, an `InversifyAjvValidationError` is thrown and can be converted to a Bad Request HTTP response by `ValidationErrorFilter`.
 
 ### Example: validate request body with JSON Schema
 
@@ -68,9 +69,38 @@ On validation failure, an `InversifyValidationError` is thrown and can be conver
 
 ### Error Handling
 
-When validation fails, Ajv provides detailed error information including:
+When validation fails, the pipe throws an `InversifyAjvValidationError` (a subclass of `InversifyValidationError`) with:
+- A user-friendly `message` built from Ajv errors
+- An `errors` field containing the raw Ajv `ErrorObject[]`
+
+Ajv error details include:
 - Property path where validation failed
 - Expected vs actual values
 - Validation rule that was violated
 
-The `AjvValidationPipe` automatically converts these errors into user-friendly messages that can be returned as HTTP responses.
+Use `InversifyValidationErrorFilter` (from `@inversifyjs/http-validation`) or a custom `@CatchError(InversifyValidationError)` / `@CatchError(InversifyAjvValidationError)` filter to convert these errors into HTTP 400 responses.
+
+## Customizing validation error responses
+
+`InversifyValidationErrorFilter` returns `{ message }` by default. When frontends need field-level errors, catch `InversifyAjvValidationError` and map its `errors` field into the response body you want:
+
+<CodeBlock language="ts">{customValidationErrorFilterSource}</CodeBlock>
+
+Register the filter instead of (or in addition to) the built-in one:
+
+```ts
+adapter.useGlobalFilters(CustomAjvValidationErrorFilter);
+```
+
+That yields responses like:
+
+```json
+{
+  "success": false,
+  "message": "Validation failed",
+  "errors": {
+    "firstName": "must NOT have fewer than 1 characters",
+    "lastName": "must NOT have fewer than 1 characters"
+  }
+}
+```

--- a/packages/docs/services/inversify-framework-site/validation-docs/ajv/api.mdx
+++ b/packages/docs/services/inversify-framework-site/validation-docs/ajv/api.mdx
@@ -61,7 +61,7 @@ Parameters
 
 When multiple schemas are provided, they run in sequence. The value must pass all schema validations. Any schemas provided to `AjvValidationPipe` run first; parameter-level schemas run afterwards.
 
-On validation failure, an `InversifyAjvValidationError` is thrown and can be converted to a Bad Request HTTP response by `ValidationErrorFilter`.
+On validation failure, an `InversifyAjvValidationError` is thrown and can be converted to a Bad Request HTTP response by `InversifyValidationErrorFilter`.
 
 ### Example: validate request body with JSON Schema
 

--- a/packages/docs/services/inversify-framework-site/validation-docs/class-validator/api.mdx
+++ b/packages/docs/services/inversify-framework-site/validation-docs/class-validator/api.mdx
@@ -4,6 +4,7 @@ title: API
 ---
 import apiClassValidationPipeSource from '@inversifyjs/validation-code-examples/generated/examples/v1/classValidator/apiClassValidationPipe.ts.txt';
 import gettingStartedSource from '@inversifyjs/validation-code-examples/generated/examples/v1/classValidator/gettingStarted.ts.txt';
+import customValidationErrorFilterSource from '@inversifyjs/validation-code-examples/generated/examples/v1/classValidator/customValidationErrorFilter.ts.txt';
 import CodeBlock from '@theme/CodeBlock';
 
 ## ClassValidationPipe
@@ -21,7 +22,7 @@ This way, controller parameters with decorated classes are automatically validat
 
 To validate request parameters, create classes with class-validator decorators and use them as parameter types in your controller methods. The `ClassValidationPipe` will automatically validate and transform the data.
 
-On validation failure, an `InversifyValidationError` is thrown and can be converted to a Bad Request HTTP response by `InversifyValidationErrorFilter`.
+On validation failure, an `InversifyClassValidationError` (a subclass of `InversifyValidationError`) is thrown with an `errors` field containing the raw class-validator `ValidationError[]`. It can be converted to a Bad Request HTTP response by `InversifyValidationErrorFilter`.
 
 ### Example: validate request body with class-validator
 
@@ -30,3 +31,28 @@ On validation failure, an `InversifyValidationError` is thrown and can be conver
 ### Available Validation Decorators
 
 Class-validator provides many built-in validation decorators. For a complete list of available decorators, see the [class-validator documentation](https://github.com/typestack/class-validator#validation-decorators).
+
+## Customizing validation error responses
+
+`InversifyValidationErrorFilter` returns `{ message }` by default. When frontends need field-level errors, catch `InversifyClassValidationError` and map its `errors` field into the response body you want:
+
+<CodeBlock language="ts">{customValidationErrorFilterSource}</CodeBlock>
+
+Register the filter instead of (or in addition to) the built-in one:
+
+```ts
+adapter.useGlobalFilters(CustomClassValidationErrorFilter);
+```
+
+That yields responses like:
+
+```json
+{
+  "success": false,
+  "message": "Validation failed",
+  "errors": {
+    "firstName": "First name is required",
+    "lastName": "Last name is required"
+  }
+}
+```

--- a/packages/docs/services/inversify-framework-site/validation-docs/introduction/getting-started.mdx
+++ b/packages/docs/services/inversify-framework-site/validation-docs/introduction/getting-started.mdx
@@ -77,7 +77,7 @@ In order to enable validation in your application, you need to configure the ser
     },
   );
 
-  adapter.useGlobalFilters(ValidationErrorFilter);
+  adapter.useGlobalFilters(InversifyValidationErrorFilter);
   adapter.useGlobalPipe(new StandardSchemaValidationPipe());
 ```
 

--- a/packages/docs/services/inversify-framework-site/validation-docs/introduction/getting-started.mdx
+++ b/packages/docs/services/inversify-framework-site/validation-docs/introduction/getting-started.mdx
@@ -66,7 +66,7 @@ Validation tools are designed to work outside HTTP context. In order to use them
 In order to enable validation in your application, you need to configure the server:
 
 1. Use the specific validator error pipe. If we take the previous example, we need to use a `StandardSchemaValidationPipe`, for Zod is integrated via Standard Schema integration.
-2. Use the `ValidationErrorFilter` to handle validation errors. This error filter provided by the `@inversifyjs/http-validation` package catches validation errors in order to send Bad Request HTTP responses on top of them.
+2. Use the `InversifyValidationErrorFilter` to handle validation errors. This error filter provided by the `@inversifyjs/http-validation` package catches validation errors in order to send Bad Request HTTP responses on top of them.
 
 ```ts
   const adapter: InversifyExpressHttpAdapter = new InversifyExpressHttpAdapter(

--- a/packages/docs/services/inversify-framework-site/validation-docs/openapi/api.mdx
+++ b/packages/docs/services/inversify-framework-site/validation-docs/openapi/api.mdx
@@ -7,6 +7,7 @@ import apiValidateDecoratorSource from '@inversifyjs/validation-code-examples/ge
 import apiValidateHeadersDecoratorSource from '@inversifyjs/validation-code-examples/generated/examples/v1/openApiValidation/apiValidateHeadersDecorator.ts.txt';
 import apiValidateParamsDecoratorSource from '@inversifyjs/validation-code-examples/generated/examples/v1/openApiValidation/apiValidateParamsDecorator.ts.txt';
 import apiValidateQueryDecoratorSource from '@inversifyjs/validation-code-examples/generated/examples/v1/openApiValidation/apiValidateQueryDecorator.ts.txt';
+import customValidationErrorFilterSource from '@inversifyjs/validation-code-examples/generated/examples/v1/openApiValidation/customValidationErrorFilter.ts.txt';
 import CodeBlock from '@theme/CodeBlock';
 
 ## OpenApiValidationPipe
@@ -91,25 +92,6 @@ public getResources(@ValidatedHeaders() _headers: Record<string, unknown>): stri
 
 <CodeBlock language="ts">{apiValidateHeadersDecoratorSource}</CodeBlock>
 
-### Error Handling
-
-When validation fails, the pipe throws an `InversifyValidationError` with a detailed message containing:
-- The JSON Schema path where validation failed
-- The instance path in the request body or header
-- The validation error message from Ajv
-
-For example, a body validation failure:
-```
-[schema: #/properties/email/format, instance: /email]: "must match format \"email\""
-```
-
-A header validation failure:
-```
-[schema: #/components/parameters/x-page-size/schema, instance: /x-page-size]: "must be integer"
-```
-
-Use `InversifyValidationErrorFilter` (from `@inversifyjs/http-validation`) or a custom `@CatchError(InversifyValidationError)` filter to convert these errors into HTTP 400 responses.
-
 ## ValidatedParams
 
 A custom parameter decorator that extracts URL path parameters along with the HTTP method and URL, and marks the parameter for OpenAPI path parameter validation.
@@ -155,3 +137,46 @@ public getProducts(@ValidatedQuery() query: Record<string, unknown>): string {
 ### Example: validate query parameters with OpenAPI schema
 
 <CodeBlock language="ts">{apiValidateQueryDecoratorSource}</CodeBlock>
+
+## Error Handling
+
+When schema validation fails, the pipe throws an `InversifyOpenApiValidationError` (a subclass of `InversifyValidationError`) with:
+- A detailed `message` containing the JSON Schema path, instance path, and Ajv error message
+- An `errors` field containing the raw Ajv `ErrorObject[]`
+
+For example, a body validation failure:
+```
+[schema: #/properties/email/format, instance: /email]: "must match format \"email\""
+```
+
+A header validation failure:
+```
+[schema: #/components/parameters/x-page-size/schema, instance: /x-page-size]: "must be integer"
+```
+
+Use `InversifyValidationErrorFilter` (from `@inversifyjs/http-validation`) or a custom `@CatchError(InversifyValidationError)` / `@CatchError(InversifyOpenApiValidationError)` filter to convert these errors into HTTP 400 responses.
+
+### Customizing validation error responses
+
+`InversifyValidationErrorFilter` returns `{ message }` by default. When frontends need field-level errors, catch `InversifyOpenApiValidationError` and map its Ajv `errors` field into the response body you want:
+
+<CodeBlock language="ts">{customValidationErrorFilterSource}</CodeBlock>
+
+Register the filter instead of (or in addition to) the built-in one:
+
+```ts
+adapter.useGlobalFilters(CustomOpenApiValidationErrorFilter);
+```
+
+That yields responses like:
+
+```json
+{
+  "success": false,
+  "message": "Validation failed",
+  "errors": {
+    "firstName": "must NOT have fewer than 1 characters",
+    "lastName": "must NOT have fewer than 1 characters"
+  }
+}
+```

--- a/packages/docs/services/inversify-framework-site/validation-docs/openapi/introduction.mdx
+++ b/packages/docs/services/inversify-framework-site/validation-docs/openapi/introduction.mdx
@@ -52,7 +52,7 @@ This example:
 3. Uses `SwaggerUiProvider` to populate the OpenAPI spec from controller metadata.
 4. Creates an `OpenApiValidationPipe` from the populated spec and registers it globally.
 
-When a request arrives, the pipe validates the body against the OpenAPI schema. Invalid requests are rejected with an `InversifyValidationError`, which the `InversifyValidationErrorFilter` converts into a 400 Bad Request response.
+When a request arrives, the pipe validates the body against the OpenAPI schema. Invalid requests are rejected with an `InversifyOpenApiValidationError` (including the raw Ajv errors), which the `InversifyValidationErrorFilter` converts into a 400 Bad Request response.
 
 ## How It Works
 
@@ -65,7 +65,7 @@ The validation flow:
    - Resolves the content type (extracted from the request by `@ValidatedBody()`, or falls back to a single declared type).
    - Locates the matching schema using JSON pointer navigation.
    - Validates the body against the schema using Ajv.
-4. **Error handling** — Validation failures throw `InversifyValidationError` with detailed error information.
+4. **Error handling** — Schema validation failures throw `InversifyOpenApiValidationError` with detailed Ajv error information.
 
 ## OpenAPI Version Support
 

--- a/packages/docs/services/inversify-framework-site/validation-docs/standard-schema/api.mdx
+++ b/packages/docs/services/inversify-framework-site/validation-docs/standard-schema/api.mdx
@@ -40,7 +40,7 @@ Parameters
 
 When multiple schemas are provided, they run in order. The output of one becomes the input of the next. Any schemas provided to `StandardSchemaValidationPipe` run first; parameter-level schemas run afterwards. If a schema transforms the value (e.g., parsing/coercion), the controller receives the transformed value.
 
-On failure, an `InversifyStandardSchemaValidationError` (a subclass of `InversifyValidationError`) is thrown with an `errors` field containing the raw Standard Schema `Issue[]`. It can be converted to a Bad Request HTTP response by `ValidationErrorFilter`.
+On failure, an `InversifyStandardSchemaValidationError` (a subclass of `InversifyValidationError`) is thrown with an `errors` field containing the raw Standard Schema `Issue[]`. It can be converted to a Bad Request HTTP response by `InversifyValidationErrorFilter`.
 
 Example: validate request body with Zod
 

--- a/packages/docs/services/inversify-framework-site/validation-docs/standard-schema/api.mdx
+++ b/packages/docs/services/inversify-framework-site/validation-docs/standard-schema/api.mdx
@@ -4,6 +4,7 @@ title: API
 ---
 import apiStandardSchemaValidationPipeSource from '@inversifyjs/validation-code-examples/generated/examples/v1/standardSchema/apiStandardSchemaValidationPipe.ts.txt';
 import apiValidateStandardSchemaV1Source from '@inversifyjs/validation-code-examples/generated/examples/v1/standardSchema/apiValidateStandardSchemaV1.ts.txt';
+import customValidationErrorFilterSource from '@inversifyjs/validation-code-examples/generated/examples/v1/standardSchema/customValidationErrorFilter.ts.txt';
 import CodeBlock from '@theme/CodeBlock';
 
 ## StandardSchemaValidationPipe
@@ -39,8 +40,33 @@ Parameters
 
 When multiple schemas are provided, they run in order. The output of one becomes the input of the next. Any schemas provided to `StandardSchemaValidationPipe` run first; parameter-level schemas run afterwards. If a schema transforms the value (e.g., parsing/coercion), the controller receives the transformed value.
 
-On failure, an `InversifyValidationError` is thrown and can be converted to a Bad Request HTTP response by `ValidationErrorFilter`.
+On failure, an `InversifyStandardSchemaValidationError` (a subclass of `InversifyValidationError`) is thrown with an `errors` field containing the raw Standard Schema `Issue[]`. It can be converted to a Bad Request HTTP response by `ValidationErrorFilter`.
 
 Example: validate request body with Zod
 
 <CodeBlock language="ts">{apiValidateStandardSchemaV1Source}</CodeBlock>
+
+## Customizing validation error responses
+
+`InversifyValidationErrorFilter` returns `{ message }` by default. When frontends need field-level errors, catch `InversifyStandardSchemaValidationError` and map its `errors` field into the response body you want:
+
+<CodeBlock language="ts">{customValidationErrorFilterSource}</CodeBlock>
+
+Register the filter instead of (or in addition to) the built-in one:
+
+```ts
+adapter.useGlobalFilters(CustomStandardSchemaValidationErrorFilter);
+```
+
+That yields responses like:
+
+```json
+{
+  "success": false,
+  "message": "Validation failed",
+  "errors": {
+    "firstName": "First name is required",
+    "lastName": "Last name is required"
+  }
+}
+```

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/ajv/customValidationErrorFilter.int.spec.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/ajv/customValidationErrorFilter.int.spec.ts
@@ -1,0 +1,102 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { AjvValidationPipe } from '@inversifyjs/ajv-validation';
+import Ajv from 'ajv';
+import { Container } from 'inversify';
+
+import { buildExpressServer } from '../../../server/adapter/express/actions/buildExpressServer.js';
+import { type Server } from '../../../server/models/Server.js';
+import {
+  CustomAjvValidationErrorFilter,
+  UserController,
+} from './customValidationErrorFilter.js';
+
+describe(CustomAjvValidationErrorFilter, () => {
+  describe('having an AjvValidationPipe with a custom validation error filter', () => {
+    let server: Server;
+
+    beforeAll(async () => {
+      const container: Container = new Container();
+      const ajv: Ajv = new Ajv({ allErrors: true });
+
+      container
+        .bind(CustomAjvValidationErrorFilter)
+        .toSelf()
+        .inSingletonScope();
+      container.bind(UserController).toSelf().inSingletonScope();
+
+      server = await buildExpressServer(
+        container,
+        [CustomAjvValidationErrorFilter],
+        [new AjvValidationPipe(ajv)],
+      );
+    });
+
+    afterAll(async () => {
+      await server.shutdown();
+    });
+
+    describe('when a valid POST /users request is made', () => {
+      let response: Response;
+
+      beforeAll(async () => {
+        response = await fetch(
+          `http://${server.host}:${server.port.toString()}/users`,
+          {
+            body: JSON.stringify({
+              firstName: 'Jane',
+              lastName: 'Doe',
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+          },
+        );
+      });
+
+      it('should return expected Response', async () => {
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toStrictEqual({
+          firstName: 'Jane',
+          lastName: 'Doe',
+        });
+      });
+    });
+
+    describe('when an invalid POST /users request is made', () => {
+      let response: Response;
+
+      beforeAll(async () => {
+        response = await fetch(
+          `http://${server.host}:${server.port.toString()}/users`,
+          {
+            body: JSON.stringify({
+              firstName: '',
+              lastName: '',
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+          },
+        );
+      });
+
+      it('should return a field-mapped validation error body', async () => {
+        expect(response.status).toBe(400);
+        expect(response.headers.get('content-type')).toStrictEqual(
+          expect.stringContaining('application/json'),
+        );
+        await expect(response.json()).resolves.toStrictEqual({
+          errors: {
+            firstName: 'must NOT have fewer than 1 characters',
+            lastName: 'must NOT have fewer than 1 characters',
+          },
+          message: 'Validation failed',
+          success: false,
+        });
+      });
+    });
+  });
+});

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/ajv/customValidationErrorFilter.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/ajv/customValidationErrorFilter.ts
@@ -1,0 +1,90 @@
+// Begin-example
+import { InversifyAjvValidationError } from '@inversifyjs/ajv-validation';
+import {
+  BadRequestHttpResponse,
+  CatchError,
+  type ErrorFilter,
+} from '@inversifyjs/http-core';
+import { InversifyValidationErrorKind } from '@inversifyjs/validation-common';
+import { type ErrorObject } from 'ajv';
+
+function mapAjvErrors(errors: Partial<ErrorObject>[]): Record<string, string> {
+  const result: Record<string, string> = {};
+
+  for (const error of errors) {
+    const missingProperty: unknown = error.params?.['missingProperty'];
+    const path: string =
+      error.instancePath === undefined || error.instancePath === ''
+        ? typeof missingProperty === 'string'
+          ? missingProperty
+          : ''
+        : error.instancePath.replace(/^\//, '').replaceAll('/', '.');
+
+    if (
+      path !== '' &&
+      error.message !== undefined &&
+      result[path] === undefined
+    ) {
+      result[path] = error.message;
+    }
+  }
+
+  return result;
+}
+
+@CatchError(InversifyAjvValidationError)
+export class CustomAjvValidationErrorFilter implements ErrorFilter<InversifyAjvValidationError> {
+  public catch(error: InversifyAjvValidationError): never {
+    switch (error.kind) {
+      case InversifyValidationErrorKind.validationFailed:
+        throw new BadRequestHttpResponse(
+          {
+            errors: mapAjvErrors(error.errors ?? []),
+            message: 'Validation failed',
+            success: false,
+          },
+          error.message,
+          {
+            cause: error,
+          },
+        );
+      default:
+        throw new Error(error.message, {
+          cause: error,
+        });
+    }
+  }
+}
+// End-example
+
+/* eslint-disable no-useless-assignment */
+import { ValidateAjvSchema } from '@inversifyjs/ajv-validation';
+import { Body, Controller, Post } from '@inversifyjs/http-core';
+import { type AnySchema } from 'ajv';
+
+interface User {
+  firstName: string;
+  lastName: string;
+}
+
+const userSchema: AnySchema = {
+  additionalProperties: false,
+  properties: {
+    firstName: { minLength: 1, type: 'string' },
+    lastName: { minLength: 1, type: 'string' },
+  },
+  required: ['firstName', 'lastName'],
+  type: 'object',
+};
+
+@Controller('/users')
+export class UserController {
+  @Post()
+  public async createUser(
+    @Body()
+    @ValidateAjvSchema(userSchema)
+    user: User,
+  ): Promise<User> {
+    return user;
+  }
+}

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/classValidator/customValidationErrorFilter.int.spec.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/classValidator/customValidationErrorFilter.int.spec.ts
@@ -42,6 +42,9 @@ describe(CustomClassValidationErrorFilter, () => {
           `http://${server.host}:${server.port.toString()}/users`,
           {
             body: JSON.stringify({
+              address: {
+                city: 'New York',
+              },
               firstName: 'Jane',
               lastName: 'Doe',
             }),
@@ -56,6 +59,9 @@ describe(CustomClassValidationErrorFilter, () => {
       it('should return expected Response', async () => {
         expect(response.status).toBe(200);
         await expect(response.json()).resolves.toStrictEqual({
+          address: {
+            city: 'New York',
+          },
           firstName: 'Jane',
           lastName: 'Doe',
         });
@@ -70,6 +76,9 @@ describe(CustomClassValidationErrorFilter, () => {
           `http://${server.host}:${server.port.toString()}/users`,
           {
             body: JSON.stringify({
+              address: {
+                city: '',
+              },
               firstName: '',
               lastName: '',
             }),
@@ -88,6 +97,7 @@ describe(CustomClassValidationErrorFilter, () => {
         );
         await expect(response.json()).resolves.toStrictEqual({
           errors: {
+            city: 'City is required',
             firstName: 'First name is required',
             lastName: 'Last name is required',
           },

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/classValidator/customValidationErrorFilter.int.spec.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/classValidator/customValidationErrorFilter.int.spec.ts
@@ -1,0 +1,100 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { ClassValidationPipe } from '@inversifyjs/class-validation';
+import { Container } from 'inversify';
+
+import { buildExpressServer } from '../../../server/adapter/express/actions/buildExpressServer.js';
+import { type Server } from '../../../server/models/Server.js';
+import {
+  CustomClassValidationErrorFilter,
+  UserController,
+} from './customValidationErrorFilter.js';
+
+describe(CustomClassValidationErrorFilter, () => {
+  describe('having a ClassValidationPipe with a custom validation error filter', () => {
+    let server: Server;
+
+    beforeAll(async () => {
+      const container: Container = new Container();
+
+      container
+        .bind(CustomClassValidationErrorFilter)
+        .toSelf()
+        .inSingletonScope();
+      container.bind(UserController).toSelf().inSingletonScope();
+
+      server = await buildExpressServer(
+        container,
+        [CustomClassValidationErrorFilter],
+        [new ClassValidationPipe()],
+      );
+    });
+
+    afterAll(async () => {
+      await server.shutdown();
+    });
+
+    describe('when a valid POST /users request is made', () => {
+      let response: Response;
+
+      beforeAll(async () => {
+        response = await fetch(
+          `http://${server.host}:${server.port.toString()}/users`,
+          {
+            body: JSON.stringify({
+              firstName: 'Jane',
+              lastName: 'Doe',
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+          },
+        );
+      });
+
+      it('should return expected Response', async () => {
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toStrictEqual({
+          firstName: 'Jane',
+          lastName: 'Doe',
+        });
+      });
+    });
+
+    describe('when an invalid POST /users request is made', () => {
+      let response: Response;
+
+      beforeAll(async () => {
+        response = await fetch(
+          `http://${server.host}:${server.port.toString()}/users`,
+          {
+            body: JSON.stringify({
+              firstName: '',
+              lastName: '',
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+          },
+        );
+      });
+
+      it('should return a field-mapped validation error body', async () => {
+        expect(response.status).toBe(400);
+        expect(response.headers.get('content-type')).toStrictEqual(
+          expect.stringContaining('application/json'),
+        );
+        await expect(response.json()).resolves.toStrictEqual({
+          errors: {
+            firstName: 'First name is required',
+            lastName: 'Last name is required',
+          },
+          message: 'Validation failed',
+          success: false,
+        });
+      });
+    });
+  });
+});

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/classValidator/customValidationErrorFilter.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/classValidator/customValidationErrorFilter.ts
@@ -22,6 +22,8 @@ function mapClassValidationErrors(
     if (message !== undefined) {
       result[error.property] = message;
     }
+
+    Object.assign(result, mapClassValidationErrors(error.children ?? []));
   }
 
   return result;
@@ -53,9 +55,20 @@ export class CustomClassValidationErrorFilter implements ErrorFilter<InversifyCl
 // End-example
 
 import { Body, Controller, Post } from '@inversifyjs/http-core';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsNotEmpty, IsString, ValidateNested } from 'class-validator';
+
+export class Address {
+  @IsString()
+  @IsNotEmpty({ message: 'City is required' })
+  public readonly city!: string;
+}
 
 export class User {
+  @ValidateNested()
+  @Type(() => Address)
+  public readonly address!: Address;
+
   @IsString()
   @IsNotEmpty({ message: 'First name is required' })
   public readonly firstName!: string;

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/classValidator/customValidationErrorFilter.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/classValidator/customValidationErrorFilter.ts
@@ -1,0 +1,74 @@
+// Begin-example
+import { InversifyClassValidationError } from '@inversifyjs/class-validation';
+import {
+  BadRequestHttpResponse,
+  CatchError,
+  type ErrorFilter,
+} from '@inversifyjs/http-core';
+import { InversifyValidationErrorKind } from '@inversifyjs/validation-common';
+import { type ValidationError } from 'class-validator';
+
+function mapClassValidationErrors(
+  errors: ValidationError[],
+): Record<string, string> {
+  const result: Record<string, string> = {};
+
+  for (const error of errors) {
+    const message: string | undefined =
+      error.constraints === undefined
+        ? undefined
+        : Object.values(error.constraints)[0];
+
+    if (message !== undefined) {
+      result[error.property] = message;
+    }
+  }
+
+  return result;
+}
+
+@CatchError(InversifyClassValidationError)
+export class CustomClassValidationErrorFilter implements ErrorFilter<InversifyClassValidationError> {
+  public catch(error: InversifyClassValidationError): never {
+    switch (error.kind) {
+      case InversifyValidationErrorKind.validationFailed:
+        throw new BadRequestHttpResponse(
+          {
+            errors: mapClassValidationErrors(error.errors ?? []),
+            message: 'Validation failed',
+            success: false,
+          },
+          error.message,
+          {
+            cause: error,
+          },
+        );
+      default:
+        throw new Error(error.message, {
+          cause: error,
+        });
+    }
+  }
+}
+// End-example
+
+import { Body, Controller, Post } from '@inversifyjs/http-core';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class User {
+  @IsString()
+  @IsNotEmpty({ message: 'First name is required' })
+  public readonly firstName!: string;
+
+  @IsString()
+  @IsNotEmpty({ message: 'Last name is required' })
+  public readonly lastName!: string;
+}
+
+@Controller('/users')
+export class UserController {
+  @Post()
+  public async createUser(@Body() user: User): Promise<User> {
+    return user;
+  }
+}

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/classValidator/gettingStarted.int.spec.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/classValidator/gettingStarted.int.spec.ts
@@ -1,30 +1,12 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { ClassValidationPipe } from '@inversifyjs/class-validation';
-import {
-  BadRequestHttpResponse,
-  CatchError,
-  ErrorFilter,
-} from '@inversifyjs/http-core';
-import { InversifyValidationError } from '@inversifyjs/validation-common';
+import { InversifyValidationErrorFilter } from '@inversifyjs/http-validation';
 import { Container } from 'inversify';
 
 import { buildExpressServer } from '../../../server/adapter/express/actions/buildExpressServer.js';
-import { Server } from '../../../server/models/Server.js';
+import { type Server } from '../../../server/models/Server.js';
 import { MessageController } from './gettingStarted.js';
-
-@CatchError(InversifyValidationError)
-class ValidationErrorFilter implements ErrorFilter<InversifyValidationError> {
-  public catch(error: InversifyValidationError): never {
-    throw new BadRequestHttpResponse(
-      { message: error.message },
-      error.message,
-      {
-        cause: error,
-      },
-    );
-  }
-}
 
 describe('Getting started', () => {
   describe('having a ClassValidationPipe in an HTTP server with validated endpoints', () => {
@@ -33,12 +15,15 @@ describe('Getting started', () => {
     beforeAll(async () => {
       const container: Container = new Container();
 
-      container.bind(ValidationErrorFilter).toSelf().inSingletonScope();
+      container
+        .bind(InversifyValidationErrorFilter)
+        .toSelf()
+        .inSingletonScope();
       container.bind(MessageController).toSelf().inSingletonScope();
 
       server = await buildExpressServer(
         container,
-        [ValidationErrorFilter],
+        [InversifyValidationErrorFilter],
         [new ClassValidationPipe()],
       );
     });

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/openApiValidation/customValidationErrorFilter.int.spec.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/openApiValidation/customValidationErrorFilter.int.spec.ts
@@ -1,0 +1,116 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { SwaggerUiProvider } from '@inversifyjs/http-open-api';
+import { type OpenApi3Dot1Object } from '@inversifyjs/open-api-types/v3Dot1';
+import { OpenApiValidationPipe } from '@inversifyjs/open-api-validation/v3Dot1';
+import { Container } from 'inversify';
+
+import { buildExpressServer } from '../../../server/adapter/express/actions/buildExpressServer.js';
+import { type Server } from '../../../server/models/Server.js';
+import {
+  CustomOpenApiValidationErrorFilter,
+  UserController,
+} from './customValidationErrorFilter.js';
+
+describe(CustomOpenApiValidationErrorFilter, () => {
+  describe('having an OpenApiValidationPipe with a custom validation error filter', () => {
+    let server: Server;
+
+    beforeAll(async () => {
+      const container: Container = new Container();
+
+      const openApiObject: OpenApi3Dot1Object = {
+        info: { title: 'My API', version: '1.0.0' },
+        openapi: '3.1.1',
+      };
+
+      const swaggerProvider: SwaggerUiProvider = new SwaggerUiProvider({
+        api: {
+          openApiObject,
+          path: '/docs',
+        },
+      });
+
+      container
+        .bind(CustomOpenApiValidationErrorFilter)
+        .toSelf()
+        .inSingletonScope();
+      container.bind(UserController).toSelf().inSingletonScope();
+
+      swaggerProvider.provide(container);
+
+      server = await buildExpressServer(
+        container,
+        [CustomOpenApiValidationErrorFilter],
+        [new OpenApiValidationPipe(swaggerProvider.openApiObject)],
+      );
+    });
+
+    afterAll(async () => {
+      await server.shutdown();
+    });
+
+    describe('when a valid POST /users request is made', () => {
+      let response: Response;
+
+      beforeAll(async () => {
+        response = await fetch(
+          `http://${server.host}:${server.port.toString()}/users`,
+          {
+            body: JSON.stringify({
+              firstName: 'Jane',
+              lastName: 'Doe',
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+          },
+        );
+      });
+
+      it('should return expected Response', async () => {
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toStrictEqual({
+          firstName: 'Jane',
+          lastName: 'Doe',
+        });
+      });
+    });
+
+    describe('when an invalid POST /users request is made', () => {
+      let response: Response;
+
+      beforeAll(async () => {
+        response = await fetch(
+          `http://${server.host}:${server.port.toString()}/users`,
+          {
+            body: JSON.stringify({
+              firstName: '',
+              lastName: '',
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+          },
+        );
+      });
+
+      it('should return a field-mapped validation error body', async () => {
+        expect(response.status).toBe(400);
+        expect(response.headers.get('content-type')).toStrictEqual(
+          expect.stringContaining('application/json'),
+        );
+        await expect(response.json()).resolves.toStrictEqual({
+          errors: {
+            firstName: 'must NOT have fewer than 1 characters',
+            lastName: 'must NOT have fewer than 1 characters',
+          },
+          message: 'Validation failed',
+          success: false,
+        });
+      });
+    });
+  });
+});

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/openApiValidation/customValidationErrorFilter.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/openApiValidation/customValidationErrorFilter.ts
@@ -1,0 +1,90 @@
+// Begin-example
+import {
+  BadRequestHttpResponse,
+  CatchError,
+  type ErrorFilter,
+} from '@inversifyjs/http-core';
+import { InversifyOpenApiValidationError } from '@inversifyjs/open-api-validation';
+import { InversifyValidationErrorKind } from '@inversifyjs/validation-common';
+import { type ErrorObject } from 'ajv';
+
+function mapAjvErrors(errors: Partial<ErrorObject>[]): Record<string, string> {
+  const result: Record<string, string> = {};
+
+  for (const error of errors) {
+    const missingProperty: unknown = error.params?.['missingProperty'];
+    const path: string =
+      error.instancePath === undefined || error.instancePath === ''
+        ? typeof missingProperty === 'string'
+          ? missingProperty
+          : ''
+        : error.instancePath.replace(/^\//, '').replaceAll('/', '.');
+
+    if (
+      path !== '' &&
+      error.message !== undefined &&
+      result[path] === undefined
+    ) {
+      result[path] = error.message;
+    }
+  }
+
+  return result;
+}
+
+@CatchError(InversifyOpenApiValidationError)
+export class CustomOpenApiValidationErrorFilter implements ErrorFilter<InversifyOpenApiValidationError> {
+  public catch(error: InversifyOpenApiValidationError): never {
+    switch (error.kind) {
+      case InversifyValidationErrorKind.validationFailed:
+        throw new BadRequestHttpResponse(
+          {
+            errors: mapAjvErrors(error.errors ?? []),
+            message: 'Validation failed',
+            success: false,
+          },
+          error.message,
+          {
+            cause: error,
+          },
+        );
+      default:
+        throw new Error(error.message, {
+          cause: error,
+        });
+    }
+  }
+}
+// End-example
+
+import { Controller, Post } from '@inversifyjs/http-core';
+import { OasRequestBody } from '@inversifyjs/http-open-api';
+import { ValidatedBody } from '@inversifyjs/open-api-validation';
+
+interface User {
+  firstName: string;
+  lastName: string;
+}
+
+@Controller('/users')
+export class UserController {
+  @OasRequestBody({
+    content: {
+      'application/json': {
+        schema: {
+          additionalProperties: false,
+          properties: {
+            firstName: { minLength: 1, type: 'string' },
+            lastName: { minLength: 1, type: 'string' },
+          },
+          required: ['firstName', 'lastName'],
+          type: 'object',
+        },
+      },
+    },
+  })
+  @Post('/')
+  public createUser(@ValidatedBody() user: User): User {
+    return user;
+  }
+}

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/standardSchema/customValidationErrorFilter.int.spec.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/standardSchema/customValidationErrorFilter.int.spec.ts
@@ -1,0 +1,100 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { StandardSchemaValidationPipe } from '@inversifyjs/standard-schema-validation';
+import { Container } from 'inversify';
+
+import { buildExpressServer } from '../../../server/adapter/express/actions/buildExpressServer.js';
+import { type Server } from '../../../server/models/Server.js';
+import {
+  CustomStandardSchemaValidationErrorFilter,
+  UserController,
+} from './customValidationErrorFilter.js';
+
+describe(CustomStandardSchemaValidationErrorFilter, () => {
+  describe('having a StandardSchemaValidationPipe with a custom validation error filter', () => {
+    let server: Server;
+
+    beforeAll(async () => {
+      const container: Container = new Container();
+
+      container
+        .bind(CustomStandardSchemaValidationErrorFilter)
+        .toSelf()
+        .inSingletonScope();
+      container.bind(UserController).toSelf().inSingletonScope();
+
+      server = await buildExpressServer(
+        container,
+        [CustomStandardSchemaValidationErrorFilter],
+        [new StandardSchemaValidationPipe()],
+      );
+    });
+
+    afterAll(async () => {
+      await server.shutdown();
+    });
+
+    describe('when a valid POST /users request is made', () => {
+      let response: Response;
+
+      beforeAll(async () => {
+        response = await fetch(
+          `http://${server.host}:${server.port.toString()}/users`,
+          {
+            body: JSON.stringify({
+              firstName: 'Jane',
+              lastName: 'Doe',
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+          },
+        );
+      });
+
+      it('should return expected Response', async () => {
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toStrictEqual({
+          firstName: 'Jane',
+          lastName: 'Doe',
+        });
+      });
+    });
+
+    describe('when an invalid POST /users request is made', () => {
+      let response: Response;
+
+      beforeAll(async () => {
+        response = await fetch(
+          `http://${server.host}:${server.port.toString()}/users`,
+          {
+            body: JSON.stringify({
+              firstName: '',
+              lastName: '',
+            }),
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            method: 'POST',
+          },
+        );
+      });
+
+      it('should return a field-mapped validation error body', async () => {
+        expect(response.status).toBe(400);
+        expect(response.headers.get('content-type')).toStrictEqual(
+          expect.stringContaining('application/json'),
+        );
+        await expect(response.json()).resolves.toStrictEqual({
+          errors: {
+            firstName: 'First name is required',
+            lastName: 'Last name is required',
+          },
+          message: 'Validation failed',
+          success: false,
+        });
+      });
+    });
+  });
+});

--- a/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/standardSchema/customValidationErrorFilter.ts
+++ b/packages/docs/tools/inversify-validation-code-examples/src/examples/v1/standardSchema/customValidationErrorFilter.ts
@@ -1,0 +1,84 @@
+// Begin-example
+import {
+  BadRequestHttpResponse,
+  CatchError,
+  type ErrorFilter,
+} from '@inversifyjs/http-core';
+import { InversifyStandardSchemaValidationError } from '@inversifyjs/standard-schema-validation';
+import { InversifyValidationErrorKind } from '@inversifyjs/validation-common';
+
+function mapStandardSchemaIssues(
+  issues: NonNullable<InversifyStandardSchemaValidationError['errors']>,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+
+  for (const issue of issues) {
+    const path: string =
+      issue.path
+        ?.map((segment: PropertyKey | { key: PropertyKey }): string =>
+          typeof segment === 'object' && 'key' in segment
+            ? String(segment.key)
+            : String(segment),
+        )
+        .join('.') ?? '';
+
+    if (path !== '' && result[path] === undefined) {
+      result[path] = issue.message;
+    }
+  }
+
+  return result;
+}
+
+@CatchError(InversifyStandardSchemaValidationError)
+export class CustomStandardSchemaValidationErrorFilter implements ErrorFilter<InversifyStandardSchemaValidationError> {
+  public catch(error: InversifyStandardSchemaValidationError): never {
+    switch (error.kind) {
+      case InversifyValidationErrorKind.validationFailed:
+        throw new BadRequestHttpResponse(
+          {
+            errors: mapStandardSchemaIssues(error.errors ?? []),
+            message: 'Validation failed',
+            success: false,
+          },
+          error.message,
+          {
+            cause: error,
+          },
+        );
+      default:
+        throw new Error(error.message, {
+          cause: error,
+        });
+    }
+  }
+}
+// End-example
+
+import { Body, Controller, Post } from '@inversifyjs/http-core';
+import { ValidateStandardSchemaV1 } from '@inversifyjs/standard-schema-validation';
+import zod from 'zod';
+
+interface User {
+  firstName: string;
+  lastName: string;
+}
+
+@Controller('/users')
+export class UserController {
+  @Post()
+  public async createUser(
+    @Body()
+    @ValidateStandardSchemaV1(
+      zod
+        .object({
+          firstName: zod.string().min(1, 'First name is required'),
+          lastName: zod.string().min(1, 'Last name is required'),
+        })
+        .strict(),
+    )
+    user: User,
+  ): Promise<User> {
+    return user;
+  }
+}

--- a/packages/framework/validation/libraries/ajv/src/index.ts
+++ b/packages/framework/validation/libraries/ajv/src/index.ts
@@ -1,3 +1,4 @@
 export { ValidateAjvSchema } from './decorators/ValidateAjvSchema.js';
+export { InversifyAjvValidationError } from './models/InversifyAjvValidationError.js';
 export { AjvCompiledValidationPipe } from './pipes/AjvCompiledValidationPipe.js';
 export { AjvValidationPipe } from './pipes/AjvValidationPipe.js';

--- a/packages/framework/validation/libraries/ajv/src/models/InversifyAjvValidationError.ts
+++ b/packages/framework/validation/libraries/ajv/src/models/InversifyAjvValidationError.ts
@@ -1,0 +1,7 @@
+import { InversifyValidationError } from '@inversifyjs/validation-common';
+import { type ErrorObject } from 'ajv';
+
+export class InversifyAjvValidationError extends InversifyValidationError<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Partial<ErrorObject<string, Record<string, any>, unknown>>[]
+> {}

--- a/packages/framework/validation/libraries/ajv/src/pipes/AjvCompiledValidationPipe.ts
+++ b/packages/framework/validation/libraries/ajv/src/pipes/AjvCompiledValidationPipe.ts
@@ -6,6 +6,7 @@ import {
 import Ajv, { type AnySchema, type ValidateFunction } from 'ajv';
 
 import { stringifyAjvErrors } from '../calculations/stringifyAjvErrors.js';
+import { InversifyAjvValidationError } from '../models/InversifyAjvValidationError.js';
 import { AjvValidationPipe } from './AjvValidationPipe.js';
 
 export class AjvCompiledValidationPipe extends AjvValidationPipe {
@@ -42,9 +43,11 @@ export class AjvCompiledValidationPipe extends AjvValidationPipe {
         return;
       }
 
-      throw new InversifyValidationError(
+      throw new InversifyAjvValidationError(
         InversifyValidationErrorKind.validationFailed,
         stringifyAjvErrors(validateFunction.errors ?? []),
+        undefined,
+        validateFunction.errors ?? [],
       );
     }
 
@@ -52,9 +55,11 @@ export class AjvCompiledValidationPipe extends AjvValidationPipe {
       await this._ajv.validate(schema, input);
     } catch (error: unknown) {
       if (error instanceof Ajv.ValidationError) {
-        throw new InversifyValidationError(
+        throw new InversifyAjvValidationError(
           InversifyValidationErrorKind.validationFailed,
           stringifyAjvErrors(error.errors),
+          undefined,
+          error.errors,
         );
       }
     }

--- a/packages/framework/validation/libraries/ajv/src/pipes/AjvCompiledValidationPipe.ts
+++ b/packages/framework/validation/libraries/ajv/src/pipes/AjvCompiledValidationPipe.ts
@@ -62,6 +62,8 @@ export class AjvCompiledValidationPipe extends AjvValidationPipe {
           error.errors,
         );
       }
+
+      throw error;
     }
   }
 }

--- a/packages/framework/validation/libraries/ajv/src/pipes/AjvCompiledValidationPipe.ts
+++ b/packages/framework/validation/libraries/ajv/src/pipes/AjvCompiledValidationPipe.ts
@@ -52,7 +52,7 @@ export class AjvCompiledValidationPipe extends AjvValidationPipe {
     }
 
     try {
-      await this._ajv.validate(schema, input);
+      await result;
     } catch (error: unknown) {
       if (error instanceof Ajv.ValidationError) {
         throw new InversifyAjvValidationError(

--- a/packages/framework/validation/libraries/ajv/src/pipes/AjvValidationPipe.spec.ts
+++ b/packages/framework/validation/libraries/ajv/src/pipes/AjvValidationPipe.spec.ts
@@ -13,13 +13,15 @@ vitest.mock(import('../calculations/stringifyAjvErrors.js'));
 
 import { type PipeMetadata } from '@inversifyjs/framework-core';
 import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
-import {
-  InversifyValidationError,
-  InversifyValidationErrorKind,
-} from '@inversifyjs/validation-common';
-import Ajv, { type AnySchema, type ValidationError } from 'ajv';
+import { InversifyValidationErrorKind } from '@inversifyjs/validation-common';
+import Ajv, {
+  type AnySchema,
+  type ErrorObject,
+  type ValidationError,
+} from 'ajv';
 
 import { stringifyAjvErrors } from '../calculations/stringifyAjvErrors.js';
+import { InversifyAjvValidationError } from '../models/InversifyAjvValidationError.js';
 import { ajvValidationMetadataReflectKey } from '../reflectMetadata/models/ajvValidationMetadataReflectKey.js';
 import { AjvValidationPipe } from './AjvValidationPipe.js';
 
@@ -129,12 +131,13 @@ describe(AjvValidationPipe, () => {
       });
 
       it('should throw expected Error', () => {
-        const expectedErrorProperties: Partial<InversifyValidationError> = {
+        const expectedErrorProperties: Partial<InversifyAjvValidationError> = {
+          errors: [],
           kind: InversifyValidationErrorKind.validationFailed,
           message: stringifyAjvErrorsResultFixture,
         };
 
-        expect(result).toBeInstanceOf(InversifyValidationError);
+        expect(result).toBeInstanceOf(InversifyAjvValidationError);
         expect(result).toMatchObject(expectedErrorProperties);
       });
     });
@@ -182,12 +185,14 @@ describe(AjvValidationPipe, () => {
 
     describe('when called, and getOwnReflectMetadata() returns undefined and this._ajv.validate() returns rejected Promise', () => {
       let errorFixture: ValidationError;
+      let ajvErrorsFixture: ErrorObject[];
       let stringifyAjvErrorsResultFixture: string;
 
       let result: unknown;
 
       beforeAll(async () => {
-        errorFixture = new Ajv.ValidationError([]);
+        ajvErrorsFixture = [];
+        errorFixture = new Ajv.ValidationError(ajvErrorsFixture);
         stringifyAjvErrorsResultFixture = 'error1\nerror2';
 
         vitest.mocked(ajvMock.validate).mockRejectedValueOnce(errorFixture);
@@ -223,16 +228,19 @@ describe(AjvValidationPipe, () => {
       });
 
       it('should call stringifyAjvErrors()', () => {
-        expect(stringifyAjvErrors).toHaveBeenCalledExactlyOnceWith([]);
+        expect(stringifyAjvErrors).toHaveBeenCalledExactlyOnceWith(
+          ajvErrorsFixture,
+        );
       });
 
       it('should throw expected Error', () => {
-        const expectedErrorProperties: Partial<InversifyValidationError> = {
+        const expectedErrorProperties: Partial<InversifyAjvValidationError> = {
+          errors: ajvErrorsFixture,
           kind: InversifyValidationErrorKind.validationFailed,
           message: stringifyAjvErrorsResultFixture,
         };
 
-        expect(result).toBeInstanceOf(InversifyValidationError);
+        expect(result).toBeInstanceOf(InversifyAjvValidationError);
         expect(result).toMatchObject(expectedErrorProperties);
       });
     });

--- a/packages/framework/validation/libraries/ajv/src/pipes/AjvValidationPipe.ts
+++ b/packages/framework/validation/libraries/ajv/src/pipes/AjvValidationPipe.ts
@@ -1,13 +1,11 @@
 import { isPromise } from '@inversifyjs/common';
 import { type Pipe, type PipeMetadata } from '@inversifyjs/framework-core';
 import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
-import {
-  InversifyValidationError,
-  InversifyValidationErrorKind,
-} from '@inversifyjs/validation-common';
+import { InversifyValidationErrorKind } from '@inversifyjs/validation-common';
 import Ajv, { type AnySchema } from 'ajv';
 
 import { stringifyAjvErrors } from '../calculations/stringifyAjvErrors.js';
+import { InversifyAjvValidationError } from '../models/InversifyAjvValidationError.js';
 import { ajvValidationMetadataReflectKey } from '../reflectMetadata/models/ajvValidationMetadataReflectKey.js';
 
 export class AjvValidationPipe implements Pipe {
@@ -52,9 +50,11 @@ export class AjvValidationPipe implements Pipe {
         return;
       }
 
-      throw new InversifyValidationError(
+      throw new InversifyAjvValidationError(
         InversifyValidationErrorKind.validationFailed,
         stringifyAjvErrors(this._ajv.errors ?? []),
+        undefined,
+        this._ajv.errors ?? [],
       );
     }
 
@@ -62,9 +62,11 @@ export class AjvValidationPipe implements Pipe {
       await result;
     } catch (error: unknown) {
       if (error instanceof Ajv.ValidationError) {
-        throw new InversifyValidationError(
+        throw new InversifyAjvValidationError(
           InversifyValidationErrorKind.validationFailed,
           stringifyAjvErrors(error.errors),
+          undefined,
+          error.errors,
         );
       }
     }

--- a/packages/framework/validation/libraries/class-validator/src/index.ts
+++ b/packages/framework/validation/libraries/class-validator/src/index.ts
@@ -1,1 +1,2 @@
+export { InversifyClassValidationError } from './models/InversifyClassValidationError.js';
 export { ClassValidationPipe } from './pipes/ClassValidationPipe.js';

--- a/packages/framework/validation/libraries/class-validator/src/models/InversifyClassValidationError.ts
+++ b/packages/framework/validation/libraries/class-validator/src/models/InversifyClassValidationError.ts
@@ -1,0 +1,6 @@
+import { InversifyValidationError } from '@inversifyjs/validation-common';
+import { type ValidationError } from 'class-validator';
+
+export class InversifyClassValidationError extends InversifyValidationError<
+  ValidationError[]
+> {}

--- a/packages/framework/validation/libraries/class-validator/src/pipes/ClassValidationPipe.spec.ts
+++ b/packages/framework/validation/libraries/class-validator/src/pipes/ClassValidationPipe.spec.ts
@@ -21,6 +21,7 @@ import {
 import { plainToInstance } from 'class-transformer';
 import { validate, type ValidationError } from 'class-validator';
 
+import { InversifyClassValidationError } from '../models/InversifyClassValidationError.js';
 import { ClassValidationPipe } from './ClassValidationPipe.js';
 
 describe(ClassValidationPipe, () => {
@@ -482,13 +483,15 @@ describe(ClassValidationPipe, () => {
           });
         });
 
-        it('should throw an InversifyValidationError', () => {
-          const expectedErrorProperties: Partial<InversifyValidationError> = {
-            kind: InversifyValidationErrorKind.validationFailed,
-            message: expect.stringContaining(errorMessageFixture),
-          };
+        it('should throw an InversifyClassValidationError', () => {
+          const expectedErrorProperties: Partial<InversifyClassValidationError> =
+            {
+              errors: [errorFixtureMock],
+              kind: InversifyValidationErrorKind.validationFailed,
+              message: expect.stringContaining(errorMessageFixture),
+            };
 
-          expect(result).toBeInstanceOf(InversifyValidationError);
+          expect(result).toBeInstanceOf(InversifyClassValidationError);
           expect(result).toMatchObject(expectedErrorProperties);
         });
       });

--- a/packages/framework/validation/libraries/class-validator/src/pipes/ClassValidationPipe.ts
+++ b/packages/framework/validation/libraries/class-validator/src/pipes/ClassValidationPipe.ts
@@ -7,6 +7,8 @@ import {
 import { type ClassConstructor, plainToInstance } from 'class-transformer';
 import { validate, type ValidationError } from 'class-validator';
 
+import { InversifyClassValidationError } from '../models/InversifyClassValidationError.js';
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
 const ALLOW_NULLISH_VALUE_TYPES_LIST: (Function | undefined)[] = [
   Object,
@@ -77,11 +79,13 @@ export class ClassValidationPipe implements Pipe {
     });
 
     if (validationResult.length > 0) {
-      throw new InversifyValidationError(
+      throw new InversifyClassValidationError(
         InversifyValidationErrorKind.validationFailed,
         validationResult
           .map((error: ValidationError) => error.toString(false, false))
           .join('\n'),
+        undefined,
+        validationResult,
       );
     }
 

--- a/packages/framework/validation/libraries/common/src/error/models/InversifyValidationError.ts
+++ b/packages/framework/validation/libraries/common/src/error/models/InversifyValidationError.ts
@@ -4,23 +4,22 @@ const isAppErrorSymbol: unique symbol = Symbol.for(
   '@inversifyjs/validation-common/InversifyValidationError',
 );
 
-export class InversifyValidationError extends Error {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export class InversifyValidationError<TErrors = any> extends Error {
   public [isAppErrorSymbol]: true;
 
-  public kind: InversifyValidationErrorKind;
-
   constructor(
-    kind: InversifyValidationErrorKind,
+    public readonly kind: InversifyValidationErrorKind,
     message?: string,
     options?: ErrorOptions,
+    public readonly errors?: TErrors,
   ) {
     super(message, options);
 
     this[isAppErrorSymbol] = true;
-    this.kind = kind;
   }
 
-  public static is(value: unknown): value is InversifyValidationError {
+  public static is(value: unknown): value is InversifyValidationError<unknown> {
     return (
       typeof value === 'object' &&
       value !== null &&
@@ -31,7 +30,7 @@ export class InversifyValidationError extends Error {
   public static isErrorOfKind(
     value: unknown,
     kind: InversifyValidationErrorKind,
-  ): value is InversifyValidationError {
+  ): value is InversifyValidationError<unknown> {
     return InversifyValidationError.is(value) && value.kind === kind;
   }
 }

--- a/packages/framework/validation/libraries/openapi/src/index.ts
+++ b/packages/framework/validation/libraries/openapi/src/index.ts
@@ -2,3 +2,4 @@ export { ValidatedBody } from './metadata/decorators/ValidatedBody.js';
 export { ValidatedHeaders } from './metadata/decorators/ValidatedHeaders.js';
 export { ValidatedParams } from './metadata/decorators/ValidatedParams.js';
 export { ValidatedQuery } from './metadata/decorators/ValidatedQuery.js';
+export { InversifyOpenApiValidationError } from './models/InversifyOpenApiValidationError.js';

--- a/packages/framework/validation/libraries/openapi/src/models/InversifyOpenApiValidationError.ts
+++ b/packages/framework/validation/libraries/openapi/src/models/InversifyOpenApiValidationError.ts
@@ -1,0 +1,7 @@
+import { InversifyValidationError } from '@inversifyjs/validation-common';
+import { type ErrorObject } from 'ajv';
+
+export class InversifyOpenApiValidationError extends InversifyValidationError<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Partial<ErrorObject<string, Record<string, any>, unknown>>[]
+> {}

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleBodyValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleBodyValidation.spec.ts
@@ -26,6 +26,7 @@ import {
 import type Ajv from 'ajv';
 import { type ValidateFunction } from 'ajv';
 
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type OpenApiRouter } from '../../../router/services/OpenApiRouter.js';
 import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
 import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
@@ -353,14 +354,24 @@ describe(handleBodyValidation, () => {
         vitest.clearAllMocks();
       });
 
-      it('should throw an InversifyValidationError', () => {
-        const expectedErrorProperties: Partial<InversifyValidationError> = {
-          kind: InversifyValidationErrorKind.validationFailed,
-          message:
-            '[schema: #/properties/name/type, instance: /name]: "must be string"',
-        };
+      it('should throw an InversifyOpenApiValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+          {
+            errors: [
+              {
+                instancePath: '/name',
+                keyword: 'type',
+                message: 'must be string',
+                params: {},
+                schemaPath: '#/properties/name/type',
+              },
+            ],
+            kind: InversifyValidationErrorKind.validationFailed,
+            message:
+              '[schema: #/properties/name/type, instance: /name]: "must be string"',
+          };
 
-        expect(result).toBeInstanceOf(InversifyValidationError);
+        expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
         expect(result).toMatchObject(expectedErrorProperties);
       });
     });

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleBodyValidation.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleBodyValidation.ts
@@ -11,6 +11,7 @@ import {
 import type Ajv from 'ajv';
 import { type ErrorObject, type ValidateFunction } from 'ajv';
 
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
 import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { SCHEMA_ID } from '../../models/v3Dot1/schemaId.js';
@@ -103,7 +104,7 @@ function handleRequiredBodyValidation(
   const valid: boolean = validate(inputParam.body);
 
   if (!valid) {
-    throw new InversifyValidationError(
+    throw new InversifyOpenApiValidationError(
       InversifyValidationErrorKind.validationFailed,
       (validate.errors ?? [])
         .map(
@@ -111,6 +112,8 @@ function handleRequiredBodyValidation(
             `[schema: ${error.schemaPath}, instance: ${error.instancePath}]: "${error.message ?? '-'}"`,
         )
         .join('\n'),
+      undefined,
+      validate.errors ?? [],
     );
   }
 

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleHeaderValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleHeaderValidation.spec.ts
@@ -20,6 +20,7 @@ import {
 import type Ajv from 'ajv';
 import { type ValidateFunction } from 'ajv';
 
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type OpenApiRouter } from '../../../router/services/OpenApiRouter.js';
 import { type HeaderValidationInputParam } from '../../models/HeaderValidationInputParam.js';
 import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
@@ -377,13 +378,23 @@ describe(handleHeaderValidation, () => {
       vitest.clearAllMocks();
     });
 
-    it('should throw an InversifyValidationError', () => {
-      const expectedErrorProperties: Partial<InversifyValidationError> = {
-        kind: InversifyValidationErrorKind.validationFailed,
-        message: expect.stringContaining('x-count'),
-      };
+    it('should throw an InversifyOpenApiValidationError', () => {
+      const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+        {
+          errors: [
+            {
+              instancePath: '',
+              keyword: 'type',
+              message: 'must be integer',
+              params: {},
+              schemaPath: '#/type',
+            },
+          ],
+          kind: InversifyValidationErrorKind.validationFailed,
+          message: expect.stringContaining('x-count'),
+        };
 
-      expect(result).toBeInstanceOf(InversifyValidationError);
+      expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
       expect(result).toMatchObject(expectedErrorProperties);
     });
   });

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleHeaderValidation.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleHeaderValidation.ts
@@ -6,6 +6,7 @@ import {
 import type Ajv from 'ajv';
 import { type ErrorObject, type ValidateFunction } from 'ajv';
 
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type HeaderValidationInputParam } from '../../models/HeaderValidationInputParam.js';
 import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { SCHEMA_ID } from '../../models/v3Dot1/schemaId.js';
@@ -138,7 +139,7 @@ export function handleHeaderValidation(
   }
 
   if (!valid) {
-    throw new InversifyValidationError(
+    throw new InversifyOpenApiValidationError(
       InversifyValidationErrorKind.validationFailed,
       Object.entries(headerToErrorObject)
         .map(([headerName, errors]: [string, ErrorObject[]]): string =>
@@ -150,6 +151,8 @@ export function handleHeaderValidation(
             .join('\n'),
         )
         .join('\n'),
+      undefined,
+      Object.values(headerToErrorObject).flat(),
     );
   }
 

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleParamValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleParamValidation.spec.ts
@@ -20,6 +20,7 @@ import {
 import type Ajv from 'ajv';
 import { type ValidateFunction } from 'ajv';
 
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type OpenApiRouter } from '../../../router/services/OpenApiRouter.js';
 import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { type ParamValidationInputParam } from '../../models/ParamValidationInputParam.js';
@@ -302,13 +303,23 @@ describe(handleParamValidation, () => {
       vitest.clearAllMocks();
     });
 
-    it('should throw an InversifyValidationError', () => {
-      const expectedErrorProperties: Partial<InversifyValidationError> = {
-        kind: InversifyValidationErrorKind.validationFailed,
-        message: expect.stringContaining('userId'),
-      };
+    it('should throw an InversifyOpenApiValidationError', () => {
+      const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+        {
+          errors: [
+            {
+              instancePath: '',
+              keyword: 'type',
+              message: 'must be integer',
+              params: {},
+              schemaPath: '#/type',
+            },
+          ],
+          kind: InversifyValidationErrorKind.validationFailed,
+          message: expect.stringContaining('userId'),
+        };
 
-      expect(result).toBeInstanceOf(InversifyValidationError);
+      expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
       expect(result).toMatchObject(expectedErrorProperties);
     });
   });

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleParamValidation.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleParamValidation.ts
@@ -6,6 +6,7 @@ import {
 import type Ajv from 'ajv';
 import { type ErrorObject, type ValidateFunction } from 'ajv';
 
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { type ParamValidationInputParam } from '../../models/ParamValidationInputParam.js';
 import { SCHEMA_ID } from '../../models/v3Dot1/schemaId.js';
@@ -133,7 +134,7 @@ export function handleParamValidation(
   }
 
   if (!valid) {
-    throw new InversifyValidationError(
+    throw new InversifyOpenApiValidationError(
       InversifyValidationErrorKind.validationFailed,
       Object.entries(paramToErrorObject)
         .map(([paramName, errors]: [string, ErrorObject[]]): string =>
@@ -145,6 +146,8 @@ export function handleParamValidation(
             .join('\n'),
         )
         .join('\n'),
+      undefined,
+      Object.values(paramToErrorObject).flat(),
     );
   }
 

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleQueryValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleQueryValidation.spec.ts
@@ -20,6 +20,7 @@ import {
 import type Ajv from 'ajv';
 import { type ValidateFunction } from 'ajv';
 
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type OpenApiRouter } from '../../../router/services/OpenApiRouter.js';
 import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { type QueryValidationInputParam } from '../../models/QueryValidationInputParam.js';
@@ -351,13 +352,23 @@ describe(handleQueryValidation, () => {
       vitest.clearAllMocks();
     });
 
-    it('should throw an InversifyValidationError', () => {
-      const expectedErrorProperties: Partial<InversifyValidationError> = {
-        kind: InversifyValidationErrorKind.validationFailed,
-        message: expect.stringContaining('limit'),
-      };
+    it('should throw an InversifyOpenApiValidationError', () => {
+      const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+        {
+          errors: [
+            {
+              instancePath: '',
+              keyword: 'type',
+              message: 'must be integer',
+              params: {},
+              schemaPath: '#/type',
+            },
+          ],
+          kind: InversifyValidationErrorKind.validationFailed,
+          message: expect.stringContaining('limit'),
+        };
 
-      expect(result).toBeInstanceOf(InversifyValidationError);
+      expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
       expect(result).toMatchObject(expectedErrorProperties);
     });
   });

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleQueryValidation.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleQueryValidation.ts
@@ -6,6 +6,7 @@ import {
 import type Ajv from 'ajv';
 import { type ErrorObject, type ValidateFunction } from 'ajv';
 
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { type QueryValidationInputParam } from '../../models/QueryValidationInputParam.js';
 import { SCHEMA_ID } from '../../models/v3Dot1/schemaId.js';
@@ -136,7 +137,7 @@ export function handleQueryValidation(
   }
 
   if (!valid) {
-    throw new InversifyValidationError(
+    throw new InversifyOpenApiValidationError(
       InversifyValidationErrorKind.validationFailed,
       Object.entries(queryToErrorObject)
         .map(([queryName, errors]: [string, ErrorObject[]]): string =>
@@ -148,6 +149,8 @@ export function handleQueryValidation(
             .join('\n'),
         )
         .join('\n'),
+      undefined,
+      Object.values(queryToErrorObject).flat(),
     );
   }
 

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleBodyValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleBodyValidation.spec.ts
@@ -26,6 +26,7 @@ import {
 import type Ajv from 'ajv';
 import { type ValidateFunction } from 'ajv';
 
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type OpenApiRouter } from '../../../router/services/OpenApiRouter.js';
 import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
 import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
@@ -353,14 +354,24 @@ describe(handleBodyValidation, () => {
         vitest.clearAllMocks();
       });
 
-      it('should throw an InversifyValidationError', () => {
-        const expectedErrorProperties: Partial<InversifyValidationError> = {
-          kind: InversifyValidationErrorKind.validationFailed,
-          message:
-            '[schema: #/properties/name/type, instance: /name]: "must be string"',
-        };
+      it('should throw an InversifyOpenApiValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+          {
+            errors: [
+              {
+                instancePath: '/name',
+                keyword: 'type',
+                message: 'must be string',
+                params: {},
+                schemaPath: '#/properties/name/type',
+              },
+            ],
+            kind: InversifyValidationErrorKind.validationFailed,
+            message:
+              '[schema: #/properties/name/type, instance: /name]: "must be string"',
+          };
 
-        expect(result).toBeInstanceOf(InversifyValidationError);
+        expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
         expect(result).toMatchObject(expectedErrorProperties);
       });
     });

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleBodyValidation.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleBodyValidation.ts
@@ -11,6 +11,7 @@ import {
 import type Ajv from 'ajv';
 import { type ErrorObject, type ValidateFunction } from 'ajv';
 
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type BodyValidationInputParam } from '../../models/BodyValidationInputParam.js';
 import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { SCHEMA_ID } from '../../models/v3Dot2/schemaId.js';
@@ -103,7 +104,7 @@ function handleRequiredBodyValidation(
   const valid: boolean = validate(inputParam.body);
 
   if (!valid) {
-    throw new InversifyValidationError(
+    throw new InversifyOpenApiValidationError(
       InversifyValidationErrorKind.validationFailed,
       (validate.errors ?? [])
         .map(
@@ -111,6 +112,8 @@ function handleRequiredBodyValidation(
             `[schema: ${error.schemaPath}, instance: ${error.instancePath}]: "${error.message ?? '-'}"`,
         )
         .join('\n'),
+      undefined,
+      validate.errors ?? [],
     );
   }
 

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleHeaderValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleHeaderValidation.spec.ts
@@ -20,6 +20,7 @@ import {
 import type Ajv from 'ajv';
 import { type ValidateFunction } from 'ajv';
 
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type OpenApiRouter } from '../../../router/services/OpenApiRouter.js';
 import { type HeaderValidationInputParam } from '../../models/HeaderValidationInputParam.js';
 import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
@@ -377,13 +378,23 @@ describe(handleHeaderValidation, () => {
       vitest.clearAllMocks();
     });
 
-    it('should throw an InversifyValidationError', () => {
-      const expectedErrorProperties: Partial<InversifyValidationError> = {
-        kind: InversifyValidationErrorKind.validationFailed,
-        message: expect.stringContaining('x-count'),
-      };
+    it('should throw an InversifyOpenApiValidationError', () => {
+      const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+        {
+          errors: [
+            {
+              instancePath: '',
+              keyword: 'type',
+              message: 'must be integer',
+              params: {},
+              schemaPath: '#/type',
+            },
+          ],
+          kind: InversifyValidationErrorKind.validationFailed,
+          message: expect.stringContaining('x-count'),
+        };
 
-      expect(result).toBeInstanceOf(InversifyValidationError);
+      expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
       expect(result).toMatchObject(expectedErrorProperties);
     });
   });

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleHeaderValidation.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleHeaderValidation.ts
@@ -6,6 +6,7 @@ import {
 import type Ajv from 'ajv';
 import { type ErrorObject, type ValidateFunction } from 'ajv';
 
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type HeaderValidationInputParam } from '../../models/HeaderValidationInputParam.js';
 import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { SCHEMA_ID } from '../../models/v3Dot2/schemaId.js';
@@ -138,7 +139,7 @@ export function handleHeaderValidation(
   }
 
   if (!valid) {
-    throw new InversifyValidationError(
+    throw new InversifyOpenApiValidationError(
       InversifyValidationErrorKind.validationFailed,
       Object.entries(headerToErrorObject)
         .map(([headerName, errors]: [string, ErrorObject[]]): string =>
@@ -150,6 +151,8 @@ export function handleHeaderValidation(
             .join('\n'),
         )
         .join('\n'),
+      undefined,
+      Object.values(headerToErrorObject).flat(),
     );
   }
 

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleParamValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleParamValidation.spec.ts
@@ -20,6 +20,7 @@ import {
 import type Ajv from 'ajv';
 import { type ValidateFunction } from 'ajv';
 
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type OpenApiRouter } from '../../../router/services/OpenApiRouter.js';
 import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { type ParamValidationInputParam } from '../../models/ParamValidationInputParam.js';
@@ -302,13 +303,23 @@ describe(handleParamValidation, () => {
       vitest.clearAllMocks();
     });
 
-    it('should throw an InversifyValidationError', () => {
-      const expectedErrorProperties: Partial<InversifyValidationError> = {
-        kind: InversifyValidationErrorKind.validationFailed,
-        message: expect.stringContaining('userId'),
-      };
+    it('should throw an InversifyOpenApiValidationError', () => {
+      const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+        {
+          errors: [
+            {
+              instancePath: '',
+              keyword: 'type',
+              message: 'must be integer',
+              params: {},
+              schemaPath: '#/type',
+            },
+          ],
+          kind: InversifyValidationErrorKind.validationFailed,
+          message: expect.stringContaining('userId'),
+        };
 
-      expect(result).toBeInstanceOf(InversifyValidationError);
+      expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
       expect(result).toMatchObject(expectedErrorProperties);
     });
   });

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleParamValidation.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleParamValidation.ts
@@ -6,6 +6,7 @@ import {
 import type Ajv from 'ajv';
 import { type ErrorObject, type ValidateFunction } from 'ajv';
 
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { type ParamValidationInputParam } from '../../models/ParamValidationInputParam.js';
 import { SCHEMA_ID } from '../../models/v3Dot2/schemaId.js';
@@ -133,7 +134,7 @@ export function handleParamValidation(
   }
 
   if (!valid) {
-    throw new InversifyValidationError(
+    throw new InversifyOpenApiValidationError(
       InversifyValidationErrorKind.validationFailed,
       Object.entries(paramToErrorObject)
         .map(([paramName, errors]: [string, ErrorObject[]]): string =>
@@ -145,6 +146,8 @@ export function handleParamValidation(
             .join('\n'),
         )
         .join('\n'),
+      undefined,
+      Object.values(paramToErrorObject).flat(),
     );
   }
 

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleQueryValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleQueryValidation.spec.ts
@@ -20,6 +20,7 @@ import {
 import type Ajv from 'ajv';
 import { type ValidateFunction } from 'ajv';
 
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type OpenApiRouter } from '../../../router/services/OpenApiRouter.js';
 import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { type QueryValidationInputParam } from '../../models/QueryValidationInputParam.js';
@@ -351,13 +352,23 @@ describe(handleQueryValidation, () => {
       vitest.clearAllMocks();
     });
 
-    it('should throw an InversifyValidationError', () => {
-      const expectedErrorProperties: Partial<InversifyValidationError> = {
-        kind: InversifyValidationErrorKind.validationFailed,
-        message: expect.stringContaining('limit'),
-      };
+    it('should throw an InversifyOpenApiValidationError', () => {
+      const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+        {
+          errors: [
+            {
+              instancePath: '',
+              keyword: 'type',
+              message: 'must be integer',
+              params: {},
+              schemaPath: '#/type',
+            },
+          ],
+          kind: InversifyValidationErrorKind.validationFailed,
+          message: expect.stringContaining('limit'),
+        };
 
-      expect(result).toBeInstanceOf(InversifyValidationError);
+      expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
       expect(result).toMatchObject(expectedErrorProperties);
     });
   });

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleQueryValidation.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleQueryValidation.ts
@@ -6,6 +6,7 @@ import {
 import type Ajv from 'ajv';
 import { type ErrorObject, type ValidateFunction } from 'ajv';
 
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type OpenApiValidationContext } from '../../models/OpenApiValidationContext.js';
 import { type QueryValidationInputParam } from '../../models/QueryValidationInputParam.js';
 import { SCHEMA_ID } from '../../models/v3Dot2/schemaId.js';
@@ -136,7 +137,7 @@ export function handleQueryValidation(
   }
 
   if (!valid) {
-    throw new InversifyValidationError(
+    throw new InversifyOpenApiValidationError(
       InversifyValidationErrorKind.validationFailed,
       Object.entries(queryToErrorObject)
         .map(([queryName, errors]: [string, ErrorObject[]]): string =>
@@ -148,6 +149,8 @@ export function handleQueryValidation(
             .join('\n'),
         )
         .join('\n'),
+      undefined,
+      Object.values(queryToErrorObject).flat(),
     );
   }
 

--- a/packages/framework/validation/libraries/standard-schema/src/index.ts
+++ b/packages/framework/validation/libraries/standard-schema/src/index.ts
@@ -1,2 +1,3 @@
 export { ValidateStandardSchemaV1 } from './decorators/ValidateStandardSchemaV1.js';
+export { InversifyStandardSchemaValidationError } from './models/InversifyStandardSchemaValidationError.js';
 export { StandardSchemaValidationPipe } from './pipes/StandardSchemaValidationPipe.js';

--- a/packages/framework/validation/libraries/standard-schema/src/models/InversifyStandardSchemaValidationError.ts
+++ b/packages/framework/validation/libraries/standard-schema/src/models/InversifyStandardSchemaValidationError.ts
@@ -1,0 +1,6 @@
+import { InversifyValidationError } from '@inversifyjs/validation-common';
+import { type StandardSchemaV1 } from '@standard-schema/spec';
+
+export class InversifyStandardSchemaValidationError extends InversifyValidationError<
+  readonly StandardSchemaV1.Issue[]
+> {}

--- a/packages/framework/validation/libraries/standard-schema/src/pipes/StandardSchemaValidationPipe.spec.ts
+++ b/packages/framework/validation/libraries/standard-schema/src/pipes/StandardSchemaValidationPipe.spec.ts
@@ -12,12 +12,10 @@ vitest.mock(import('@inversifyjs/reflect-metadata-utils'));
 
 import { type PipeMetadata } from '@inversifyjs/framework-core';
 import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
-import {
-  InversifyValidationError,
-  InversifyValidationErrorKind,
-} from '@inversifyjs/validation-common';
+import { InversifyValidationErrorKind } from '@inversifyjs/validation-common';
 import { type StandardSchemaV1 } from '@standard-schema/spec';
 
+import { InversifyStandardSchemaValidationError } from '../models/InversifyStandardSchemaValidationError.js';
 import { standardSchemaValidationMetadataReflectKey } from '../reflectMetadata/models/standardSchemaValidationMetadataReflectKey.js';
 import { StandardSchemaValidationPipe } from './StandardSchemaValidationPipe.js';
 
@@ -183,10 +181,13 @@ describe(StandardSchemaValidationPipe, () => {
         ).toHaveBeenCalledExactlyOnceWith(inputFixture);
       });
 
-      it('should throw InversifyValidationError', () => {
-        expect(result).toBeInstanceOf(InversifyValidationError);
+      it('should throw InversifyStandardSchemaValidationError', () => {
+        expect(result).toBeInstanceOf(InversifyStandardSchemaValidationError);
         expect(result).toStrictEqual(
-          expect.objectContaining<Partial<InversifyValidationError>>({
+          expect.objectContaining<
+            Partial<InversifyStandardSchemaValidationError>
+          >({
+            errors: [standardSchemaIssueFixture],
             kind: InversifyValidationErrorKind.validationFailed,
             message: standardSchemaIssueFixture.message,
           }),

--- a/packages/framework/validation/libraries/standard-schema/src/pipes/StandardSchemaValidationPipe.ts
+++ b/packages/framework/validation/libraries/standard-schema/src/pipes/StandardSchemaValidationPipe.ts
@@ -1,11 +1,9 @@
 import { type Pipe, type PipeMetadata } from '@inversifyjs/framework-core';
 import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
-import {
-  InversifyValidationError,
-  InversifyValidationErrorKind,
-} from '@inversifyjs/validation-common';
+import { InversifyValidationErrorKind } from '@inversifyjs/validation-common';
 import { type StandardSchemaV1 } from '@standard-schema/spec';
 
+import { InversifyStandardSchemaValidationError } from '../models/InversifyStandardSchemaValidationError.js';
 import { standardSchemaValidationMetadataReflectKey } from '../reflectMetadata/models/standardSchemaValidationMetadataReflectKey.js';
 
 export class StandardSchemaValidationPipe implements Pipe {
@@ -47,11 +45,13 @@ export class StandardSchemaValidationPipe implements Pipe {
         await standardSchema['~standard'].validate(result);
 
       if (parsedResult.issues !== undefined) {
-        throw new InversifyValidationError(
+        throw new InversifyStandardSchemaValidationError(
           InversifyValidationErrorKind.validationFailed,
           parsedResult.issues
             .map((issue: StandardSchemaV1.Issue) => issue.message)
             .join('\n'),
+          undefined,
+          parsedResult.issues,
         );
       }
 


### PR DESCRIPTION
### Context
- See #2029.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation-specific error types for AJV, OpenAPI, class-validator, and Standard Schema.
  * Validation errors now carry structured `errors` details (field-level information) via the base validation error type.
* **Documentation**
  * Updated validation docs with clearer “Error Handling” behavior and new examples for customizing JSON 400 responses with field-level errors.
* **Bug Fixes**
  * Improved validation failure behavior to throw the correct framework-specific error type and include detailed underlying validation issues across bodies, headers, params, and queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->