### PR TITLE
Openapi validation anchor resolution

### DIFF
--- a/.changeset/olive-ways-prove.md
+++ b/.changeset/olive-ways-prove.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/open-api-validation": patch
+---
+
+- Updated OpenAPI resolvers to resolve `$anchor` URIs in addition to `$id` references.

--- a/.changeset/silly-news-hug.md
+++ b/.changeset/silly-news-hug.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/json-schema-utils": minor
+---
+
+- Updated `traverse` to provide `rootSchema` instead of parent schema.

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/getClosestAncestor.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/getClosestAncestor.spec.ts
@@ -1,0 +1,159 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { type JsonValue } from '@inversifyjs/json-schema-types';
+import {
+  InversifyValidationError,
+  InversifyValidationErrorKind,
+} from '@inversifyjs/validation-common';
+
+import { getClosestAncestorId } from './getClosestAncestor.js';
+
+describe(getClosestAncestorId, () => {
+  describe('having a root schema with no $id and an empty JSON pointer', () => {
+    let rootSchemaFixture: JsonValue;
+    let jsonPointerFixture: string;
+
+    beforeAll(() => {
+      rootSchemaFixture = {
+        type: 'object',
+      };
+      jsonPointerFixture = '';
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = getClosestAncestorId(rootSchemaFixture, jsonPointerFixture);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a root schema with $id and an empty JSON pointer', () => {
+    let rootSchemaFixture: JsonValue;
+    let jsonPointerFixture: string;
+    let idFixture: string;
+
+    beforeAll(() => {
+      idFixture = 'https://example.com/schemas/Root.json';
+      rootSchemaFixture = {
+        $id: idFixture,
+        type: 'object',
+      };
+      jsonPointerFixture = '';
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = getClosestAncestorId(rootSchemaFixture, jsonPointerFixture);
+      });
+
+      it('should return the root schema $id', () => {
+        expect(result).toBe(idFixture);
+      });
+    });
+  });
+
+  describe('having a nested schema with no $id under a root schema with $id', () => {
+    let rootSchemaFixture: JsonValue;
+    let jsonPointerFixture: string;
+    let idFixture: string;
+
+    beforeAll(() => {
+      idFixture = 'https://example.com/schemas/Root.json';
+      rootSchemaFixture = {
+        $id: idFixture,
+        properties: {
+          nested: {
+            type: 'string',
+          },
+        },
+        type: 'object',
+      };
+      jsonPointerFixture = '/properties/nested';
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = getClosestAncestorId(rootSchemaFixture, jsonPointerFixture);
+      });
+
+      it('should return the closest ancestor $id', () => {
+        expect(result).toBe(idFixture);
+      });
+    });
+  });
+
+  describe('having a nested schema with its own $id', () => {
+    let rootSchemaFixture: JsonValue;
+    let jsonPointerFixture: string;
+    let nestedIdFixture: string;
+
+    beforeAll(() => {
+      nestedIdFixture = 'https://example.com/schemas/Nested.json';
+      rootSchemaFixture = {
+        $id: 'https://example.com/schemas/Root.json',
+        properties: {
+          nested: {
+            $id: nestedIdFixture,
+            type: 'string',
+          },
+        },
+        type: 'object',
+      };
+      jsonPointerFixture = '/properties/nested';
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = getClosestAncestorId(rootSchemaFixture, jsonPointerFixture);
+      });
+
+      it('should return the nested schema $id', () => {
+        expect(result).toBe(nestedIdFixture);
+      });
+    });
+  });
+
+  describe('having a JSON pointer that does not resolve', () => {
+    let rootSchemaFixture: JsonValue;
+    let jsonPointerFixture: string;
+
+    beforeAll(() => {
+      rootSchemaFixture = {
+        type: 'object',
+      };
+      jsonPointerFixture = '/properties/missing';
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        try {
+          getClosestAncestorId(rootSchemaFixture, jsonPointerFixture);
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      it('should throw an InversifyValidationError', () => {
+        expect(result).toBeInstanceOf(InversifyValidationError);
+        expect(result).toMatchObject({
+          kind: InversifyValidationErrorKind.unknown,
+          message: expect.stringContaining(jsonPointerFixture),
+        });
+      });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/getClosestAncestor.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/getClosestAncestor.ts
@@ -1,0 +1,47 @@
+import { resolveJsonPointer } from '@inversifyjs/json-schema-pointer';
+import { type JsonValue } from '@inversifyjs/json-schema-types';
+import { type JsonSchemaObject } from '@inversifyjs/json-schema-types/2020-12';
+import {
+  InversifyValidationError,
+  InversifyValidationErrorKind,
+} from '@inversifyjs/validation-common';
+
+const SPACES_INDENTATION: number = 2;
+
+export function getClosestAncestorId(
+  rootSchema: JsonValue,
+  jsonPointer: string,
+): string | undefined {
+  const jsonPointerParts: string[] = jsonPointer.split('/').slice(1);
+
+  let jsonSchemaAncestor: JsonValue | undefined = rootSchema;
+
+  let closestId: string | undefined = maybeGetId(jsonSchemaAncestor);
+
+  for (const jsonPointerPart of jsonPointerParts) {
+    jsonSchemaAncestor = resolveJsonPointer(
+      jsonSchemaAncestor,
+      `/${jsonPointerPart}`,
+    );
+
+    if (jsonSchemaAncestor === undefined) {
+      throw new InversifyValidationError(
+        InversifyValidationErrorKind.unknown,
+        `Could not find JSON schema for JSON pointer ${jsonPointer}.
+JSON schema: ${JSON.stringify(rootSchema, null, SPACES_INDENTATION)}`,
+      );
+    }
+
+    closestId = maybeGetId(jsonSchemaAncestor) ?? closestId;
+  }
+
+  return closestId;
+}
+
+function maybeGetId(value: JsonValue): string | undefined {
+  if (typeof value === 'object' && value !== null) {
+    return (value as Partial<JsonSchemaObject>).$id;
+  }
+
+  return undefined;
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/services/BaseOpenApiResolver.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/services/BaseOpenApiResolver.ts
@@ -28,9 +28,15 @@ export abstract class BaseOpenApiResolver implements OpenApiResolver {
       );
     }
 
+    const uriSchema: JsonValue | undefined = this._maybeResolveUri(reference);
+
+    if (uriSchema !== undefined) {
+      return uriSchema;
+    }
+
     const [id, fragment]: [string, string?] = uriParts;
 
-    const idSchema: JsonValue | undefined = this._resolveId(id);
+    const idSchema: JsonValue | undefined = this._maybeResolveUri(id);
 
     if (idSchema === undefined || fragment === undefined) {
       return idSchema;
@@ -48,5 +54,5 @@ export abstract class BaseOpenApiResolver implements OpenApiResolver {
     );
   }
 
-  protected abstract _resolveId(id: string): JsonValue | undefined;
+  protected abstract _maybeResolveUri(uri: string): JsonValue | undefined;
 }

--- a/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot1/DefaultOpenApiResolver.int.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot1/DefaultOpenApiResolver.int.spec.ts
@@ -1,0 +1,309 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { type OpenApi3Dot1Object } from '@inversifyjs/open-api-types/v3Dot1';
+
+import { DefaultOpenApiResolver } from './DefaultOpenApiResolver.js';
+
+describe(DefaultOpenApiResolver, () => {
+  describe('having an OpenAPI object with schema $id references', () => {
+    let openApiObjectFixture: OpenApi3Dot1Object;
+    let defaultOpenApiResolver: DefaultOpenApiResolver;
+
+    beforeAll(() => {
+      openApiObjectFixture = {
+        components: {
+          schemas: {
+            Item: {
+              $id: 'https://example.com/schemas/Item.json',
+              properties: {
+                label: {
+                  type: 'string',
+                },
+              },
+              required: ['label'],
+              type: 'object',
+            },
+          },
+        },
+        info: { title: 'Test API', version: '1.0.0' },
+        openapi: '3.1.0',
+      };
+
+      defaultOpenApiResolver = new DefaultOpenApiResolver(openApiObjectFixture);
+    });
+
+    describe('.resolveReference', () => {
+      describe('when called with a schema $id', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.resolveReference(
+            'https://example.com/schemas/Item.json',
+          );
+        });
+
+        it('should return the schema identified by $id', () => {
+          expect(result).toBe(
+            openApiObjectFixture.components?.schemas?.['Item'],
+          );
+        });
+      });
+
+      describe('when called with a schema $id and a JSON pointer fragment', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.resolveReference(
+            'https://example.com/schemas/Item.json#/properties/label',
+          );
+        });
+
+        it('should return the schema at the JSON pointer', () => {
+          expect(result).toStrictEqual({
+            type: 'string',
+          });
+        });
+      });
+
+      describe('when called with a document JSON pointer reference', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.resolveReference(
+            '#/components/schemas/Item',
+          );
+        });
+
+        it('should return the schema at the document JSON pointer', () => {
+          expect(result).toBe(
+            openApiObjectFixture.components?.schemas?.['Item'],
+          );
+        });
+      });
+
+      describe('when called with an unknown reference', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.resolveReference(
+            'https://example.com/schemas/Unknown.json',
+          );
+        });
+
+        it('should return undefined', () => {
+          expect(result).toBeUndefined();
+        });
+      });
+
+      describe('when called with a reference with multiple fragments', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          try {
+            defaultOpenApiResolver.resolveReference(
+              'https://example.com/schemas/Item.json#foo#bar',
+            );
+          } catch (error: unknown) {
+            result = error;
+          }
+        });
+
+        it('should throw an Error', () => {
+          expect(result).toBeInstanceOf(Error);
+          expect(result).toMatchObject({
+            message: expect.stringContaining('at most one fragment'),
+          });
+        });
+      });
+    });
+  });
+
+  describe('having an OpenAPI object with $anchor on a schema with $id', () => {
+    let openApiObjectFixture: OpenApi3Dot1Object;
+    let defaultOpenApiResolver: DefaultOpenApiResolver;
+
+    beforeAll(() => {
+      openApiObjectFixture = {
+        components: {
+          schemas: {
+            Item: {
+              $anchor: 'item',
+              $id: 'https://example.com/schemas/Item.json',
+              properties: {
+                label: {
+                  type: 'string',
+                },
+              },
+              type: 'object',
+            },
+          },
+        },
+        info: { title: 'Test API', version: '1.0.0' },
+        openapi: '3.1.0',
+      };
+
+      defaultOpenApiResolver = new DefaultOpenApiResolver(openApiObjectFixture);
+    });
+
+    describe('.resolveReference', () => {
+      describe('when called with an $id and $anchor URI', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.resolveReference(
+            'https://example.com/schemas/Item.json#item',
+          );
+        });
+
+        it('should return the schema identified by the anchor URI', () => {
+          expect(result).toBe(
+            openApiObjectFixture.components?.schemas?.['Item'],
+          );
+        });
+      });
+    });
+  });
+
+  describe('having an OpenAPI object with a nested $anchor under a schema with $id', () => {
+    let openApiObjectFixture: OpenApi3Dot1Object;
+    let defaultOpenApiResolver: DefaultOpenApiResolver;
+
+    beforeAll(() => {
+      openApiObjectFixture = {
+        components: {
+          schemas: {
+            Item: {
+              $id: 'https://example.com/schemas/Item.json',
+              properties: {
+                label: {
+                  $anchor: 'label',
+                  type: 'string',
+                },
+              },
+              type: 'object',
+            },
+          },
+        },
+        info: { title: 'Test API', version: '1.0.0' },
+        openapi: '3.1.0',
+      };
+
+      defaultOpenApiResolver = new DefaultOpenApiResolver(openApiObjectFixture);
+    });
+
+    describe('.resolveReference', () => {
+      describe('when called with the closest ancestor $id and nested $anchor URI', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.resolveReference(
+            'https://example.com/schemas/Item.json#label',
+          );
+        });
+
+        it('should return the nested schema identified by the anchor URI', () => {
+          expect(result).toStrictEqual({
+            $anchor: 'label',
+            type: 'string',
+          });
+        });
+      });
+    });
+  });
+
+  describe('having an OpenAPI object with a nested $anchor and no $id', () => {
+    let openApiObjectFixture: OpenApi3Dot1Object;
+    let defaultOpenApiResolver: DefaultOpenApiResolver;
+
+    beforeAll(() => {
+      openApiObjectFixture = {
+        components: {
+          schemas: {
+            Item: {
+              properties: {
+                label: {
+                  $anchor: 'label',
+                  type: 'string',
+                },
+              },
+              type: 'object',
+            },
+          },
+        },
+        info: { title: 'Test API', version: '1.0.0' },
+        openapi: '3.1.0',
+      };
+
+      defaultOpenApiResolver = new DefaultOpenApiResolver(openApiObjectFixture);
+    });
+
+    describe('.resolveReference', () => {
+      describe('when called with a document-relative anchor URI', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          try {
+            defaultOpenApiResolver.resolveReference('#label');
+          } catch (error: unknown) {
+            result = error;
+          }
+        });
+
+        it('should throw an Error', () => {
+          expect(result).toBeInstanceOf(Error);
+          expect(result).toMatchObject({
+            message: 'Invalid JSON pointer!',
+          });
+        });
+      });
+    });
+  });
+
+  describe('having an OpenAPI object with chained $ref references', () => {
+    let openApiObjectFixture: OpenApi3Dot1Object;
+    let defaultOpenApiResolver: DefaultOpenApiResolver;
+
+    beforeAll(() => {
+      openApiObjectFixture = {
+        components: {
+          schemas: {
+            Item: {
+              $id: 'https://example.com/schemas/Item.json',
+              properties: {
+                label: {
+                  type: 'string',
+                },
+              },
+              type: 'object',
+            },
+            ItemRef: {
+              $ref: 'https://example.com/schemas/Item.json',
+            },
+          },
+        },
+        info: { title: 'Test API', version: '1.0.0' },
+        openapi: '3.1.0',
+      };
+
+      defaultOpenApiResolver = new DefaultOpenApiResolver(openApiObjectFixture);
+    });
+
+    describe('.deepResolveReference', () => {
+      describe('when called with a reference that resolves to another reference', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.deepResolveReference(
+            '#/components/schemas/ItemRef',
+          );
+        });
+
+        it('should return the deeply resolved schema', () => {
+          expect(result).toBe(
+            openApiObjectFixture.components?.schemas?.['Item'],
+          );
+        });
+      });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot1/DefaultOpenApiResolver.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot1/DefaultOpenApiResolver.ts
@@ -1,37 +1,62 @@
 import { type JsonValue } from '@inversifyjs/json-schema-types';
-import { type TraverseJsonSchemaParams } from '@inversifyjs/json-schema-utils/2020-12';
+import {
+  type JsonRootSchemaObject,
+  type JsonSchemaObject,
+} from '@inversifyjs/json-schema-types/2020-12';
+import { type TraverseJsonSchemaCallbackParams } from '@inversifyjs/json-schema-utils/2020-12';
 import { type OpenApi3Dot1Object } from '@inversifyjs/open-api-types/v3Dot1';
 import { traverseOpenApiObjectJsonSchemas } from '@inversifyjs/open-api-utils/v3Dot1';
 
+import { getClosestAncestorId } from '../../calculations/getClosestAncestor.js';
 import { BaseOpenApiResolver } from '../BaseOpenApiResolver.js';
 
 export class DefaultOpenApiResolver extends BaseOpenApiResolver {
-  readonly #idToSchemaMap: Map<string, JsonValue>;
+  readonly #uriToSchemaMap: Map<string, JsonValue>;
 
   constructor(openApiObject: OpenApi3Dot1Object) {
     super();
 
-    this.#idToSchemaMap = new Map();
+    this.#uriToSchemaMap = new Map();
 
-    this.#populateIdToSchemaMap(openApiObject);
+    this.#populateUriToSchemaMap(openApiObject);
   }
 
-  protected _resolveId(id: string): JsonValue | undefined {
-    return this.#idToSchemaMap.get(id);
+  protected _maybeResolveUri(uri: string): JsonValue | undefined {
+    return this.#uriToSchemaMap.get(uri);
   }
 
-  #populateIdToSchemaMap(openApiObject: OpenApi3Dot1Object): void {
-    this.#idToSchemaMap.set('', openApiObject as unknown as JsonValue);
+  #hasId(
+    schema: JsonRootSchemaObject | JsonSchemaObject,
+  ): schema is (JsonRootSchemaObject | JsonSchemaObject) & { $id: string } {
+    return schema.$id !== undefined;
+  }
+
+  #populateUriToSchemaMap(openApiObject: OpenApi3Dot1Object): void {
+    this.#uriToSchemaMap.set('', openApiObject as unknown as JsonValue);
 
     traverseOpenApiObjectJsonSchemas(
       openApiObject,
-      (params: TraverseJsonSchemaParams) => {
-        if (
-          params.schema !== true &&
-          params.schema !== false &&
-          params.schema.$id !== undefined
-        ) {
-          this.#idToSchemaMap.set(params.schema.$id, params.schema);
+      (params: TraverseJsonSchemaCallbackParams) => {
+        if (params.schema === true || params.schema === false) {
+          return;
+        }
+
+        if (this.#hasId(params.schema)) {
+          this.#uriToSchemaMap.set(params.schema.$id, params.schema);
+        }
+
+        if (params.schema.$anchor !== undefined) {
+          const anchorRelatedId: string | undefined = getClosestAncestorId(
+            params.rootSchema,
+            params.jsonPointer,
+          );
+
+          if (anchorRelatedId !== undefined) {
+            this.#uriToSchemaMap.set(
+              `${anchorRelatedId}#${params.schema.$anchor}`,
+              params.schema,
+            );
+          }
         }
       },
     );

--- a/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot2/DefaultOpenApiResolver.int.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot2/DefaultOpenApiResolver.int.spec.ts
@@ -1,0 +1,309 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { type OpenApi3Dot2Object } from '@inversifyjs/open-api-types/v3Dot2';
+
+import { DefaultOpenApiResolver } from './DefaultOpenApiResolver.js';
+
+describe(DefaultOpenApiResolver, () => {
+  describe('having an OpenAPI object with schema $id references', () => {
+    let openApiObjectFixture: OpenApi3Dot2Object;
+    let defaultOpenApiResolver: DefaultOpenApiResolver;
+
+    beforeAll(() => {
+      openApiObjectFixture = {
+        components: {
+          schemas: {
+            Item: {
+              $id: 'https://example.com/schemas/Item.json',
+              properties: {
+                label: {
+                  type: 'string',
+                },
+              },
+              required: ['label'],
+              type: 'object',
+            },
+          },
+        },
+        info: { title: 'Test API', version: '1.0.0' },
+        openapi: '3.2.0',
+      };
+
+      defaultOpenApiResolver = new DefaultOpenApiResolver(openApiObjectFixture);
+    });
+
+    describe('.resolveReference', () => {
+      describe('when called with a schema $id', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.resolveReference(
+            'https://example.com/schemas/Item.json',
+          );
+        });
+
+        it('should return the schema identified by $id', () => {
+          expect(result).toBe(
+            openApiObjectFixture.components?.schemas?.['Item'],
+          );
+        });
+      });
+
+      describe('when called with a schema $id and a JSON pointer fragment', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.resolveReference(
+            'https://example.com/schemas/Item.json#/properties/label',
+          );
+        });
+
+        it('should return the schema at the JSON pointer', () => {
+          expect(result).toStrictEqual({
+            type: 'string',
+          });
+        });
+      });
+
+      describe('when called with a document JSON pointer reference', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.resolveReference(
+            '#/components/schemas/Item',
+          );
+        });
+
+        it('should return the schema at the document JSON pointer', () => {
+          expect(result).toBe(
+            openApiObjectFixture.components?.schemas?.['Item'],
+          );
+        });
+      });
+
+      describe('when called with an unknown reference', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.resolveReference(
+            'https://example.com/schemas/Unknown.json',
+          );
+        });
+
+        it('should return undefined', () => {
+          expect(result).toBeUndefined();
+        });
+      });
+
+      describe('when called with a reference with multiple fragments', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          try {
+            defaultOpenApiResolver.resolveReference(
+              'https://example.com/schemas/Item.json#foo#bar',
+            );
+          } catch (error: unknown) {
+            result = error;
+          }
+        });
+
+        it('should throw an Error', () => {
+          expect(result).toBeInstanceOf(Error);
+          expect(result).toMatchObject({
+            message: expect.stringContaining('at most one fragment'),
+          });
+        });
+      });
+    });
+  });
+
+  describe('having an OpenAPI object with $anchor on a schema with $id', () => {
+    let openApiObjectFixture: OpenApi3Dot2Object;
+    let defaultOpenApiResolver: DefaultOpenApiResolver;
+
+    beforeAll(() => {
+      openApiObjectFixture = {
+        components: {
+          schemas: {
+            Item: {
+              $anchor: 'item',
+              $id: 'https://example.com/schemas/Item.json',
+              properties: {
+                label: {
+                  type: 'string',
+                },
+              },
+              type: 'object',
+            },
+          },
+        },
+        info: { title: 'Test API', version: '1.0.0' },
+        openapi: '3.2.0',
+      };
+
+      defaultOpenApiResolver = new DefaultOpenApiResolver(openApiObjectFixture);
+    });
+
+    describe('.resolveReference', () => {
+      describe('when called with an $id and $anchor URI', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.resolveReference(
+            'https://example.com/schemas/Item.json#item',
+          );
+        });
+
+        it('should return the schema identified by the anchor URI', () => {
+          expect(result).toBe(
+            openApiObjectFixture.components?.schemas?.['Item'],
+          );
+        });
+      });
+    });
+  });
+
+  describe('having an OpenAPI object with a nested $anchor under a schema with $id', () => {
+    let openApiObjectFixture: OpenApi3Dot2Object;
+    let defaultOpenApiResolver: DefaultOpenApiResolver;
+
+    beforeAll(() => {
+      openApiObjectFixture = {
+        components: {
+          schemas: {
+            Item: {
+              $id: 'https://example.com/schemas/Item.json',
+              properties: {
+                label: {
+                  $anchor: 'label',
+                  type: 'string',
+                },
+              },
+              type: 'object',
+            },
+          },
+        },
+        info: { title: 'Test API', version: '1.0.0' },
+        openapi: '3.2.0',
+      };
+
+      defaultOpenApiResolver = new DefaultOpenApiResolver(openApiObjectFixture);
+    });
+
+    describe('.resolveReference', () => {
+      describe('when called with the closest ancestor $id and nested $anchor URI', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.resolveReference(
+            'https://example.com/schemas/Item.json#label',
+          );
+        });
+
+        it('should return the nested schema identified by the anchor URI', () => {
+          expect(result).toStrictEqual({
+            $anchor: 'label',
+            type: 'string',
+          });
+        });
+      });
+    });
+  });
+
+  describe('having an OpenAPI object with a nested $anchor and no $id', () => {
+    let openApiObjectFixture: OpenApi3Dot2Object;
+    let defaultOpenApiResolver: DefaultOpenApiResolver;
+
+    beforeAll(() => {
+      openApiObjectFixture = {
+        components: {
+          schemas: {
+            Item: {
+              properties: {
+                label: {
+                  $anchor: 'label',
+                  type: 'string',
+                },
+              },
+              type: 'object',
+            },
+          },
+        },
+        info: { title: 'Test API', version: '1.0.0' },
+        openapi: '3.2.0',
+      };
+
+      defaultOpenApiResolver = new DefaultOpenApiResolver(openApiObjectFixture);
+    });
+
+    describe('.resolveReference', () => {
+      describe('when called with a document-relative anchor URI', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          try {
+            defaultOpenApiResolver.resolveReference('#label');
+          } catch (error: unknown) {
+            result = error;
+          }
+        });
+
+        it('should throw an Error', () => {
+          expect(result).toBeInstanceOf(Error);
+          expect(result).toMatchObject({
+            message: 'Invalid JSON pointer!',
+          });
+        });
+      });
+    });
+  });
+
+  describe('having an OpenAPI object with chained $ref references', () => {
+    let openApiObjectFixture: OpenApi3Dot2Object;
+    let defaultOpenApiResolver: DefaultOpenApiResolver;
+
+    beforeAll(() => {
+      openApiObjectFixture = {
+        components: {
+          schemas: {
+            Item: {
+              $id: 'https://example.com/schemas/Item.json',
+              properties: {
+                label: {
+                  type: 'string',
+                },
+              },
+              type: 'object',
+            },
+            ItemRef: {
+              $ref: 'https://example.com/schemas/Item.json',
+            },
+          },
+        },
+        info: { title: 'Test API', version: '1.0.0' },
+        openapi: '3.2.0',
+      };
+
+      defaultOpenApiResolver = new DefaultOpenApiResolver(openApiObjectFixture);
+    });
+
+    describe('.deepResolveReference', () => {
+      describe('when called with a reference that resolves to another reference', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.deepResolveReference(
+            '#/components/schemas/ItemRef',
+          );
+        });
+
+        it('should return the deeply resolved schema', () => {
+          expect(result).toBe(
+            openApiObjectFixture.components?.schemas?.['Item'],
+          );
+        });
+      });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot2/DefaultOpenApiResolver.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot2/DefaultOpenApiResolver.ts
@@ -1,37 +1,62 @@
 import { type JsonValue } from '@inversifyjs/json-schema-types';
-import { type TraverseJsonSchemaParams } from '@inversifyjs/json-schema-utils/2020-12';
+import {
+  type JsonRootSchemaObject,
+  type JsonSchemaObject,
+} from '@inversifyjs/json-schema-types/2020-12';
+import { type TraverseJsonSchemaCallbackParams } from '@inversifyjs/json-schema-utils/2020-12';
 import { type OpenApi3Dot2Object } from '@inversifyjs/open-api-types/v3Dot2';
 import { traverseOpenApiObjectJsonSchemas } from '@inversifyjs/open-api-utils/v3Dot2';
 
+import { getClosestAncestorId } from '../../calculations/getClosestAncestor.js';
 import { BaseOpenApiResolver } from '../BaseOpenApiResolver.js';
 
 export class DefaultOpenApiResolver extends BaseOpenApiResolver {
-  readonly #idToSchemaMap: Map<string, JsonValue>;
+  readonly #uriToSchemaMap: Map<string, JsonValue>;
 
   constructor(openApiObject: OpenApi3Dot2Object) {
     super();
 
-    this.#idToSchemaMap = new Map();
+    this.#uriToSchemaMap = new Map();
 
-    this.#populateIdToSchemaMap(openApiObject);
+    this.#populateUriToSchemaMap(openApiObject);
   }
 
-  protected _resolveId(id: string): JsonValue | undefined {
-    return this.#idToSchemaMap.get(id);
+  protected _maybeResolveUri(uri: string): JsonValue | undefined {
+    return this.#uriToSchemaMap.get(uri);
   }
 
-  #populateIdToSchemaMap(openApiObject: OpenApi3Dot2Object): void {
-    this.#idToSchemaMap.set('', openApiObject as unknown as JsonValue);
+  #hasId(
+    schema: JsonRootSchemaObject | JsonSchemaObject,
+  ): schema is (JsonRootSchemaObject | JsonSchemaObject) & { $id: string } {
+    return schema.$id !== undefined;
+  }
+
+  #populateUriToSchemaMap(openApiObject: OpenApi3Dot2Object): void {
+    this.#uriToSchemaMap.set('', openApiObject as unknown as JsonValue);
 
     traverseOpenApiObjectJsonSchemas(
       openApiObject,
-      (params: TraverseJsonSchemaParams) => {
-        if (
-          params.schema !== true &&
-          params.schema !== false &&
-          params.schema.$id !== undefined
-        ) {
-          this.#idToSchemaMap.set(params.schema.$id, params.schema);
+      (params: TraverseJsonSchemaCallbackParams) => {
+        if (params.schema === true || params.schema === false) {
+          return;
+        }
+
+        if (this.#hasId(params.schema)) {
+          this.#uriToSchemaMap.set(params.schema.$id, params.schema);
+        }
+
+        if (params.schema.$anchor !== undefined) {
+          const anchorRelatedId: string | undefined = getClosestAncestorId(
+            params.rootSchema,
+            params.jsonPointer,
+          );
+
+          if (anchorRelatedId !== undefined) {
+            this.#uriToSchemaMap.set(
+              `${anchorRelatedId}#${params.schema.$anchor}`,
+              params.schema,
+            );
+          }
         }
       },
     );

--- a/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/actions/traverse.spec.ts
+++ b/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/actions/traverse.spec.ts
@@ -37,8 +37,7 @@ describe(traverse, () => {
       const expectedTraverseJsonSchemaCallbackParams: TraverseJsonSchemaCallbackParams =
         {
           jsonPointer: '',
-          parentJsonPointer: undefined,
-          parentSchema: undefined,
+          rootSchema: JsonRootSchemaFixtures.any,
           schema: JsonRootSchemaFixtures.any,
         };
 
@@ -69,8 +68,7 @@ describe(traverse, () => {
         const expectedTraverseJsonSchemaCallbackParams: TraverseJsonSchemaCallbackParams =
           {
             jsonPointer: '',
-            parentJsonPointer: undefined,
-            parentSchema: undefined,
+            rootSchema: schemaFixture,
             schema: schemaFixture,
           };
 
@@ -99,8 +97,7 @@ describe(traverse, () => {
           const expectedTraverseJsonSchemaCallbackParams: TraverseJsonSchemaCallbackParams =
             {
               jsonPointer: `/${schemaKey}/${subschemaKey}`,
-              parentJsonPointer: '',
-              parentSchema: schemaFixture,
+              rootSchema: schemaFixture,
               schema: subschema,
             };
 
@@ -133,8 +130,7 @@ describe(traverse, () => {
         const expectedTraverseJsonSchemaCallbackParams: TraverseJsonSchemaCallbackParams =
           {
             jsonPointer: '',
-            parentJsonPointer: undefined,
-            parentSchema: undefined,
+            rootSchema: schemaFixture,
             schema: schemaFixture,
           };
 
@@ -155,8 +151,7 @@ describe(traverse, () => {
           const expectedTraverseJsonSchemaCallbackParams: TraverseJsonSchemaCallbackParams =
             {
               jsonPointer: `/${schemaKey}/${subschemaIndex.toString()}`,
-              parentJsonPointer: '',
-              parentSchema: schemaFixture,
+              rootSchema: schemaFixture,
               schema: subschema,
             };
 
@@ -195,8 +190,7 @@ describe(traverse, () => {
         const expectedTraverseJsonSchemaCallbackParams: TraverseJsonSchemaCallbackParams =
           {
             jsonPointer: '',
-            parentJsonPointer: undefined,
-            parentSchema: undefined,
+            rootSchema: schemaFixture,
             schema: schemaFixture,
           };
 
@@ -214,8 +208,7 @@ describe(traverse, () => {
         const expectedTraverseJsonSchemaCallbackParams: TraverseJsonSchemaCallbackParams =
           {
             jsonPointer: `/${schemaKey}`,
-            parentJsonPointer: '',
-            parentSchema: schemaFixture,
+            rootSchema: schemaFixture,
             schema: subschema,
           };
 

--- a/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/actions/traverse.ts
+++ b/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/actions/traverse.ts
@@ -53,8 +53,7 @@ export function traverse(
   traverseJsonSchemaFromParams(
     {
       jsonPointer: params.jsonPointer ?? '',
-      parentJsonPointer: undefined,
-      parentSchema: undefined,
+      rootSchema: params.schema,
       schema: params.schema,
     },
     callback,
@@ -94,8 +93,7 @@ function traverseDirectChildSchema(
 ): void {
   const traverseChildSchemaCallbackParams: TraverseJsonSchemaCallbackParams = {
     jsonPointer: `${params.jsonPointer}/${escapeJsonPointerFragments(key)}`,
-    parentJsonPointer: params.jsonPointer,
-    parentSchema: params.schema,
+    rootSchema: params.rootSchema,
     schema: childSchema,
   };
 
@@ -112,8 +110,7 @@ function traverseDirectChildSchemaArray(
     const traverseChildSchemaCallbackParams: TraverseJsonSchemaCallbackParams =
       {
         jsonPointer: `${params.jsonPointer}/${escapeJsonPointerFragments(key)}/${index.toString()}`,
-        parentJsonPointer: params.jsonPointer,
-        parentSchema: params.schema,
+        rootSchema: params.rootSchema,
         schema,
       };
 
@@ -131,8 +128,7 @@ function traverseDirectChildSchemaMap(
     const traverseChildSchemaCallbackParams: TraverseJsonSchemaCallbackParams =
       {
         jsonPointer: `${params.jsonPointer}/${escapeJsonPointerFragments(key, mapKey)}`,
-        parentJsonPointer: params.jsonPointer,
-        parentSchema: params.schema,
+        rootSchema: params.rootSchema,
         schema,
       };
 

--- a/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/models/TraverseJsonSchemaCallbackParams.ts
+++ b/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/models/TraverseJsonSchemaCallbackParams.ts
@@ -5,7 +5,6 @@ import {
 
 export interface TraverseJsonSchemaCallbackParams {
   jsonPointer: string;
-  parentJsonPointer: string | undefined;
-  parentSchema: JsonRootSchema | JsonSchema | undefined;
+  rootSchema: JsonRootSchema | JsonSchema;
   schema: JsonRootSchema | JsonSchema;
 }


### PR DESCRIPTION
### Changed
- Updated OpenAPI resolvers to resolve `$anchor` URIs in addition to `$id` references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenAPI 3.1 and 3.2 resolvers now support references to JSON Schema `$anchor` values, including nested anchors and chained references.
  * Improved resolution of complete schema URIs and JSON Pointer fragments.

* **Updates**
  * Schema traversal callbacks now provide the root schema for improved context.

* **Bug Fixes**
  * Invalid or unresolved schema references now produce clearer validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->