### PR TITLE
Add uwebsockets request transformers

### DIFF
--- a/.changeset/http-core-route-params-identity.md
+++ b/.changeset/http-core-route-params-identity.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/http-core": minor
+---
+
+- Updated `RouterParams` with a mandatory `target` property and `RouteParams` with a mandatory `methodKey` property so adapters can resolve adapter-specific route metadata.

--- a/.changeset/uwebsockets-request-transformers.md
+++ b/.changeset/uwebsockets-request-transformers.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/http-uwebsockets": minor
+---
+
+- Added `RequestTransformer` and `UseRequestTransformers` so routes can run request transformers before middleware, with failures routed through `RouteParams.handleError`.

--- a/packages/framework/http/libraries/core/src/http/adapter/InversifyHttpAdapter.spec.ts
+++ b/packages/framework/http/libraries/core/src/http/adapter/InversifyHttpAdapter.spec.ts
@@ -227,6 +227,12 @@ function buildSharedHandleErrorContainer(): Container {
 describe(InversifyHttpAdapter, () => {
   describe('.build', () => {
     describe('when called', () => {
+      let routerParams: RouterParams<
+        TestRequest,
+        TestResponse,
+        () => void,
+        void
+      >;
       let routeParams: RouteParams<TestRequest, TestResponse, () => void, void>;
 
       beforeAll(async () => {
@@ -234,13 +240,24 @@ describe(InversifyHttpAdapter, () => {
 
         await adapter.build();
 
-        [routeParams] = adapter.routerParamsList[0]?.routeParamsList as [
+        [routerParams] = adapter.routerParamsList as [
+          RouterParams<TestRequest, TestResponse, () => void, void>,
+        ];
+        [routeParams] = routerParams.routeParamsList as [
           RouteParams<TestRequest, TestResponse, () => void, void>,
         ];
       });
 
       it('should build route params with an error handler', () => {
         expect(routeParams.handleError).toBeInstanceOf(Function);
+      });
+
+      it('should build router params with the controller target', () => {
+        expect(routerParams.target).toBe(TestController);
+      });
+
+      it('should build route params with the controller method key', () => {
+        expect(routeParams.methodKey).toBe('get');
       });
     });
 

--- a/packages/framework/http/libraries/core/src/http/adapter/InversifyHttpAdapter.ts
+++ b/packages/framework/http/libraries/core/src/http/adapter/InversifyHttpAdapter.ts
@@ -625,6 +625,7 @@ export abstract class InversifyHttpAdapter<
             routerExplorerControllerMetadata.target,
             routerExplorerControllerMethodMetadata,
           ),
+          methodKey: routerExplorerControllerMethodMetadata.methodKey,
           path: routerExplorerControllerMethodMetadata.path,
           postHandlerMiddlewareList: this.#buildRoutePostMiddlewareList(
             handleError,
@@ -1078,6 +1079,7 @@ export abstract class InversifyHttpAdapter<
         routeParamsList: this.#buildRouteParamHandlerList(
           routerExplorerControllerMetadata,
         ),
+        target: routerExplorerControllerMetadata.target,
       });
 
       this.#printController(

--- a/packages/framework/http/libraries/core/src/http/models/RouteParams.ts
+++ b/packages/framework/http/libraries/core/src/http/models/RouteParams.ts
@@ -15,6 +15,7 @@ export interface RouteParams<TRequest, TResponse, TNextFunction, TResult> {
     error: unknown,
   ) => Promise<TResult>;
   handler: RequestHandler<TRequest, TResponse, TNextFunction, TResult>;
+  methodKey: string | symbol;
   path: string;
   postHandlerMiddlewareList: MiddlewareHandler<
     TRequest,

--- a/packages/framework/http/libraries/core/src/http/models/RouterParams.ts
+++ b/packages/framework/http/libraries/core/src/http/models/RouterParams.ts
@@ -3,4 +3,5 @@ import { type RouteParams } from './RouteParams.js';
 export interface RouterParams<TRequest, TResponse, TNextFunction, TResult> {
   path: string;
   routeParamsList: RouteParams<TRequest, TResponse, TNextFunction, TResult>[];
+  target: NewableFunction;
 }

--- a/packages/framework/http/libraries/uwebsockets/package.json
+++ b/packages/framework/http/libraries/uwebsockets/package.json
@@ -6,6 +6,7 @@
   "description": "InversifyJs http express package",
   "dependencies": {
     "@inversifyjs/http-core": "workspace:*",
+    "@inversifyjs/reflect-metadata-utils": "1.5.0",
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.69.0",
     "statuses": "^2.0.2"
   },

--- a/packages/framework/http/libraries/uwebsockets/src/adapter/InversifyUwebSocketsHttpAdapter.spec.ts
+++ b/packages/framework/http/libraries/uwebsockets/src/adapter/InversifyUwebSocketsHttpAdapter.spec.ts
@@ -1,0 +1,501 @@
+import { beforeAll, describe, expect, it, type Mock, vitest } from 'vitest';
+
+import {
+  ApplyMiddleware,
+  CatchError,
+  Controller,
+  Get,
+  UseErrorFilter,
+} from '@inversifyjs/http-core';
+import { type Logger } from '@inversifyjs/logger';
+import { Container, injectable } from 'inversify';
+import {
+  type HttpRequest,
+  type HttpResponse,
+  type TemplatedApp,
+} from 'uWebSockets.js';
+
+import { UseRequestTransformers } from '../decorators/UseRequestTransformers.js';
+import { type RequestTransformer } from '../models/RequestTransformer.js';
+import { type UwebSocketsErrorFilter } from '../models/UwebSocketsErrorFilter.js';
+import { type UwebSocketsMiddleware } from '../models/UwebSocketsMiddleware.js';
+import { InversifyUwebSocketsHttpAdapter } from './InversifyUwebSocketsHttpAdapter.js';
+
+type RouteHandler = (
+  response: HttpResponse,
+  request: HttpRequest,
+) => void | Promise<void>;
+
+interface TemplatedAppMock {
+  any: Mock<(pattern: string, handler: RouteHandler) => TemplatedApp>;
+  get: Mock<(pattern: string, handler: RouteHandler) => TemplatedApp>;
+}
+
+class TransformerError extends Error {}
+
+function buildLoggerMock(): Logger {
+  return {
+    debug: vitest.fn(),
+    error: vitest.fn(),
+    http: vitest.fn(),
+    info: vitest.fn(),
+    log: vitest.fn(),
+    silly: vitest.fn(),
+    verbose: vitest.fn(),
+    warn: vitest.fn(),
+  };
+}
+
+function buildTemplatedAppMock(): TemplatedAppMock {
+  return {
+    any: vitest.fn(),
+    get: vitest.fn(),
+  };
+}
+
+function buildNativeRequestMock(): HttpRequest {
+  return {
+    getMethod: vitest.fn().mockReturnValue('get'),
+  } as unknown as HttpRequest;
+}
+
+function buildResponseMock(): HttpResponse {
+  return {
+    cork: vitest.fn((callback: () => void): void => {
+      callback();
+    }),
+    end: vitest.fn(),
+    onAborted: vitest.fn(),
+    writeHeader: vitest.fn(),
+    writeStatus: vitest.fn(),
+  } as unknown as HttpResponse;
+}
+
+function getRouteHandler(templatedAppMock: TemplatedAppMock): RouteHandler {
+  const [, routeHandler]: [string, RouteHandler] = templatedAppMock.get.mock
+    .calls[0] as [string, RouteHandler];
+
+  return routeHandler;
+}
+
+async function buildAdapter(
+  container: Container,
+  templatedAppMock: TemplatedAppMock,
+): Promise<InversifyUwebSocketsHttpAdapter> {
+  const adapter: InversifyUwebSocketsHttpAdapter =
+    new InversifyUwebSocketsHttpAdapter(
+      container,
+      { logger: buildLoggerMock() },
+      templatedAppMock as unknown as TemplatedApp,
+    );
+
+  await adapter.build();
+
+  return adapter;
+}
+
+describe(InversifyUwebSocketsHttpAdapter, () => {
+  describe('having a controller method with no request transformers', () => {
+    let requestListFixture: HttpRequest[];
+    let templatedAppMock: TemplatedAppMock;
+
+    beforeAll(async () => {
+      requestListFixture = [];
+
+      @injectable()
+      class TestMiddleware implements UwebSocketsMiddleware {
+        public execute(
+          request: HttpRequest,
+          _response: HttpResponse,
+          next: () => void,
+        ): void {
+          requestListFixture.push(request);
+
+          next();
+        }
+      }
+
+      @Controller('/no-transformers')
+      class TestController {
+        @ApplyMiddleware(TestMiddleware)
+        @Get()
+        public async get(): Promise<string> {
+          return 'test';
+        }
+      }
+
+      const container: Container = new Container();
+
+      container.bind(TestMiddleware).toSelf().inSingletonScope();
+      container.bind(TestController).toSelf().inSingletonScope();
+
+      templatedAppMock = buildTemplatedAppMock();
+
+      await buildAdapter(container, templatedAppMock);
+    });
+
+    describe('when the registered route handler is called', () => {
+      let nativeRequestFixture: HttpRequest;
+      let responseMock: HttpResponse;
+
+      beforeAll(async () => {
+        nativeRequestFixture = buildNativeRequestMock();
+        responseMock = buildResponseMock();
+
+        await getRouteHandler(templatedAppMock)(
+          responseMock,
+          nativeRequestFixture,
+        );
+      });
+
+      it('should register the route', () => {
+        expect(templatedAppMock.get).toHaveBeenCalledExactlyOnceWith(
+          '/no-transformers',
+          expect.any(Function),
+        );
+      });
+
+      it('should register an onAborted handler', () => {
+        expect(responseMock.onAborted).toHaveBeenCalledExactlyOnceWith(
+          expect.any(Function),
+        );
+      });
+
+      it('should call the middleware list with the native request', () => {
+        expect(requestListFixture).toStrictEqual([nativeRequestFixture]);
+      });
+    });
+  });
+
+  describe('having a controller method with two request transformers', () => {
+    let firstTransformedRequestFixture: HttpRequest;
+    let secondTransformedRequestFixture: HttpRequest;
+    let requestListFixture: HttpRequest[];
+    let requestTransformerCallList: HttpRequest[];
+    let templatedAppMock: TemplatedAppMock;
+
+    beforeAll(async () => {
+      firstTransformedRequestFixture = buildNativeRequestMock();
+      secondTransformedRequestFixture = buildNativeRequestMock();
+      requestListFixture = [];
+      requestTransformerCallList = [];
+
+      const firstRequestTransformer: RequestTransformer<
+        HttpRequest,
+        HttpResponse
+      > = (request: HttpRequest): HttpRequest => {
+        requestTransformerCallList.push(request);
+
+        return firstTransformedRequestFixture;
+      };
+
+      const secondRequestTransformer: RequestTransformer<
+        HttpRequest,
+        HttpResponse
+      > = async (request: HttpRequest): Promise<HttpRequest> => {
+        requestTransformerCallList.push(request);
+
+        return Promise.resolve(secondTransformedRequestFixture);
+      };
+
+      @injectable()
+      class TestMiddleware implements UwebSocketsMiddleware {
+        public execute(
+          request: HttpRequest,
+          _response: HttpResponse,
+          next: () => void,
+        ): void {
+          requestListFixture.push(request);
+
+          next();
+        }
+      }
+
+      @Controller('/transformers')
+      class TestController {
+        @UseRequestTransformers(
+          firstRequestTransformer,
+          secondRequestTransformer,
+        )
+        @ApplyMiddleware(TestMiddleware)
+        @Get()
+        public async get(): Promise<string> {
+          return 'test';
+        }
+      }
+
+      const container: Container = new Container();
+
+      container.bind(TestMiddleware).toSelf().inSingletonScope();
+      container.bind(TestController).toSelf().inSingletonScope();
+
+      templatedAppMock = buildTemplatedAppMock();
+
+      await buildAdapter(container, templatedAppMock);
+    });
+
+    describe('when the registered route handler is called', () => {
+      let nativeRequestFixture: HttpRequest;
+      let responseMock: HttpResponse;
+
+      beforeAll(async () => {
+        nativeRequestFixture = buildNativeRequestMock();
+        responseMock = buildResponseMock();
+
+        await getRouteHandler(templatedAppMock)(
+          responseMock,
+          nativeRequestFixture,
+        );
+      });
+
+      it('should register an onAborted handler', () => {
+        expect(responseMock.onAborted).toHaveBeenCalledExactlyOnceWith(
+          expect.any(Function),
+        );
+      });
+
+      it('should call the request transformers sequentially', () => {
+        expect(requestTransformerCallList).toStrictEqual([
+          nativeRequestFixture,
+          firstTransformedRequestFixture,
+        ]);
+      });
+
+      it('should call the middleware list with the last transformed request', () => {
+        expect(requestListFixture).toStrictEqual([
+          secondTransformedRequestFixture,
+        ]);
+      });
+    });
+  });
+
+  describe('having a controller method with a request transformer and a global pre handler middleware', () => {
+    let executionOrderFixture: string[];
+    let templatedAppMock: TemplatedAppMock;
+
+    beforeAll(async () => {
+      executionOrderFixture = [];
+
+      @injectable()
+      class TestGlobalMiddleware implements UwebSocketsMiddleware {
+        public execute(
+          _request: HttpRequest,
+          _response: HttpResponse,
+          next: () => void,
+        ): void {
+          executionOrderFixture.push('global-middleware');
+
+          next();
+        }
+      }
+
+      const requestTransformer: RequestTransformer<
+        HttpRequest,
+        HttpResponse
+      > = (request: HttpRequest): HttpRequest => {
+        executionOrderFixture.push('request-transformer');
+
+        return request;
+      };
+
+      @Controller('/global-middleware')
+      class TestController {
+        @UseRequestTransformers(requestTransformer)
+        @Get()
+        public async get(): Promise<string> {
+          return 'test';
+        }
+      }
+
+      const container: Container = new Container();
+
+      container.bind(TestGlobalMiddleware).toSelf().inSingletonScope();
+      container.bind(TestController).toSelf().inSingletonScope();
+
+      templatedAppMock = buildTemplatedAppMock();
+
+      const adapter: InversifyUwebSocketsHttpAdapter =
+        new InversifyUwebSocketsHttpAdapter(
+          container,
+          { logger: buildLoggerMock() },
+          templatedAppMock as unknown as TemplatedApp,
+        );
+
+      adapter.applyGlobalMiddleware(TestGlobalMiddleware);
+
+      await adapter.build();
+    });
+
+    describe('when the registered route handler is called', () => {
+      beforeAll(async () => {
+        await getRouteHandler(templatedAppMock)(
+          buildResponseMock(),
+          buildNativeRequestMock(),
+        );
+      });
+
+      it('should call the request transformer before the global pre handler middleware', () => {
+        expect(executionOrderFixture).toStrictEqual([
+          'request-transformer',
+          'global-middleware',
+        ]);
+      });
+    });
+  });
+
+  describe('having a controller method with a throwing request transformer and a route error filter', () => {
+    let errorFilterCallList: unknown[];
+    let requestListFixture: HttpRequest[];
+    let templatedAppMock: TemplatedAppMock;
+
+    beforeAll(async () => {
+      errorFilterCallList = [];
+      requestListFixture = [];
+
+      @CatchError(TransformerError)
+      class TestErrorFilter implements UwebSocketsErrorFilter {
+        public catch(
+          error: unknown,
+          _request: HttpRequest,
+          response: HttpResponse,
+        ): void {
+          errorFilterCallList.push(error);
+
+          response.cork((): void => {
+            response.end('handled');
+          });
+        }
+      }
+
+      @injectable()
+      class TestMiddleware implements UwebSocketsMiddleware {
+        public execute(
+          request: HttpRequest,
+          _response: HttpResponse,
+          next: () => void,
+        ): void {
+          requestListFixture.push(request);
+
+          next();
+        }
+      }
+
+      const requestTransformer: RequestTransformer<
+        HttpRequest,
+        HttpResponse
+      > = (): HttpRequest => {
+        throw new TransformerError('Transformer error');
+      };
+
+      @Controller('/throwing-transformer')
+      class TestController {
+        @UseRequestTransformers(requestTransformer)
+        @ApplyMiddleware(TestMiddleware)
+        @UseErrorFilter(TestErrorFilter)
+        @Get()
+        public async get(): Promise<string> {
+          return 'test';
+        }
+      }
+
+      const container: Container = new Container();
+
+      container.bind(TestErrorFilter).toSelf().inSingletonScope();
+      container.bind(TestMiddleware).toSelf().inSingletonScope();
+      container.bind(TestController).toSelf().inSingletonScope();
+
+      templatedAppMock = buildTemplatedAppMock();
+
+      await buildAdapter(container, templatedAppMock);
+    });
+
+    describe('when the registered route handler is called', () => {
+      let responseMock: HttpResponse;
+
+      beforeAll(async () => {
+        responseMock = buildResponseMock();
+
+        await getRouteHandler(templatedAppMock)(
+          responseMock,
+          buildNativeRequestMock(),
+        );
+      });
+
+      it('should call the route error filter', () => {
+        expect(errorFilterCallList).toHaveLength(1);
+        expect(errorFilterCallList[0]).toBeInstanceOf(TransformerError);
+      });
+
+      it('should not call the middleware list', () => {
+        expect(requestListFixture).toStrictEqual([]);
+      });
+
+      it('should reply with the error filter response', () => {
+        expect(responseMock.end).toHaveBeenCalledExactlyOnceWith('handled');
+      });
+    });
+  });
+
+  describe('having a controller method with a rejecting request transformer and a route error filter', () => {
+    let errorFilterCallList: unknown[];
+    let templatedAppMock: TemplatedAppMock;
+
+    beforeAll(async () => {
+      errorFilterCallList = [];
+
+      @CatchError(TransformerError)
+      class TestErrorFilter implements UwebSocketsErrorFilter {
+        public catch(
+          error: unknown,
+          _request: HttpRequest,
+          response: HttpResponse,
+        ): void {
+          errorFilterCallList.push(error);
+
+          response.cork((): void => {
+            response.end('handled');
+          });
+        }
+      }
+
+      const requestTransformer: RequestTransformer<
+        HttpRequest,
+        HttpResponse
+      > = async (): Promise<HttpRequest> =>
+        Promise.reject(new TransformerError('Rejected transformer'));
+
+      @Controller('/rejecting-transformer')
+      class TestController {
+        @UseRequestTransformers(requestTransformer)
+        @UseErrorFilter(TestErrorFilter)
+        @Get()
+        public async get(): Promise<string> {
+          return 'test';
+        }
+      }
+
+      const container: Container = new Container();
+
+      container.bind(TestErrorFilter).toSelf().inSingletonScope();
+      container.bind(TestController).toSelf().inSingletonScope();
+
+      templatedAppMock = buildTemplatedAppMock();
+
+      await buildAdapter(container, templatedAppMock);
+    });
+
+    describe('when the registered route handler is called', () => {
+      beforeAll(async () => {
+        await getRouteHandler(templatedAppMock)(
+          buildResponseMock(),
+          buildNativeRequestMock(),
+        );
+      });
+
+      it('should call the route error filter', () => {
+        expect(errorFilterCallList).toHaveLength(1);
+        expect(errorFilterCallList[0]).toBeInstanceOf(TransformerError);
+      });
+    });
+  });
+});

--- a/packages/framework/http/libraries/uwebsockets/src/adapter/InversifyUwebSocketsHttpAdapter.ts
+++ b/packages/framework/http/libraries/uwebsockets/src/adapter/InversifyUwebSocketsHttpAdapter.ts
@@ -3,6 +3,7 @@ import { type URLSearchParamsIterator } from 'node:url';
 
 import {
   buildNormalizedPath,
+  type CustomParameterDecoratorHandlerOptions,
   handleMiddlewareList,
   type HttpStatusCode,
   InversifyHttpAdapter,
@@ -24,8 +25,11 @@ import {
 } from 'uWebSockets.js';
 
 import { pipeStreamOverResponse } from '../actions/pipeStreamOverResponse.js';
+import { getClassMethodRequestTransformerList } from '../calculations/getClassMethodRequestTransformerList.js';
+import { getClassRequestTransformerList } from '../calculations/getClassRequestTransformerList.js';
 import { abortedSymbol } from '../data/abortedSymbol.js';
 import { type CustomHttpResponse } from '../models/CustomHttpResponse.js';
+import { type RequestTransformer } from '../models/RequestTransformer.js';
 import { type UwebSocketsHttpAdapterOptions } from '../models/UwebSocketsHttpAdapterOptions.js';
 
 const ADAPTER_ID: unique symbol = Symbol.for(
@@ -49,6 +53,11 @@ export class InversifyUwebSocketsHttpAdapter extends InversifyHttpAdapter<
     void
   >[] = [];
 
+  readonly #requestTransformerOptions: CustomParameterDecoratorHandlerOptions<
+    HttpRequest,
+    HttpResponse
+  >;
+
   constructor(
     container: Container,
     httpAdapterOptions?: UwebSocketsHttpAdapterOptions,
@@ -63,6 +72,18 @@ export class InversifyUwebSocketsHttpAdapter extends InversifyHttpAdapter<
       [RequestMethodParameterType.Body],
       customApp,
     );
+
+    this.#requestTransformerOptions = {
+      getBody: this._getBody.bind(this),
+      getCookies: this._getCookies.bind(this),
+      getHeaders: this._getHeaders.bind(this),
+      getMethod: this._getMethod.bind(this),
+      getParams: this._getParams.bind(this),
+      getQuery: this._getQuery.bind(this),
+      getUrl: this._getUrl.bind(this),
+      setHeader: this._setHeader.bind(this),
+      setStatus: this._setStatus.bind(this),
+    };
   }
 
   protected _buildApp(customApp: TemplatedApp | undefined): TemplatedApp {
@@ -95,16 +116,56 @@ export class InversifyUwebSocketsHttpAdapter extends InversifyHttpAdapter<
         response: HttpResponse,
       ) => Promise<void> = handleMiddlewareList(orderedHandlers);
 
-      this.#getAppRouteHandler(routeParams.requestMethodType)(
-        routePath,
-        async (res: HttpResponse, req: HttpRequest) => {
-          res.onAborted(() => {
-            (res as CustomHttpResponse)[abortedSymbol] = true;
-          });
+      const requestTransformerList: RequestTransformer<
+        HttpRequest,
+        HttpResponse
+      >[] = [
+        ...getClassRequestTransformerList(routerParams.target),
+        ...getClassMethodRequestTransformerList(
+          routerParams.target,
+          routeParams.methodKey,
+        ),
+      ];
 
-          await handleMiddlewares(req, res);
-        },
-      );
+      if (requestTransformerList.length === 0) {
+        this.#getAppRouteHandler(routeParams.requestMethodType)(
+          routePath,
+          async (res: HttpResponse, req: HttpRequest) => {
+            res.onAborted(() => {
+              (res as CustomHttpResponse)[abortedSymbol] = true;
+            });
+
+            await handleMiddlewares(req, res);
+          },
+        );
+      } else {
+        this.#getAppRouteHandler(routeParams.requestMethodType)(
+          routePath,
+          async (res: HttpResponse, req: HttpRequest) => {
+            res.onAborted(() => {
+              (res as CustomHttpResponse)[abortedSymbol] = true;
+            });
+
+            let request: HttpRequest = req;
+
+            try {
+              for (const requestTransformer of requestTransformerList) {
+                request = await requestTransformer(
+                  request,
+                  res,
+                  this.#requestTransformerOptions,
+                );
+              }
+            } catch (error: unknown) {
+              await routeParams.handleError(request, res, error);
+
+              return;
+            }
+
+            await handleMiddlewares(request, res);
+          },
+        );
+      }
     }
 
     if (this.#globalPreHandlerMiddlewareList.length > 0) {

--- a/packages/framework/http/libraries/uwebsockets/src/calculations/getClassMethodRequestTransformerList.spec.ts
+++ b/packages/framework/http/libraries/uwebsockets/src/calculations/getClassMethodRequestTransformerList.spec.ts
@@ -1,0 +1,80 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+vitest.mock(import('@inversifyjs/reflect-metadata-utils'));
+
+import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+import { type HttpRequest, type HttpResponse } from 'uWebSockets.js';
+
+import { type RequestTransformer } from '../models/RequestTransformer.js';
+import { classMethodRequestTransformerMetadataReflectKey } from '../reflectMetadata/data/classMethodRequestTransformerMetadataReflectKey.js';
+import { getClassMethodRequestTransformerList } from './getClassMethodRequestTransformerList.js';
+
+describe(getClassMethodRequestTransformerList, () => {
+  describe('having a class constructor and a method key', () => {
+    let classConstructorFixture: NewableFunction;
+    let methodKeyFixture: string;
+
+    beforeAll(() => {
+      classConstructorFixture = class TestController {};
+      methodKeyFixture = 'testMethod';
+    });
+
+    describe('when called, and getOwnReflectMetadata() returns a request transformer list', () => {
+      let requestTransformerListFixture: RequestTransformer<
+        HttpRequest,
+        HttpResponse
+      >[];
+      let result: unknown;
+
+      beforeAll(() => {
+        requestTransformerListFixture = [vitest.fn()];
+
+        vitest
+          .mocked(getOwnReflectMetadata)
+          .mockReturnValueOnce(requestTransformerListFixture);
+
+        result = getClassMethodRequestTransformerList(
+          classConstructorFixture,
+          methodKeyFixture,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call getOwnReflectMetadata()', () => {
+        expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
+          classConstructorFixture,
+          classMethodRequestTransformerMetadataReflectKey,
+          methodKeyFixture,
+        );
+      });
+
+      it('should return the request transformer list', () => {
+        expect(result).toBe(requestTransformerListFixture);
+      });
+    });
+
+    describe('when called, and getOwnReflectMetadata() returns undefined', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest.mocked(getOwnReflectMetadata).mockReturnValueOnce(undefined);
+
+        result = getClassMethodRequestTransformerList(
+          classConstructorFixture,
+          methodKeyFixture,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should return an empty list', () => {
+        expect(result).toStrictEqual([]);
+      });
+    });
+  });
+});

