### PR TITLE
Add JSON Schema resolver

### DIFF
--- a/.changeset/green-papayas-divide.md
+++ b/.changeset/green-papayas-divide.md
@@ -1,0 +1,6 @@
+---
+"@inversifyjs/json-schema-utils": minor
+---
+
+- Added `JsonSchemaResolver`.
+- Updated `TraverseJsonSchemaCallback` with optional `TraverseJsonSchemaCallbackParamsResult`.

--- a/packages/json-schema/libraries/json-schema-utils/package.json
+++ b/packages/json-schema/libraries/json-schema-utils/package.json
@@ -5,11 +5,11 @@
   },
   "description": "InversifyJs JSON Schema utils package",
   "dependencies": {
+    "@inversifyjs/common": "workspace:*",
     "@inversifyjs/json-schema-pointer": "workspace:*",
     "@inversifyjs/uri": "workspace:*"
   },
   "devDependencies": {
-    "@inversifyjs/common": "workspace:*",
     "@inversifyjs/eslint-plugin-require-extensions": "workspace:*",
     "@inversifyjs/json-schema-types": "workspace:*",
     "@stryker-mutator/core": "9.6.1",

--- a/packages/json-schema/libraries/json-schema-utils/package.json
+++ b/packages/json-schema/libraries/json-schema-utils/package.json
@@ -5,9 +5,11 @@
   },
   "description": "InversifyJs JSON Schema utils package",
   "dependencies": {
-    "@inversifyjs/json-schema-pointer": "workspace:*"
+    "@inversifyjs/json-schema-pointer": "workspace:*",
+    "@inversifyjs/uri": "workspace:*"
   },
   "devDependencies": {
+    "@inversifyjs/common": "workspace:*",
     "@inversifyjs/eslint-plugin-require-extensions": "workspace:*",
     "@inversifyjs/json-schema-types": "workspace:*",
     "@stryker-mutator/core": "9.6.1",

--- a/packages/json-schema/libraries/json-schema-utils/src/common/models/SingleImmutableLinkedList.spec.ts
+++ b/packages/json-schema/libraries/json-schema-utils/src/common/models/SingleImmutableLinkedList.spec.ts
@@ -1,0 +1,59 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { SingleImmutableLinkedList } from './SingleImmutableLinkedList.js';
+
+describe(SingleImmutableLinkedList, () => {
+  let singleImmutableLinkedListFixture: SingleImmutableLinkedList<unknown>;
+
+  beforeAll(() => {
+    singleImmutableLinkedListFixture = new SingleImmutableLinkedList(
+      {
+        elem: Symbol(),
+        previous: undefined,
+      },
+      1,
+    );
+  });
+
+  describe('.concat', () => {
+    describe('when called', () => {
+      let elementFixture: unknown;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        elementFixture = Symbol();
+
+        result = singleImmutableLinkedListFixture.concat(elementFixture);
+      });
+
+      it('should return linked list', () => {
+        const expected: Partial<SingleImmutableLinkedList<unknown>> = {
+          last: {
+            elem: elementFixture,
+            previous: singleImmutableLinkedListFixture.last,
+          },
+          length: 2,
+        };
+
+        expect(result).toStrictEqual(expect.objectContaining(expected));
+      });
+    });
+  });
+
+  describe('[Symbol.iterator]', () => {
+    describe('when called', () => {
+      let result: Iterable<unknown>;
+
+      beforeAll(() => {
+        result = [...singleImmutableLinkedListFixture];
+      });
+
+      it('should return expected result', () => {
+        expect(result).toStrictEqual([
+          singleImmutableLinkedListFixture.last.elem,
+        ]);
+      });
+    });
+  });
+});

--- a/packages/json-schema/libraries/json-schema-utils/src/common/models/SingleImmutableLinkedList.ts
+++ b/packages/json-schema/libraries/json-schema-utils/src/common/models/SingleImmutableLinkedList.ts
@@ -1,0 +1,56 @@
+export interface SingleImmutableLinkedListNode<T> {
+  elem: T;
+  previous: SingleImmutableLinkedListNode<T> | undefined;
+}
+
+export class SingleImmutableLinkedList<T> implements Iterable<T> {
+  constructor(
+    public readonly last: SingleImmutableLinkedListNode<T>,
+    public readonly length: number = 1,
+  ) {}
+
+  public concat(elem: T): SingleImmutableLinkedList<T> {
+    return new SingleImmutableLinkedList(
+      {
+        elem,
+        previous: this.last,
+      },
+      this.length + 1,
+    );
+  }
+
+  public [Symbol.iterator](): Iterator<T> {
+    let node: SingleImmutableLinkedListNode<T> | undefined = this.last;
+
+    return {
+      next: (): IteratorResult<T> => {
+        if (node === undefined) {
+          return {
+            done: true,
+            value: undefined,
+          };
+        }
+
+        const elem: T = node.elem;
+        node = node.previous;
+
+        return {
+          done: false,
+          value: elem,
+        };
+      },
+    };
+  }
+
+  public toArray(): T[] {
+    const array: T[] = new Array<T>(this.length);
+
+    let currentIndex: number = this.length;
+
+    for (const elem of this) {
+      array[--currentIndex] = elem;
+    }
+
+    return array;
+  }
+}

--- a/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/actions/traverse.spec.ts
+++ b/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/actions/traverse.spec.ts
@@ -22,7 +22,7 @@ describe(traverse, () => {
   let callbackMock: Mock<TraverseJsonSchemaCallback>;
 
   beforeAll(() => {
-    callbackMock = vitest.fn().mockReturnValue({});
+    callbackMock = vitest.fn();
   });
 
   describe('when called', () => {
@@ -220,4 +220,136 @@ describe(traverse, () => {
       });
     },
   );
+
+  describe('having a schema with nested properties', () => {
+    let schemaFixture: JsonRootSchemaObject;
+    let nestedSchemaFixture: JsonSchema;
+    let descendantSchemaFixture: JsonSchema;
+
+    beforeAll(() => {
+      descendantSchemaFixture = {
+        type: 'string',
+      };
+      nestedSchemaFixture = {
+        properties: {
+          bar: descendantSchemaFixture,
+        },
+      };
+      schemaFixture = {
+        ...JsonRootSchemaFixtures.any,
+        properties: {
+          foo: nestedSchemaFixture,
+        },
+      };
+    });
+
+    describe('when called, and the root callback returns traverseChildren false', () => {
+      beforeAll(() => {
+        callbackMock.mockReturnValueOnce({
+          traverseChildren: false,
+        });
+
+        traverse({ schema: schemaFixture }, callbackMock);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call callback() with the schema', () => {
+        const expectedTraverseJsonSchemaCallbackParams: TraverseJsonSchemaCallbackParams =
+          {
+            jsonPointer: '',
+            rootSchema: schemaFixture,
+            schema: schemaFixture,
+          };
+
+        expect(callbackMock).toHaveBeenCalledTimes(1);
+        expect(callbackMock).toHaveBeenCalledWith(
+          expectedTraverseJsonSchemaCallbackParams,
+        );
+      });
+
+      it('should not call callback() with descendants', () => {
+        const expectedNestedTraverseJsonSchemaCallbackParams: TraverseJsonSchemaCallbackParams =
+          {
+            jsonPointer: '/properties/foo',
+            rootSchema: schemaFixture,
+            schema: nestedSchemaFixture,
+          };
+        const expectedDescendantTraverseJsonSchemaCallbackParams: TraverseJsonSchemaCallbackParams =
+          {
+            jsonPointer: '/properties/foo/properties/bar',
+            rootSchema: schemaFixture,
+            schema: descendantSchemaFixture,
+          };
+
+        expect(callbackMock).not.toHaveBeenCalledWith(
+          expectedNestedTraverseJsonSchemaCallbackParams,
+        );
+        expect(callbackMock).not.toHaveBeenCalledWith(
+          expectedDescendantTraverseJsonSchemaCallbackParams,
+        );
+      });
+    });
+
+    describe('when called, and a nested callback returns traverseChildren false', () => {
+      beforeAll(() => {
+        callbackMock.mockReturnValueOnce({
+          traverseChildren: true,
+        });
+        callbackMock.mockReturnValueOnce({
+          traverseChildren: false,
+        });
+
+        traverse({ schema: schemaFixture }, callbackMock);
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call callback() with the schema', () => {
+        const expectedTraverseJsonSchemaCallbackParams: TraverseJsonSchemaCallbackParams =
+          {
+            jsonPointer: '',
+            rootSchema: schemaFixture,
+            schema: schemaFixture,
+          };
+
+        expect(callbackMock).toHaveBeenNthCalledWith(
+          1,
+          expectedTraverseJsonSchemaCallbackParams,
+        );
+      });
+
+      it('should call callback() with the nested schema', () => {
+        const expectedTraverseJsonSchemaCallbackParams: TraverseJsonSchemaCallbackParams =
+          {
+            jsonPointer: '/properties/foo',
+            rootSchema: schemaFixture,
+            schema: nestedSchemaFixture,
+          };
+
+        expect(callbackMock).toHaveBeenCalledTimes(2);
+        expect(callbackMock).toHaveBeenNthCalledWith(
+          2,
+          expectedTraverseJsonSchemaCallbackParams,
+        );
+      });
+
+      it('should not call callback() with descendants of the nested schema', () => {
+        const expectedDescendantTraverseJsonSchemaCallbackParams: TraverseJsonSchemaCallbackParams =
+          {
+            jsonPointer: '/properties/foo/properties/bar',
+            rootSchema: schemaFixture,
+            schema: descendantSchemaFixture,
+          };
+
+        expect(callbackMock).not.toHaveBeenCalledWith(
+          expectedDescendantTraverseJsonSchemaCallbackParams,
+        );
+      });
+    });
+  });
 });

--- a/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/actions/traverse.spec.ts
+++ b/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/actions/traverse.spec.ts
@@ -14,14 +14,15 @@ import {
 } from '@inversifyjs/json-schema-types/2020-12';
 
 import { JsonRootSchemaFixtures } from '../fixtures/JsonRootSchemaFixtures.js';
