### PR TITLE
Update createHttpApp to rely on config package

### DIFF
--- a/.changeset/odd-rules-tickle.md
+++ b/.changeset/odd-rules-tickle.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/create-http": patch
+---
+
+- Updated `createHttpApp` to rely on config package.

--- a/packages/framework/http/tools/create-http/package.json
+++ b/packages/framework/http/tools/create-http/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@clack/prompts": "1.7.0",
     "citty": "0.2.2",
+    "prettier": "3.9.6",
     "ts-morph": "28.0.0"
   },
   "devDependencies": {
@@ -17,7 +18,6 @@
     "@types/node": "24.13.3",
     "@vitest/coverage-v8": "4.1.10",
     "eslint": "10.8.0",
-    "prettier": "3.9.6",
     "rimraf": "6.1.3",
     "typescript": "6.0.3",
     "vitest": "4.1.10"

--- a/packages/framework/http/tools/create-http/src/dependencies/calculations/composeScaffoldDependencies.spec.ts
+++ b/packages/framework/http/tools/create-http/src/dependencies/calculations/composeScaffoldDependencies.spec.ts
@@ -10,6 +10,8 @@ describe(composeScaffoldDependencies, () => {
     catalogFixture = {
       dependencies: {
         '@hono/node-server': '2.0.12',
+        '@inversifyjs/config': '1.0.0',
+        '@inversifyjs/config-dotenv': '1.0.0',
         '@inversifyjs/http-core': '5.4.8',
         '@inversifyjs/http-express': '5.4.8',
         '@inversifyjs/http-fastify': '5.4.8',
@@ -20,12 +22,15 @@ describe(composeScaffoldDependencies, () => {
         hono: '4.12.34',
         inversify: '8.2.3',
         'uWebSockets.js': 'github:uNetworking/uWebSockets.js#v20.69.0',
+        zod: '4.4.3',
       },
       devDependencies: {
         '@eslint/js': '10.0.1',
         '@types/express': '5.0.6',
         '@types/node': '24.13.3',
         eslint: '10.8.0',
+        'eslint-config-prettier': '10.1.8',
+        'eslint-plugin-prettier': '5.5.6',
         prettier: '3.9.6',
         typescript: '6.0.3',
         'typescript-eslint': '8.65.0',
@@ -43,10 +48,13 @@ describe(composeScaffoldDependencies, () => {
 
       it('should include only express adapter dependencies', () => {
         expect(result.dependencies).toStrictEqual({
+          '@inversifyjs/config': '1.0.0',
+          '@inversifyjs/config-dotenv': '1.0.0',
           '@inversifyjs/http-core': '5.4.8',
           '@inversifyjs/http-express': '5.4.8',
           express: '5.2.1',
           inversify: '8.2.3',
+          zod: '4.4.3',
         });
         expect(result.devDependencies).toMatchObject({
           '@types/express': '5.0.6',
@@ -72,10 +80,13 @@ describe(composeScaffoldDependencies, () => {
       it('should include hono and node-server without express types', () => {
         expect(result.dependencies).toStrictEqual({
           '@hono/node-server': '2.0.12',
+          '@inversifyjs/config': '1.0.0',
+          '@inversifyjs/config-dotenv': '1.0.0',
           '@inversifyjs/http-core': '5.4.8',
           '@inversifyjs/http-hono': '5.4.8',
           hono: '4.12.34',
           inversify: '8.2.3',
+          zod: '4.4.3',
         });
         expect(result.devDependencies).not.toHaveProperty('@types/express');
       });

--- a/packages/framework/http/tools/create-http/src/dependencies/models/HttpAdapterDependencySpecs.ts
+++ b/packages/framework/http/tools/create-http/src/dependencies/models/HttpAdapterDependencySpecs.ts
@@ -9,8 +9,11 @@ export interface AdapterDependencySpec {
  * Always-installed runtime dependencies, regardless of adapter.
  */
 export const BASE_DEPENDENCY_NAMES: readonly string[] = [
+  '@inversifyjs/config',
+  '@inversifyjs/config-dotenv',
   '@inversifyjs/http-core',
   'inversify',
+  'zod',
 ];
 
 /**
@@ -20,6 +23,8 @@ export const BASE_DEV_DEPENDENCY_NAMES: readonly string[] = [
   '@eslint/js',
   '@types/node',
   'eslint',
+  'eslint-config-prettier',
+  'eslint-plugin-prettier',
   'prettier',
   'typescript',
   'typescript-eslint',

--- a/packages/framework/http/tools/create-http/src/generation/calculations/generateBootstrapSource.spec.ts
+++ b/packages/framework/http/tools/create-http/src/generation/calculations/generateBootstrapSource.spec.ts
@@ -8,8 +8,8 @@ describe(generateBootstrapSource, () => {
     describe('when called', () => {
       let result: string;
 
-      beforeAll(() => {
-        result = BootstrapSourceFixtures.withHttpAdapterExpress;
+      beforeAll(async () => {
+        result = await BootstrapSourceFixtures.withHttpAdapterExpress();
       });
 
       it('should generate initializeContainer and adapter bootstrap', () => {
@@ -21,19 +21,42 @@ describe(generateBootstrapSource, () => {
         expect(result).toContain(
           "import { StatusContainerModule } from '../../status/containerModules/StatusContainerModule.js';",
         );
-        expect(result).toContain('const PORT: number = 3000;');
-        expect(result).toContain('function initializeContainer(): Container');
+        expect(result).toContain("from '@inversifyjs/config'");
+        expect(result).toContain('ConfigContainerModule');
+        expect(result).toContain('ConfigService');
+        expect(result).toContain('configServiceIdentifier');
+        expect(result).toContain(
+          "import { envFile } from '@inversifyjs/config-dotenv';",
+        );
+        expect(result).toContain("import { z } from 'zod';");
+        expect(result).toContain('appConfigSchema');
+        expect(result).toContain(
+          'type AppConfig = z.infer<typeof appConfigSchema>',
+        );
+        expect(result).toContain('configModule');
+        expect(result).toContain(
+          'async function initializeContainer(): Promise<Container>',
+        );
         expect(result).toContain(
           'const container: Container = new Container();',
         );
+        expect(result).toContain('await container.loadAsync(configModule);');
         expect(result).toContain(
           'container.load(new StatusContainerModule());',
         );
         expect(result).toContain('return container;');
         expect(result).not.toContain('export function initializeContainer');
+        expect(result).not.toContain(
+          'export async function initializeContainer',
+        );
         expect(result).toContain(
           'export async function bootstrap(): Promise<void>',
         );
+        expect(result).toContain(
+          'const container: Container = await initializeContainer();',
+        );
+        expect(result).toContain('configServiceIdentifier');
+        expect(result).toContain('const { PORT } = configService.get();');
         expect(result).toContain(
           'const adapter: InversifyExpressHttpAdapter = new InversifyExpressHttpAdapter(',
         );
@@ -41,6 +64,10 @@ describe(generateBootstrapSource, () => {
           'const app: express.Application = await adapter.build();',
         );
         expect(result).toContain('app.listen(PORT,');
+        expect(result).toMatch(
+          /^ {2}const container: Container = new Container\(\);$/m,
+        );
+        expect(result).toMatch(/^ {2}NODE_ENV:/m);
       });
     });
   });
@@ -49,8 +76,8 @@ describe(generateBootstrapSource, () => {
     describe('when called', () => {
       let result: string;
 
-      beforeAll(() => {
-        result = BootstrapSourceFixtures.withHttpAdapterFastify;
+      beforeAll(async () => {
+        result = await BootstrapSourceFixtures.withHttpAdapterFastify();
       });
 
       it('should generate a Fastify adapter bootstrap', () => {
@@ -63,6 +90,7 @@ describe(generateBootstrapSource, () => {
         expect(result).toContain(
           "await app.listen({ host: '0.0.0.0', port: PORT });",
         );
+        expect(result).toContain('const { PORT } = configService.get();');
       });
     });
   });
@@ -71,8 +99,8 @@ describe(generateBootstrapSource, () => {
     describe('when called', () => {
       let result: string;
 
-      beforeAll(() => {
-        result = BootstrapSourceFixtures.withHttpAdapterHono;
+      beforeAll(async () => {
+        result = await BootstrapSourceFixtures.withHttpAdapterHono();
       });
 
       it('should generate a Hono adapter bootstrap with node-server serve', () => {
@@ -83,6 +111,7 @@ describe(generateBootstrapSource, () => {
         expect(result).toContain('const app: Hono = await adapter.build();');
         expect(result).toContain('fetch: app.fetch,');
         expect(result).toContain('port: PORT,');
+        expect(result).toContain('const { PORT } = configService.get();');
       });
     });
   });
@@ -91,8 +120,8 @@ describe(generateBootstrapSource, () => {
     describe('when called', () => {
       let result: string;
 
-      beforeAll(() => {
-        result = BootstrapSourceFixtures.withHttpAdapterUwebsockets;
+      beforeAll(async () => {
+        result = await BootstrapSourceFixtures.withHttpAdapterUwebsockets();
       });
 
       it('should generate a uWebSockets adapter bootstrap', () => {
@@ -102,6 +131,7 @@ describe(generateBootstrapSource, () => {
         expect(result).toContain('const app = await adapter.build();');
         expect(result).toContain("app.listen('0.0.0.0', PORT,");
         expect(result).toContain('if (socket !== false)');
+        expect(result).toContain('const { PORT } = configService.get();');
       });
     });
   });
@@ -110,16 +140,20 @@ describe(generateBootstrapSource, () => {
     describe('when called', () => {
       let result: string;
 
-      beforeAll(() => {
+      beforeAll(async () => {
         result =
-          BootstrapSourceFixtures.withUseCaseExtraInitializeContainerBodyStatements;
+          await BootstrapSourceFixtures.withUseCaseExtraInitializeContainerBodyStatements();
       });
 
-      it('should include the extra statements before returning', () => {
+      it('should include the extra statements after loading the config module', () => {
+        expect(result).toContain('await container.loadAsync(configModule);');
         expect(result).toContain('container.load(new UserContainerModule());');
 
         const containerIndex: number = result.indexOf(
           'const container: Container = new Container();',
+        );
+        const configLoadIndex: number = result.indexOf(
+          'await container.loadAsync(configModule);',
         );
         const loadIndex: number = result.indexOf(
           'container.load(new UserContainerModule());',
@@ -127,7 +161,8 @@ describe(generateBootstrapSource, () => {
         const returnIndex: number = result.indexOf('return container;');
 
         expect(containerIndex).toBeGreaterThan(-1);
-        expect(loadIndex).toBeGreaterThan(containerIndex);
+        expect(configLoadIndex).toBeGreaterThan(containerIndex);
+        expect(loadIndex).toBeGreaterThan(configLoadIndex);
         expect(returnIndex).toBeGreaterThan(loadIndex);
       });
     });

--- a/packages/framework/http/tools/create-http/src/generation/calculations/generateBootstrapSource.ts
+++ b/packages/framework/http/tools/create-http/src/generation/calculations/generateBootstrapSource.ts
@@ -1,3 +1,4 @@
+import prettier from 'prettier';
 import {
   type ImportDeclarationStructure,
   type OptionalKind,
@@ -12,8 +13,7 @@ import {
   type SourceImport,
   type SourceNamedImport,
 } from '../models/BootstrapSourceModel.js';
-
-const DEFAULT_PORT: number = 3000;
+import { SCAFFOLD_PRETTIER_OPTIONS } from '../models/scaffoldPrettierOptions.js';
 
 function toImportDeclarationStructure(
   sourceImport: SourceImport,
@@ -47,7 +47,9 @@ function toImportDeclarationStructure(
   };
 }
 
-export function generateBootstrapSource(model: BootstrapSourceModel): string {
+export async function generateBootstrapSource(
+  model: BootstrapSourceModel,
+): Promise<string> {
   const project: Project = new Project({
     manipulationSettings: {
       quoteKind: QuoteKind.Single,
@@ -57,34 +59,69 @@ export function generateBootstrapSource(model: BootstrapSourceModel): string {
   });
 
   const sourceFile: SourceFile = project.createSourceFile('bootstrap.ts');
-  const port: number = model.port ?? DEFAULT_PORT;
 
   for (const sourceImport of model.imports) {
     sourceFile.addImportDeclaration(toImportDeclarationStructure(sourceImport));
   }
 
+  sourceFile.addImportDeclaration({
+    moduleSpecifier: '@inversifyjs/config',
+    namedImports: [
+      { name: 'ConfigContainerModule' },
+      { isTypeOnly: true, name: 'ConfigService' },
+      { name: 'configServiceIdentifier' },
+    ],
+  });
+
+  sourceFile.addImportDeclaration({
+    moduleSpecifier: '@inversifyjs/config-dotenv',
+    namedImports: [{ name: 'envFile' }],
+  });
+
+  sourceFile.addImportDeclaration({
+    moduleSpecifier: 'zod',
+    namedImports: [{ name: 'z' }],
+  });
+
   sourceFile.addVariableStatement({
     declarationKind: VariableDeclarationKind.Const,
     declarations: [
       {
-        initializer: String(port),
-        name: 'PORT',
-        type: 'number',
+        initializer:
+          "z.object({\n  NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),\n  PORT: z.coerce.number().min(1).max(65535).default(3000),\n})",
+        name: 'appConfigSchema',
+      },
+    ],
+  });
+
+  sourceFile.addTypeAlias({
+    name: 'AppConfig',
+    type: 'z.infer<typeof appConfigSchema>',
+  });
+
+  sourceFile.addVariableStatement({
+    declarationKind: VariableDeclarationKind.Const,
+    declarations: [
+      {
+        initializer:
+          'ConfigContainerModule.fromOptions({\n  source: envFile(),\n  validate: appConfigSchema,\n})',
+        name: 'configModule',
       },
     ],
   });
 
   const initializeContainerBodyStatements: string[] = [
     'const container: Container = new Container();',
+    'await container.loadAsync(configModule);',
     ...(model.initializeContainerBodyStatements ?? []),
     'return container;',
   ];
 
   sourceFile.addFunction({
-    isAsync: false,
+    isAsync: true,
     isExported: false,
     name: 'initializeContainer',
-    returnType: 'Container',
+    returnType: 'Promise<Container>',
     statements: initializeContainerBodyStatements,
   });
 
@@ -94,7 +131,9 @@ export function generateBootstrapSource(model: BootstrapSourceModel): string {
       : `const app: ${model.applicationType} = await adapter.build();`;
 
   const bootstrapBodyStatements: string[] = [
-    'const container: Container = initializeContainer();',
+    'const container: Container = await initializeContainer();',
+    'const configService: ConfigService<AppConfig> = container.get(configServiceIdentifier);',
+    'const { PORT } = configService.get();',
     `const adapter: ${model.adapter.className} = new ${model.adapter.className}(
   container,
   ${model.adapter.optionsObjectLiteral},
@@ -111,9 +150,5 @@ export function generateBootstrapSource(model: BootstrapSourceModel): string {
     statements: bootstrapBodyStatements,
   });
 
-  sourceFile.formatText({
-    ensureNewLineAtEndOfFile: true,
-  });
-
-  return sourceFile.getFullText();
+  return prettier.format(sourceFile.getFullText(), SCAFFOLD_PRETTIER_OPTIONS);
 }

--- a/packages/framework/http/tools/create-http/src/generation/fixtures/BootstrapSourceFixtures.ts
+++ b/packages/framework/http/tools/create-http/src/generation/fixtures/BootstrapSourceFixtures.ts
@@ -2,31 +2,31 @@ import { generateBootstrapSource } from '../calculations/generateBootstrapSource
 import { BootstrapSourceModelFixtures } from './BootstrapSourceModelFixtures.js';
 
 export class BootstrapSourceFixtures {
-  public static get withHttpAdapterExpress(): string {
+  public static async withHttpAdapterExpress(): Promise<string> {
     return generateBootstrapSource(
       BootstrapSourceModelFixtures.withHttpAdapterExpress,
     );
   }
 
-  public static get withHttpAdapterFastify(): string {
+  public static async withHttpAdapterFastify(): Promise<string> {
     return generateBootstrapSource(
       BootstrapSourceModelFixtures.withHttpAdapterFastify,
     );
   }
 
-  public static get withHttpAdapterHono(): string {
+  public static async withHttpAdapterHono(): Promise<string> {
     return generateBootstrapSource(
       BootstrapSourceModelFixtures.withHttpAdapterHono,
     );
   }
 
-  public static get withHttpAdapterUwebsockets(): string {
+  public static async withHttpAdapterUwebsockets(): Promise<string> {
     return generateBootstrapSource(
       BootstrapSourceModelFixtures.withHttpAdapterUwebsockets,
     );
   }
 
-  public static get withUseCaseExtraInitializeContainerBodyStatements(): string {
+  public static async withUseCaseExtraInitializeContainerBodyStatements(): Promise<string> {
     return generateBootstrapSource(
       BootstrapSourceModelFixtures.withUseCaseExtraInitializeContainerBodyStatements,
     );

--- a/packages/framework/http/tools/create-http/src/generation/models/BootstrapSourceModel.ts
+++ b/packages/framework/http/tools/create-http/src/generation/models/BootstrapSourceModel.ts
@@ -44,11 +44,7 @@ export interface BootstrapSourceModel {
   imports: readonly SourceImport[];
   /**
    * Statements after `const app = await adapter.build()`.
-   * `app` and `PORT` are in scope.
+   * `app` and `PORT` (from `ConfigService`) are in scope.
    */
   listenStatements: readonly string[];
-  /**
-   * Listening port constant. Defaults to `3000`.
-   */
-  port?: number;
 }

--- a/packages/framework/http/tools/create-http/src/generation/models/scaffoldPrettierOptions.ts
+++ b/packages/framework/http/tools/create-http/src/generation/models/scaffoldPrettierOptions.ts
@@ -1,0 +1,17 @@
+import { type Options } from 'prettier';
+
+/**
+ * Must stay aligned with `templates/base/prettier.config.mjs.template`.
+ */
+export const SCAFFOLD_PRETTIER_OPTIONS: Options = {
+  arrowParens: 'always',
+  bracketSpacing: true,
+  endOfLine: 'lf',
+  parser: 'typescript',
+  printWidth: 80,
+  semi: true,
+  singleQuote: true,
+  tabWidth: 2,
+  trailingComma: 'all',
+  useTabs: false,
+};

--- a/packages/framework/http/tools/create-http/src/services/createHttpApp.spec.ts
+++ b/packages/framework/http/tools/create-http/src/services/createHttpApp.spec.ts
@@ -42,9 +42,20 @@ describe(createHttpApp, () => {
         await expect(
           fs.readFile(path.join(projectPath, 'tsconfig.json'), 'utf8'),
         ).resolves.toContain('"outDir": "./dist"');
-        await expect(
-          fs.readFile(path.join(projectPath, 'eslint.config.mjs'), 'utf8'),
-        ).resolves.toContain('typescript-eslint');
+
+        const eslintConfigContents: string = await fs.readFile(
+          path.join(projectPath, 'eslint.config.mjs'),
+          'utf8',
+        );
+
+        expect(eslintConfigContents).toContain('typescript-eslint');
+        expect(eslintConfigContents).toContain(
+          "import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended'",
+        );
+        expect(eslintConfigContents).toContain(
+          'eslintPluginPrettierRecommended',
+        );
+
         await expect(
           fs.readFile(path.join(projectPath, 'prettier.config.mjs'), 'utf8'),
         ).resolves.toContain('trailingComma');
@@ -65,7 +76,7 @@ describe(createHttpApp, () => {
         );
 
         expect(bootstrapSource).toContain(
-          'function initializeContainer(): Container',
+          'async function initializeContainer(): Promise<Container>',
         );
         expect(bootstrapSource).toContain(
           'export async function bootstrap(): Promise<void>',
@@ -74,11 +85,27 @@ describe(createHttpApp, () => {
         expect(bootstrapSource).toContain(
           'const app: express.Application = await adapter.build();',
         );
+        expect(bootstrapSource).toContain("from '@inversifyjs/config'");
+        expect(bootstrapSource).toContain('ConfigContainerModule');
+        expect(bootstrapSource).toContain('configServiceIdentifier');
+        expect(bootstrapSource).toMatch(
+          /^ {2}const container: Container = new Container\(\);$/m,
+        );
         expect(bootstrapSource).toContain(
-          "import { StatusContainerModule } from '../../status/containerModules/StatusContainerModule.js';",
+          "import { envFile } from '@inversifyjs/config-dotenv';",
+        );
+        expect(bootstrapSource).toContain("import { z } from 'zod';");
+        expect(bootstrapSource).toContain(
+          'await container.loadAsync(configModule);',
         );
         expect(bootstrapSource).toContain(
           'container.load(new StatusContainerModule());',
+        );
+        expect(bootstrapSource).toContain(
+          'const container: Container = await initializeContainer();',
+        );
+        expect(bootstrapSource).toContain(
+          'const { PORT } = configService.get();',
         );
 
         await expect(
@@ -115,12 +142,31 @@ describe(createHttpApp, () => {
         expect(gitIgnoreContents).toContain('.yarn/*');
         expect(gitIgnoreContents).toContain('.pnpm-store/');
 
+        const envContents: string = await fs.readFile(
+          path.join(projectPath, '.env'),
+          'utf8',
+        );
+
+        expect(envContents).toContain('NODE_ENV=development');
+        expect(envContents).toContain('PORT=3000');
+
+        const envExampleContents: string = await fs.readFile(
+          path.join(projectPath, '.env.example'),
+          'utf8',
+        );
+
+        expect(envExampleContents).toContain('NODE_ENV=development');
+        expect(envExampleContents).toContain('PORT=3000');
+
         expect(packageJson).toMatchObject({
           dependencies: {
+            '@inversifyjs/config': expect.any(String) as string,
+            '@inversifyjs/config-dotenv': expect.any(String) as string,
             '@inversifyjs/http-core': expect.any(String) as string,
             '@inversifyjs/http-express': expect.any(String) as string,
             express: expect.any(String) as string,
             inversify: expect.any(String) as string,
+            zod: expect.any(String) as string,
           },
           name: 'demo-app',
           packageManager: expect.stringMatching(/^pnpm@/) as string,
@@ -145,6 +191,8 @@ describe(createHttpApp, () => {
         ).toMatchObject({
           '@types/express': expect.any(String) as string,
           eslint: expect.any(String) as string,
+          'eslint-config-prettier': expect.any(String) as string,
+          'eslint-plugin-prettier': expect.any(String) as string,
           prettier: expect.any(String) as string,
           typescript: expect.any(String) as string,
         });

--- a/packages/framework/http/tools/create-http/src/services/createHttpApp.ts
+++ b/packages/framework/http/tools/create-http/src/services/createHttpApp.ts
@@ -117,6 +117,13 @@ export async function createHttpApp(
     baseTemplateRoot,
     'prettier.config.mjs',
   );
+  await copyTemplateFile(
+    '.env.example',
+    projectPath,
+    baseTemplateRoot,
+    '.env.example',
+  );
+  await copyTemplateFile('.env.example', projectPath, baseTemplateRoot, '.env');
   await fs.mkdir(path.join(projectPath, 'src'), { recursive: true });
   await fs.writeFile(
     path.join(projectPath, 'src/index.ts'),

--- a/packages/framework/http/tools/create-http/src/services/writeBootstrapSourceFile.ts
+++ b/packages/framework/http/tools/create-http/src/services/writeBootstrapSourceFile.ts
@@ -16,7 +16,11 @@ export async function writeBootstrapSourceFile(
   );
 
   await fs.mkdir(path.dirname(bootstrapPath), { recursive: true });
-  await fs.writeFile(bootstrapPath, generateBootstrapSource(model), 'utf8');
+  await fs.writeFile(
+    bootstrapPath,
+    await generateBootstrapSource(model),
+    'utf8',
+  );
 
   return bootstrapPath;
 }

--- a/packages/framework/http/tools/create-http/templates/base/.env.example
+++ b/packages/framework/http/tools/create-http/templates/base/.env.example
@@ -1,0 +1,5 @@
+# Environment configuration
+# Copy this file to .env and update values as needed
+
+NODE_ENV=development
+PORT=3000

--- a/packages/framework/http/tools/create-http/templates/base/eslint.config.mjs.template
+++ b/packages/framework/http/tools/create-http/templates/base/eslint.config.mjs.template
@@ -1,7 +1,9 @@
 import eslint from '@eslint/js';
+import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
+  eslintPluginPrettierRecommended,
 );

--- a/packages/framework/http/tools/create-http/templates/base/package.json
+++ b/packages/framework/http/tools/create-http/templates/base/package.json
@@ -3,6 +3,8 @@
   "description": "Dependency version catalog for apps scaffolded by @inversifyjs/create-http. Renovate updates this file; the CLI composes a subset into generated package.json files based on the selected recipe.",
   "dependencies": {
     "@hono/node-server": "2.1.0",
+    "@inversifyjs/config": "1.0.0",
+    "@inversifyjs/config-dotenv": "1.0.0",
     "@inversifyjs/http-core": "5.4.8",
     "@inversifyjs/http-express": "5.4.8",
     "@inversifyjs/http-fastify": "5.4.8",
@@ -12,13 +14,16 @@
     "fastify": "5.11.2",
     "hono": "4.13.0",
     "inversify": "8.2.3",
-    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.69.0"
+    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.69.0",
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@types/express": "5.0.6",
     "@types/node": "24.13.3",
     "eslint": "10.8.0",
+    "eslint-config-prettier": "10.1.8",
+    "eslint-plugin-prettier": "5.5.6",
     "prettier": "3.9.6",
     "typescript": "6.0.3",
     "typescript-eslint": "8.66.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated HTTP applications now support environment-based configuration for development mode and port settings.
  * Added `.env.example` and `.env` files with a default port of 3000.
  * Generated projects now validate configuration values during startup.
  * Added consistent Prettier and ESLint formatting support to generated projects.

* **Bug Fixes**
  * Improved generated application startup to load configuration before launching the server.
  * Updated generated projects to include all required configuration and validation packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->