--- a/packages/framework/http/libraries/uwebsockets/src/calculations/getClassMethodRequestTransformerList.ts
+++ b/packages/framework/http/libraries/uwebsockets/src/calculations/getClassMethodRequestTransformerList.ts
@@ -1,0 +1,18 @@
+import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+import { type HttpRequest, type HttpResponse } from 'uWebSockets.js';
+
+import { type RequestTransformer } from '../models/RequestTransformer.js';
+import { classMethodRequestTransformerMetadataReflectKey } from '../reflectMetadata/data/classMethodRequestTransformerMetadataReflectKey.js';
+
+export function getClassMethodRequestTransformerList(
+  classConstructor: NewableFunction,
+  methodKey: string | symbol,
+): RequestTransformer<HttpRequest, HttpResponse>[] {
+  return (
+    getOwnReflectMetadata(
+      classConstructor,
+      classMethodRequestTransformerMetadataReflectKey,
+      methodKey,
+    ) ?? []
+  );
+}

--- a/packages/framework/http/libraries/uwebsockets/src/calculations/getClassRequestTransformerList.spec.ts
+++ b/packages/framework/http/libraries/uwebsockets/src/calculations/getClassRequestTransformerList.spec.ts
@@ -1,0 +1,71 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+vitest.mock(import('@inversifyjs/reflect-metadata-utils'));
+
+import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+import { type HttpRequest, type HttpResponse } from 'uWebSockets.js';
+
+import { type RequestTransformer } from '../models/RequestTransformer.js';
+import { classRequestTransformerMetadataReflectKey } from '../reflectMetadata/data/classRequestTransformerMetadataReflectKey.js';
+import { getClassRequestTransformerList } from './getClassRequestTransformerList.js';
+
+describe(getClassRequestTransformerList, () => {
+  describe('having a class constructor', () => {
+    let classConstructorFixture: NewableFunction;
+
+    beforeAll(() => {
+      classConstructorFixture = class TestController {};
+    });
+
+    describe('when called, and getOwnReflectMetadata() returns a request transformer list', () => {
+      let requestTransformerListFixture: RequestTransformer<
+        HttpRequest,
+        HttpResponse
+      >[];
+      let result: unknown;
+
+      beforeAll(() => {
+        requestTransformerListFixture = [vitest.fn()];
+
+        vitest
+          .mocked(getOwnReflectMetadata)
+          .mockReturnValueOnce(requestTransformerListFixture);
+
+        result = getClassRequestTransformerList(classConstructorFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call getOwnReflectMetadata()', () => {
+        expect(getOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
+          classConstructorFixture,
+          classRequestTransformerMetadataReflectKey,
+        );
+      });
+
+      it('should return the request transformer list', () => {
+        expect(result).toBe(requestTransformerListFixture);
+      });
+    });
+
+    describe('when called, and getOwnReflectMetadata() returns undefined', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest.mocked(getOwnReflectMetadata).mockReturnValueOnce(undefined);
+
+        result = getClassRequestTransformerList(classConstructorFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should return an empty list', () => {
+        expect(result).toStrictEqual([]);
+      });
+    });
+  });
+});

