### PR TITLE
Add OpenApiResolver

### DIFF
--- a/.changeset/smart-houses-count.md
+++ b/.changeset/smart-houses-count.md
@@ -1,0 +1,6 @@
+---
+"@inversifyjs/open-api-utils": minor
+---
+
+- Added `OpenApi3Dot1Resolver`.
+- Added `OpenApi3Dot2Resolver`.

--- a/packages/open-api/libraries/open-api-utils/package.json
+++ b/packages/open-api/libraries/open-api-utils/package.json
@@ -5,7 +5,10 @@
   },
   "description": "InversifyJs OpenAPI utils package",
   "dependencies": {
-    "@inversifyjs/json-schema-utils": "workspace:*"
+    "@inversifyjs/json-schema-pointer": "workspace:*",
+    "@inversifyjs/json-schema-types": "workspace:*",
+    "@inversifyjs/json-schema-utils": "workspace:*",
+    "@inversifyjs/uri": "workspace:*"
   },
   "devDependencies": {
     "@inversifyjs/eslint-plugin-require-extensions": "workspace:*",

--- a/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot1/calculations/isOpenApi3Dot1ReferenceObject.spec.ts
+++ b/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot1/calculations/isOpenApi3Dot1ReferenceObject.spec.ts
@@ -1,0 +1,60 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { type JsonValue } from '@inversifyjs/json-schema-types';
+
+import { isOpenApi3Dot1ReferenceObject } from './isOpenApi3Dot1ReferenceObject.js';
+
+describe(isOpenApi3Dot1ReferenceObject, () => {
+  describe.each<[string, JsonValue, boolean]>([
+    [
+      'an object with only a $ref property',
+      { $ref: '#/components/requestBodies/Pet' },
+      true,
+    ],
+    [
+      'an object with $ref, summary, and description properties',
+      {
+        $ref: '#/components/requestBodies/Pet',
+        description: 'A pet',
+        summary: 'Pet',
+      },
+      true,
+    ],
+    [
+      'an object with a $ref property and a schema type',
+      {
+        $ref: '#/components/schemas/Animal',
+        type: 'object',
+      },
+      false,
+    ],
+    [
+      'an object with a $ref property and a path item operation',
+      {
+        $ref: '#/components/pathItems/Pet',
+        get: {},
+      },
+      false,
+    ],
+    ['null', null, false],
+    ['a string', '#/components/requestBodies/Pet', false],
+    ['an array', [{ $ref: '#/components/requestBodies/Pet' }], false],
+    ['an object without a $ref property', { description: 'A pet' }, false],
+    ['an object with a non-string $ref property', { $ref: 42 }, false],
+  ])(
+    'having %s',
+    (_name: string, valueFixture: JsonValue, expectedResult: boolean) => {
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = isOpenApi3Dot1ReferenceObject(valueFixture);
+        });
+
+        it('should return the expected result', () => {
+          expect(result).toBe(expectedResult);
+        });
+      });
+    },
+  );
+});

--- a/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot1/calculations/isOpenApi3Dot1ReferenceObject.ts
+++ b/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot1/calculations/isOpenApi3Dot1ReferenceObject.ts
@@ -1,0 +1,24 @@
+import { type JsonValue } from '@inversifyjs/json-schema-types';
+
+const OPEN_API_3_DOT_1_REFERENCE_OBJECT_KEYS: ReadonlySet<string> = new Set([
+  '$ref',
+  'description',
+  'summary',
+]);
+
+export function isOpenApi3Dot1ReferenceObject(
+  value: JsonValue,
+): value is JsonValue & { $ref: string } {
+  if (
+    value === null ||
+    typeof value !== 'object' ||
+    Array.isArray(value) ||
+    typeof value['$ref'] !== 'string'
+  ) {
+    return false;
+  }
+
+  return Object.keys(value).every((key: string) =>
+    OPEN_API_3_DOT_1_REFERENCE_OBJECT_KEYS.has(key),
+  );
+}

--- a/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot1/index.ts
+++ b/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot1/index.ts
@@ -12,3 +12,11 @@ export {
   traverseOpenApi3Dot1ResponsesObjectJsonSchemas,
   traverseOpenApiObjectJsonSchemas,
 } from './actions/traverse.js';
+export {
+  type OpenApi3Dot1RefResolutionChainEntry,
+  type OpenApi3Dot1RefResolutionContext,
+  type OpenApi3Dot1RefResolutionFailure,
+  type OpenApi3Dot1RefResolutionResult,
+  type OpenApi3Dot1RefResolutionSuccess,
+  OpenApi3Dot1Resolver,
+} from './services/OpenApi3Dot1Resolver.js';