+import { type TraverseJsonSchemaCallback } from '../models/TraverseJsonSchemaCallback.js';
 import { type TraverseJsonSchemaCallbackParams } from '../models/TraverseJsonSchemaCallbackParams.js';
 import { traverse } from './traverse.js';
 
 describe(traverse, () => {
-  let callbackMock: Mock<(params: TraverseJsonSchemaCallbackParams) => void>;
+  let callbackMock: Mock<TraverseJsonSchemaCallback>;
 
   beforeAll(() => {
-    callbackMock = vitest.fn();
+    callbackMock = vitest.fn().mockReturnValue({});
   });
 
   describe('when called', () => {

--- a/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/actions/traverse.ts
+++ b/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/actions/traverse.ts
@@ -7,7 +7,6 @@ import {
 
 import { type TraverseJsonSchemaCallback } from '../models/TraverseJsonSchemaCallback.js';
 import { type TraverseJsonSchemaCallbackParams } from '../models/TraverseJsonSchemaCallbackParams.js';
-import { type TraverseJsonSchemaCallbackParamsResult } from '../models/TraverseJsonSchemaCallbackParamsResult.js';
 import { type TraverseJsonSchemaParams } from '../models/TraverseJsonSchemaParams.js';
 
 type JsonRootSchemaSchemaProperty =
@@ -66,11 +65,11 @@ function traverseJsonSchemaFromParams(
   params: TraverseJsonSchemaCallbackParams,
   callback: TraverseJsonSchemaCallback,
 ): void {
-  const callbackResult: TraverseJsonSchemaCallbackParamsResult =
-    callback(params);
+  // eslint-disable-next-line @typescript-eslint/typedef
+  const callbackResult = callback(params);
 
   const shouldTraverseChildren: boolean =
-    callbackResult.traverseChildren ?? true;
+    callbackResult?.traverseChildren ?? true;
 
   if (
     shouldTraverseChildren &&

--- a/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/actions/traverse.ts
+++ b/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/actions/traverse.ts
@@ -5,6 +5,7 @@ import {
   type JsonSchema,
 } from '@inversifyjs/json-schema-types/2020-12';
 
+import { type TraverseJsonSchemaCallback } from '../models/TraverseJsonSchemaCallback.js';
 import { type TraverseJsonSchemaCallbackParams } from '../models/TraverseJsonSchemaCallbackParams.js';
 import { type TraverseJsonSchemaParams } from '../models/TraverseJsonSchemaParams.js';
 
@@ -15,7 +16,7 @@ type JsonRootSchemaSchemaPropertyHandler = (
   params: TraverseJsonSchemaCallbackParams,
   childSchema: JsonRootSchemaSchemaProperty,
   key: string,
-  callback: (params: TraverseJsonSchemaCallbackParams) => void,
+  callback: TraverseJsonSchemaCallback,
 ) => void;
 
 const jsonRootSchemaObjectPropertyToHandlerMap: {
@@ -23,7 +24,7 @@ const jsonRootSchemaObjectPropertyToHandlerMap: {
     params: TraverseJsonSchemaCallbackParams,
     childSchema: Exclude<JsonRootSchemaObject[TKey], undefined>,
     key: string,
-    callback: (params: TraverseJsonSchemaCallbackParams) => void,
+    callback: TraverseJsonSchemaCallback,
   ) => void;
 } = {
   $defs: traverseDirectChildSchemaMap,
@@ -48,7 +49,7 @@ const jsonRootSchemaObjectPropertyToHandlerMap: {
 
 export function traverse(
   params: TraverseJsonSchemaParams,
-  callback: (params: TraverseJsonSchemaCallbackParams) => void,
+  callback: TraverseJsonSchemaCallback,
 ): void {
   traverseJsonSchemaFromParams(
     {
@@ -62,11 +63,19 @@ export function traverse(
 
 function traverseJsonSchemaFromParams(
   params: TraverseJsonSchemaCallbackParams,
-  callback: (params: TraverseJsonSchemaCallbackParams) => void,
+  callback: TraverseJsonSchemaCallback,
 ): void {
-  callback(params);
+  // eslint-disable-next-line @typescript-eslint/typedef
+  const callbackResult = callback(params);
 
-  if (params.schema !== true && params.schema !== false) {
+  const shouldTraverseChildren: boolean =
+    callbackResult?.traverseChildren ?? true;
+
+  if (
+    shouldTraverseChildren &&
+    params.schema !== true &&
+    params.schema !== false
+  ) {
     for (const key of Object.keys(params.schema)) {
       const handler: JsonRootSchemaSchemaPropertyHandler | undefined =
         jsonRootSchemaObjectPropertyToHandlerMap[
@@ -89,7 +98,7 @@ function traverseDirectChildSchema(
   params: TraverseJsonSchemaCallbackParams,
   childSchema: JsonSchema,
   key: string,
-  callback: (params: TraverseJsonSchemaCallbackParams) => void,
+  callback: TraverseJsonSchemaCallback,
 ): void {
   const traverseChildSchemaCallbackParams: TraverseJsonSchemaCallbackParams = {
     jsonPointer: `${params.jsonPointer}/${escapeJsonPointerFragments(key)}`,
@@ -104,7 +113,7 @@ function traverseDirectChildSchemaArray(
   params: TraverseJsonSchemaCallbackParams,
   childSchemas: JsonSchema[],
   key: string,
-  callback: (params: TraverseJsonSchemaCallbackParams) => void,
+  callback: TraverseJsonSchemaCallback,
 ): void {
   for (const [index, schema] of childSchemas.entries()) {
     const traverseChildSchemaCallbackParams: TraverseJsonSchemaCallbackParams =
@@ -122,7 +131,7 @@ function traverseDirectChildSchemaMap(
   params: TraverseJsonSchemaCallbackParams,
   schemasMap: Record<string, JsonSchema>,
   key: string,
-  callback: (params: TraverseJsonSchemaCallbackParams) => void,
+  callback: TraverseJsonSchemaCallback,
 ): void {
   for (const [mapKey, schema] of Object.entries(schemasMap)) {
     const traverseChildSchemaCallbackParams: TraverseJsonSchemaCallbackParams =

--- a/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/actions/traverse.ts
+++ b/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/actions/traverse.ts
@@ -7,6 +7,7 @@ import {
 
 import { type TraverseJsonSchemaCallback } from '../models/TraverseJsonSchemaCallback.js';
 import { type TraverseJsonSchemaCallbackParams } from '../models/TraverseJsonSchemaCallbackParams.js';
+import { type TraverseJsonSchemaCallbackParamsResult } from '../models/TraverseJsonSchemaCallbackParamsResult.js';
 import { type TraverseJsonSchemaParams } from '../models/TraverseJsonSchemaParams.js';
 
 type JsonRootSchemaSchemaProperty =
@@ -65,11 +66,11 @@ function traverseJsonSchemaFromParams(
   params: TraverseJsonSchemaCallbackParams,
   callback: TraverseJsonSchemaCallback,
 ): void {
-  // eslint-disable-next-line @typescript-eslint/typedef
-  const callbackResult = callback(params);
+  const callbackResult: TraverseJsonSchemaCallbackParamsResult =
+    callback(params);
 
   const shouldTraverseChildren: boolean =
-    callbackResult?.traverseChildren ?? true;
+    callbackResult.traverseChildren ?? true;
 
   if (
     shouldTraverseChildren &&

--- a/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/index.ts
+++ b/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/index.ts
@@ -1,3 +1,13 @@
+export {
+  type DynamicScopeEntry,
+  type LexicalScope,
+  type ResolutionContext,
+  type ResolutionFailure,
+  type SchemaResolutionSuccessLinks,
+  type SchemaResolutionSuccessNode,
+  type SchemaResolutionSuccessTree,
+  JsonSchemaResolver,
+} from './services/JsonSchemaResolver.js';
 export { type TraverseJsonSchemaCallbackParams } from './models/TraverseJsonSchemaCallbackParams.js';
 export { type TraverseJsonSchemaParams } from './models/TraverseJsonSchemaParams.js';
 

--- a/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/models/TraverseJsonSchemaCallback.ts
+++ b/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/models/TraverseJsonSchemaCallback.ts
@@ -1,6 +1,8 @@
 import { type TraverseJsonSchemaCallbackParams } from './TraverseJsonSchemaCallbackParams.js';
 import { type TraverseJsonSchemaCallbackParamsResult } from './TraverseJsonSchemaCallbackParamsResult.js';
 
-export type TraverseJsonSchemaCallback = (
-  params: TraverseJsonSchemaCallbackParams,
-) => TraverseJsonSchemaCallbackParamsResult;
+export type TraverseJsonSchemaCallback =
+  | ((params: TraverseJsonSchemaCallbackParams) => void)
+  | ((
+      params: TraverseJsonSchemaCallbackParams,
+    ) => TraverseJsonSchemaCallbackParamsResult);

--- a/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/models/TraverseJsonSchemaCallback.ts
+++ b/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/models/TraverseJsonSchemaCallback.ts
@@ -1,0 +1,8 @@
+import { type TraverseJsonSchemaCallbackParams } from './TraverseJsonSchemaCallbackParams.js';
+import { type TraverseJsonSchemaCallbackParamsResult } from './TraverseJsonSchemaCallbackParamsResult.js';
+
+export type TraverseJsonSchemaCallback =
+  | ((params: TraverseJsonSchemaCallbackParams) => void)
+  | ((
+      params: TraverseJsonSchemaCallbackParams,
+    ) => TraverseJsonSchemaCallbackParamsResult);

--- a/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/models/TraverseJsonSchemaCallback.ts
+++ b/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/models/TraverseJsonSchemaCallback.ts
@@ -1,8 +1,6 @@
 import { type TraverseJsonSchemaCallbackParams } from './TraverseJsonSchemaCallbackParams.js';
 import { type TraverseJsonSchemaCallbackParamsResult } from './TraverseJsonSchemaCallbackParamsResult.js';
 
-export type TraverseJsonSchemaCallback =
-  | ((params: TraverseJsonSchemaCallbackParams) => void)
-  | ((
-      params: TraverseJsonSchemaCallbackParams,
-    ) => TraverseJsonSchemaCallbackParamsResult);
+export type TraverseJsonSchemaCallback = (
+  params: TraverseJsonSchemaCallbackParams,
+) => TraverseJsonSchemaCallbackParamsResult;

--- a/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/models/TraverseJsonSchemaCallbackParamsResult.ts
+++ b/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/models/TraverseJsonSchemaCallbackParamsResult.ts
@@ -1,0 +1,3 @@
+export interface TraverseJsonSchemaCallbackParamsResult {
+  traverseChildren?: boolean;
+}

--- a/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/services/JsonSchemaResolver.int.spec.ts
+++ b/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/services/JsonSchemaResolver.int.spec.ts
@@ -1,0 +1,1421 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { type Either } from '@inversifyjs/common';
+import {
+  type JsonSchema,
+  type JsonSchemaObject,
+} from '@inversifyjs/json-schema-types/2020-12';
+import { Uri } from '@inversifyjs/uri';
+
+import { SingleImmutableLinkedList } from '../../../common/models/SingleImmutableLinkedList.js';
+import {
+  type DynamicScopeEntry,
+  JsonSchemaResolver,
+  type ResolutionFailure,
+  type SchemaResolutionSuccessTree,
+} from './JsonSchemaResolver.js';
+
+function buildDynamicScopeEntries(
+  first: DynamicScopeEntry,
+  ...rest: DynamicScopeEntry[]
+): SingleImmutableLinkedList<DynamicScopeEntry> {
+  let dynamicScopeEntries: SingleImmutableLinkedList<DynamicScopeEntry> =
+    new SingleImmutableLinkedList({
+      elem: first,
+      previous: undefined,
+    });
+
+  for (const dynamicScopeEntry of rest) {
+    dynamicScopeEntries = dynamicScopeEntries.concat(dynamicScopeEntry);
+  }
+
+  return dynamicScopeEntries;
+}
+
+describe(JsonSchemaResolver, () => {
+  describe('.resolveSchema', () => {
+    describe('having a boolean schema', () => {
+      let jsonSchemaResolver: JsonSchemaResolver;
+      let schemaFixture: JsonSchema;
+
+      beforeAll(() => {
+        schemaFixture = true;
+
+        jsonSchemaResolver = new JsonSchemaResolver(() => undefined);
+      });
+
+      describe('when called', () => {
+        let result: Either<ResolutionFailure, SchemaResolutionSuccessTree>;
+
+        beforeAll(() => {
+          result = jsonSchemaResolver.resolveSchema(schemaFixture);
+        });
+
+        it('should return an empty resolution tree', () => {
+          const expected: Either<
+            ResolutionFailure,
+            SchemaResolutionSuccessTree
+          > = {
+            isRight: true,
+            value: {
+              $dynamicRef: undefined,
+              $ref: undefined,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a schema object with no $ref or $dynamicRef', () => {
+      let jsonSchemaResolver: JsonSchemaResolver;
+      let schemaFixture: JsonSchemaObject;
+      let schemaIdFixture: string;
+
+      beforeAll(() => {
+        schemaIdFixture = 'https://example.com/schema.json';
+        schemaFixture = {
+          $id: schemaIdFixture,
+          type: 'object',
+        };
+
+        const schemaById: Map<string, JsonSchema> = new Map([
+          [schemaIdFixture, schemaFixture],
+        ]);
+
+        jsonSchemaResolver = new JsonSchemaResolver((id: string) =>
+          schemaById.get(id),
+        );
+      });
+
+      describe('when called', () => {
+        let result: Either<ResolutionFailure, SchemaResolutionSuccessTree>;
+
+        beforeAll(() => {
+          result = jsonSchemaResolver.resolveSchema(schemaFixture);
+        });
+
+        it('should return an empty resolution tree', () => {
+          const expected: Either<
+            ResolutionFailure,
+            SchemaResolutionSuccessTree
+          > = {
+            isRight: true,
+            value: {
+              $dynamicRef: undefined,
+              $ref: undefined,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a schema with a relative $ref to another resource', () => {
+      let jsonSchemaResolver: JsonSchemaResolver;
+      let otherSchemaFixture: JsonSchemaObject;
+      let otherSchemaIdFixture: string;
+      let schemaFixture: JsonSchemaObject;
+      let schemaIdFixture: string;
+
+      beforeAll(() => {
+        schemaIdFixture = 'https://example.com/schema.json';
+        otherSchemaIdFixture = 'https://example.com/other.json';
+        otherSchemaFixture = {
+          $id: otherSchemaIdFixture,
+          type: 'string',
+        };
+        schemaFixture = {
+          $id: schemaIdFixture,
+          $ref: 'other.json',
+          type: 'object',
+        };
+
+        const schemaById: Map<string, JsonSchema> = new Map([
+          [otherSchemaIdFixture, otherSchemaFixture],
+          [schemaIdFixture, schemaFixture],
+        ]);
+
+        jsonSchemaResolver = new JsonSchemaResolver((id: string) =>
+          schemaById.get(id),
+        );
+      });
+
+      describe('when called', () => {
+        let result: Either<ResolutionFailure, SchemaResolutionSuccessTree>;
+
+        beforeAll(() => {
+          result = jsonSchemaResolver.resolveSchema(schemaFixture);
+        });
+
+        it('should return a tree with the referenced resource', () => {
+          const expected: Either<
+            ResolutionFailure,
+            SchemaResolutionSuccessTree
+          > = {
+            isRight: true,
+            value: {
+              $dynamicRef: undefined,
+              $ref: {
+                $dynamicRef: undefined,
+                $ref: undefined,
+                dynamicScopeEntries: buildDynamicScopeEntries(
+                  {
+                    lexicalScope: {
+                      $canonicalId: new Uri(schemaIdFixture),
+                    },
+                    resolutionContext: {
+                      $ref: schemaIdFixture,
+                      isDynamic: false,
+                    },
+                  },
+                  {
+                    lexicalScope: {
+                      $canonicalId: new Uri(otherSchemaIdFixture),
+                    },
+                    resolutionContext: {
+                      $ref: 'other.json',
+                      isDynamic: false,
+                    },
+                  },
+                ),
+                value: otherSchemaFixture,
+              },
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a schema with a JSON Pointer $ref to a $defs subschema', () => {
+      let jsonSchemaResolver: JsonSchemaResolver;
+      let schemaFixture: JsonSchemaObject;
+      let schemaIdFixture: string;
+      let subschemaFixture: JsonSchemaObject;
+
+      beforeAll(() => {
+        schemaIdFixture = 'https://example.com/schema.json';
+        subschemaFixture = {
+          exclusiveMinimum: 0,
+          type: 'integer',
+        };
+        schemaFixture = {
+          $defs: {
+            positiveInteger: subschemaFixture,
+          },
+          $id: schemaIdFixture,
+          $ref: '#/$defs/positiveInteger',
+        };
+
+        const schemaById: Map<string, JsonSchema> = new Map([
+          [schemaIdFixture, schemaFixture],
+        ]);
+
+        jsonSchemaResolver = new JsonSchemaResolver((id: string) =>
+          schemaById.get(id),
+        );
+      });
+
+      describe('when called', () => {
+        let result: Either<ResolutionFailure, SchemaResolutionSuccessTree>;
+
+        beforeAll(() => {
+          result = jsonSchemaResolver.resolveSchema(schemaFixture);
+        });
+
+        it('should return a tree with the referenced subschema', () => {
+          const expected: Either<
+            ResolutionFailure,
+            SchemaResolutionSuccessTree
+          > = {
+            isRight: true,
+            value: {
+              $dynamicRef: undefined,
+              $ref: {
+                $dynamicRef: undefined,
+                $ref: undefined,
+                dynamicScopeEntries: buildDynamicScopeEntries(
+                  {
+                    lexicalScope: {
+                      $canonicalId: new Uri(schemaIdFixture),
+                    },
+                    resolutionContext: {
+                      $ref: schemaIdFixture,
+                      isDynamic: false,
+                    },
+                  },
+                  {
+                    lexicalScope: {
+                      $canonicalId: new Uri(schemaIdFixture),
+                    },
+                    resolutionContext: {
+                      $ref: '#/$defs/positiveInteger',
+                      isDynamic: false,
+                    },
+                  },
+                ),
+                value: subschemaFixture,
+              },
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a schema with a $ref only inside properties', () => {
+      let jsonSchemaResolver: JsonSchemaResolver;
+      let otherSchemaFixture: JsonSchemaObject;
+      let otherSchemaIdFixture: string;
+      let schemaFixture: JsonSchemaObject;
+      let schemaIdFixture: string;
+
+      beforeAll(() => {
+        schemaIdFixture = 'https://example.com/schema.json';
+        otherSchemaIdFixture = 'https://example.com/other.json';
+        otherSchemaFixture = {
+          $id: otherSchemaIdFixture,
+          type: 'string',
+        };
+        schemaFixture = {
+          $id: schemaIdFixture,
+          properties: {
+            foo: {
+              $ref: 'other.json',
+            },
+          },
+          type: 'object',
+        };
+
+        const schemaById: Map<string, JsonSchema> = new Map([
+          [otherSchemaIdFixture, otherSchemaFixture],
+          [schemaIdFixture, schemaFixture],
+        ]);
+
+        jsonSchemaResolver = new JsonSchemaResolver((id: string) =>
+          schemaById.get(id),
+        );
+      });
+
+      describe('when called', () => {
+        let result: Either<ResolutionFailure, SchemaResolutionSuccessTree>;
+
+        beforeAll(() => {
+          result = jsonSchemaResolver.resolveSchema(schemaFixture);
+        });
+
+        it('should return an empty resolution tree', () => {
+          const expected: Either<
+            ResolutionFailure,
+            SchemaResolutionSuccessTree
+          > = {
+            isRight: true,
+            value: {
+              $dynamicRef: undefined,
+              $ref: undefined,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a schema with a $ref to itself', () => {
+      let jsonSchemaResolver: JsonSchemaResolver;
+      let schemaFixture: JsonSchemaObject;
+      let schemaIdFixture: string;
+
+      beforeAll(() => {
+        schemaIdFixture = 'https://example.com/node.json';
+        schemaFixture = {
+          $id: schemaIdFixture,
+          $ref: '#',
+        };
+
+        const schemaById: Map<string, JsonSchema> = new Map([
+          [schemaIdFixture, schemaFixture],
+        ]);
+
+        jsonSchemaResolver = new JsonSchemaResolver((id: string) =>
+          schemaById.get(id),
+        );
+      });
+
+      describe('when called', () => {
+        let result: Either<ResolutionFailure, SchemaResolutionSuccessTree>;
+
+        beforeAll(() => {
+          result = jsonSchemaResolver.resolveSchema(schemaFixture);
+        });
+
+        it('should return a tree with a single self-reference hop', () => {
+          const expected: Either<
+            ResolutionFailure,
+            SchemaResolutionSuccessTree
+          > = {
+            isRight: true,
+            value: {
+              $dynamicRef: undefined,
+              $ref: {
+                $dynamicRef: undefined,
+                $ref: undefined,
+                dynamicScopeEntries: buildDynamicScopeEntries(
+                  {
+                    lexicalScope: {
+                      $canonicalId: new Uri(schemaIdFixture),
+                    },
+                    resolutionContext: {
+                      $ref: schemaIdFixture,
+                      isDynamic: false,
+                    },
+                  },
+                  {
+                    lexicalScope: {
+                      $canonicalId: new Uri(schemaIdFixture),
+                    },
+                    resolutionContext: {
+                      $ref: '#',
+                      isDynamic: false,
+                    },
+                  },
+                ),
+                value: schemaFixture,
+              },
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a schema with a $ref to a missing resource', () => {
+      let jsonSchemaResolver: JsonSchemaResolver;
+      let missingSchemaIdFixture: string;
+      let schemaFixture: JsonSchemaObject;
+      let schemaIdFixture: string;
+
+      beforeAll(() => {
+        schemaIdFixture = 'https://example.com/schema.json';
+        missingSchemaIdFixture = 'https://example.com/missing.json';
+        schemaFixture = {
+          $id: schemaIdFixture,
+          $ref: missingSchemaIdFixture,
+        };
+
+        const schemaById: Map<string, JsonSchema> = new Map([
+          [schemaIdFixture, schemaFixture],
+        ]);
+
+        jsonSchemaResolver = new JsonSchemaResolver((id: string) =>
+          schemaById.get(id),
+        );
+      });
+
+      describe('when called', () => {
+        let result: Either<ResolutionFailure, SchemaResolutionSuccessTree>;
+
+        beforeAll(() => {
+          result = jsonSchemaResolver.resolveSchema(schemaFixture);
+        });
+
+        it('should return a resolution failure', () => {
+          const expected: Either<
+            ResolutionFailure,
+            SchemaResolutionSuccessTree
+          > = {
+            isRight: false,
+            value: {
+              reason: `Failed to resolve resource identified by: ${missingSchemaIdFixture}`,
+              resolutionContextStack: [
+                {
+                  $ref: schemaIdFixture,
+                  isDynamic: false,
+                },
+                {
+                  $ref: missingSchemaIdFixture,
+                  isDynamic: false,
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a schema with a $ref chain through two other resources', () => {
+      let aSchemaFixture: JsonSchemaObject;
+      let aSchemaIdFixture: string;
+      let bSchemaFixture: JsonSchemaObject;
+      let bSchemaIdFixture: string;
+      let cSchemaFixture: JsonSchemaObject;
+      let cSchemaIdFixture: string;
+      let jsonSchemaResolver: JsonSchemaResolver;
+
+      beforeAll(() => {
+        aSchemaIdFixture = 'https://example.com/a.json';
+        bSchemaIdFixture = 'https://example.com/b.json';
+        cSchemaIdFixture = 'https://example.com/c.json';
+        cSchemaFixture = {
+          $id: cSchemaIdFixture,
+          type: 'string',
+        };
+        bSchemaFixture = {
+          $id: bSchemaIdFixture,
+          $ref: 'c.json',
+        };
+        aSchemaFixture = {
+          $id: aSchemaIdFixture,
+          $ref: 'b.json',
+        };
+
+        const schemaById: Map<string, JsonSchema> = new Map([
+          [aSchemaIdFixture, aSchemaFixture],
+          [bSchemaIdFixture, bSchemaFixture],
+          [cSchemaIdFixture, cSchemaFixture],
+        ]);
+
+        jsonSchemaResolver = new JsonSchemaResolver((id: string) =>
+          schemaById.get(id),
+        );
+      });
+
+      describe('when called', () => {
+        let result: Either<ResolutionFailure, SchemaResolutionSuccessTree>;
+
+        beforeAll(() => {
+          result = jsonSchemaResolver.resolveSchema(aSchemaFixture);
+        });
+
+        it('should return a tree with each referenced resource', () => {
+          const aOriginEntry: DynamicScopeEntry = {
+            lexicalScope: {
+              $canonicalId: new Uri(aSchemaIdFixture),
+            },
+            resolutionContext: {
+              $ref: aSchemaIdFixture,
+              isDynamic: false,
+            },
+          };
+          const bHopEntry: DynamicScopeEntry = {
+            lexicalScope: {
+              $canonicalId: new Uri(bSchemaIdFixture),
+            },
+            resolutionContext: {
+              $ref: 'b.json',
+              isDynamic: false,
+            },
+          };
+          const cHopEntry: DynamicScopeEntry = {
+            lexicalScope: {
+              $canonicalId: new Uri(cSchemaIdFixture),
+            },
+            resolutionContext: {
+              $ref: 'c.json',
+              isDynamic: false,
+            },
+          };
+
+          const expected: Either<
+            ResolutionFailure,
+            SchemaResolutionSuccessTree
+          > = {
+            isRight: true,
+            value: {
+              $dynamicRef: undefined,
+              $ref: {
+                $dynamicRef: undefined,
+                $ref: {
+                  $dynamicRef: undefined,
+                  $ref: undefined,
+                  dynamicScopeEntries: buildDynamicScopeEntries(
+                    aOriginEntry,
+                    bHopEntry,
+                    cHopEntry,
+                  ),
+                  value: cSchemaFixture,
+                },
+                dynamicScopeEntries: buildDynamicScopeEntries(
+                  aOriginEntry,
+                  bHopEntry,
+                ),
+                value: bSchemaFixture,
+              },
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a schema with a cyclic $ref through another resource', () => {
+      let aSchemaFixture: JsonSchemaObject;
+      let aSchemaIdFixture: string;
+      let bSchemaFixture: JsonSchemaObject;
+      let bSchemaIdFixture: string;
+      let jsonSchemaResolver: JsonSchemaResolver;
+
+      beforeAll(() => {
+        aSchemaIdFixture = 'https://example.com/a.json';
+        bSchemaIdFixture = 'https://example.com/b.json';
+        aSchemaFixture = {
+          $id: aSchemaIdFixture,
+          $ref: 'b.json',
+        };
+        bSchemaFixture = {
+          $id: bSchemaIdFixture,
+          $ref: 'a.json',
+        };
+
+        const schemaById: Map<string, JsonSchema> = new Map([
+          [aSchemaIdFixture, aSchemaFixture],
+          [bSchemaIdFixture, bSchemaFixture],
+        ]);
+
+        jsonSchemaResolver = new JsonSchemaResolver((id: string) =>
+          schemaById.get(id),
+        );
+      });
+
+      describe('when called', () => {
+        let result: Either<ResolutionFailure, SchemaResolutionSuccessTree>;
+
+        beforeAll(() => {
+          result = jsonSchemaResolver.resolveSchema(aSchemaFixture);
+        });
+
+        it('should return a tree that records the cycle hop without expanding it again', () => {
+          const aOriginEntry: DynamicScopeEntry = {
+            lexicalScope: {
+              $canonicalId: new Uri(aSchemaIdFixture),
+            },
+            resolutionContext: {
+              $ref: aSchemaIdFixture,
+              isDynamic: false,
+            },
+          };
+          const bHopEntry: DynamicScopeEntry = {
+            lexicalScope: {
+              $canonicalId: new Uri(bSchemaIdFixture),
+            },
+            resolutionContext: {
+              $ref: 'b.json',
+              isDynamic: false,
+            },
+          };
+          const aHopEntry: DynamicScopeEntry = {
+            lexicalScope: {
+              $canonicalId: new Uri(aSchemaIdFixture),
+            },
+            resolutionContext: {
+              $ref: 'a.json',
+              isDynamic: false,
+            },
+          };
+
+          const expected: Either<
+            ResolutionFailure,
+            SchemaResolutionSuccessTree
+          > = {
+            isRight: true,
+            value: {
+              $dynamicRef: undefined,
+              $ref: {
+                $dynamicRef: undefined,
+                $ref: {
+                  $dynamicRef: undefined,
+                  $ref: undefined,
+                  dynamicScopeEntries: buildDynamicScopeEntries(
+                    aOriginEntry,
+                    bHopEntry,
+                    aHopEntry,
+                  ),
+                  value: aSchemaFixture,
+                },
+                dynamicScopeEntries: buildDynamicScopeEntries(
+                  aOriginEntry,
+                  bHopEntry,
+                ),
+                value: bSchemaFixture,
+              },
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a schema with a $dynamicRef to a $dynamicAnchor also defined on the root', () => {
+      let jsonSchemaResolver: JsonSchemaResolver;
+      let strictTreeFixture: JsonSchemaObject;
+      let strictTreeIdFixture: string;
+      let treeFixture: JsonSchemaObject;
+      let treeIdFixture: string;
+
+      beforeAll(() => {
+        treeIdFixture = 'https://example.com/tree';
+        strictTreeIdFixture = 'https://example.com/strict-tree';
+        treeFixture = {
+          $dynamicAnchor: 'node',
+          $id: treeIdFixture,
+          type: 'object',
+        };
+        strictTreeFixture = {
+          $dynamicAnchor: 'node',
+          $dynamicRef: 'tree#node',
+          $id: strictTreeIdFixture,
+        };
+
+        const schemaById: Map<string, JsonSchema> = new Map([
+          [strictTreeIdFixture, strictTreeFixture],
+          [treeIdFixture, treeFixture],
+        ]);
+
+        jsonSchemaResolver = new JsonSchemaResolver((id: string) =>
+          schemaById.get(id),
+        );
+      });
+
+      describe('when called', () => {
+        let result: Either<ResolutionFailure, SchemaResolutionSuccessTree>;
+
+        beforeAll(() => {
+          result = jsonSchemaResolver.resolveSchema(strictTreeFixture);
+        });
+
+        it('should return a tree retargeted to the outermost $dynamicAnchor', () => {
+          const expected: Either<
+            ResolutionFailure,
+            SchemaResolutionSuccessTree
+          > = {
+            isRight: true,
+            value: {
+              $dynamicRef: {
+                $dynamicRef: undefined,
+                $ref: undefined,
+                dynamicScopeEntries: buildDynamicScopeEntries(
+                  {
+                    lexicalScope: {
+                      $canonicalId: new Uri(strictTreeIdFixture),
+                    },
+                    resolutionContext: {
+                      $ref: strictTreeIdFixture,
+                      isDynamic: true,
+                    },
+                  },
+                  {
+                    lexicalScope: {
+                      $canonicalId: new Uri(treeIdFixture),
+                    },
+                    resolutionContext: {
+                      $ref: 'tree#node',
+                      isDynamic: true,
+                    },
+                  },
+                  {
+                    lexicalScope: {
+                      $canonicalId: new Uri(strictTreeIdFixture),
+                    },
+                    resolutionContext: {
+                      $ref: 'tree#node',
+                      isDynamic: true,
+                    },
+                  },
+                ),
+                value: strictTreeFixture,
+              },
+              $ref: undefined,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a schema with sibling $ref and $dynamicRef', () => {
+      let dynamicTargetFixture: JsonSchemaObject;
+      let dynamicTargetIdFixture: string;
+      let jsonSchemaResolver: JsonSchemaResolver;
+      let refTargetFixture: JsonSchemaObject;
+      let refTargetIdFixture: string;
+      let schemaFixture: JsonSchemaObject;
+      let schemaIdFixture: string;
+
+      beforeAll(() => {
+        schemaIdFixture = 'https://example.com/root.json';
+        refTargetIdFixture = 'https://example.com/ref-target.json';
+        dynamicTargetIdFixture = 'https://example.com/dynamic-target.json';
+        refTargetFixture = {
+          $id: refTargetIdFixture,
+          type: 'string',
+        };
+        dynamicTargetFixture = {
+          $id: dynamicTargetIdFixture,
+          type: 'number',
+        };
+        schemaFixture = {
+          $dynamicRef: 'dynamic-target.json',
+          $id: schemaIdFixture,
+          $ref: 'ref-target.json',
+        };
+
+        const schemaById: Map<string, JsonSchema> = new Map([
+          [dynamicTargetIdFixture, dynamicTargetFixture],
+          [refTargetIdFixture, refTargetFixture],
+          [schemaIdFixture, schemaFixture],
+        ]);
+
+        jsonSchemaResolver = new JsonSchemaResolver((id: string) =>
+          schemaById.get(id),
+        );
+      });
+
+      describe('when called', () => {
+        let result: Either<ResolutionFailure, SchemaResolutionSuccessTree>;
+
+        beforeAll(() => {
+          result = jsonSchemaResolver.resolveSchema(schemaFixture);
+        });
+
+        it('should return a tree with independent $ref and $dynamicRef branches', () => {
+          const expected: Either<
+            ResolutionFailure,
+            SchemaResolutionSuccessTree
+          > = {
+            isRight: true,
+            value: {
+              $dynamicRef: {
+                $dynamicRef: undefined,
+                $ref: undefined,
+                dynamicScopeEntries: buildDynamicScopeEntries(
+                  {
+                    lexicalScope: {
+                      $canonicalId: new Uri(schemaIdFixture),
+                    },
+                    resolutionContext: {
+                      $ref: schemaIdFixture,
+                      isDynamic: true,
+                    },
+                  },
+                  {
+                    lexicalScope: {
+                      $canonicalId: new Uri(dynamicTargetIdFixture),
+                    },
+                    resolutionContext: {
+                      $ref: 'dynamic-target.json',
+                      isDynamic: true,
+                    },
+                  },
+                ),
+                value: dynamicTargetFixture,
+              },
+              $ref: {
+                $dynamicRef: undefined,
+                $ref: undefined,
+                dynamicScopeEntries: buildDynamicScopeEntries(
+                  {
+                    lexicalScope: {
+                      $canonicalId: new Uri(schemaIdFixture),
+                    },
+                    resolutionContext: {
+                      $ref: schemaIdFixture,
+                      isDynamic: false,
+                    },
+                  },
+                  {
+                    lexicalScope: {
+                      $canonicalId: new Uri(refTargetIdFixture),
+                    },
+                    resolutionContext: {
+                      $ref: 'ref-target.json',
+                      isDynamic: false,
+                    },
+                  },
+                ),
+                value: refTargetFixture,
+              },
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a schema with a JSON Pointer $ref to a nested $id that itself has a relative $ref', () => {
+      let barSchemaFixture: JsonSchemaObject;
+      let barSchemaIdFixture: string;
+      let fooSchemaFixture: JsonSchemaObject;
+      let fooSchemaIdFixture: string;
+      let jsonSchemaResolver: JsonSchemaResolver;
+      let schemaFixture: JsonSchemaObject;
+      let schemaIdFixture: string;
+
+      beforeAll(() => {
+        schemaIdFixture = 'https://example.com/schema.json';
+        fooSchemaIdFixture = 'https://example.com/foo.json';
+        barSchemaIdFixture = 'https://example.com/bar.json';
+        barSchemaFixture = {
+          $id: barSchemaIdFixture,
+          type: 'boolean',
+        };
+        fooSchemaFixture = {
+          $id: fooSchemaIdFixture,
+          $ref: 'bar.json',
+        };
+        schemaFixture = {
+          $id: schemaIdFixture,
+          $ref: '#/properties/foo',
+          properties: {
+            foo: fooSchemaFixture,
+          },
+        };
+
+        const schemaById: Map<string, JsonSchema> = new Map([
+          [barSchemaIdFixture, barSchemaFixture],
+          [fooSchemaIdFixture, fooSchemaFixture],
+          [schemaIdFixture, schemaFixture],
+        ]);
+
+        jsonSchemaResolver = new JsonSchemaResolver((id: string) =>
+          schemaById.get(id),
+        );
+      });
+
+      describe('when called', () => {
+        let result: Either<ResolutionFailure, SchemaResolutionSuccessTree>;
+
+        beforeAll(() => {
+          result = jsonSchemaResolver.resolveSchema(schemaFixture);
+        });
+
+        it('should resolve the nested $ref against the nested resource base URI', () => {
+          const originEntry: DynamicScopeEntry = {
+            lexicalScope: {
+              $canonicalId: new Uri(schemaIdFixture),
+            },
+            resolutionContext: {
+              $ref: schemaIdFixture,
+              isDynamic: false,
+            },
+          };
+          const nestedIdEntry: DynamicScopeEntry = {
+            lexicalScope: {
+              $canonicalId: new Uri(fooSchemaIdFixture),
+            },
+            resolutionContext: {
+              $ref: '#/properties/foo',
+              isDynamic: false,
+            },
+          };
+          const barHopEntry: DynamicScopeEntry = {
+            lexicalScope: {
+              $canonicalId: new Uri(barSchemaIdFixture),
+            },
+            resolutionContext: {
+              $ref: 'bar.json',
+              isDynamic: false,
+            },
+          };
+
+          const expected: Either<
+            ResolutionFailure,
+            SchemaResolutionSuccessTree
+          > = {
+            isRight: true,
+            value: {
+              $dynamicRef: undefined,
+              $ref: {
+                $dynamicRef: undefined,
+                $ref: {
+                  $dynamicRef: undefined,
+                  $ref: undefined,
+                  dynamicScopeEntries: buildDynamicScopeEntries(
+                    originEntry,
+                    nestedIdEntry,
+                    barHopEntry,
+                  ),
+                  value: barSchemaFixture,
+                },
+                dynamicScopeEntries: buildDynamicScopeEntries(
+                  originEntry,
+                  nestedIdEntry,
+                ),
+                value: fooSchemaFixture,
+              },
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a schema with a $ref to an $anchor fragment', () => {
+      let jsonSchemaResolver: JsonSchemaResolver;
+      let schemaFixture: JsonSchemaObject;
+      let schemaIdFixture: string;
+      let subschemaFixture: JsonSchemaObject;
+
+      beforeAll(() => {
+        schemaIdFixture = 'https://example.com/schema.json';
+        subschemaFixture = {
+          $anchor: 'item',
+          type: 'object',
+        };
+        schemaFixture = {
+          $defs: {
+            single: subschemaFixture,
+          },
+          $id: schemaIdFixture,
+          $ref: '#item',
+        };
+
+        const schemaById: Map<string, JsonSchema> = new Map([
+          [schemaIdFixture, schemaFixture],
+        ]);
+
+        jsonSchemaResolver = new JsonSchemaResolver((id: string) =>
+          schemaById.get(id),
+        );
+      });
+
+      describe('when called', () => {
+        let result: Either<ResolutionFailure, SchemaResolutionSuccessTree>;
+
+        beforeAll(() => {
+          result = jsonSchemaResolver.resolveSchema(schemaFixture);
+        });
+
+        it('should return a tree with the node identified by the $anchor', () => {
+          const expected: Either<
+            ResolutionFailure,
+            SchemaResolutionSuccessTree
+          > = {
+            isRight: true,
+            value: {
+              $dynamicRef: undefined,
+              $ref: {
+                $dynamicRef: undefined,
+                $ref: undefined,
+                dynamicScopeEntries: buildDynamicScopeEntries(
+                  {
+                    lexicalScope: {
+                      $canonicalId: new Uri(schemaIdFixture),
+                    },
+                    resolutionContext: {
+                      $ref: schemaIdFixture,
+                      isDynamic: false,
+                    },
+                  },
+                  {
+                    lexicalScope: {
+                      $canonicalId: new Uri(schemaIdFixture),
+                    },
+                    resolutionContext: {
+                      $ref: '#item',
+                      isDynamic: false,
+                    },
+                  },
+                ),
+                value: subschemaFixture,
+              },
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a schema with a $ref to a $dynamicAnchor fragment', () => {
+      let jsonSchemaResolver: JsonSchemaResolver;
+      let schemaFixture: JsonSchemaObject;
+      let schemaIdFixture: string;
+      let subschemaFixture: JsonSchemaObject;
+
+      beforeAll(() => {
+        schemaIdFixture = 'https://example.com/schema.json';
+        subschemaFixture = {
+          $dynamicAnchor: 'node',
+          type: 'object',
+        };
+        schemaFixture = {
+          $defs: {
+            node: subschemaFixture,
+          },
+          $id: schemaIdFixture,
+          $ref: '#node',
+        };
+
+        const schemaById: Map<string, JsonSchema> = new Map([
+          [schemaIdFixture, schemaFixture],
+        ]);
+
+        jsonSchemaResolver = new JsonSchemaResolver((id: string) =>
+          schemaById.get(id),
+        );
+      });
+
+      describe('when called', () => {
+        let result: Either<ResolutionFailure, SchemaResolutionSuccessTree>;
+
+        beforeAll(() => {
+          result = jsonSchemaResolver.resolveSchema(schemaFixture);
+        });
+
+        it('should return a tree with the node identified by the $dynamicAnchor', () => {
+          const expected: Either<
+            ResolutionFailure,
+            SchemaResolutionSuccessTree
+          > = {
+            isRight: true,
+            value: {
+              $dynamicRef: undefined,
+              $ref: {
+                $dynamicRef: undefined,
+                $ref: undefined,
+                dynamicScopeEntries: buildDynamicScopeEntries(
+                  {
+                    lexicalScope: {
+                      $canonicalId: new Uri(schemaIdFixture),
+                    },
+                    resolutionContext: {
+                      $ref: schemaIdFixture,
+                      isDynamic: false,
+                    },
+                  },
+                  {
+                    lexicalScope: {
+                      $canonicalId: new Uri(schemaIdFixture),
+                    },
+                    resolutionContext: {
+                      $ref: '#node',
+                      isDynamic: false,
+                    },
+                  },
+                ),
+                value: subschemaFixture,
+              },
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a schema with a $dynamicRef to a resource that only defines that name with $anchor', () => {
+      let jsonSchemaResolver: JsonSchemaResolver;
+      let otherSchemaFixture: JsonSchemaObject;
+      let otherSchemaIdFixture: string;
+      let otherSubschemaFixture: JsonSchemaObject;
+      let treeFixture: JsonSchemaObject;
+      let treeIdFixture: string;
+
+      beforeAll(() => {
+        treeIdFixture = 'https://example.com/tree';
+        otherSchemaIdFixture = 'https://example.com/other.json';
+        otherSubschemaFixture = {
+          $anchor: 'node',
+          type: 'string',
+        };
+        otherSchemaFixture = {
+          $defs: {
+            node: otherSubschemaFixture,
+          },
+          $id: otherSchemaIdFixture,
+        };
+        treeFixture = {
+          $dynamicAnchor: 'node',
+          $dynamicRef: 'other.json#node',
+          $id: treeIdFixture,
+          type: 'object',
+        };
+
+        const schemaById: Map<string, JsonSchema> = new Map([
+          [otherSchemaIdFixture, otherSchemaFixture],
+          [treeIdFixture, treeFixture],
+        ]);
+
+        jsonSchemaResolver = new JsonSchemaResolver((id: string) =>
+          schemaById.get(id),
+        );
+      });
+
+      describe('when called', () => {
+        let result: Either<ResolutionFailure, SchemaResolutionSuccessTree>;
+
+        beforeAll(() => {
+          result = jsonSchemaResolver.resolveSchema(treeFixture);
+        });
+
+        it('should resolve the $dynamicRef like a $ref and not retarget to the outer $dynamicAnchor', () => {
+          const expected: Either<
+            ResolutionFailure,
+            SchemaResolutionSuccessTree
+          > = {
+            isRight: true,
+            value: {
+              $dynamicRef: {
+                $dynamicRef: undefined,
+                $ref: undefined,
+                dynamicScopeEntries: buildDynamicScopeEntries(
+                  {
+                    lexicalScope: {
+                      $canonicalId: new Uri(treeIdFixture),
+                    },
+                    resolutionContext: {
+                      $ref: treeIdFixture,
+                      isDynamic: true,
+                    },
+                  },
+                  {
+                    lexicalScope: {
+                      $canonicalId: new Uri(otherSchemaIdFixture),
+                    },
+                    resolutionContext: {
+                      $ref: 'other.json#node',
+                      isDynamic: true,
+                    },
+                  },
+                ),
+                value: otherSubschemaFixture,
+              },
+              $ref: undefined,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a schema with a $ref to an invalid fragment', () => {
+      let jsonSchemaResolver: JsonSchemaResolver;
+      let schemaFixture: JsonSchemaObject;
+      let schemaIdFixture: string;
+
+      beforeAll(() => {
+        schemaIdFixture = 'https://example.com/schema.json';
+        schemaFixture = {
+          $id: schemaIdFixture,
+          $ref: '#1node',
+        };
+
+        const schemaById: Map<string, JsonSchema> = new Map([
+          [schemaIdFixture, schemaFixture],
+        ]);
+
+        jsonSchemaResolver = new JsonSchemaResolver((id: string) =>
+          schemaById.get(id),
+        );
+      });
+
+      describe('when called', () => {
+        let result: Either<ResolutionFailure, SchemaResolutionSuccessTree>;
+
+        beforeAll(() => {
+          result = jsonSchemaResolver.resolveSchema(schemaFixture);
+        });
+
+        it('should return a resolution failure', () => {
+          const expected: Either<
+            ResolutionFailure,
+            SchemaResolutionSuccessTree
+          > = {
+            isRight: false,
+            value: {
+              reason: 'Invalid JSON Schema fragment: 1node',
+              resolutionContextStack: [
+                {
+                  $ref: schemaIdFixture,
+                  isDynamic: false,
+                },
+                {
+                  $ref: '#1node',
+                  isDynamic: false,
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a schema with a $ref to a malformed JSON Pointer fragment', () => {
+      let jsonSchemaResolver: JsonSchemaResolver;
+      let schemaFixture: JsonSchemaObject;
+      let schemaIdFixture: string;
+
+      beforeAll(() => {
+        schemaIdFixture = 'https://example.com/schema.json';
+        schemaFixture = {
+          $id: schemaIdFixture,
+          $ref: '#/foo~2',
+        };
+
+        const schemaById: Map<string, JsonSchema> = new Map([
+          [schemaIdFixture, schemaFixture],
+        ]);
+
+        jsonSchemaResolver = new JsonSchemaResolver((id: string) =>
+          schemaById.get(id),
+        );
+      });
+
+      describe('when called', () => {
+        let result: Either<ResolutionFailure, SchemaResolutionSuccessTree>;
+
+        beforeAll(() => {
+          result = jsonSchemaResolver.resolveSchema(schemaFixture);
+        });
+
+        it('should return a resolution failure', () => {
+          const expected: Either<
+            ResolutionFailure,
+            SchemaResolutionSuccessTree
+          > = {
+            isRight: false,
+            value: {
+              reason: 'Invalid JSON Schema fragment: /foo~2',
+              resolutionContextStack: [
+                {
+                  $ref: schemaIdFixture,
+                  isDynamic: false,
+                },
+                {
+                  $ref: '#/foo~2',
+                  isDynamic: false,
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a schema with a $ref to an unknown $anchor', () => {
+      let jsonSchemaResolver: JsonSchemaResolver;
+      let schemaFixture: JsonSchemaObject;
+      let schemaIdFixture: string;
+
+      beforeAll(() => {
+        schemaIdFixture = 'https://example.com/schema.json';
+        schemaFixture = {
+          $id: schemaIdFixture,
+          $ref: '#missing',
+        };
+
+        const schemaById: Map<string, JsonSchema> = new Map([
+          [schemaIdFixture, schemaFixture],
+        ]);
+
+        jsonSchemaResolver = new JsonSchemaResolver((id: string) =>
+          schemaById.get(id),
+        );
+      });
+
+      describe('when called', () => {
+        let result: Either<ResolutionFailure, SchemaResolutionSuccessTree>;
+
+        beforeAll(() => {
+          result = jsonSchemaResolver.resolveSchema(schemaFixture);
+        });
+
+        it('should return a resolution failure', () => {
+          const expected: Either<
+            ResolutionFailure,
+            SchemaResolutionSuccessTree
+          > = {
+            isRight: false,
+            value: {
+              reason: 'Failed to resolve anchor: missing',
+              resolutionContextStack: [
+                {
+                  $ref: schemaIdFixture,
+                  isDynamic: false,
+                },
+                {
+                  $ref: '#missing',
+                  isDynamic: false,
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a schema with a $ref to a missing JSON Pointer node', () => {
+      let jsonSchemaResolver: JsonSchemaResolver;
+      let schemaFixture: JsonSchemaObject;
+      let schemaIdFixture: string;
+
+      beforeAll(() => {
+        schemaIdFixture = 'https://example.com/schema.json';
+        schemaFixture = {
+          $id: schemaIdFixture,
+          $ref: '#/$defs/missing',
+        };
+
+        const schemaById: Map<string, JsonSchema> = new Map([
+          [schemaIdFixture, schemaFixture],
+        ]);
+
+        jsonSchemaResolver = new JsonSchemaResolver((id: string) =>
+          schemaById.get(id),
+        );
+      });
+
+      describe('when called', () => {
+        let result: Either<ResolutionFailure, SchemaResolutionSuccessTree>;
+
+        beforeAll(() => {
+          result = jsonSchemaResolver.resolveSchema(schemaFixture);
+        });
+
+        it('should return a resolution failure', () => {
+          const expected: Either<
+            ResolutionFailure,
+            SchemaResolutionSuccessTree
+          > = {
+            isRight: false,
+            value: {
+              reason: 'Failed to resolve JSON Pointer: /$defs/missing',
+              resolutionContextStack: [
+                {
+                  $ref: schemaIdFixture,
+                  isDynamic: false,
+                },
+                {
+                  $ref: '#/$defs/missing',
+                  isDynamic: false,
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+  });
+});

--- a/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/services/JsonSchemaResolver.int.spec.ts
+++ b/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/services/JsonSchemaResolver.int.spec.ts
@@ -1364,6 +1364,148 @@ describe(JsonSchemaResolver, () => {
       });
     });
 
+    describe('having a schema with a JSON Pointer $ref to an allOf item', () => {
+      let jsonSchemaResolver: JsonSchemaResolver;
+      let schemaFixture: JsonSchemaObject;
+      let schemaIdFixture: string;
+      let subschemaFixture: JsonSchemaObject;
+
+      beforeAll(() => {
+        schemaIdFixture = 'https://example.com/schema.json';
+        subschemaFixture = {
+          type: 'string',
+        };
+        schemaFixture = {
+          $id: schemaIdFixture,
+          $ref: '#/allOf/0',
+          allOf: [subschemaFixture],
+        };
+
+        const schemaById: Map<string, JsonSchema> = new Map([
+          [schemaIdFixture, schemaFixture],
+        ]);
+
+        jsonSchemaResolver = new JsonSchemaResolver((id: string) =>
+          schemaById.get(id),
+        );
+      });
+
+      describe('when called', () => {
+        let result: Either<ResolutionFailure, SchemaResolutionSuccessTree>;
+
+        beforeAll(() => {
+          result = jsonSchemaResolver.resolveSchema(schemaFixture);
+        });
+
+        it('should return a tree with the referenced allOf item', () => {
+          const expected: Either<
+            ResolutionFailure,
+            SchemaResolutionSuccessTree
+          > = {
+            isRight: true,
+            value: {
+              $dynamicRef: undefined,
+              $ref: {
+                $dynamicRef: undefined,
+                $ref: undefined,
+                dynamicScopeEntries: buildDynamicScopeEntries(
+                  {
+                    lexicalScope: {
+                      $canonicalId: new Uri(schemaIdFixture),
+                    },
+                    resolutionContext: {
+                      $ref: schemaIdFixture,
+                      isDynamic: false,
+                    },
+                  },
+                  {
+                    lexicalScope: {
+                      $canonicalId: new Uri(schemaIdFixture),
+                    },
+                    resolutionContext: {
+                      $ref: '#/allOf/0',
+                      isDynamic: false,
+                    },
+                  },
+                ),
+                value: subschemaFixture,
+              },
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe.each<[string, string]>([
+      ['1abc', '#/allOf/1abc'],
+      ['01', '#/allOf/01'],
+    ])(
+      'having a schema with a $ref to a non-RFC 6901 array index "%s"',
+      (_pointerSegment: string, refFixture: string) => {
+        let jsonSchemaResolver: JsonSchemaResolver;
+        let schemaFixture: JsonSchemaObject;
+        let schemaIdFixture: string;
+
+        beforeAll(() => {
+          schemaIdFixture = 'https://example.com/schema.json';
+          schemaFixture = {
+            $id: schemaIdFixture,
+            $ref: refFixture,
+            allOf: [
+              {
+                type: 'string',
+              },
+              {
+                type: 'number',
+              },
+            ],
+          };
+
+          const schemaById: Map<string, JsonSchema> = new Map([
+            [schemaIdFixture, schemaFixture],
+          ]);
+
+          jsonSchemaResolver = new JsonSchemaResolver((id: string) =>
+            schemaById.get(id),
+          );
+        });
+
+        describe('when called', () => {
+          let result: Either<ResolutionFailure, SchemaResolutionSuccessTree>;
+
+          beforeAll(() => {
+            result = jsonSchemaResolver.resolveSchema(schemaFixture);
+          });
+
+          it('should return a resolution failure', () => {
+            const expected: Either<
+              ResolutionFailure,
+              SchemaResolutionSuccessTree
+            > = {
+              isRight: false,
+              value: {
+                reason: `Failed to resolve JSON Pointer: ${refFixture.slice(1)}`,
+                resolutionContextStack: [
+                  {
+                    $ref: schemaIdFixture,
+                    isDynamic: false,
+                  },
+                  {
+                    $ref: refFixture,
+                    isDynamic: false,
+                  },
+                ],
+              },
+            };
+
+            expect(result).toStrictEqual(expected);
+          });
+        });
+      },
+    );
+
     describe('having a schema with a $ref to a missing JSON Pointer node', () => {
       let jsonSchemaResolver: JsonSchemaResolver;
       let schemaFixture: JsonSchemaObject;

--- a/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/services/JsonSchemaResolver.ts
+++ b/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/services/JsonSchemaResolver.ts
@@ -1,0 +1,1024 @@
+import { type Either } from '@inversifyjs/common';
+import { type JsonValue } from '@inversifyjs/json-schema-types';
+import {
+  type JsonSchema,
+  type JsonSchemaObject,
+} from '@inversifyjs/json-schema-types/2020-12';
+import { Uri } from '@inversifyjs/uri';
+
+import { SingleImmutableLinkedList } from '../../../common/models/SingleImmutableLinkedList.js';
+import { traverse } from '../actions/traverse.js';
+import { type TraverseJsonSchemaCallbackParams } from '../models/TraverseJsonSchemaCallbackParams.js';
+import { type TraverseJsonSchemaCallbackParamsResult } from '../models/TraverseJsonSchemaCallbackParamsResult.js';
+
+const ANCHOR_FRAGMENT_REGEXP: RegExp = /^[A-Za-z_][A-Za-z0-9._-]*$/;
+const JSON_POINTER_FRAGMENT_REGEXP: RegExp = /^(?:\/(?:[^~/]|~[01])*)*$/u;
+const JSON_POINTER_SEGMENT_SEPARATOR: string = '/';
+const JSON_POINTER_SEGMENT_SEPARATOR_ENCODED: string = '~1';
+const JSON_POINTER_SEGMENT_ENCODER: string = '~';
+const JSON_POINTER_SEGMENT_ENCODER_ENCODED: string = '~0';
+const WHOLE_DOCUMENT_FRAGMENT: string = '';
+
+export interface DynamicScopeEntry {
+  readonly resolutionContext: ResolutionContext;
+  readonly lexicalScope: LexicalScope;
+}
+
+interface JsonSchemaResolverCacheEntry {
+  readonly $anchorToValueMap: Map<string, JsonValue>;
+  readonly $canonicalId: Uri;
+  readonly $dynamicAnchorToValueMap: Map<string, JsonValue>;
+  readonly value: JsonValue;
+}
+
+export interface LexicalScope {
+  /** Absolute URI reference from the lexical scope. */
+  readonly $canonicalId: Uri;
+}
+
+export interface ResolutionContext {
+  readonly $ref: string;
+  readonly isDynamic: boolean;
+}
+
+export interface ResolutionFailure {
+  readonly resolutionContextStack: ResolutionContext[];
+  readonly reason: string;
+}
+
+interface ResolutionSuccess {
+  readonly dynamicScopeEntries: SingleImmutableLinkedList<DynamicScopeEntry>;
+  readonly value: JsonValue;
+}
+
+export interface SchemaResolutionSuccessLinks {
+  $dynamicRef: SchemaResolutionSuccessNode | undefined;
+  $ref: SchemaResolutionSuccessNode | undefined;
+}
+
+export interface SchemaResolutionSuccessNode extends SchemaResolutionSuccessLinks {
+  readonly dynamicScopeEntries: Iterable<DynamicScopeEntry>;
+  readonly value: JsonValue;
+}
+
+export type SchemaResolutionSuccessTree = SchemaResolutionSuccessLinks;
+
+export class JsonSchemaResolver {
+  readonly #idToCacheEntryMap: Map<string, JsonSchemaResolverCacheEntry>;
+  readonly #resolveId: (id: string) => JsonValue | undefined;
+
+  constructor(resolveId: (id: string) => JsonValue | undefined) {
+    this.#idToCacheEntryMap = new Map();
+    this.#resolveId = resolveId;
+  }
+
+  public resolveSchema(
+    schema: JsonValue,
+  ): Either<ResolutionFailure, SchemaResolutionSuccessTree> {
+    if (
+      schema === null ||
+      typeof schema !== 'object' ||
+      Array.isArray(schema)
+    ) {
+      return {
+        isRight: true,
+        value: {
+          $dynamicRef: undefined,
+          $ref: undefined,
+        },
+      };
+    }
+
+    const tree: SchemaResolutionSuccessTree = {
+      $dynamicRef: undefined,
+      $ref: undefined,
+    };
+
+    const jsonSchema: JsonSchemaObject = schema;
+
+    if (jsonSchema.$id !== undefined) {
+      let idUri: Uri;
+
+      try {
+        idUri = new Uri(jsonSchema.$id);
+      } catch (_error: unknown) {
+        return {
+          isRight: false,
+          value: this.#buildResolutionFailure(
+            undefined,
+            `Invalid URI: ${jsonSchema.$id}`,
+          ),
+        };
+      }
+
+      // Load root schema to cache
+      this.#tryGetOrCreateCacheEntry(
+        Uri.fromAttributes({
+          ...idUri.attributes,
+          fragment: undefined,
+        }),
+      );
+    }
+
+    if (jsonSchema.$dynamicRef !== undefined) {
+      const result: Either<ResolutionFailure, ResolutionSuccess> =
+        this.#resolveRootJsonSchemaDynamicRef(
+          jsonSchema as JsonSchemaObject &
+            Required<Pick<JsonSchemaObject, '$dynamicRef'>>,
+        );
+
+      if (!result.isRight) {
+        return result;
+      }
+
+      tree.$dynamicRef = {
+        $dynamicRef: undefined,
+        $ref: undefined,
+        dynamicScopeEntries: result.value.dynamicScopeEntries,
+        value: result.value.value,
+      };
+
+      const nodePropagationResult: Either<ResolutionFailure, void> =
+        this.#resolveNodeRefs(
+          result.value.dynamicScopeEntries,
+          tree.$dynamicRef,
+          new Set([jsonSchema]),
+        );
+
+      if (!nodePropagationResult.isRight) {
+        return nodePropagationResult;
+      }
+    }
+
+    if (jsonSchema.$ref !== undefined) {
+      const result: Either<ResolutionFailure, ResolutionSuccess> =
+        this.#resolveRootJsonSchemaRef(
+          jsonSchema as JsonSchemaObject &
+            Required<Pick<JsonSchemaObject, '$ref'>>,
+        );
+
+      if (!result.isRight) {
+        return result;
+      }
+
+      tree.$ref = {
+        $dynamicRef: undefined,
+        $ref: undefined,
+        dynamicScopeEntries: result.value.dynamicScopeEntries,
+        value: result.value.value,
+      };
+
+      const nodePropagationResult: Either<ResolutionFailure, void> =
+        this.#resolveNodeRefs(
+          result.value.dynamicScopeEntries,
+          tree.$ref,
+          new Set([jsonSchema]),
+        );
+
+      if (!nodePropagationResult.isRight) {
+        return nodePropagationResult;
+      }
+    }
+
+    return {
+      isRight: true,
+      value: tree,
+    };
+  }
+
+  #buildAnchorToValueMap(schema: JsonValue): Map<string, JsonValue> {
+    const $anchorToValueMap: Map<string, JsonValue> = new Map();
+
+    traverse(
+      {
+        schema: schema as JsonSchema,
+      },
+      (
+        params: TraverseJsonSchemaCallbackParams,
+      ): TraverseJsonSchemaCallbackParamsResult => {
+        if (
+          params.schema === true ||
+          params.schema === false ||
+          (params.schema.$id !== undefined &&
+            params.schema !== params.rootSchema)
+        ) {
+          return {
+            traverseChildren: false,
+          };
+        }
+
+        if (params.schema.$anchor !== undefined) {
+          $anchorToValueMap.set(params.schema.$anchor, params.schema);
+        }
+
+        return {
+          traverseChildren: true,
+        };
+      },
+    );
+
+    return $anchorToValueMap;
+  }
+
+  #buildDynamicAnchorToValueMap(schema: JsonValue): Map<string, JsonValue> {
+    const $dynamicAnchorToValueMap: Map<string, JsonValue> = new Map();
+
+    traverse(
+      {
+        schema: schema as JsonSchema,
+      },
+      (
+        params: TraverseJsonSchemaCallbackParams,
+      ): TraverseJsonSchemaCallbackParamsResult => {
+        if (
+          params.schema === true ||
+          params.schema === false ||
+          (params.schema.$id !== undefined &&
+            params.schema !== params.rootSchema)
+        ) {
+          return {
+            traverseChildren: false,
+          };
+        }
+
+        if (params.schema.$dynamicAnchor !== undefined) {
+          $dynamicAnchorToValueMap.set(
+            params.schema.$dynamicAnchor,
+            params.schema,
+          );
+        }
+
+        return {
+          traverseChildren: true,
+        };
+      },
+    );
+
+    return $dynamicAnchorToValueMap;
+  }
+
+  #buildResolutionFailure(
+    dynamicScopeEntries:
+      SingleImmutableLinkedList<DynamicScopeEntry> | undefined,
+    reason: string,
+  ): ResolutionFailure {
+    const resolutionContextStack: ResolutionContext[] = (
+      dynamicScopeEntries?.toArray() ?? []
+    ).map((dynamicScope: DynamicScopeEntry) => dynamicScope.resolutionContext);
+
+    return {
+      reason,
+      resolutionContextStack,
+    };
+  }
+
+  #calculateBaseUri(
+    dynamicScopeEntries: SingleImmutableLinkedList<DynamicScopeEntry>,
+  ): Uri | undefined {
+    const lastLexicalScope: LexicalScope =
+      dynamicScopeEntries.last.elem.lexicalScope;
+
+    return lastLexicalScope.$canonicalId;
+  }
+
+  #calculateCanonicalId(
+    dynamicScopeEntries:
+      SingleImmutableLinkedList<DynamicScopeEntry> | undefined,
+    ref: string,
+    baseRef: string | undefined,
+  ): Either<ResolutionFailure, Uri> {
+    try {
+      const canonicalUri: Uri = new Uri(ref, baseRef);
+      return {
+        isRight: true,
+        value: Uri.fromAttributes({
+          ...canonicalUri.attributes,
+          fragment: undefined,
+        }),
+      };
+    } catch (error: unknown) {
+      return {
+        isRight: false,
+        value: this.#buildResolutionFailure(
+          dynamicScopeEntries,
+          `Failed to calculate canonical ID: ${error instanceof Error ? error.message : String(error)}`,
+        ),
+      };
+    }
+  }
+
+  #getAnchorValue(
+    anchor: string,
+    currentCacheEntry: JsonSchemaResolverCacheEntry,
+  ): JsonValue | undefined {
+    return (
+      currentCacheEntry.$anchorToValueMap.get(anchor) ??
+      currentCacheEntry.$dynamicAnchorToValueMap.get(anchor)
+    );
+  }
+
+  #getCacheEntryOrFail(
+    canonicalId: string,
+    dynamicScopeEntries: SingleImmutableLinkedList<DynamicScopeEntry>,
+  ): Either<ResolutionFailure, JsonSchemaResolverCacheEntry> {
+    const currentCacheEntry: JsonSchemaResolverCacheEntry | undefined =
+      this.#idToCacheEntryMap.get(canonicalId);
+
+    if (currentCacheEntry === undefined) {
+      return {
+        isRight: false,
+        value: this.#buildResolutionFailure(
+          dynamicScopeEntries,
+          `Failed to resolve resource identified by: ${canonicalId}`,
+        ),
+      };
+    }
+
+    return {
+      isRight: true,
+      value: currentCacheEntry,
+    };
+  }
+
+  #resolve(
+    dynamicScopeEntries: SingleImmutableLinkedList<DynamicScopeEntry>,
+  ): Either<ResolutionFailure, ResolutionSuccess> {
+    /*
+     * 1. Resolve resolutionContext.$ref against the current lexical base URI
+     *    (last dynamic scope entry). On URI parse failure, return error.
+     * 2. Take the fragment aside. Look up the fragment-less URI with
+     *    #resolveId / cache. If missing, return error.
+     * 3. Append a new dynamic scope entry for that resource (this hop) and
+     *    return { value, dynamicScopeEntries } as follows:
+     * 4. No fragment, or empty fragment: return the resource root.
+     * 5. Plain-name fragment:
+     *    5.1 If isDynamic:
+     *        If the current (last) entry's resource defines that name with
+     *        $dynamicAnchor, walk entries from the outside and return the
+     *        first match. If that match is not the last entry, append a new
+     *        entry with the matched resource's $canonicalId and this hop's
+     *        resolutionContext. Otherwise resolve like $ref (step 5.2).
+     *        If $anchor and $dynamicAnchor both define the name in the
+     *        current resource, $ref prefers $anchor; $dynamicRef still uses
+     *        the $dynamicAnchor gate.
+     *    5.2 If not isDynamic: resolve the name in the current resource
+     *        ($anchor, then $dynamicAnchor). If missing, return error.
+     * 6. JSON Pointer fragment: walk the pointer. On each object node with
+     *    $id, resolve that id against the current lexical base, require it
+     *    in the cache, and replace the last dynamic scope entry with that
+     *    resource (same resolutionContext). If the pointer fails, return
+     *    error. Return the node at the pointer.
+     * 7. Any other fragment: return error.
+     *
+     * This method returns the referenced node. It does not follow $ref or
+     * $dynamicRef on that node; those are applicators for the evaluator.
+     */
+
+    const lastDynamicScope: DynamicScopeEntry = dynamicScopeEntries.last.elem;
+
+    const canonicalId: Uri = lastDynamicScope.lexicalScope.$canonicalId;
+
+    const currentCacheEntry: JsonSchemaResolverCacheEntry | undefined =
+      this.#tryGetOrCreateCacheEntry(canonicalId);
+
+    if (currentCacheEntry === undefined) {
+      return {
+        isRight: false,
+        value: this.#buildResolutionFailure(
+          dynamicScopeEntries,
+          `Failed to resolve resource identified by: ${canonicalId.toString()}`,
+        ),
+      };
+    }
+
+    let canonicalUri: Uri;
+
+    try {
+      canonicalUri = new Uri(
+        lastDynamicScope.resolutionContext.$ref,
+        canonicalId.toString(),
+      );
+    } catch (_error: unknown) {
+      return {
+        isRight: false,
+        value: this.#buildResolutionFailure(
+          dynamicScopeEntries,
+          `Invalid URI: ${lastDynamicScope.resolutionContext.$ref} Base: ${canonicalId.toString()}`,
+        ),
+      };
+    }
+
+    if (
+      canonicalUri.attributes.fragment === undefined ||
+      canonicalUri.attributes.fragment === WHOLE_DOCUMENT_FRAGMENT
+    ) {
+      return {
+        isRight: true,
+        value: {
+          dynamicScopeEntries,
+          value: currentCacheEntry.value,
+        },
+      };
+    }
+
+    if (ANCHOR_FRAGMENT_REGEXP.test(canonicalUri.attributes.fragment)) {
+      if (lastDynamicScope.resolutionContext.isDynamic) {
+        return this.#resolveFromDynamicAnchor(
+          canonicalUri.attributes.fragment,
+          currentCacheEntry,
+          dynamicScopeEntries,
+        );
+      } else {
+        return this.#resolveFromAnchor(
+          canonicalUri.attributes.fragment,
+          currentCacheEntry,
+          dynamicScopeEntries,
+        );
+      }
+    }
+
+    if (JSON_POINTER_FRAGMENT_REGEXP.test(canonicalUri.attributes.fragment)) {
+      return this.#resolveFromJsonPointer(
+        canonicalUri.attributes.fragment,
+        currentCacheEntry,
+        dynamicScopeEntries,
+      );
+    }
+
+    return {
+      isRight: false,
+      value: this.#buildResolutionFailure(
+        dynamicScopeEntries,
+        `Invalid JSON Schema fragment: ${canonicalUri.attributes.fragment}`,
+      ),
+    };
+  }
+
+  #resolveFromAnchor(
+    anchor: string,
+    currentCacheEntry: JsonSchemaResolverCacheEntry,
+    dynamicScopeEntries: SingleImmutableLinkedList<DynamicScopeEntry>,
+  ): Either<ResolutionFailure, ResolutionSuccess> {
+    const anchorValue: JsonValue | undefined = this.#getAnchorValue(
+      anchor,
+      currentCacheEntry,
+    );
+
+    if (anchorValue === undefined) {
+      return {
+        isRight: false,
+        value: this.#buildResolutionFailure(
+          dynamicScopeEntries,
+          `Failed to resolve anchor: ${anchor}`,
+        ),
+      };
+    }
+
+    return {
+      isRight: true,
+      value: {
+        dynamicScopeEntries,
+        value: anchorValue,
+      },
+    };
+  }
+
+  #resolveFromDynamicAnchor(
+    anchor: string,
+    currentCacheEntry: JsonSchemaResolverCacheEntry,
+    dynamicScopeEntries: SingleImmutableLinkedList<DynamicScopeEntry>,
+  ): Either<ResolutionFailure, ResolutionSuccess> {
+    const isAnchorInCurrentDynamicScope: boolean =
+      currentCacheEntry.$dynamicAnchorToValueMap.get(anchor) !== undefined;
+
+    if (isAnchorInCurrentDynamicScope) {
+      for (const dynamicScope of dynamicScopeEntries.toArray()) {
+        const canonicalId: Uri = dynamicScope.lexicalScope.$canonicalId;
+
+        const cacheEntryResult: Either<
+          ResolutionFailure,
+          JsonSchemaResolverCacheEntry
+        > = this.#getCacheEntryOrFail(
+          canonicalId.toString(),
+          dynamicScopeEntries,
+        );
+
+        if (!cacheEntryResult.isRight) {
+          return cacheEntryResult;
+        }
+
+        const dynamicAnchorValue: JsonValue | undefined =
+          cacheEntryResult.value.$dynamicAnchorToValueMap.get(anchor);
+
+        if (dynamicAnchorValue !== undefined) {
+          const lastDynamicScope: DynamicScopeEntry =
+            dynamicScopeEntries.last.elem;
+
+          return {
+            isRight: true,
+            value: {
+              dynamicScopeEntries:
+                dynamicScope === lastDynamicScope
+                  ? dynamicScopeEntries
+                  : dynamicScopeEntries.concat({
+                      lexicalScope: dynamicScope.lexicalScope,
+                      resolutionContext: lastDynamicScope.resolutionContext,
+                    }),
+              value: dynamicAnchorValue,
+            },
+          };
+        }
+      }
+
+      return {
+        isRight: false,
+        value: this.#buildResolutionFailure(
+          dynamicScopeEntries,
+          `Failed to resolve dynamic anchor: ${anchor}`,
+        ),
+      };
+    } else {
+      return this.#resolveFromAnchor(
+        anchor,
+        currentCacheEntry,
+        dynamicScopeEntries,
+      );
+    }
+  }
+
+  #resolveFromJsonPointer(
+    jsonPointer: string,
+    currentCacheEntry: JsonSchemaResolverCacheEntry,
+    dynamicScopeEntries: SingleImmutableLinkedList<DynamicScopeEntry>,
+  ): Either<ResolutionFailure, ResolutionSuccess> {
+    const pointerSegments: string[] = jsonPointer
+      .split(JSON_POINTER_SEGMENT_SEPARATOR)
+      .map((segment: string) =>
+        segment
+          .replaceAll(
+            JSON_POINTER_SEGMENT_SEPARATOR_ENCODED,
+            JSON_POINTER_SEGMENT_SEPARATOR,
+          )
+          .replaceAll(
+            JSON_POINTER_SEGMENT_ENCODER_ENCODED,
+            JSON_POINTER_SEGMENT_ENCODER,
+          ),
+      );
+
+    let result: JsonValue | undefined = currentCacheEntry.value;
+    let currentDynamicScopeEntries: SingleImmutableLinkedList<DynamicScopeEntry> =
+      dynamicScopeEntries;
+
+    for (let i: number = 1; i < pointerSegments.length; ++i) {
+      const pointerSegment: string = pointerSegments[i] as string;
+
+      if (result == null || typeof result !== 'object') {
+        result = undefined;
+        break;
+      }
+
+      if (Array.isArray(result)) {
+        const pointerIndex: number = parseInt(pointerSegment, 10);
+
+        if (Number.isNaN(pointerIndex)) {
+          result = undefined;
+          break;
+        }
+
+        result = result[pointerIndex];
+      } else {
+        const syncResult: Either<
+          ResolutionFailure,
+          SingleImmutableLinkedList<DynamicScopeEntry>
+        > = this.#syncCacheAndDynamicScopeOnJsonPointerObjectTraversal(
+          currentDynamicScopeEntries,
+          result,
+        );
+
+        if (syncResult.isRight) {
+          currentDynamicScopeEntries = syncResult.value;
+        } else {
+          return syncResult;
+        }
+
+        result = result[pointerSegment];
+      }
+    }
+
+    if (result === undefined) {
+      return {
+        isRight: false,
+        value: this.#buildResolutionFailure(
+          currentDynamicScopeEntries,
+          `Failed to resolve JSON Pointer: ${jsonPointer}`,
+        ),
+      };
+    }
+
+    if (
+      result !== null &&
+      typeof result === 'object' &&
+      !Array.isArray(result)
+    ) {
+      const syncResult: Either<
+        ResolutionFailure,
+        SingleImmutableLinkedList<DynamicScopeEntry>
+      > = this.#syncCacheAndDynamicScopeOnJsonPointerObjectTraversal(
+        currentDynamicScopeEntries,
+        result,
+      );
+
+      if (syncResult.isRight) {
+        currentDynamicScopeEntries = syncResult.value;
+      } else {
+        return syncResult;
+      }
+    }
+
+    return {
+      isRight: true,
+      value: {
+        dynamicScopeEntries: currentDynamicScopeEntries,
+        value: result,
+      },
+    };
+  }
+
+  #resolveRootJsonSchemaDynamicRef(
+    jsonSchema: JsonSchemaObject &
+      Required<Pick<JsonSchemaObject, '$dynamicRef'>>,
+  ): Either<ResolutionFailure, ResolutionSuccess> {
+    const canonicalIdResult: Either<ResolutionFailure, Uri> =
+      this.#calculateCanonicalId(
+        undefined,
+        jsonSchema.$dynamicRef,
+        jsonSchema.$id,
+      );
+
+    if (!canonicalIdResult.isRight) {
+      return canonicalIdResult;
+    }
+
+    let dynamicScopeEntries: SingleImmutableLinkedList<DynamicScopeEntry>;
+
+    if (jsonSchema.$id === undefined) {
+      dynamicScopeEntries = new SingleImmutableLinkedList({
+        elem: {
+          lexicalScope: {
+            $canonicalId: canonicalIdResult.value,
+          },
+          resolutionContext: {
+            $ref: jsonSchema.$dynamicRef,
+            isDynamic: true,
+          },
+        },
+        previous: undefined,
+      });
+    } else {
+      let $canonicalId: Uri;
+
+      try {
+        $canonicalId = Uri.fromAttributes({
+          ...new Uri(jsonSchema.$id).attributes,
+          fragment: undefined,
+        });
+      } catch (_error: unknown) {
+        return {
+          isRight: false,
+          value: this.#buildResolutionFailure(
+            undefined,
+            `Invalid URI: ${jsonSchema.$id}`,
+          ),
+        };
+      }
+
+      dynamicScopeEntries = new SingleImmutableLinkedList({
+        elem: {
+          lexicalScope: {
+            $canonicalId,
+          },
+          resolutionContext: {
+            $ref: jsonSchema.$id,
+            isDynamic: true,
+          },
+        },
+        previous: undefined,
+      }).concat({
+        lexicalScope: {
+          $canonicalId: canonicalIdResult.value,
+        },
+        resolutionContext: {
+          $ref: jsonSchema.$dynamicRef,
+          isDynamic: true,
+        },
+      });
+    }
+
+    return this.#resolve(dynamicScopeEntries);
+  }
+
+  #resolveRootJsonSchemaRef(
+    jsonSchema: JsonSchemaObject & Required<Pick<JsonSchemaObject, '$ref'>>,
+  ): Either<ResolutionFailure, ResolutionSuccess> {
+    const canonicalIdResult: Either<ResolutionFailure, Uri> =
+      this.#calculateCanonicalId(undefined, jsonSchema.$ref, jsonSchema.$id);
+
+    if (!canonicalIdResult.isRight) {
+      return canonicalIdResult;
+    }
+
+    let dynamicScopeEntries: SingleImmutableLinkedList<DynamicScopeEntry>;
+
+    if (jsonSchema.$id === undefined) {
+      dynamicScopeEntries = new SingleImmutableLinkedList({
+        elem: {
+          lexicalScope: {
+            $canonicalId: canonicalIdResult.value,
+          },
+          resolutionContext: {
+            $ref: jsonSchema.$ref,
+            isDynamic: false,
+          },
+        },
+        previous: undefined,
+      });
+    } else {
+      let $canonicalId: Uri;
+
+      try {
+        $canonicalId = Uri.fromAttributes({
+          ...new Uri(jsonSchema.$id).attributes,
+          fragment: undefined,
+        });
+      } catch (_error: unknown) {
+        return {
+          isRight: false,
+          value: this.#buildResolutionFailure(
+            undefined,
+            `Invalid URI: ${jsonSchema.$id}`,
+          ),
+        };
+      }
+
+      dynamicScopeEntries = new SingleImmutableLinkedList({
+        elem: {
+          lexicalScope: {
+            $canonicalId,
+          },
+          resolutionContext: {
+            $ref: jsonSchema.$id,
+            isDynamic: false,
+          },
+        },
+        previous: undefined,
+      }).concat({
+        lexicalScope: {
+          $canonicalId: canonicalIdResult.value,
+        },
+        resolutionContext: {
+          $ref: jsonSchema.$ref,
+          isDynamic: false,
+        },
+      });
+    }
+
+    return this.#resolve(dynamicScopeEntries);
+  }
+
+  #resolveNodeRefs(
+    dynamicScopeEntries: SingleImmutableLinkedList<DynamicScopeEntry>,
+    node: SchemaResolutionSuccessNode,
+    visitedJsonSchemas: Set<JsonSchemaObject>,
+  ): Either<ResolutionFailure, void> {
+    const value: JsonValue = node.value;
+
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+      return {
+        isRight: true,
+        value: undefined,
+      };
+    }
+
+    const jsonSchema: JsonSchemaObject = value;
+
+    const nextVisitedJsonSchemas: Set<JsonSchemaObject> | undefined =
+      this.#tryVisitJsonSchema(visitedJsonSchemas, jsonSchema);
+
+    if (nextVisitedJsonSchemas === undefined) {
+      return {
+        isRight: true,
+        value: undefined,
+      };
+    }
+
+    if (jsonSchema.$dynamicRef !== undefined) {
+      const canonicalIdResult: Either<ResolutionFailure, Uri> =
+        this.#calculateCanonicalId(
+          dynamicScopeEntries,
+          jsonSchema.$dynamicRef,
+          dynamicScopeEntries.last.elem.lexicalScope.$canonicalId.toString(),
+        );
+
+      if (!canonicalIdResult.isRight) {
+        return canonicalIdResult;
+      }
+
+      const result: Either<ResolutionFailure, ResolutionSuccess> =
+        this.#resolve(
+          dynamicScopeEntries.concat({
+            lexicalScope: {
+              $canonicalId: canonicalIdResult.value,
+            },
+            resolutionContext: {
+              $ref: jsonSchema.$dynamicRef,
+              isDynamic: true,
+            },
+          }),
+        );
+
+      if (!result.isRight) {
+        return result;
+      }
+
+      node.$dynamicRef = {
+        $dynamicRef: undefined,
+        $ref: undefined,
+        dynamicScopeEntries: result.value.dynamicScopeEntries,
+        value: result.value.value,
+      };
+
+      const nodePropagationResult: Either<ResolutionFailure, void> =
+        this.#resolveNodeRefs(
+          result.value.dynamicScopeEntries,
+          node.$dynamicRef,
+          nextVisitedJsonSchemas,
+        );
+
+      if (!nodePropagationResult.isRight) {
+        return nodePropagationResult;
+      }
+    }
+
+    if (jsonSchema.$ref !== undefined) {
+      const canonicalIdResult: Either<ResolutionFailure, Uri> =
+        this.#calculateCanonicalId(
+          dynamicScopeEntries,
+          jsonSchema.$ref,
+          dynamicScopeEntries.last.elem.lexicalScope.$canonicalId.toString(),
+        );
+
+      if (!canonicalIdResult.isRight) {
+        return canonicalIdResult;
+      }
+
+      const result: Either<ResolutionFailure, ResolutionSuccess> =
+        this.#resolve(
+          dynamicScopeEntries.concat({
+            lexicalScope: {
+              $canonicalId: canonicalIdResult.value,
+            },
+            resolutionContext: {
+              $ref: jsonSchema.$ref,
+              isDynamic: false,
+            },
+          }),
+        );
+
+      if (!result.isRight) {
+        return result;
+      }
+
+      node.$ref = {
+        $dynamicRef: undefined,
+        $ref: undefined,
+        dynamicScopeEntries: result.value.dynamicScopeEntries,
+        value: result.value.value,
+      };
+
+      const nodePropagationResult: Either<ResolutionFailure, void> =
+        this.#resolveNodeRefs(
+          result.value.dynamicScopeEntries,
+          node.$ref,
+          nextVisitedJsonSchemas,
+        );
+
+      if (!nodePropagationResult.isRight) {
+        return nodePropagationResult;
+      }
+    }
+
+    return {
+      isRight: true,
+      value: undefined,
+    };
+  }
+
+  #syncCacheAndDynamicScopeOnJsonPointerObjectTraversal(
+    dynamicScopeEntries: SingleImmutableLinkedList<DynamicScopeEntry>,
+    maybeJsonSchema: Partial<JsonSchemaObject>,
+  ): Either<ResolutionFailure, SingleImmutableLinkedList<DynamicScopeEntry>> {
+    if (maybeJsonSchema.$id !== undefined) {
+      const baseUri: Uri | undefined =
+        this.#calculateBaseUri(dynamicScopeEntries);
+      let canonicalUri: Uri;
+
+      try {
+        canonicalUri = new Uri(maybeJsonSchema.$id, baseUri?.toString());
+      } catch (_error: unknown) {
+        return {
+          isRight: false,
+          value: this.#buildResolutionFailure(
+            dynamicScopeEntries,
+            `Failed to create canonical URI from ID: ${maybeJsonSchema.$id}`,
+          ),
+        };
+      }
+
+      const canonicalId: Uri = Uri.fromAttributes({
+        ...canonicalUri.attributes,
+        fragment: undefined,
+      });
+      const currentCacheEntry: JsonSchemaResolverCacheEntry | undefined =
+        this.#tryGetOrCreateCacheEntry(canonicalId);
+
+      if (currentCacheEntry === undefined) {
+        return {
+          isRight: false,
+          value: this.#buildResolutionFailure(
+            dynamicScopeEntries,
+            `Failed to resolve resource identified by: ${canonicalId.toString()}`,
+          ),
+        };
+      }
+
+      const lastDynamicScope: DynamicScopeEntry = dynamicScopeEntries.last.elem;
+
+      return {
+        isRight: true,
+        value: new SingleImmutableLinkedList(
+          {
+            elem: {
+              lexicalScope: {
+                $canonicalId: canonicalId,
+              },
+              resolutionContext: lastDynamicScope.resolutionContext,
+            },
+            previous: dynamicScopeEntries.last.previous,
+          },
+          dynamicScopeEntries.length,
+        ),
+      };
+    }
+
+    return {
+      isRight: true,
+      value: dynamicScopeEntries,
+    };
+  }
+
+  #tryGetOrCreateCacheEntry(
+    canonicalId: Uri,
+  ): JsonSchemaResolverCacheEntry | undefined {
+    let currentCacheEntry: JsonSchemaResolverCacheEntry | undefined =
+      this.#idToCacheEntryMap.get(canonicalId.toString());
+
+    if (currentCacheEntry === undefined) {
+      const canonicalIdResource: JsonValue | undefined = this.#resolveId(
+        canonicalId.toString(),
+      );
+
+      if (canonicalIdResource === undefined) {
+        return undefined;
+      }
+
+      currentCacheEntry = {
+        $anchorToValueMap: this.#buildAnchorToValueMap(canonicalIdResource),
+        $canonicalId: canonicalId,
+        $dynamicAnchorToValueMap:
+          this.#buildDynamicAnchorToValueMap(canonicalIdResource),
+        value: canonicalIdResource,
+      };
+
+      this.#idToCacheEntryMap.set(canonicalId.toString(), currentCacheEntry);
+    }
+
+    return currentCacheEntry;
+  }
+
+  #tryVisitJsonSchema(
+    visitedJsonSchemas: Set<JsonSchemaObject>,
+    jsonSchema: JsonSchemaObject,
+  ): Set<JsonSchemaObject> | undefined {
+    if (visitedJsonSchemas.has(jsonSchema)) {
+      return undefined;
+    }
+
+    const nextVisitedJsonSchemas: Set<JsonSchemaObject> = new Set(
+      visitedJsonSchemas,
+    );
+
+    nextVisitedJsonSchemas.add(jsonSchema);
+
+    return nextVisitedJsonSchemas;
+  }
+}

--- a/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/services/JsonSchemaResolver.ts
+++ b/packages/json-schema/libraries/json-schema-utils/src/jsonSchema/202012/services/JsonSchemaResolver.ts
@@ -12,6 +12,7 @@ import { type TraverseJsonSchemaCallbackParams } from '../models/TraverseJsonSch
 import { type TraverseJsonSchemaCallbackParamsResult } from '../models/TraverseJsonSchemaCallbackParamsResult.js';
 
 const ANCHOR_FRAGMENT_REGEXP: RegExp = /^[A-Za-z_][A-Za-z0-9._-]*$/;
+const JSON_POINTER_ARRAY_INDEX_REGEXP: RegExp = /^(?:0|[1-9]\d*)$/;
 const JSON_POINTER_FRAGMENT_REGEXP: RegExp = /^(?:\/(?:[^~/]|~[01])*)*$/u;
 const JSON_POINTER_SEGMENT_SEPARATOR: string = '/';
 const JSON_POINTER_SEGMENT_SEPARATOR_ENCODED: string = '~1';
@@ -578,14 +579,12 @@ export class JsonSchemaResolver {
       }
 
       if (Array.isArray(result)) {
-        const pointerIndex: number = parseInt(pointerSegment, 10);
-
-        if (Number.isNaN(pointerIndex)) {
+        if (!JSON_POINTER_ARRAY_INDEX_REGEXP.test(pointerSegment)) {
           result = undefined;
           break;
         }
 
-        result = result[pointerIndex];
+        result = result[Number.parseInt(pointerSegment, 10)];
       } else {
         const syncResult: Either<
           ResolutionFailure,


### PR DESCRIPTION
### Added
- Added  `JsonSchemaResolver`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSON Schema 2020-12 resolution for `$ref`, `$dynamicRef`, anchors, and JSON Pointer fragments.
  * Added structured resolution results, scope tracking, cycle handling, and clear failure reporting.
  * Added callback controls to stop traversal of child schemas when needed.
  * Added an immutable linked-list utility with concatenation, iteration, and array conversion.
  * Improved validation of JSON Pointer array indices.
* **Documentation**
  * Updated package release notes to document the schema resolver and traversal callback options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->