--- a/packages/framework/http/libraries/uwebsockets/src/calculations/getClassRequestTransformerList.ts
+++ b/packages/framework/http/libraries/uwebsockets/src/calculations/getClassRequestTransformerList.ts
@@ -1,0 +1,16 @@
+import { getOwnReflectMetadata } from '@inversifyjs/reflect-metadata-utils';
+import { type HttpRequest, type HttpResponse } from 'uWebSockets.js';
+
+import { type RequestTransformer } from '../models/RequestTransformer.js';
+import { classRequestTransformerMetadataReflectKey } from '../reflectMetadata/data/classRequestTransformerMetadataReflectKey.js';
+
+export function getClassRequestTransformerList(
+  classConstructor: NewableFunction,
+): RequestTransformer<HttpRequest, HttpResponse>[] {
+  return (
+    getOwnReflectMetadata(
+      classConstructor,
+      classRequestTransformerMetadataReflectKey,
+    ) ?? []
+  );
+}

--- a/packages/framework/http/libraries/uwebsockets/src/decorators/UseRequestTransformers.spec.ts
+++ b/packages/framework/http/libraries/uwebsockets/src/decorators/UseRequestTransformers.spec.ts
@@ -1,0 +1,115 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+vitest.mock(import('@inversifyjs/reflect-metadata-utils'));
+
+import {
+  buildArrayMetadataWithArray,
+  buildEmptyArrayMetadata,
+  updateOwnReflectMetadata,
+} from '@inversifyjs/reflect-metadata-utils';
+import { type HttpRequest, type HttpResponse } from 'uWebSockets.js';
+
+import { type RequestTransformer } from '../models/RequestTransformer.js';
+import { classMethodRequestTransformerMetadataReflectKey } from '../reflectMetadata/data/classMethodRequestTransformerMetadataReflectKey.js';
+import { classRequestTransformerMetadataReflectKey } from '../reflectMetadata/data/classRequestTransformerMetadataReflectKey.js';
+import { UseRequestTransformers } from './UseRequestTransformers.js';
+
+describe(UseRequestTransformers, () => {
+  describe('having a ClassDecorator', () => {
+    describe('when called', () => {
+      let requestTransformerFixture: RequestTransformer<
+        HttpRequest,
+        HttpResponse
+      >;
+      let targetFixture: NewableFunction;
+      let callbackFixture: (arrayMetadata: unknown[]) => unknown[];
+
+      beforeAll(() => {
+        requestTransformerFixture = vitest.fn();
+        targetFixture = class TestController {};
+        callbackFixture = (arrayMetadata: unknown[]): unknown[] =>
+          arrayMetadata;
+
+        vitest
+          .mocked(buildArrayMetadataWithArray)
+          .mockReturnValueOnce(callbackFixture);
+
+        UseRequestTransformers(requestTransformerFixture)(targetFixture);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call buildArrayMetadataWithArray()', () => {
+        expect(buildArrayMetadataWithArray).toHaveBeenCalledExactlyOnceWith([
+          requestTransformerFixture,
+        ]);
+      });
+
+      it('should call updateOwnReflectMetadata()', () => {
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
+          targetFixture,
+          classRequestTransformerMetadataReflectKey,
+          buildEmptyArrayMetadata,
+          callbackFixture,
+          undefined,
+        );
+      });
+    });
+  });
+
+  describe('having a MethodDecorator', () => {
+    describe('when called', () => {
+      let targetFixture: NewableFunction;
+      let methodKeyFixture: string | symbol;
+      let requestTransformerFixture: RequestTransformer<
+        HttpRequest,
+        HttpResponse
+      >;
+      let descriptorFixture: PropertyDescriptor;
+      let callbackFixture: (arrayMetadata: unknown[]) => unknown[];
+
+      beforeAll(() => {
+        targetFixture = class TestController {};
+        methodKeyFixture = 'testMethod';
+        requestTransformerFixture = vitest.fn();
+        descriptorFixture = {
+          value: 'value-descriptor-example',
+        };
+        callbackFixture = (arrayMetadata: unknown[]): unknown[] =>
+          arrayMetadata;
+
+        vitest
+          .mocked(buildArrayMetadataWithArray)
+          .mockReturnValueOnce(callbackFixture);
+
+        UseRequestTransformers(requestTransformerFixture)(
+          targetFixture.prototype as object,
+          methodKeyFixture,
+          descriptorFixture,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call buildArrayMetadataWithArray()', () => {
+        expect(buildArrayMetadataWithArray).toHaveBeenCalledExactlyOnceWith([
+          requestTransformerFixture,
+        ]);
+      });
+
+      it('should call updateOwnReflectMetadata()', () => {
+        expect(updateOwnReflectMetadata).toHaveBeenCalledExactlyOnceWith(
+          targetFixture,
+          classMethodRequestTransformerMetadataReflectKey,
+          buildEmptyArrayMetadata,
+          callbackFixture,
+          methodKeyFixture,
+        );
+      });
+    });
+  });
+});