--- a/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot1/services/OpenApi3Dot1Resolver.int.spec.ts
+++ b/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot1/services/OpenApi3Dot1Resolver.int.spec.ts
@@ -1,0 +1,1903 @@
+import { beforeAll, describe, expect, it, type Mock, vitest } from 'vitest';
+
+import { type JsonValue } from '@inversifyjs/json-schema-types';
+
+import {
+  type OpenApi3Dot1RefResolutionResult,
+  OpenApi3Dot1Resolver,
+} from './OpenApi3Dot1Resolver.js';
+
+const INVALID_REFERENCE_OBJECT_REASON: string =
+  'Invalid OpenAPI Reference Object: expected an object with a string "$ref" property and optional "summary" and "description" properties';
+
+const OPEN_API_DOCUMENT_URI_FIXTURE: string =
+  'https://example.com/openapi.json';
+
+describe(OpenApi3Dot1Resolver, () => {
+  describe('constructor', () => {
+    describe('having a relative OpenAPI document URI', () => {
+      let openApiDocumentUriFixture: string;
+
+      beforeAll(() => {
+        openApiDocumentUriFixture = 'openapi.json';
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          try {
+            new OpenApi3Dot1Resolver(
+              openApiDocumentUriFixture,
+              () => undefined,
+            );
+          } catch (error: unknown) {
+            result = error;
+          }
+        });
+
+        it('should throw an Error', () => {
+          expect(result).toBeInstanceOf(Error);
+          expect((result as Error).cause).toBeInstanceOf(Error);
+          expect((result as Error).message).toBe(
+            `Invalid OpenAPI document URI: ${openApiDocumentUriFixture}`,
+          );
+        });
+      });
+    });
+  });
+
+  describe('.resolveRef', () => {
+    describe('having a same-document ref and an OpenAPI document URI with a fragment', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+      let requestBodyFixture: JsonValue;
+      let resolveIdMock: Mock<(id: string) => JsonValue | undefined>;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        requestBodyFixture = {
+          content: {},
+        };
+        documentFixture = {
+          components: {
+            requestBodies: {
+              Pet: requestBodyFixture,
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        resolveIdMock = vitest.fn((id: string) => documentById.get(id));
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          `${documentIdFixture}#/unused`,
+          resolveIdMock,
+        );
+
+        refFixture = {
+          $ref: '#/components/requestBodies/Pet',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should load the document without the fragment', () => {
+          expect(resolveIdMock).toHaveBeenCalledTimes(1);
+          expect(resolveIdMock).toHaveBeenCalledWith(documentIdFixture);
+        });
+
+        it('should return the referenced request body', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: '#/components/requestBodies/Pet',
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/Pet`,
+                  value: refFixture,
+                },
+              ],
+              value: requestBodyFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a null ref value', () => {
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        refFixture = null;
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          OPEN_API_DOCUMENT_URI_FIXTURE,
+          () => undefined,
+        );
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: INVALID_REFERENCE_OBJECT_REASON,
+              resolutionContextStack: [],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a primitive ref value', () => {
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        refFixture = 'https://example.com/requestBody.json';
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          OPEN_API_DOCUMENT_URI_FIXTURE,
+          () => undefined,
+        );
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: INVALID_REFERENCE_OBJECT_REASON,
+              resolutionContextStack: [],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref object without a $ref property', () => {
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        refFixture = {
+          description: 'A reference-like object',
+        };
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          OPEN_API_DOCUMENT_URI_FIXTURE,
+          () => undefined,
+        );
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: INVALID_REFERENCE_OBJECT_REASON,
+              resolutionContextStack: [],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref object with a non-string $ref property', () => {
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        refFixture = {
+          $ref: 42,
+        };
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          OPEN_API_DOCUMENT_URI_FIXTURE,
+          () => undefined,
+        );
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: INVALID_REFERENCE_OBJECT_REASON,
+              resolutionContextStack: [],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref object with additional properties', () => {
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        refFixture = {
+          $ref: 'https://example.com/requestBody.json',
+          type: 'object',
+        };
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          OPEN_API_DOCUMENT_URI_FIXTURE,
+          () => undefined,
+        );
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: INVALID_REFERENCE_OBJECT_REASON,
+              resolutionContextStack: [],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having an array ref value', () => {
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        refFixture = [
+          {
+            $ref: 'https://example.com/requestBody.json',
+          },
+        ];
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          OPEN_API_DOCUMENT_URI_FIXTURE,
+          () => undefined,
+        );
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: INVALID_REFERENCE_OBJECT_REASON,
+              resolutionContextStack: [],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref to an entire document', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+      let resolveIdMock: Mock<(id: string) => JsonValue | undefined>;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/requestBody.json';
+        documentFixture = {
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/Pet',
+              },
+            },
+          },
+          required: true,
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        resolveIdMock = vitest.fn((id: string) => documentById.get(id));
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          resolveIdMock,
+        );
+
+        refFixture = {
+          $ref: documentIdFixture,
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return the referenced document', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: documentIdFixture,
+                  canonicalId: documentIdFixture,
+                  value: refFixture,
+                },
+              ],
+              value: documentFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+
+        it('should not resolve JSON Schema $refs within the target', () => {
+          expect(resolveIdMock).toHaveBeenCalledTimes(1);
+          expect(resolveIdMock).toHaveBeenCalledWith(documentIdFixture);
+        });
+      });
+    });
+
+    describe('having a ref with a JSON pointer fragment', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+      let requestBodyFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        requestBodyFixture = {
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/Pet',
+              },
+            },
+          },
+          required: true,
+        };
+        documentFixture = {
+          components: {
+            requestBodies: {
+              Pet: requestBodyFixture,
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/components/requestBodies/Pet',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return the referenced request body', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: '#/components/requestBodies/Pet',
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/Pet`,
+                  value: refFixture,
+                },
+              ],
+              value: requestBodyFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref with an escaped JSON pointer fragment', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+      let requestBodyFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        requestBodyFixture = {
+          content: {},
+        };
+        documentFixture = {
+          components: {
+            'a/b': requestBodyFixture,
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: `${documentIdFixture}#/components/a~1b`,
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return the request body at the escaped pointer', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: `${documentIdFixture}#/components/a~1b`,
+                  canonicalId: `${documentIdFixture}#/components/a~1b`,
+                  value: refFixture,
+                },
+              ],
+              value: requestBodyFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref with a percent-encoded JSON pointer fragment', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+      let requestBodyFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        requestBodyFixture = {
+          content: {},
+        };
+        documentFixture = {
+          components: {
+            'Pet Name': requestBodyFixture,
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: `${documentIdFixture}#/components/${encodeURIComponent('Pet Name')}`,
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return the request body at the decoded pointer', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: `${documentIdFixture}#/components/Pet%20Name`,
+                  canonicalId: `${documentIdFixture}#/components/Pet%20Name`,
+                  value: refFixture,
+                },
+              ],
+              value: requestBodyFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref with a malformed percent-encoded fragment', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        documentFixture = {
+          components: {},
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: `${documentIdFixture}#%GG`,
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: 'Invalid URI fragment: %GG',
+              resolutionContextStack: [
+                {
+                  $ref: `${documentIdFixture}#%GG`,
+                  canonicalId: `${documentIdFixture}#%GG`,
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref with a JSON pointer to an array element', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+      let requestBodyFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        requestBodyFixture = {
+          content: {},
+        };
+        documentFixture = {
+          list: [requestBodyFixture],
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: `${documentIdFixture}#/list/0`,
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return the request body at the array index', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: `${documentIdFixture}#/list/0`,
+                  canonicalId: `${documentIdFixture}#/list/0`,
+                  value: refFixture,
+                },
+              ],
+              value: requestBodyFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a relative ref', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let openApiDocumentUriFixture: string;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        openApiDocumentUriFixture = 'https://example.com/api/openapi.json';
+        documentIdFixture = 'https://example.com/api/requestBody.json';
+        documentFixture = {
+          content: {},
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          openApiDocumentUriFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: 'requestBody.json',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should resolve the ref against the OpenAPI document URI', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: 'requestBody.json',
+                  canonicalId: documentIdFixture,
+                  value: refFixture,
+                },
+              ],
+              value: documentFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a relative ref to a missing resource', () => {
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        refFixture = {
+          $ref: 'requestBody.json',
+        };
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          OPEN_API_DOCUMENT_URI_FIXTURE,
+          () => undefined,
+        );
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason:
+                'Failed to resolve resource identified by: https://example.com/requestBody.json',
+              resolutionContextStack: [
+                {
+                  $ref: 'requestBody.json',
+                  canonicalId: 'https://example.com/requestBody.json',
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref to a ref to a request body', () => {
+      let aliasRefFixture: JsonValue;
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+      let requestBodyFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        requestBodyFixture = {
+          content: {},
+          required: true,
+        };
+        aliasRefFixture = {
+          $ref: '#/components/requestBodies/Pet',
+        };
+        documentFixture = {
+          components: {
+            requestBodies: {
+              Alias: aliasRefFixture,
+              Pet: requestBodyFixture,
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/components/requestBodies/Alias',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return the final request body', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: '#/components/requestBodies/Alias',
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/Alias`,
+                  value: refFixture,
+                },
+                {
+                  $ref: '#/components/requestBodies/Pet',
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/Pet`,
+                  value: aliasRefFixture,
+                },
+              ],
+              value: requestBodyFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref to a schema object with a JSON Schema $ref and sibling keywords', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let petSchemaFixture: JsonValue;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        petSchemaFixture = {
+          $ref: '#/components/schemas/Animal',
+          description: 'A pet',
+          type: 'object',
+        };
+        documentFixture = {
+          components: {
+            schemas: {
+              Animal: {
+                type: 'object',
+              },
+              Pet: petSchemaFixture,
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/components/schemas/Pet',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return the schema object without following its $ref', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: '#/components/schemas/Pet',
+                  canonicalId: `${documentIdFixture}#/components/schemas/Pet`,
+                  value: refFixture,
+                },
+              ],
+              value: petSchemaFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref to a $ref-only schema object', () => {
+      let animalSchemaFixture: JsonValue;
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let petSchemaFixture: JsonValue;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        animalSchemaFixture = {
+          type: 'object',
+        };
+        petSchemaFixture = {
+          $ref: '#/components/schemas/Animal',
+        };
+        documentFixture = {
+          components: {
+            schemas: {
+              Animal: animalSchemaFixture,
+              Pet: petSchemaFixture,
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/components/schemas/Pet',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should follow the $ref as an OpenAPI Reference Object', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: '#/components/schemas/Pet',
+                  canonicalId: `${documentIdFixture}#/components/schemas/Pet`,
+                  value: refFixture,
+                },
+                {
+                  $ref: '#/components/schemas/Animal',
+                  canonicalId: `${documentIdFixture}#/components/schemas/Animal`,
+                  value: petSchemaFixture,
+                },
+              ],
+              value: animalSchemaFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref to a media type schema with a JSON Schema $ref and sibling keywords', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+      let schemaFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        schemaFixture = {
+          $ref: '#/components/schemas/Pet',
+          type: 'object',
+        };
+        documentFixture = {
+          paths: {
+            '/pets': {
+              get: {
+                requestBody: {
+                  content: {
+                    'application/json': {
+                      schema: schemaFixture,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/paths/~1pets/get/requestBody/content/application~1json/schema',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return the schema object without following its $ref', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: '#/paths/~1pets/get/requestBody/content/application~1json/schema',
+                  canonicalId: `${documentIdFixture}#/paths/~1pets/get/requestBody/content/application~1json/schema`,
+                  value: refFixture,
+                },
+              ],
+              value: schemaFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref to a path item object with a $ref field', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let pathItemFixture: JsonValue;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        pathItemFixture = {
+          $ref: '#/components/pathItems/Pet',
+          get: {
+            responses: {},
+          },
+        };
+        documentFixture = {
+          components: {
+            pathItems: {
+              Pet: {
+                get: {
+                  operationId: 'getPet',
+                },
+              },
+            },
+          },
+          paths: {
+            '/pets': pathItemFixture,
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/paths/~1pets',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return the path item object without following its $ref', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: '#/paths/~1pets',
+                  canonicalId: `${documentIdFixture}#/paths/~1pets`,
+                  value: refFixture,
+                },
+              ],
+              value: pathItemFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref to a webhook that is a path item reference', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let pathItemFixture: JsonValue;
+      let refFixture: JsonValue;
+      let webhookRefFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        pathItemFixture = {
+          get: {
+            responses: {},
+          },
+        };
+        webhookRefFixture = {
+          $ref: '#/paths/~1pets',
+        };
+        documentFixture = {
+          paths: {
+            '/pets': pathItemFixture,
+          },
+          webhooks: {
+            newPet: webhookRefFixture,
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/webhooks/newPet',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should follow the webhook reference object', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: '#/webhooks/newPet',
+                  canonicalId: `${documentIdFixture}#/webhooks/newPet`,
+                  value: refFixture,
+                },
+                {
+                  $ref: '#/paths/~1pets',
+                  canonicalId: `${documentIdFixture}#/paths/~1pets`,
+                  value: webhookRefFixture,
+                },
+              ],
+              value: pathItemFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref chain across documents', () => {
+      let aliasRefFixture: JsonValue;
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+      let requestBodyFixture: JsonValue;
+      let sharedDocumentFixture: JsonValue;
+      let sharedDocumentIdFixture: string;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        sharedDocumentIdFixture = 'https://example.com/shared.json';
+        requestBodyFixture = {
+          content: {},
+          required: true,
+        };
+        aliasRefFixture = {
+          $ref: 'shared.json#/components/requestBodies/Pet',
+        };
+        documentFixture = {
+          components: {
+            requestBodies: {
+              Alias: aliasRefFixture,
+            },
+          },
+        };
+        sharedDocumentFixture = {
+          components: {
+            requestBodies: {
+              Pet: requestBodyFixture,
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+          [sharedDocumentIdFixture, sharedDocumentFixture],
+        ]);
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/components/requestBodies/Alias',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should resolve the second hop against the referring document', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: '#/components/requestBodies/Alias',
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/Alias`,
+                  value: refFixture,
+                },
+                {
+                  $ref: 'shared.json#/components/requestBodies/Pet',
+                  canonicalId: `${sharedDocumentIdFixture}#/components/requestBodies/Pet`,
+                  value: aliasRefFixture,
+                },
+              ],
+              value: requestBodyFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a circular ref chain', () => {
+      let aRefFixture: JsonValue;
+      let bRefFixture: JsonValue;
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        aRefFixture = {
+          $ref: '#/components/requestBodies/B',
+        };
+        bRefFixture = {
+          $ref: '#/components/requestBodies/A',
+        };
+        documentFixture = {
+          components: {
+            requestBodies: {
+              A: aRefFixture,
+              B: bRefFixture,
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/components/requestBodies/A',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure with the followed chain', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: `Circular reference detected: ${documentIdFixture}#/components/requestBodies/A`,
+              resolutionContextStack: [
+                {
+                  $ref: '#/components/requestBodies/A',
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/A`,
+                },
+                {
+                  $ref: '#/components/requestBodies/B',
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/B`,
+                },
+                {
+                  $ref: '#/components/requestBodies/A',
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/A`,
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a self-referencing ref', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        documentFixture = {
+          components: {
+            requestBodies: {
+              A: {
+                $ref: '#/components/requestBodies/A',
+              },
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/components/requestBodies/A',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a circular reference failure', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: `Circular reference detected: ${documentIdFixture}#/components/requestBodies/A`,
+              resolutionContextStack: [
+                {
+                  $ref: '#/components/requestBodies/A',
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/A`,
+                },
+                {
+                  $ref: '#/components/requestBodies/A',
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/A`,
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref to a missing resource', () => {
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        refFixture = {
+          $ref: 'https://example.com/missing.json',
+        };
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          OPEN_API_DOCUMENT_URI_FIXTURE,
+          () => undefined,
+        );
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason:
+                'Failed to resolve resource identified by: https://example.com/missing.json',
+              resolutionContextStack: [
+                {
+                  $ref: 'https://example.com/missing.json',
+                  canonicalId: 'https://example.com/missing.json',
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref to a ref to a missing resource', () => {
+      let aliasRefFixture: JsonValue;
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        aliasRefFixture = {
+          $ref: 'https://example.com/missing.json',
+        };
+        documentFixture = {
+          components: {
+            requestBodies: {
+              Alias: aliasRefFixture,
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/components/requestBodies/Alias',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure including the missing hop', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason:
+                'Failed to resolve resource identified by: https://example.com/missing.json',
+              resolutionContextStack: [
+                {
+                  $ref: '#/components/requestBodies/Alias',
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/Alias`,
+                },
+                {
+                  $ref: 'https://example.com/missing.json',
+                  canonicalId: 'https://example.com/missing.json',
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref with a non-pointer fragment', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        documentFixture = {
+          pet: 'Rex',
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: `${documentIdFixture}#Pet`,
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason:
+                'Invalid fragment: Pet (OpenAPI reference fragments MUST be JSON Pointers)',
+              resolutionContextStack: [
+                {
+                  $ref: `${documentIdFixture}#Pet`,
+                  canonicalId: `${documentIdFixture}#Pet`,
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref with a pointer to a missing key', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        documentFixture = {
+          components: {},
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: `${documentIdFixture}#/components/requestBodies/Pet`,
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason:
+                'Failed to resolve JSON Pointer: /components/requestBodies/Pet',
+              resolutionContextStack: [
+                {
+                  $ref: `${documentIdFixture}#/components/requestBodies/Pet`,
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/Pet`,
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref with a pointer traversing a non-object', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        documentFixture = {
+          pet: 'Rex',
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: `${documentIdFixture}#/pet/child`,
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: 'Failed to resolve JSON Pointer: /pet/child',
+              resolutionContextStack: [
+                {
+                  $ref: `${documentIdFixture}#/pet/child`,
+                  canonicalId: `${documentIdFixture}#/pet/child`,
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref whose target is a primitive', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        documentFixture = {
+          pet: 'Rex',
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: `${documentIdFixture}#/pet`,
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return the primitive target', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: `${documentIdFixture}#/pet`,
+                  canonicalId: `${documentIdFixture}#/pet`,
+                  value: refFixture,
+                },
+              ],
+              value: 'Rex',
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref whose target is null', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        documentFixture = {
+          empty: null,
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: `${documentIdFixture}#/empty`,
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a null target', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: `${documentIdFixture}#/empty`,
+                  canonicalId: `${documentIdFixture}#/empty`,
+                  value: refFixture,
+                },
+              ],
+              value: null,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref with summary and description properties', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/requestBody.json';
+        documentFixture = {
+          content: {},
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: documentIdFixture,
+          description: 'A reference description',
+          summary: 'A reference summary',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot1RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should ignore the summary and description properties', () => {
+          const expected: OpenApi3Dot1RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: documentIdFixture,
+                  canonicalId: documentIdFixture,
+                  value: refFixture,
+                },
+              ],
+              value: documentFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having the same document referenced multiple times', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot1Resolver: OpenApi3Dot1Resolver;
+      let refFixture: JsonValue;
+      let resolveIdMock: Mock<(id: string) => JsonValue | undefined>;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/requestBody.json';
+        documentFixture = {
+          content: {},
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        resolveIdMock = vitest.fn((id: string) => documentById.get(id));
+
+        openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
+          documentIdFixture,
+          resolveIdMock,
+        );
+
+        refFixture = {
+          $ref: documentIdFixture,
+        };
+      });
+
+      describe('when called twice', () => {
+        beforeAll(() => {
+          openApi3Dot1Resolver.resolveRef(refFixture);
+          openApi3Dot1Resolver.resolveRef(refFixture);
+        });
+
+        it('should load the document only once', () => {
+          expect(resolveIdMock).toHaveBeenCalledTimes(1);
+          expect(resolveIdMock).toHaveBeenCalledWith(documentIdFixture);
+        });
+      });
+    });
+  });
+});

--- a/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot1/services/OpenApi3Dot1Resolver.ts
+++ b/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot1/services/OpenApi3Dot1Resolver.ts
@@ -1,0 +1,237 @@
+/*
+ * Resolves OpenAPI 3.1 Reference Objects per:
+ * - https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.1.md#referenceObject
+ * - https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.1.md#relativeReferencesInApiDescriptionUris
+ *
+ * Unlike JsonSchemaResolver, this resolver does not interpret JSON Schema
+ * keywords ($ref, $dynamicRef, $anchor, $id, ...). It only follows OpenAPI
+ * Reference Objects (`$ref` with optional `summary` and `description`) until
+ * a non-reference target is reached.
+ */
+
+import { resolveJsonPointer } from '@inversifyjs/json-schema-pointer';
+import { type JsonValue } from '@inversifyjs/json-schema-types';
+import { Uri } from '@inversifyjs/uri';
+
+import { isOpenApi3Dot1ReferenceObject } from '../calculations/isOpenApi3Dot1ReferenceObject.js';
+
+export interface OpenApi3Dot1RefResolutionContext {
+  /** The `$ref` URI exactly as declared in the Reference Object. */
+  readonly $ref: string;
+  /** The canonical URI of the referenced location. */
+  readonly canonicalId: string;
+}
+
+export interface OpenApi3Dot1RefResolutionChainEntry extends OpenApi3Dot1RefResolutionContext {
+  /** The Reference Object of the hop. */
+  readonly value: JsonValue;
+}
+
+export interface OpenApi3Dot1RefResolutionFailure {
+  readonly resolutionContextStack: readonly OpenApi3Dot1RefResolutionContext[];
+  readonly reason: string;
+}
+
+export interface OpenApi3Dot1RefResolutionSuccess {
+  /** The references followed, in order, from the first hop to the last. */
+  readonly chain: readonly OpenApi3Dot1RefResolutionChainEntry[];
+  /** The final resolved value. OpenAPI Reference Object chains are fully followed. The value may still be a Schema Object or Path Item Object that uses `$ref` with sibling fields. */
+  readonly value: JsonValue;
+}
+
+export type OpenApi3Dot1RefResolutionResult =
+  | {
+      isRight: false;
+      value: OpenApi3Dot1RefResolutionFailure;
+    }
+  | {
+      isRight: true;
+      value: OpenApi3Dot1RefResolutionSuccess;
+    };
+
+export class OpenApi3Dot1Resolver {
+  readonly #idToDocumentMap: Map<string, JsonValue>;
+  readonly #openApiDocumentUri: string;
+  readonly #resolveId: (id: string) => JsonValue | undefined;
+
+  constructor(
+    openApiDocumentUri: string,
+    resolveId: (id: string) => JsonValue | undefined,
+  ) {
+    let documentUri: Uri;
+
+    try {
+      documentUri = new Uri(openApiDocumentUri);
+    } catch (error: unknown) {
+      throw new Error(`Invalid OpenAPI document URI: ${openApiDocumentUri}`, {
+        cause: error,
+      });
+    }
+
+    this.#idToDocumentMap = new Map();
+    this.#openApiDocumentUri = Uri.fromAttributes({
+      ...documentUri.attributes,
+      fragment: undefined,
+    }).toString();
+    this.#resolveId = resolveId;
+  }
+
+  public resolveRef(openApiRef: JsonValue): OpenApi3Dot1RefResolutionResult {
+    return this.#resolveRefChain(
+      openApiRef,
+      this.#openApiDocumentUri,
+      [],
+      new Set<string>(),
+    );
+  }
+
+  #resolveRefChain(
+    openApiRef: JsonValue,
+    baseRef: string,
+    chain: readonly OpenApi3Dot1RefResolutionChainEntry[],
+    visitedCanonicalIds: ReadonlySet<string>,
+  ): OpenApi3Dot1RefResolutionResult {
+    if (!isOpenApi3Dot1ReferenceObject(openApiRef)) {
+      return this.#buildFailure(
+        chain,
+        'Invalid OpenAPI Reference Object: expected an object with a string "$ref" property and optional "summary" and "description" properties',
+      );
+    }
+
+    const ref: string = openApiRef['$ref'];
+
+    let canonicalUri: Uri;
+
+    try {
+      canonicalUri = new Uri(ref, baseRef);
+    } catch (_error: unknown) {
+      return this.#buildFailure(chain, `Invalid URI: ${ref} Base: ${baseRef}`);
+    }
+
+    const canonicalId: string = canonicalUri.toString();
+    const nextChain: readonly OpenApi3Dot1RefResolutionChainEntry[] = [
+      ...chain,
+      {
+        $ref: ref,
+        canonicalId,
+        value: openApiRef,
+      },
+    ];
+
+    if (visitedCanonicalIds.has(canonicalId)) {
+      return this.#buildFailure(
+        nextChain,
+        `Circular reference detected: ${canonicalId}`,
+      );
+    }
+
+    const nextVisitedCanonicalIds: Set<string> = new Set(visitedCanonicalIds);
+
+    nextVisitedCanonicalIds.add(canonicalId);
+
+    const documentUri: Uri = Uri.fromAttributes({
+      ...canonicalUri.attributes,
+      fragment: undefined,
+    });
+
+    const document: JsonValue | undefined = this.#tryGetDocument(documentUri);
+
+    if (document === undefined) {
+      return this.#buildFailure(
+        nextChain,
+        `Failed to resolve resource identified by: ${documentUri.toString()}`,
+      );
+    }
+
+    const fragment: string | undefined = canonicalUri.attributes.fragment;
+
+    let target: JsonValue;
+
+    if (fragment === undefined || fragment === '') {
+      target = document;
+    } else {
+      let decodedFragment: string;
+
+      try {
+        decodedFragment = decodeURIComponent(fragment);
+      } catch (_error: unknown) {
+        return this.#buildFailure(
+          nextChain,
+          `Invalid URI fragment: ${fragment}`,
+        );
+      }
+
+      if (decodedFragment.startsWith('/')) {
+        const resolvedTarget: JsonValue | undefined = resolveJsonPointer(
+          document,
+          decodedFragment,
+        );
+
+        if (resolvedTarget === undefined) {
+          return this.#buildFailure(
+            nextChain,
+            `Failed to resolve JSON Pointer: ${decodedFragment}`,
+          );
+        }
+
+        target = resolvedTarget;
+      } else {
+        return this.#buildFailure(
+          nextChain,
+          `Invalid fragment: ${decodedFragment} (OpenAPI reference fragments MUST be JSON Pointers)`,
+        );
+      }
+    }
+
+    if (isOpenApi3Dot1ReferenceObject(target)) {
+      return this.#resolveRefChain(
+        target,
+        documentUri.toString(),
+        nextChain,
+        nextVisitedCanonicalIds,
+      );
+    }
+
+    return {
+      isRight: true,
+      value: {
+        chain: nextChain,
+        value: target,
+      },
+    };
+  }
+
+  #buildFailure(
+    chain: readonly OpenApi3Dot1RefResolutionChainEntry[],
+    reason: string,
+  ): OpenApi3Dot1RefResolutionResult {
+    return {
+      isRight: false,
+      value: {
+        reason,
+        resolutionContextStack: chain.map(
+          (entry: OpenApi3Dot1RefResolutionChainEntry) => ({
+            $ref: entry.$ref,
+            canonicalId: entry.canonicalId,
+          }),
+        ),
+      },
+    };
+  }
+
+  #tryGetDocument(documentUri: Uri): JsonValue | undefined {
+    const canonicalId: string = documentUri.toString();
+    let document: JsonValue | undefined =
+      this.#idToDocumentMap.get(canonicalId);
+
+    if (document === undefined) {
+      document = this.#resolveId(canonicalId);
+
+      if (document !== undefined) {
+        this.#idToDocumentMap.set(canonicalId, document);
+      }
+    }
+
+    return document;
+  }
+}