--- a/packages/framework/http/libraries/uwebsockets/src/decorators/UseRequestTransformers.ts
+++ b/packages/framework/http/libraries/uwebsockets/src/decorators/UseRequestTransformers.ts
@@ -1,0 +1,36 @@
+import {
+  buildArrayMetadataWithArray,
+  buildEmptyArrayMetadata,
+  updateOwnReflectMetadata,
+} from '@inversifyjs/reflect-metadata-utils';
+import { type HttpRequest, type HttpResponse } from 'uWebSockets.js';
+
+import { type RequestTransformer } from '../models/RequestTransformer.js';
+import { classMethodRequestTransformerMetadataReflectKey } from '../reflectMetadata/data/classMethodRequestTransformerMetadataReflectKey.js';
+import { classRequestTransformerMetadataReflectKey } from '../reflectMetadata/data/classRequestTransformerMetadataReflectKey.js';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function UseRequestTransformers(
+  ...requestTransformerList: RequestTransformer<HttpRequest, HttpResponse>[]
+): ClassDecorator & MethodDecorator {
+  return (target: object, key?: string | symbol): void => {
+    let classTarget: object;
+    let metadataKey: string | symbol;
+
+    if (key === undefined) {
+      classTarget = target;
+      metadataKey = classRequestTransformerMetadataReflectKey;
+    } else {
+      classTarget = target.constructor;
+      metadataKey = classMethodRequestTransformerMetadataReflectKey;
+    }
+
+    updateOwnReflectMetadata(
+      classTarget,
+      metadataKey,
+      buildEmptyArrayMetadata,
+      buildArrayMetadataWithArray(requestTransformerList),
+      key,
+    );
+  };
+}

--- a/packages/framework/http/libraries/uwebsockets/src/index.ts
+++ b/packages/framework/http/libraries/uwebsockets/src/index.ts
@@ -1,6 +1,8 @@
 export { pipeKnownSizeStreamOverResponse } from './actions/pipeKnownSizeStreamOverResponse.js';
 export { InversifyUwebSocketsHttpAdapter } from './adapter/InversifyUwebSocketsHttpAdapter.js';
+export { UseRequestTransformers } from './decorators/UseRequestTransformers.js';
 
+export type { RequestTransformer } from './models/RequestTransformer.js';
 export type { UwebSocketsErrorFilter } from './models/UwebSocketsErrorFilter.js';
 export type { UwebSocketsGuard } from './models/UwebSocketsGuard.js';
 export type { UwebSocketsHttpAdapterOptions } from './models/UwebSocketsHttpAdapterOptions.js';

--- a/packages/framework/http/libraries/uwebsockets/src/models/RequestTransformer.ts
+++ b/packages/framework/http/libraries/uwebsockets/src/models/RequestTransformer.ts
@@ -1,0 +1,7 @@
+import { type CustomParameterDecoratorHandlerOptions } from '@inversifyjs/http-core';
+
+export type RequestTransformer<TRequest, TResponse> = (
+  request: TRequest,
+  response: TResponse,
+  options: CustomParameterDecoratorHandlerOptions<TRequest, TResponse>,
+) => TRequest | Promise<TRequest>;