--- a/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot2/calculations/isOpenApi3Dot2ReferenceObject.spec.ts
+++ b/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot2/calculations/isOpenApi3Dot2ReferenceObject.spec.ts
@@ -1,0 +1,60 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { type JsonValue } from '@inversifyjs/json-schema-types';
+
+import { isOpenApi3Dot2ReferenceObject } from './isOpenApi3Dot2ReferenceObject.js';
+
+describe(isOpenApi3Dot2ReferenceObject, () => {
+  describe.each<[string, JsonValue, boolean]>([
+    [
+      'an object with only a $ref property',
+      { $ref: '#/components/requestBodies/Pet' },
+      true,
+    ],
+    [
+      'an object with $ref, summary, and description properties',
+      {
+        $ref: '#/components/requestBodies/Pet',
+        description: 'A pet',
+        summary: 'Pet',
+      },
+      true,
+    ],
+    [
+      'an object with a $ref property and a schema type',
+      {
+        $ref: '#/components/schemas/Animal',
+        type: 'object',
+      },
+      false,
+    ],
+    [
+      'an object with a $ref property and a path item operation',
+      {
+        $ref: '#/components/pathItems/Pet',
+        get: {},
+      },
+      false,
+    ],
+    ['null', null, false],
+    ['a string', '#/components/requestBodies/Pet', false],
+    ['an array', [{ $ref: '#/components/requestBodies/Pet' }], false],
+    ['an object without a $ref property', { description: 'A pet' }, false],
+    ['an object with a non-string $ref property', { $ref: 42 }, false],
+  ])(
+    'having %s',
+    (_name: string, valueFixture: JsonValue, expectedResult: boolean) => {
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = isOpenApi3Dot2ReferenceObject(valueFixture);
+        });
+
+        it('should return the expected result', () => {
+          expect(result).toBe(expectedResult);
+        });
+      });
+    },
+  );
+});