--- a/packages/framework/http/libraries/uwebsockets/src/reflectMetadata/data/classMethodRequestTransformerMetadataReflectKey.ts
+++ b/packages/framework/http/libraries/uwebsockets/src/reflectMetadata/data/classMethodRequestTransformerMetadataReflectKey.ts
@@ -1,0 +1,2 @@
+export const classMethodRequestTransformerMetadataReflectKey: string =
+  '@inversifyjs/http-uwebsockets/classMethodRequestTransformerMetadata';

--- a/packages/framework/http/libraries/uwebsockets/src/reflectMetadata/data/classRequestTransformerMetadataReflectKey.ts
+++ b/packages/framework/http/libraries/uwebsockets/src/reflectMetadata/data/classRequestTransformerMetadataReflectKey.ts
@@ -1,0 +1,2 @@
+export const classRequestTransformerMetadataReflectKey: string =
+  '@inversifyjs/http-uwebsockets/classRequestTransformerMetadata';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added request transformers for uWebSockets routes through class- and method-level decorators.
  - Transformers can run synchronously or asynchronously before middleware.
  - Transformer failures are routed through configured route error handling.
  - Exported the request-transformer decorator and type for application use.
- **Improvements**
  - Route metadata now identifies the controller target and method, improving route context and error handling.
- **Documentation**
  - Added release notes documenting required route metadata and request-transformer APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->