--- a/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot2/calculations/isOpenApi3Dot2ReferenceObject.ts
+++ b/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot2/calculations/isOpenApi3Dot2ReferenceObject.ts
@@ -1,0 +1,24 @@
+import { type JsonValue } from '@inversifyjs/json-schema-types';
+
+const OPEN_API_3_DOT_2_REFERENCE_OBJECT_KEYS: ReadonlySet<string> = new Set([
+  '$ref',
+  'description',
+  'summary',
+]);
+
+export function isOpenApi3Dot2ReferenceObject(
+  value: JsonValue,
+): value is JsonValue & { $ref: string } {
+  if (
+    value === null ||
+    typeof value !== 'object' ||
+    Array.isArray(value) ||
+    typeof value['$ref'] !== 'string'
+  ) {
+    return false;
+  }
+
+  return Object.keys(value).every((key: string) =>
+    OPEN_API_3_DOT_2_REFERENCE_OBJECT_KEYS.has(key),
+  );
+}

--- a/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot2/index.ts
+++ b/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot2/index.ts
@@ -12,3 +12,11 @@ export {
   traverseOpenApi3Dot2ResponsesObjectJsonSchemas,
   traverseOpenApiObjectJsonSchemas,
 } from './actions/traverse.js';
+export {
+  type OpenApi3Dot2RefResolutionChainEntry,
+  type OpenApi3Dot2RefResolutionContext,
+  type OpenApi3Dot2RefResolutionFailure,
+  type OpenApi3Dot2RefResolutionResult,
+  type OpenApi3Dot2RefResolutionSuccess,
+  OpenApi3Dot2Resolver,
+} from './services/OpenApi3Dot2Resolver.js';

--- a/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot2/services/OpenApi3Dot2Resolver.int.spec.ts
+++ b/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot2/services/OpenApi3Dot2Resolver.int.spec.ts
@@ -1,0 +1,2557 @@
+import { beforeAll, describe, expect, it, type Mock, vitest } from 'vitest';
+
+import { type JsonValue } from '@inversifyjs/json-schema-types';
+
+import {
+  type OpenApi3Dot2RefResolutionResult,
+  OpenApi3Dot2Resolver,
+} from './OpenApi3Dot2Resolver.js';
+
+const INVALID_REFERENCE_OBJECT_REASON: string =
+  'Invalid OpenAPI Reference Object: expected an object with a string "$ref" property and optional "summary" and "description" properties';
+
+const OPEN_API_DOCUMENT_URI_FIXTURE: string =
+  'https://example.com/openapi.json';
+
+describe(OpenApi3Dot2Resolver, () => {
+  describe('constructor', () => {
+    describe('having a relative OpenAPI document URI', () => {
+      let openApiDocumentUriFixture: string;
+
+      beforeAll(() => {
+        openApiDocumentUriFixture = 'openapi.json';
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          try {
+            new OpenApi3Dot2Resolver(
+              openApiDocumentUriFixture,
+              () => undefined,
+            );
+          } catch (error: unknown) {
+            result = error;
+          }
+        });
+
+        it('should throw an Error', () => {
+          expect(result).toBeInstanceOf(Error);
+          expect((result as Error).cause).toBeInstanceOf(Error);
+          expect((result as Error).message).toBe(
+            `Invalid OpenAPI document URI: ${openApiDocumentUriFixture}`,
+          );
+        });
+      });
+    });
+  });
+
+  describe('.resolveRef', () => {
+    describe('having a same-document ref and an OpenAPI document URI with a fragment', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let requestBodyFixture: JsonValue;
+      let resolveIdMock: Mock<(id: string) => JsonValue | undefined>;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        requestBodyFixture = {
+          content: {},
+        };
+        documentFixture = {
+          components: {
+            requestBodies: {
+              Pet: requestBodyFixture,
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        resolveIdMock = vitest.fn((id: string) => documentById.get(id));
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          `${documentIdFixture}#/unused`,
+          resolveIdMock,
+        );
+
+        refFixture = {
+          $ref: '#/components/requestBodies/Pet',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should load the document without the fragment', () => {
+          expect(resolveIdMock).toHaveBeenCalledTimes(1);
+          expect(resolveIdMock).toHaveBeenCalledWith(documentIdFixture);
+        });
+
+        it('should return the referenced request body', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: '#/components/requestBodies/Pet',
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/Pet`,
+                  value: refFixture,
+                },
+              ],
+              value: requestBodyFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a null ref value', () => {
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        refFixture = null;
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          OPEN_API_DOCUMENT_URI_FIXTURE,
+          () => undefined,
+        );
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: INVALID_REFERENCE_OBJECT_REASON,
+              resolutionContextStack: [],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a primitive ref value', () => {
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        refFixture = 'https://example.com/requestBody.json';
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          OPEN_API_DOCUMENT_URI_FIXTURE,
+          () => undefined,
+        );
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: INVALID_REFERENCE_OBJECT_REASON,
+              resolutionContextStack: [],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref object without a $ref property', () => {
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        refFixture = {
+          description: 'A reference-like object',
+        };
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          OPEN_API_DOCUMENT_URI_FIXTURE,
+          () => undefined,
+        );
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: INVALID_REFERENCE_OBJECT_REASON,
+              resolutionContextStack: [],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref object with a non-string $ref property', () => {
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        refFixture = {
+          $ref: 42,
+        };
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          OPEN_API_DOCUMENT_URI_FIXTURE,
+          () => undefined,
+        );
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: INVALID_REFERENCE_OBJECT_REASON,
+              resolutionContextStack: [],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref object with additional properties', () => {
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        refFixture = {
+          $ref: 'https://example.com/requestBody.json',
+          type: 'object',
+        };
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          OPEN_API_DOCUMENT_URI_FIXTURE,
+          () => undefined,
+        );
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: INVALID_REFERENCE_OBJECT_REASON,
+              resolutionContextStack: [],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having an array ref value', () => {
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        refFixture = [
+          {
+            $ref: 'https://example.com/requestBody.json',
+          },
+        ];
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          OPEN_API_DOCUMENT_URI_FIXTURE,
+          () => undefined,
+        );
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: INVALID_REFERENCE_OBJECT_REASON,
+              resolutionContextStack: [],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref to an entire document', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let resolveIdMock: Mock<(id: string) => JsonValue | undefined>;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/requestBody.json';
+        documentFixture = {
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/Pet',
+              },
+            },
+          },
+          required: true,
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        resolveIdMock = vitest.fn((id: string) => documentById.get(id));
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          resolveIdMock,
+        );
+
+        refFixture = {
+          $ref: documentIdFixture,
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return the referenced document', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: documentIdFixture,
+                  canonicalId: documentIdFixture,
+                  value: refFixture,
+                },
+              ],
+              value: documentFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+
+        it('should not resolve JSON Schema $refs within the target', () => {
+          expect(resolveIdMock).toHaveBeenCalledTimes(1);
+          expect(resolveIdMock).toHaveBeenCalledWith(documentIdFixture);
+        });
+      });
+    });
+
+    describe('having a ref with a JSON pointer fragment', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let requestBodyFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        requestBodyFixture = {
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/Pet',
+              },
+            },
+          },
+          required: true,
+        };
+        documentFixture = {
+          components: {
+            requestBodies: {
+              Pet: requestBodyFixture,
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/components/requestBodies/Pet',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return the referenced request body', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: '#/components/requestBodies/Pet',
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/Pet`,
+                  value: refFixture,
+                },
+              ],
+              value: requestBodyFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref with an escaped JSON pointer fragment', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let requestBodyFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        requestBodyFixture = {
+          content: {},
+        };
+        documentFixture = {
+          components: {
+            'a/b': requestBodyFixture,
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: `${documentIdFixture}#/components/a~1b`,
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return the request body at the escaped pointer', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: `${documentIdFixture}#/components/a~1b`,
+                  canonicalId: `${documentIdFixture}#/components/a~1b`,
+                  value: refFixture,
+                },
+              ],
+              value: requestBodyFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref with a percent-encoded JSON pointer fragment', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let requestBodyFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        requestBodyFixture = {
+          content: {},
+        };
+        documentFixture = {
+          components: {
+            'Pet Name': requestBodyFixture,
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: `${documentIdFixture}#/components/${encodeURIComponent('Pet Name')}`,
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return the request body at the decoded pointer', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: `${documentIdFixture}#/components/Pet%20Name`,
+                  canonicalId: `${documentIdFixture}#/components/Pet%20Name`,
+                  value: refFixture,
+                },
+              ],
+              value: requestBodyFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref with a malformed percent-encoded fragment', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        documentFixture = {
+          components: {},
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: `${documentIdFixture}#%GG`,
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: 'Invalid URI fragment: %GG',
+              resolutionContextStack: [
+                {
+                  $ref: `${documentIdFixture}#%GG`,
+                  canonicalId: `${documentIdFixture}#%GG`,
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref with a JSON pointer to an array element', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let requestBodyFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        requestBodyFixture = {
+          content: {},
+        };
+        documentFixture = {
+          list: [requestBodyFixture],
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: `${documentIdFixture}#/list/0`,
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return the request body at the array index', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: `${documentIdFixture}#/list/0`,
+                  canonicalId: `${documentIdFixture}#/list/0`,
+                  value: refFixture,
+                },
+              ],
+              value: requestBodyFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a relative ref', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let openApiDocumentUriFixture: string;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        openApiDocumentUriFixture = 'https://example.com/api/openapi.json';
+        documentIdFixture = 'https://example.com/api/requestBody.json';
+        documentFixture = {
+          content: {},
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          openApiDocumentUriFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: 'requestBody.json',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should resolve the ref against the OpenAPI document URI', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: 'requestBody.json',
+                  canonicalId: documentIdFixture,
+                  value: refFixture,
+                },
+              ],
+              value: documentFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a relative ref to a missing resource', () => {
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        refFixture = {
+          $ref: 'requestBody.json',
+        };
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          OPEN_API_DOCUMENT_URI_FIXTURE,
+          () => undefined,
+        );
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason:
+                'Failed to resolve resource identified by: https://example.com/requestBody.json',
+              resolutionContextStack: [
+                {
+                  $ref: 'requestBody.json',
+                  canonicalId: 'https://example.com/requestBody.json',
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a same-document ref and a document with $self', () => {
+      let documentFixture: JsonValue;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let requestBodyFixture: JsonValue;
+      let resolveIdMock: Mock<(id: string) => JsonValue | undefined>;
+      let retrievalUriFixture: string;
+      let selfUriFixture: string;
+
+      beforeAll(() => {
+        retrievalUriFixture = 'https://git.example.com/blob/main/openapi.yaml';
+        selfUriFixture = 'https://example.com/api/openapi';
+        requestBodyFixture = {
+          content: {},
+        };
+        documentFixture = {
+          $self: selfUriFixture,
+          components: {
+            requestBodies: {
+              Pet: requestBodyFixture,
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [retrievalUriFixture, documentFixture],
+        ]);
+
+        resolveIdMock = vitest.fn((id: string) => documentById.get(id));
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          retrievalUriFixture,
+          resolveIdMock,
+        );
+
+        refFixture = {
+          $ref: '#/components/requestBodies/Pet',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should load the document by its retrieval URI', () => {
+          expect(resolveIdMock).toHaveBeenCalledTimes(1);
+          expect(resolveIdMock).toHaveBeenCalledWith(retrievalUriFixture);
+        });
+
+        it('should resolve the ref against $self', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: '#/components/requestBodies/Pet',
+                  canonicalId: `${selfUriFixture}#/components/requestBodies/Pet`,
+                  value: refFixture,
+                },
+              ],
+              value: requestBodyFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having an absolute ref to the entry document $self', () => {
+      let documentFixture: JsonValue;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let requestBodyFixture: JsonValue;
+      let resolveIdMock: Mock<(id: string) => JsonValue | undefined>;
+      let retrievalUriFixture: string;
+      let selfUriFixture: string;
+
+      beforeAll(() => {
+        retrievalUriFixture = 'https://git.example.com/blob/main/openapi.yaml';
+        selfUriFixture = 'https://example.com/api/openapi';
+        requestBodyFixture = {
+          content: {},
+        };
+        documentFixture = {
+          $self: selfUriFixture,
+          components: {
+            requestBodies: {
+              Pet: requestBodyFixture,
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [retrievalUriFixture, documentFixture],
+        ]);
+
+        resolveIdMock = vitest.fn((id: string) => documentById.get(id));
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          retrievalUriFixture,
+          resolveIdMock,
+        );
+
+        refFixture = {
+          $ref: `${selfUriFixture}#/components/requestBodies/Pet`,
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should load the document by its retrieval URI', () => {
+          expect(resolveIdMock).toHaveBeenCalledTimes(1);
+          expect(resolveIdMock).toHaveBeenCalledWith(retrievalUriFixture);
+        });
+
+        it('should return the request body identified by $self', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: `${selfUriFixture}#/components/requestBodies/Pet`,
+                  canonicalId: `${selfUriFixture}#/components/requestBodies/Pet`,
+                  value: refFixture,
+                },
+              ],
+              value: requestBodyFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a relative ref resolved against $self', () => {
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let requestBodyFixture: JsonValue;
+      let resolveIdMock: Mock<(id: string) => JsonValue | undefined>;
+      let retrievalUriFixture: string;
+      let selfUriFixture: string;
+      let sharedDocumentIdFixture: string;
+
+      beforeAll(() => {
+        retrievalUriFixture = 'https://git.example.com/blob/main/openapi.yaml';
+        selfUriFixture = 'https://example.com/api/openapi';
+        sharedDocumentIdFixture = 'https://example.com/api/shared/foo';
+        requestBodyFixture = {
+          content: {},
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [
+            retrievalUriFixture,
+            {
+              $self: selfUriFixture,
+              info: {
+                title: 'Example API',
+                version: '1.0',
+              },
+              openapi: '3.2.0',
+            },
+          ],
+          [
+            sharedDocumentIdFixture,
+            {
+              $self: sharedDocumentIdFixture,
+              components: {
+                requestBodies: {
+                  Foo: requestBodyFixture,
+                },
+              },
+            },
+          ],
+        ]);
+
+        resolveIdMock = vitest.fn((id: string) => documentById.get(id));
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          retrievalUriFixture,
+          resolveIdMock,
+        );
+
+        refFixture = {
+          $ref: 'shared/foo#/components/requestBodies/Foo',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should load the entry document by retrieval URI and the target by $self', () => {
+          expect(resolveIdMock).toHaveBeenCalledWith(retrievalUriFixture);
+          expect(resolveIdMock).toHaveBeenCalledWith(sharedDocumentIdFixture);
+        });
+
+        it('should return the request body from the document identified by $self', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: 'shared/foo#/components/requestBodies/Foo',
+                  canonicalId: `${sharedDocumentIdFixture}#/components/requestBodies/Foo`,
+                  value: refFixture,
+                },
+              ],
+              value: requestBodyFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a relative $self', () => {
+      let documentFixture: JsonValue;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let requestBodyFixture: JsonValue;
+      let retrievalUriFixture: string;
+      let resolvedSelfUriFixture: string;
+
+      beforeAll(() => {
+        retrievalUriFixture = 'https://staging.example.com/api/openapi';
+        resolvedSelfUriFixture = 'https://staging.example.com/openapi';
+        requestBodyFixture = {
+          content: {},
+        };
+        documentFixture = {
+          $self: '/openapi',
+          components: {
+            requestBodies: {
+              Pet: requestBodyFixture,
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [retrievalUriFixture, documentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          retrievalUriFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/components/requestBodies/Pet',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should resolve $self against the retrieval URI', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: '#/components/requestBodies/Pet',
+                  canonicalId: `${resolvedSelfUriFixture}#/components/requestBodies/Pet`,
+                  value: refFixture,
+                },
+              ],
+              value: requestBodyFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref chain whose second hop is resolved against $self', () => {
+      let aliasRefFixture: JsonValue;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let requestBodyFixture: JsonValue;
+      let retrievalUriFixture: string;
+      let selfUriFixture: string;
+      let sharedDocumentIdFixture: string;
+
+      beforeAll(() => {
+        retrievalUriFixture = 'https://git.example.com/blob/main/openapi.yaml';
+        selfUriFixture = 'https://example.com/api/openapi';
+        sharedDocumentIdFixture = 'https://example.com/api/shared/foo';
+        requestBodyFixture = {
+          content: {},
+          required: true,
+        };
+        aliasRefFixture = {
+          $ref: 'shared/foo#/components/requestBodies/Pet',
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [
+            retrievalUriFixture,
+            {
+              $self: selfUriFixture,
+              components: {
+                requestBodies: {
+                  Alias: aliasRefFixture,
+                },
+              },
+            },
+          ],
+          [
+            sharedDocumentIdFixture,
+            {
+              $self: sharedDocumentIdFixture,
+              components: {
+                requestBodies: {
+                  Pet: requestBodyFixture,
+                },
+              },
+            },
+          ],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          retrievalUriFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/components/requestBodies/Alias',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should resolve the second hop against the referring document $self', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: '#/components/requestBodies/Alias',
+                  canonicalId: `${selfUriFixture}#/components/requestBodies/Alias`,
+                  value: refFixture,
+                },
+                {
+                  $ref: 'shared/foo#/components/requestBodies/Pet',
+                  canonicalId: `${sharedDocumentIdFixture}#/components/requestBodies/Pet`,
+                  value: aliasRefFixture,
+                },
+              ],
+              value: requestBodyFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref to a schema document identified by $id', () => {
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let resolveIdMock: Mock<(id: string) => JsonValue | undefined>;
+      let retrievalUriFixture: string;
+      let schemaDocumentFixture: JsonValue;
+      let schemaIdFixture: string;
+
+      beforeAll(() => {
+        retrievalUriFixture = 'file:///tmp/pet.json';
+        schemaIdFixture = 'https://example.com/api/schemas/pet';
+        schemaDocumentFixture = {
+          $id: schemaIdFixture,
+          type: 'string',
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [retrievalUriFixture, schemaDocumentFixture],
+        ]);
+
+        resolveIdMock = vitest.fn((id: string) => documentById.get(id));
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          retrievalUriFixture,
+          resolveIdMock,
+        );
+
+        refFixture = {
+          $ref: schemaIdFixture,
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should load the document by its retrieval URI', () => {
+          expect(resolveIdMock).toHaveBeenCalledTimes(1);
+          expect(resolveIdMock).toHaveBeenCalledWith(retrievalUriFixture);
+        });
+
+        it('should identify the document by $id', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: schemaIdFixture,
+                  canonicalId: schemaIdFixture,
+                  value: refFixture,
+                },
+              ],
+              value: schemaDocumentFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a relative ref to a schema document', () => {
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let schemaDocumentFixture: JsonValue;
+      let schemaIdFixture: string;
+
+      beforeAll(() => {
+        schemaIdFixture = 'https://example.com/api/Pet.yaml';
+        schemaDocumentFixture = {
+          $id: schemaIdFixture,
+          type: 'object',
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [
+            'https://example.com/api/openapi.json',
+            {
+              $self: 'https://example.com/api/openapi.json',
+              openapi: '3.2.0',
+            },
+          ],
+          [schemaIdFixture, schemaDocumentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          'https://example.com/api/openapi.json',
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: 'Pet.yaml',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return the schema document', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: 'Pet.yaml',
+                  canonicalId: schemaIdFixture,
+                  value: refFixture,
+                },
+              ],
+              value: schemaDocumentFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having an entry document with an invalid $self URI', () => {
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let selfUriFixture: string;
+
+      beforeAll(() => {
+        selfUriFixture = '1https://example.com/openapi';
+        refFixture = {
+          $ref: '#/components/requestBodies/Pet',
+        };
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          OPEN_API_DOCUMENT_URI_FIXTURE,
+          () => ({
+            $self: selfUriFixture,
+          }),
+        );
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: `Invalid $self URI: ${selfUriFixture}`,
+              resolutionContextStack: [],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having an entry document with an invalid $self URI and an absolute ref', () => {
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let otherDocumentIdFixture: string;
+      let refFixture: JsonValue;
+      let selfUriFixture: string;
+
+      beforeAll(() => {
+        selfUriFixture = '1https://example.com/openapi';
+        otherDocumentIdFixture = 'https://example.com/other.json';
+        refFixture = {
+          $ref: otherDocumentIdFixture,
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [otherDocumentIdFixture, { content: {} }],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          OPEN_API_DOCUMENT_URI_FIXTURE,
+          (id: string) => {
+            if (id === OPEN_API_DOCUMENT_URI_FIXTURE) {
+              return {
+                $self: selfUriFixture,
+              };
+            }
+
+            return documentById.get(id);
+          },
+        );
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: `Invalid $self URI: ${selfUriFixture}`,
+              resolutionContextStack: [],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a referenced document with an invalid $self URI', () => {
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let selfUriFixture: string;
+      let sharedDocumentIdFixture: string;
+
+      beforeAll(() => {
+        sharedDocumentIdFixture = 'https://example.com/shared.json';
+        selfUriFixture = '1https://example.com/shared';
+        refFixture = {
+          $ref: 'shared.json',
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [OPEN_API_DOCUMENT_URI_FIXTURE, { openapi: '3.2.0' }],
+          [
+            sharedDocumentIdFixture,
+            {
+              $self: selfUriFixture,
+            },
+          ],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          OPEN_API_DOCUMENT_URI_FIXTURE,
+          (id: string) => documentById.get(id),
+        );
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure including the failing hop', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: `Invalid $self URI: ${selfUriFixture}`,
+              resolutionContextStack: [
+                {
+                  $ref: 'shared.json',
+                  canonicalId: sharedDocumentIdFixture,
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref to a ref to a request body', () => {
+      let aliasRefFixture: JsonValue;
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let requestBodyFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        requestBodyFixture = {
+          content: {},
+          required: true,
+        };
+        aliasRefFixture = {
+          $ref: '#/components/requestBodies/Pet',
+        };
+        documentFixture = {
+          components: {
+            requestBodies: {
+              Alias: aliasRefFixture,
+              Pet: requestBodyFixture,
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/components/requestBodies/Alias',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return the final request body', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: '#/components/requestBodies/Alias',
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/Alias`,
+                  value: refFixture,
+                },
+                {
+                  $ref: '#/components/requestBodies/Pet',
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/Pet`,
+                  value: aliasRefFixture,
+                },
+              ],
+              value: requestBodyFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref to a schema object with a JSON Schema $ref and sibling keywords', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let petSchemaFixture: JsonValue;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        petSchemaFixture = {
+          $ref: '#/components/schemas/Animal',
+          description: 'A pet',
+          type: 'object',
+        };
+        documentFixture = {
+          components: {
+            schemas: {
+              Animal: {
+                type: 'object',
+              },
+              Pet: petSchemaFixture,
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/components/schemas/Pet',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return the schema object without following its $ref', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: '#/components/schemas/Pet',
+                  canonicalId: `${documentIdFixture}#/components/schemas/Pet`,
+                  value: refFixture,
+                },
+              ],
+              value: petSchemaFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref to a $ref-only schema object', () => {
+      let animalSchemaFixture: JsonValue;
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let petSchemaFixture: JsonValue;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        animalSchemaFixture = {
+          type: 'object',
+        };
+        petSchemaFixture = {
+          $ref: '#/components/schemas/Animal',
+        };
+        documentFixture = {
+          components: {
+            schemas: {
+              Animal: animalSchemaFixture,
+              Pet: petSchemaFixture,
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/components/schemas/Pet',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should follow the $ref as an OpenAPI Reference Object', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: '#/components/schemas/Pet',
+                  canonicalId: `${documentIdFixture}#/components/schemas/Pet`,
+                  value: refFixture,
+                },
+                {
+                  $ref: '#/components/schemas/Animal',
+                  canonicalId: `${documentIdFixture}#/components/schemas/Animal`,
+                  value: petSchemaFixture,
+                },
+              ],
+              value: animalSchemaFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref to a media type schema with a JSON Schema $ref and sibling keywords', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let schemaFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        schemaFixture = {
+          $ref: '#/components/schemas/Pet',
+          type: 'object',
+        };
+        documentFixture = {
+          paths: {
+            '/pets': {
+              get: {
+                requestBody: {
+                  content: {
+                    'application/json': {
+                      schema: schemaFixture,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/paths/~1pets/get/requestBody/content/application~1json/schema',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return the schema object without following its $ref', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: '#/paths/~1pets/get/requestBody/content/application~1json/schema',
+                  canonicalId: `${documentIdFixture}#/paths/~1pets/get/requestBody/content/application~1json/schema`,
+                  value: refFixture,
+                },
+              ],
+              value: schemaFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref to a path item object with a $ref field', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let pathItemFixture: JsonValue;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        pathItemFixture = {
+          $ref: '#/components/pathItems/Pet',
+          get: {
+            responses: {},
+          },
+        };
+        documentFixture = {
+          components: {
+            pathItems: {
+              Pet: {
+                get: {
+                  operationId: 'getPet',
+                },
+              },
+            },
+          },
+          paths: {
+            '/pets': pathItemFixture,
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/paths/~1pets',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return the path item object without following its $ref', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: '#/paths/~1pets',
+                  canonicalId: `${documentIdFixture}#/paths/~1pets`,
+                  value: refFixture,
+                },
+              ],
+              value: pathItemFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref to a webhook that is a path item reference', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let pathItemFixture: JsonValue;
+      let refFixture: JsonValue;
+      let webhookRefFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        pathItemFixture = {
+          get: {
+            responses: {},
+          },
+        };
+        webhookRefFixture = {
+          $ref: '#/paths/~1pets',
+        };
+        documentFixture = {
+          paths: {
+            '/pets': pathItemFixture,
+          },
+          webhooks: {
+            newPet: webhookRefFixture,
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/webhooks/newPet',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should follow the webhook reference object', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: '#/webhooks/newPet',
+                  canonicalId: `${documentIdFixture}#/webhooks/newPet`,
+                  value: refFixture,
+                },
+                {
+                  $ref: '#/paths/~1pets',
+                  canonicalId: `${documentIdFixture}#/paths/~1pets`,
+                  value: webhookRefFixture,
+                },
+              ],
+              value: pathItemFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref chain across documents', () => {
+      let aliasRefFixture: JsonValue;
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let requestBodyFixture: JsonValue;
+      let sharedDocumentFixture: JsonValue;
+      let sharedDocumentIdFixture: string;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        sharedDocumentIdFixture = 'https://example.com/shared.json';
+        requestBodyFixture = {
+          content: {},
+          required: true,
+        };
+        aliasRefFixture = {
+          $ref: 'shared.json#/components/requestBodies/Pet',
+        };
+        documentFixture = {
+          components: {
+            requestBodies: {
+              Alias: aliasRefFixture,
+            },
+          },
+        };
+        sharedDocumentFixture = {
+          components: {
+            requestBodies: {
+              Pet: requestBodyFixture,
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+          [sharedDocumentIdFixture, sharedDocumentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/components/requestBodies/Alias',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should resolve the second hop against the referring document', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: '#/components/requestBodies/Alias',
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/Alias`,
+                  value: refFixture,
+                },
+                {
+                  $ref: 'shared.json#/components/requestBodies/Pet',
+                  canonicalId: `${sharedDocumentIdFixture}#/components/requestBodies/Pet`,
+                  value: aliasRefFixture,
+                },
+              ],
+              value: requestBodyFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a circular ref chain', () => {
+      let aRefFixture: JsonValue;
+      let bRefFixture: JsonValue;
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        aRefFixture = {
+          $ref: '#/components/requestBodies/B',
+        };
+        bRefFixture = {
+          $ref: '#/components/requestBodies/A',
+        };
+        documentFixture = {
+          components: {
+            requestBodies: {
+              A: aRefFixture,
+              B: bRefFixture,
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/components/requestBodies/A',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure with the followed chain', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: `Circular reference detected: ${documentIdFixture}#/components/requestBodies/A`,
+              resolutionContextStack: [
+                {
+                  $ref: '#/components/requestBodies/A',
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/A`,
+                },
+                {
+                  $ref: '#/components/requestBodies/B',
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/B`,
+                },
+                {
+                  $ref: '#/components/requestBodies/A',
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/A`,
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a self-referencing ref', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        documentFixture = {
+          components: {
+            requestBodies: {
+              A: {
+                $ref: '#/components/requestBodies/A',
+              },
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/components/requestBodies/A',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a circular reference failure', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: `Circular reference detected: ${documentIdFixture}#/components/requestBodies/A`,
+              resolutionContextStack: [
+                {
+                  $ref: '#/components/requestBodies/A',
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/A`,
+                },
+                {
+                  $ref: '#/components/requestBodies/A',
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/A`,
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref to a missing resource', () => {
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        refFixture = {
+          $ref: 'https://example.com/missing.json',
+        };
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          OPEN_API_DOCUMENT_URI_FIXTURE,
+          () => undefined,
+        );
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason:
+                'Failed to resolve resource identified by: https://example.com/missing.json',
+              resolutionContextStack: [
+                {
+                  $ref: 'https://example.com/missing.json',
+                  canonicalId: 'https://example.com/missing.json',
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref to a ref to a missing resource', () => {
+      let aliasRefFixture: JsonValue;
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        aliasRefFixture = {
+          $ref: 'https://example.com/missing.json',
+        };
+        documentFixture = {
+          components: {
+            requestBodies: {
+              Alias: aliasRefFixture,
+            },
+          },
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: '#/components/requestBodies/Alias',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure including the missing hop', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason:
+                'Failed to resolve resource identified by: https://example.com/missing.json',
+              resolutionContextStack: [
+                {
+                  $ref: '#/components/requestBodies/Alias',
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/Alias`,
+                },
+                {
+                  $ref: 'https://example.com/missing.json',
+                  canonicalId: 'https://example.com/missing.json',
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref with a non-pointer fragment', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        documentFixture = {
+          pet: 'Rex',
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: `${documentIdFixture}#Pet`,
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason:
+                'Invalid fragment: Pet (OpenAPI reference fragments MUST be JSON Pointers)',
+              resolutionContextStack: [
+                {
+                  $ref: `${documentIdFixture}#Pet`,
+                  canonicalId: `${documentIdFixture}#Pet`,
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref with a pointer to a missing key', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        documentFixture = {
+          components: {},
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: `${documentIdFixture}#/components/requestBodies/Pet`,
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason:
+                'Failed to resolve JSON Pointer: /components/requestBodies/Pet',
+              resolutionContextStack: [
+                {
+                  $ref: `${documentIdFixture}#/components/requestBodies/Pet`,
+                  canonicalId: `${documentIdFixture}#/components/requestBodies/Pet`,
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref with a pointer traversing a non-object', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        documentFixture = {
+          pet: 'Rex',
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: `${documentIdFixture}#/pet/child`,
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a failure', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: 'Failed to resolve JSON Pointer: /pet/child',
+              resolutionContextStack: [
+                {
+                  $ref: `${documentIdFixture}#/pet/child`,
+                  canonicalId: `${documentIdFixture}#/pet/child`,
+                },
+              ],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref whose target is a primitive', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        documentFixture = {
+          pet: 'Rex',
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: `${documentIdFixture}#/pet`,
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return the primitive target', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: `${documentIdFixture}#/pet`,
+                  canonicalId: `${documentIdFixture}#/pet`,
+                  value: refFixture,
+                },
+              ],
+              value: 'Rex',
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref whose target is null', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/openapi.json';
+        documentFixture = {
+          empty: null,
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: `${documentIdFixture}#/empty`,
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a null target', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: `${documentIdFixture}#/empty`,
+                  canonicalId: `${documentIdFixture}#/empty`,
+                  value: refFixture,
+                },
+              ],
+              value: null,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a ref with summary and description properties', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/requestBody.json';
+        documentFixture = {
+          content: {},
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          (id: string) => documentById.get(id),
+        );
+
+        refFixture = {
+          $ref: documentIdFixture,
+          description: 'A reference description',
+          summary: 'A reference summary',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should ignore the summary and description properties', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: documentIdFixture,
+                  canonicalId: documentIdFixture,
+                  value: refFixture,
+                },
+              ],
+              value: documentFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having the same document referenced multiple times', () => {
+      let documentFixture: JsonValue;
+      let documentIdFixture: string;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let resolveIdMock: Mock<(id: string) => JsonValue | undefined>;
+
+      beforeAll(() => {
+        documentIdFixture = 'https://example.com/requestBody.json';
+        documentFixture = {
+          content: {},
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          [documentIdFixture, documentFixture],
+        ]);
+
+        resolveIdMock = vitest.fn((id: string) => documentById.get(id));
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          documentIdFixture,
+          resolveIdMock,
+        );
+
+        refFixture = {
+          $ref: documentIdFixture,
+        };
+      });
+
+      describe('when called twice', () => {
+        beforeAll(() => {
+          openApi3Dot2Resolver.resolveRef(refFixture);
+          openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should load the document only once', () => {
+          expect(resolveIdMock).toHaveBeenCalledTimes(1);
+          expect(resolveIdMock).toHaveBeenCalledWith(documentIdFixture);
+        });
+      });
+    });
+  });
+});

--- a/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot2/services/OpenApi3Dot2Resolver.ts
+++ b/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot2/services/OpenApi3Dot2Resolver.ts
@@ -1,0 +1,405 @@
+/*
+ * Resolves OpenAPI 3.2 Reference Objects per:
+ * - https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.2.0.md#referenceObject
+ * - https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.2.0.md#relativeReferencesInApiDescriptionUris
+ *
+ * Unlike JsonSchemaResolver, this resolver does not follow JSON Schema
+ * keywords ($ref, $dynamicRef, $anchor, $dynamicAnchor) or nested Schema
+ * Object `$id` values. It only follows OpenAPI Reference Objects (`$ref`
+ * with optional `summary` and `description`) until a non-reference target
+ * is reached.
+ *
+ * A loaded document may declare its URI: OpenAPI Objects via `$self`, and
+ * Schema Object documents (at the document root) via `$id`. That URI is the
+ * document identity and the RFC 3986 base URI for relative `$ref` values.
+ * Relative `$self` / `$id` values are resolved against the retrieval URI.
+ *
+ * The constructor URI is the entry document's retrieval URI. That document is
+ * loaded on `resolveRef` so an invalid `$self` / `$id` fails immediately, and
+ * so later lookups by the declared URI find it without `resolveId` knowing the
+ * retrieval URI. Other documents are loaded by the URI a `$ref` resolves to,
+ * which is the declared `$self` / `$id` when the target document has one.
+ */
+
+import { resolveJsonPointer } from '@inversifyjs/json-schema-pointer';
+import { type JsonValue } from '@inversifyjs/json-schema-types';
+import { Uri } from '@inversifyjs/uri';
+
+import { isOpenApi3Dot2ReferenceObject } from '../calculations/isOpenApi3Dot2ReferenceObject.js';
+
+export interface OpenApi3Dot2RefResolutionContext {
+  /** The `$ref` URI exactly as declared in the Reference Object. */
+  readonly $ref: string;
+  /** The canonical URI of the referenced location. */
+  readonly canonicalId: string;
+}
+
+export interface OpenApi3Dot2RefResolutionChainEntry extends OpenApi3Dot2RefResolutionContext {
+  /** The Reference Object of the hop. */
+  readonly value: JsonValue;
+}
+
+export interface OpenApi3Dot2RefResolutionFailure {
+  readonly resolutionContextStack: readonly OpenApi3Dot2RefResolutionContext[];
+  readonly reason: string;
+}
+
+export interface OpenApi3Dot2RefResolutionSuccess {
+  /** The references followed, in order, from the first hop to the last. */
+  readonly chain: readonly OpenApi3Dot2RefResolutionChainEntry[];
+  /** The final resolved value. OpenAPI Reference Object chains are fully followed. The value may still be a Schema Object or Path Item Object that uses `$ref` with sibling fields. */
+  readonly value: JsonValue;
+}
+
+export type OpenApi3Dot2RefResolutionResult =
+  | {
+      isRight: false;
+      value: OpenApi3Dot2RefResolutionFailure;
+    }
+  | {
+      isRight: true;
+      value: OpenApi3Dot2RefResolutionSuccess;
+    };
+
+interface OpenApi3Dot2DocumentCacheEntry {
+  readonly baseUri: string;
+  readonly document: JsonValue;
+}
+
+type OpenApi3Dot2LoadDocumentResult =
+  | {
+      isRight: false;
+      value: string;
+    }
+  | {
+      isRight: true;
+      value: OpenApi3Dot2DocumentCacheEntry | undefined;
+    };
+
+type OpenApi3Dot2DocumentBaseUriResult =
+  | {
+      isRight: false;
+      value: string;
+    }
+  | {
+      isRight: true;
+      value: string;
+    };
+
+export class OpenApi3Dot2Resolver {
+  readonly #idToDocumentMap: Map<string, OpenApi3Dot2DocumentCacheEntry>;
+  readonly #openApiDocumentUri: string;
+  readonly #resolveId: (id: string) => JsonValue | undefined;
+
+  constructor(
+    openApiDocumentUri: string,
+    resolveId: (id: string) => JsonValue | undefined,
+  ) {
+    let documentUri: Uri;
+
+    try {
+      documentUri = new Uri(openApiDocumentUri);
+    } catch (error: unknown) {
+      throw new Error(`Invalid OpenAPI document URI: ${openApiDocumentUri}`, {
+        cause: error,
+      });
+    }
+
+    this.#idToDocumentMap = new Map();
+    this.#openApiDocumentUri = Uri.fromAttributes({
+      ...documentUri.attributes,
+      fragment: undefined,
+    }).toString();
+    this.#resolveId = resolveId;
+  }
+
+  public resolveRef(openApiRef: JsonValue): OpenApi3Dot2RefResolutionResult {
+    if (!isOpenApi3Dot2ReferenceObject(openApiRef)) {
+      return this.#buildFailure(
+        [],
+        'Invalid OpenAPI Reference Object: expected an object with a string "$ref" property and optional "summary" and "description" properties',
+      );
+    }
+
+    const entryLoadResult: OpenApi3Dot2LoadDocumentResult = this.#loadDocument(
+      new Uri(this.#openApiDocumentUri),
+    );
+
+    if (!entryLoadResult.isRight) {
+      return this.#buildFailure([], entryLoadResult.value);
+    }
+
+    const firstHopBase: string =
+      entryLoadResult.value?.baseUri ?? this.#openApiDocumentUri;
+
+    return this.#resolveRefChain(
+      openApiRef,
+      firstHopBase,
+      [],
+      new Set<string>(),
+    );
+  }
+
+  #resolveRefChain(
+    openApiRef: JsonValue,
+    baseRef: string,
+    chain: readonly OpenApi3Dot2RefResolutionChainEntry[],
+    visitedCanonicalIds: ReadonlySet<string>,
+  ): OpenApi3Dot2RefResolutionResult {
+    if (!isOpenApi3Dot2ReferenceObject(openApiRef)) {
+      return this.#buildFailure(
+        chain,
+        'Invalid OpenAPI Reference Object: expected an object with a string "$ref" property and optional "summary" and "description" properties',
+      );
+    }
+
+    const ref: string = openApiRef['$ref'];
+
+    let canonicalUri: Uri;
+
+    try {
+      canonicalUri = new Uri(ref, baseRef);
+    } catch (_error: unknown) {
+      return this.#buildFailure(chain, `Invalid URI: ${ref} Base: ${baseRef}`);
+    }
+
+    const canonicalId: string = canonicalUri.toString();
+    const nextChain: readonly OpenApi3Dot2RefResolutionChainEntry[] = [
+      ...chain,
+      {
+        $ref: ref,
+        canonicalId,
+        value: openApiRef,
+      },
+    ];
+
+    if (visitedCanonicalIds.has(canonicalId)) {
+      return this.#buildFailure(
+        nextChain,
+        `Circular reference detected: ${canonicalId}`,
+      );
+    }
+
+    const nextVisitedCanonicalIds: Set<string> = new Set(visitedCanonicalIds);
+
+    nextVisitedCanonicalIds.add(canonicalId);
+
+    const documentUri: Uri = Uri.fromAttributes({
+      ...canonicalUri.attributes,
+      fragment: undefined,
+    });
+
+    const loadResult: OpenApi3Dot2LoadDocumentResult =
+      this.#loadDocument(documentUri);
+
+    if (!loadResult.isRight) {
+      return this.#buildFailure(nextChain, loadResult.value);
+    }
+
+    if (loadResult.value === undefined) {
+      return this.#buildFailure(
+        nextChain,
+        `Failed to resolve resource identified by: ${documentUri.toString()}`,
+      );
+    }
+
+    const document: JsonValue = loadResult.value.document;
+    const documentBaseUri: string = loadResult.value.baseUri;
+
+    const fragment: string | undefined = canonicalUri.attributes.fragment;
+
+    let target: JsonValue;
+
+    if (fragment === undefined || fragment === '') {
+      target = document;
+    } else {
+      let decodedFragment: string;
+
+      try {
+        decodedFragment = decodeURIComponent(fragment);
+      } catch (_error: unknown) {
+        return this.#buildFailure(
+          nextChain,
+          `Invalid URI fragment: ${fragment}`,
+        );
+      }
+
+      if (decodedFragment.startsWith('/')) {
+        const resolvedTarget: JsonValue | undefined = resolveJsonPointer(
+          document,
+          decodedFragment,
+        );
+
+        if (resolvedTarget === undefined) {
+          return this.#buildFailure(
+            nextChain,
+            `Failed to resolve JSON Pointer: ${decodedFragment}`,
+          );
+        }
+
+        target = resolvedTarget;
+      } else {
+        return this.#buildFailure(
+          nextChain,
+          `Invalid fragment: ${decodedFragment} (OpenAPI reference fragments MUST be JSON Pointers)`,
+        );
+      }
+    }
+
+    if (isOpenApi3Dot2ReferenceObject(target)) {
+      return this.#resolveRefChain(
+        target,
+        documentBaseUri,
+        nextChain,
+        nextVisitedCanonicalIds,
+      );
+    }
+
+    return {
+      isRight: true,
+      value: {
+        chain: nextChain,
+        value: target,
+      },
+    };
+  }
+
+  #buildFailure(
+    chain: readonly OpenApi3Dot2RefResolutionChainEntry[],
+    reason: string,
+  ): OpenApi3Dot2RefResolutionResult {
+    return {
+      isRight: false,
+      value: {
+        reason,
+        resolutionContextStack: chain.map(
+          (entry: OpenApi3Dot2RefResolutionChainEntry) => ({
+            $ref: entry.$ref,
+            canonicalId: entry.canonicalId,
+          }),
+        ),
+      },
+    };
+  }
+
+  #loadDocument(documentUri: Uri): OpenApi3Dot2LoadDocumentResult {
+    const documentId: string = documentUri.toString();
+    const cachedEntry: OpenApi3Dot2DocumentCacheEntry | undefined =
+      this.#idToDocumentMap.get(documentId);
+
+    if (cachedEntry !== undefined) {
+      return {
+        isRight: true,
+        value: cachedEntry,
+      };
+    }
+
+    const document: JsonValue | undefined = this.#resolveId(documentId);
+
+    if (document === undefined) {
+      return this.#loadEntryDocumentAndRetry(documentId);
+    }
+
+    return this.#indexDocument(documentId, document);
+  }
+
+  #loadEntryDocumentAndRetry(
+    documentId: string,
+  ): OpenApi3Dot2LoadDocumentResult {
+    if (documentId === this.#openApiDocumentUri) {
+      return {
+        isRight: true,
+        value: undefined,
+      };
+    }
+
+    const entryLoadResult: OpenApi3Dot2LoadDocumentResult = this.#loadDocument(
+      new Uri(this.#openApiDocumentUri),
+    );
+
+    if (!entryLoadResult.isRight) {
+      return entryLoadResult;
+    }
+
+    return {
+      isRight: true,
+      value: this.#idToDocumentMap.get(documentId),
+    };
+  }
+
+  #indexDocument(
+    loadedId: string,
+    document: JsonValue,
+  ): OpenApi3Dot2LoadDocumentResult {
+    const baseUriResult: OpenApi3Dot2DocumentBaseUriResult =
+      this.#resolveDocumentBaseUri(document, loadedId);
+
+    if (!baseUriResult.isRight) {
+      return baseUriResult;
+    }
+
+    const entry: OpenApi3Dot2DocumentCacheEntry = {
+      baseUri: baseUriResult.value,
+      document,
+    };
+
+    this.#idToDocumentMap.set(loadedId, entry);
+
+    if (entry.baseUri !== loadedId) {
+      this.#idToDocumentMap.set(entry.baseUri, entry);
+    }
+
+    return {
+      isRight: true,
+      value: entry,
+    };
+  }
+
+  #resolveDocumentBaseUri(
+    document: JsonValue,
+    retrievalUri: string,
+  ): OpenApi3Dot2DocumentBaseUriResult {
+    if (
+      document === null ||
+      typeof document !== 'object' ||
+      Array.isArray(document)
+    ) {
+      return {
+        isRight: true,
+        value: retrievalUri,
+      };
+    }
+
+    let declaredField: '$id' | '$self';
+    let declaredUri: string;
+
+    if (typeof document['$self'] === 'string') {
+      declaredField = '$self';
+      declaredUri = document['$self'];
+    } else if (typeof document['$id'] === 'string') {
+      declaredField = '$id';
+      declaredUri = document['$id'];
+    } else {
+      return {
+        isRight: true,
+        value: retrievalUri,
+      };
+    }
+    try {
+      const uri: Uri = new Uri(declaredUri, retrievalUri);
+
+      return {
+        isRight: true,
+        value: Uri.fromAttributes({
+          ...uri.attributes,
+          fragment: undefined,
+        }).toString(),
+      };
+    } catch (_error: unknown) {
+      return {
+        isRight: false,
+        value: `Invalid ${declaredField} URI: ${declaredUri}`,
+      };
+    }
+  }
+}


### PR DESCRIPTION
### Added
- Added `OpenApi3Dot1Resolver`.
- Added `OpenApi3Dot2Resolver`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenAPI 3.1 and 3.2 reference resolution.
  * Supports same-document, cross-document, relative, and JSON Pointer references.
  * Follows chained references, handles `$self` and `$id`, and detects circular references.
  * Provides structured success and failure results with resolution context.
  * Added validation for supported Reference Object formats.

* **Tests**
  * Added comprehensive coverage for valid references, malformed inputs, missing resources, pointer handling, and circular chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->