### PR TITLE
Update OpenApi resolution flow

### DIFF
--- a/.changeset/short-eagles-knock.md
+++ b/.changeset/short-eagles-knock.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/open-api-validation": minor
+---
+
+- Updated `OpenApiValidationPipe` to rely on OpenApi resolvers

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/buildHeaderParse.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/buildHeaderParse.spec.ts
@@ -20,6 +20,7 @@ describe(buildHeaderParse, () => {
     beforeAll(() => {
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };
@@ -82,6 +83,7 @@ describe(buildHeaderParse, () => {
         deepResolveReference: vitest
           .fn()
           .mockReturnValueOnce({ type: 'integer' }),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/buildParamParse.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/buildParamParse.spec.ts
@@ -20,6 +20,7 @@ describe(buildParamParse, () => {
     beforeAll(() => {
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };
@@ -82,6 +83,7 @@ describe(buildParamParse, () => {
         deepResolveReference: vitest
           .fn()
           .mockReturnValueOnce({ type: 'integer' }),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/buildQueryParse.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/buildQueryParse.spec.ts
@@ -212,6 +212,7 @@ describe(buildQueryParse, () => {
   beforeAll(() => {
     openApiResolverFixture = {
       deepResolveReference: vitest.fn(),
+      resolveJsonSchema: vitest.fn(),
       resolveOpenApiReference: vitest.fn(),
       resolveReference: vitest.fn(),
     };

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/inferOpenApiSchemaTypes.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/inferOpenApiSchemaTypes.spec.ts
@@ -17,6 +17,7 @@ describe(inferOpenApiSchemaTypes, () => {
       [
         {
           deepResolveReference: (): undefined => undefined,
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },
@@ -29,6 +30,7 @@ describe(inferOpenApiSchemaTypes, () => {
       [
         {
           deepResolveReference: (): undefined => undefined,
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },
@@ -41,6 +43,7 @@ describe(inferOpenApiSchemaTypes, () => {
       [
         {
           deepResolveReference: (): undefined => undefined,
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },
@@ -53,6 +56,7 @@ describe(inferOpenApiSchemaTypes, () => {
       [
         {
           deepResolveReference: (): undefined => undefined,
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },
@@ -65,6 +69,7 @@ describe(inferOpenApiSchemaTypes, () => {
       [
         {
           deepResolveReference: (): undefined => undefined,
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },
@@ -79,6 +84,7 @@ describe(inferOpenApiSchemaTypes, () => {
           deepResolveReference: vitest
             .fn<(reference: string) => JsonValue | undefined>()
             .mockReturnValueOnce({ type: 'object' }),
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },
@@ -91,6 +97,7 @@ describe(inferOpenApiSchemaTypes, () => {
       [
         {
           deepResolveReference: (): undefined => undefined,
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },
@@ -108,6 +115,7 @@ describe(inferOpenApiSchemaTypes, () => {
       [
         {
           deepResolveReference: (): undefined => undefined,
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },
@@ -120,6 +128,7 @@ describe(inferOpenApiSchemaTypes, () => {
       [
         {
           deepResolveReference: (): undefined => undefined,
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },
@@ -142,6 +151,7 @@ describe(inferOpenApiSchemaTypes, () => {
             .mockReturnValueOnce({
               type: ['string', 'number', 'boolean'],
             }),
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },
@@ -159,6 +169,7 @@ describe(inferOpenApiSchemaTypes, () => {
       [
         {
           deepResolveReference: (): undefined => undefined,
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },
@@ -171,6 +182,7 @@ describe(inferOpenApiSchemaTypes, () => {
       [
         {
           deepResolveReference: (): undefined => undefined,
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },
@@ -189,6 +201,7 @@ describe(inferOpenApiSchemaTypes, () => {
       [
         {
           deepResolveReference: (): undefined => undefined,
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },
@@ -201,6 +214,7 @@ describe(inferOpenApiSchemaTypes, () => {
       [
         {
           deepResolveReference: (): undefined => undefined,
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },
@@ -213,6 +227,7 @@ describe(inferOpenApiSchemaTypes, () => {
       [
         {
           deepResolveReference: (): undefined => undefined,
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },
@@ -225,6 +240,7 @@ describe(inferOpenApiSchemaTypes, () => {
       [
         {
           deepResolveReference: (): undefined => undefined,
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },
@@ -237,6 +253,7 @@ describe(inferOpenApiSchemaTypes, () => {
       [
         {
           deepResolveReference: (): undefined => undefined,
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },
@@ -249,6 +266,7 @@ describe(inferOpenApiSchemaTypes, () => {
       [
         {
           deepResolveReference: (): undefined => undefined,
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },
@@ -261,6 +279,7 @@ describe(inferOpenApiSchemaTypes, () => {
       [
         {
           deepResolveReference: (): undefined => undefined,
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },
@@ -273,6 +292,7 @@ describe(inferOpenApiSchemaTypes, () => {
       [
         {
           deepResolveReference: (): undefined => undefined,
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },
@@ -307,6 +327,7 @@ describe(inferOpenApiSchemaTypes, () => {
       [
         {
           deepResolveReference: (): undefined => undefined,
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },
@@ -318,6 +339,7 @@ describe(inferOpenApiSchemaTypes, () => {
       [
         {
           deepResolveReference: (): undefined => undefined,
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },
@@ -329,6 +351,7 @@ describe(inferOpenApiSchemaTypes, () => {
       [
         {
           deepResolveReference: (): undefined => undefined,
+          resolveJsonSchema: vitest.fn(),
           resolveOpenApiReference: vitest.fn(),
           resolveReference: (): undefined => undefined,
         },

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/inferSchemaTypeOrPrimitivaSchemaTypeOrThrow.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/inferSchemaTypeOrPrimitivaSchemaTypeOrThrow.spec.ts
@@ -18,6 +18,7 @@ describe(inferSchemaTypeOrPrimitivaSchemaTypeOrThrow, () => {
   beforeAll(() => {
     openApiResolverFixture = {
       deepResolveReference: vitest.fn(),
+      resolveJsonSchema: vitest.fn(),
       resolveOpenApiReference: vitest.fn(),
       resolveReference: vitest.fn(),
     };

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/inferSchemaTypeOrThrow.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/inferSchemaTypeOrThrow.spec.ts
@@ -15,6 +15,7 @@ describe(inferSchemaTypeOrThrow, () => {
   beforeAll(() => {
     openApiResolverFixture = {
       deepResolveReference: vitest.fn(),
+      resolveJsonSchema: vitest.fn(),
       resolveOpenApiReference: vitest.fn(),
       resolveReference: vitest.fn(),
     };

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getHeaderParameterObjects.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getHeaderParameterObjects.spec.ts
@@ -5,6 +5,7 @@ vitest.mock(import('./getOperationObject.js'));
 vitest.mock(import('./getPathItemObject.js'));
 
 import { escapeJsonPointerFragments } from '@inversifyjs/json-schema-pointer';
+import { type JsonValue } from '@inversifyjs/json-schema-types';
 import {
   type OpenApi3Dot1Object,
   type OpenApi3Dot1OperationObject,
@@ -65,6 +66,7 @@ describe(getHeaderParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };
@@ -82,6 +84,12 @@ describe(getHeaderParameterObjects, () => {
 
     afterAll(() => {
       vitest.clearAllMocks();
+    });
+
+    it('should not call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).not.toHaveBeenCalled();
     });
 
     it('should return a map with the header parameter', () => {
@@ -123,6 +131,7 @@ describe(getHeaderParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };
@@ -185,6 +194,7 @@ describe(getHeaderParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };
@@ -232,10 +242,11 @@ describe(getHeaderParameterObjects, () => {
 
   describe('when called, and parameter is a $ref reference', () => {
     let openApiResolverFixture: OpenApiResolver;
+    let refFixture: OpenApi3Dot1ReferenceObject;
     let result: Map<string, HeaderParameterEntry>;
 
     beforeAll(() => {
-      const refFixture: OpenApi3Dot1ReferenceObject = {
+      refFixture = {
         $ref: '#/components/parameters/ApiKeyHeader',
       };
 
@@ -256,10 +267,22 @@ describe(getHeaderParameterObjects, () => {
       };
 
       openApiResolverFixture = {
-        deepResolveReference: vitest
-          .fn()
-          .mockReturnValueOnce(resolvedParamFixture),
-        resolveOpenApiReference: vitest.fn(),
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: true,
+          value: {
+            chain: [
+              {
+                $ref: refFixture.$ref,
+                canonicalId:
+                  'urn:inversifyjs:openapi-v3dot1-spec#/components/parameters/ApiKeyHeader',
+                value: refFixture as unknown as JsonValue,
+              },
+            ],
+            value: resolvedParamFixture as unknown as JsonValue,
+          },
+        }),
         resolveReference: vitest.fn(),
       };
 
@@ -278,24 +301,117 @@ describe(getHeaderParameterObjects, () => {
       vitest.clearAllMocks();
     });
 
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
     it('should resolve the $ref and return the header parameter', () => {
       expect(result.size).toBe(1);
       expect(result.has('x-api-key')).toBe(true);
     });
 
-    it('should call deepResolveReference', () => {
-      expect(
-        openApiResolverFixture.deepResolveReference,
-      ).toHaveBeenCalledExactlyOnceWith('#/components/parameters/ApiKeyHeader');
+    it('should return entry with component pointer prefix', () => {
+      const entry: HeaderParameterEntry = result.get(
+        'x-api-key',
+      ) as HeaderParameterEntry;
+
+      expect(entry.pointerPrefix).toBe('components/parameters/ApiKeyHeader');
     });
   });
 
-  describe('when called, and path item deepResolveReference returns undefined', () => {
+  describe('when called, and path item parameter is a $ref reference', () => {
     let openApiResolverFixture: OpenApiResolver;
+    let refFixture: OpenApi3Dot1ReferenceObject;
+    let result: Map<string, HeaderParameterEntry>;
+
+    beforeAll(() => {
+      refFixture = {
+        $ref: '#/components/parameters/ApiKeyHeader',
+      };
+
+      const resolvedParamFixture: OpenApi3Dot1ParameterObject = {
+        in: 'header',
+        name: 'X-Api-Key',
+        required: true,
+        schema: { type: 'string' },
+      };
+
+      const operationFixture: OpenApi3Dot1OperationObject = {
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot1PathItemObject = {
+        get: operationFixture,
+        parameters: [refFixture],
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: true,
+          value: {
+            chain: [
+              {
+                $ref: refFixture.$ref,
+                canonicalId:
+                  'urn:inversifyjs:openapi-v3dot1-spec#/components/parameters/ApiKeyHeader',
+                value: refFixture as unknown as JsonValue,
+              },
+            ],
+            value: resolvedParamFixture as unknown as JsonValue,
+          },
+        }),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getHeaderParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
+    it('should resolve the $ref and return the header parameter', () => {
+      expect(result.size).toBe(1);
+      expect(result.has('x-api-key')).toBe(true);
+    });
+
+    it('should return entry with component pointer prefix', () => {
+      const entry: HeaderParameterEntry = result.get(
+        'x-api-key',
+      ) as HeaderParameterEntry;
+
+      expect(entry.pointerPrefix).toBe('components/parameters/ApiKeyHeader');
+    });
+  });
+
+  describe('when called, and path item $ref fails to resolve', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let reasonFixture: string;
+    let refFixture: OpenApi3Dot1ReferenceObject;
     let result: unknown;
 
     beforeAll(() => {
-      const refFixture: OpenApi3Dot1ReferenceObject = {
+      reasonFixture =
+        'Failed to resolve JSON Pointer: /components/parameters/MissingHeader';
+      refFixture = {
         $ref: '#/components/parameters/MissingHeader',
       };
 
@@ -309,8 +425,15 @@ describe(getHeaderParameterObjects, () => {
       };
 
       openApiResolverFixture = {
-        deepResolveReference: vitest.fn().mockReturnValueOnce(undefined),
-        resolveOpenApiReference: vitest.fn(),
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: false,
+          value: {
+            reason: reasonFixture,
+            resolutionContextStack: [],
+          },
+        }),
         resolveReference: vitest.fn(),
       };
 
@@ -333,11 +456,17 @@ describe(getHeaderParameterObjects, () => {
       vitest.clearAllMocks();
     });
 
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
     it('should throw an InversifyOpenApiValidationError', () => {
       const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
         {
           kind: InversifyValidationErrorKind.validationFailed,
-          message: `Unable to resolve header parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0`,
+          message: `Could not resolve $ref pointer ${refFixture.$ref} for parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0: ${reasonFixture}`,
         };
 
       expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
@@ -345,12 +474,16 @@ describe(getHeaderParameterObjects, () => {
     });
   });
 
-  describe('when called, and operation deepResolveReference returns undefined', () => {
+  describe('when called, and operation $ref fails to resolve', () => {
     let openApiResolverFixture: OpenApiResolver;
+    let reasonFixture: string;
+    let refFixture: OpenApi3Dot1ReferenceObject;
     let result: unknown;
 
     beforeAll(() => {
-      const refFixture: OpenApi3Dot1ReferenceObject = {
+      reasonFixture =
+        'Failed to resolve JSON Pointer: /components/parameters/MissingHeader';
+      refFixture = {
         $ref: '#/components/parameters/MissingHeader',
       };
 
@@ -364,8 +497,84 @@ describe(getHeaderParameterObjects, () => {
       };
 
       openApiResolverFixture = {
-        deepResolveReference: vitest.fn().mockReturnValueOnce(undefined),
-        resolveOpenApiReference: vitest.fn(),
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: false,
+          value: {
+            reason: reasonFixture,
+            resolutionContextStack: [],
+          },
+        }),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      try {
+        getHeaderParameterObjects(
+          openApiObjectFixture,
+          openApiResolverFixture,
+          methodFixture,
+          pathFixture,
+        );
+      } catch (error: unknown) {
+        result = error;
+      }
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
+    it('should throw an InversifyOpenApiValidationError', () => {
+      const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+        {
+          kind: InversifyValidationErrorKind.validationFailed,
+          message: `Could not resolve $ref pointer ${refFixture.$ref} for parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0: ${reasonFixture}`,
+        };
+
+      expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
+      expect(result).toMatchObject(expectedErrorProperties);
+    });
+  });
+
+  describe('when called, and $ref resolves to a non-object', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let refFixture: OpenApi3Dot1ReferenceObject;
+    let result: unknown;
+
+    beforeAll(() => {
+      refFixture = {
+        $ref: '#/components/parameters/ApiKeyHeader',
+      };
+
+      const operationFixture: OpenApi3Dot1OperationObject = {
+        parameters: [refFixture],
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot1PathItemObject = {
+        get: operationFixture,
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: true,
+          value: {
+            chain: [],
+            value: null,
+          },
+        }),
         resolveReference: vitest.fn(),
       };
 
@@ -392,7 +601,7 @@ describe(getHeaderParameterObjects, () => {
       const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
         {
           kind: InversifyValidationErrorKind.validationFailed,
-          message: `Unable to resolve header parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0`,
+          message: `Resolved $ref pointer ${refFixture.$ref} is not a valid parameter object at path: ${pathFixture} and method: ${methodFixture} and index: 0`,
         };
 
       expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
@@ -415,6 +624,7 @@ describe(getHeaderParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };
@@ -467,6 +677,7 @@ describe(getHeaderParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getHeaderParameterObjects.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getHeaderParameterObjects.ts
@@ -6,22 +6,18 @@ import {
   type OpenApi3Dot1PathItemObject,
   type OpenApi3Dot1ReferenceObject,
 } from '@inversifyjs/open-api-types/v3Dot1';
-import { InversifyValidationErrorKind } from '@inversifyjs/validation-common';
 
-import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
 import { getOperationObject } from './getOperationObject.js';
 import { getPathItemObject } from './getPathItemObject.js';
+import {
+  type ResolvedParameterObject,
+  resolveParameterObject,
+} from './resolveParameterObject.js';
 
 export interface HeaderParameterEntry {
   parameter: OpenApi3Dot1ParameterObject;
   pointerPrefix: string;
-}
-
-function isReferenceObject(
-  param: OpenApi3Dot1ParameterObject | OpenApi3Dot1ReferenceObject,
-): param is OpenApi3Dot1ReferenceObject {
-  return '$ref' in param;
 }
 
 export function getHeaderParameterObjects(
@@ -48,23 +44,22 @@ export function getHeaderParameterObjects(
         pathItemObject.parameters[i] as
           OpenApi3Dot1ParameterObject | OpenApi3Dot1ReferenceObject;
 
-      const param: OpenApi3Dot1ParameterObject | null | undefined =
-        isReferenceObject(raw)
-          ? (openApiResolver.deepResolveReference(raw.$ref) as unknown as
-              OpenApi3Dot1ParameterObject | null | undefined)
-          : raw;
+      const resolved: ResolvedParameterObject = resolveParameterObject(
+        openApiResolver,
+        raw,
+        method,
+        path,
+        i,
+      );
 
-      if (param == undefined) {
-        throw new InversifyOpenApiValidationError(
-          InversifyValidationErrorKind.validationFailed,
-          `Unable to resolve header parameter at path: ${path} and method: ${method} and index: ${String(i)}`,
-        );
-      }
+      const param: OpenApi3Dot1ParameterObject = resolved.parameter;
 
       if (param.in === 'header') {
         result.set(param.name.toLowerCase(), {
           parameter: param,
-          pointerPrefix: `paths/${escapeJsonPointerFragments(path)}/parameters/${String(i)}`,
+          pointerPrefix:
+            resolved.pointerPrefix ??
+            `paths/${escapeJsonPointerFragments(path)}/parameters/${String(i)}`,
         });
       }
     }
@@ -76,23 +71,22 @@ export function getHeaderParameterObjects(
         operationObject.parameters[i] as
           OpenApi3Dot1ParameterObject | OpenApi3Dot1ReferenceObject;
 
-      const param: OpenApi3Dot1ParameterObject | null | undefined =
-        isReferenceObject(raw)
-          ? (openApiResolver.deepResolveReference(raw.$ref) as unknown as
-              OpenApi3Dot1ParameterObject | null | undefined)
-          : raw;
+      const resolved: ResolvedParameterObject = resolveParameterObject(
+        openApiResolver,
+        raw,
+        method,
+        path,
+        i,
+      );
 
-      if (param == undefined) {
-        throw new InversifyOpenApiValidationError(
-          InversifyValidationErrorKind.validationFailed,
-          `Unable to resolve header parameter at path: ${path} and method: ${method} and index: ${String(i)}`,
-        );
-      }
+      const param: OpenApi3Dot1ParameterObject = resolved.parameter;
 
       if (param.in === 'header') {
         result.set(param.name.toLowerCase(), {
           parameter: param,
-          pointerPrefix: `paths/${escapeJsonPointerFragments(path)}/${method}/parameters/${String(i)}`,
+          pointerPrefix:
+            resolved.pointerPrefix ??
+            `paths/${escapeJsonPointerFragments(path)}/${method}/parameters/${String(i)}`,
         });
       }
     }

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getParamParameterObjects.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getParamParameterObjects.spec.ts
@@ -5,6 +5,7 @@ vitest.mock(import('./getOperationObject.js'));
 vitest.mock(import('./getPathItemObject.js'));
 
 import { escapeJsonPointerFragments } from '@inversifyjs/json-schema-pointer';
+import { type JsonValue } from '@inversifyjs/json-schema-types';
 import {
   type OpenApi3Dot1Object,
   type OpenApi3Dot1OperationObject,
@@ -65,6 +66,7 @@ describe(getParamParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };
@@ -82,6 +84,12 @@ describe(getParamParameterObjects, () => {
 
     afterAll(() => {
       vitest.clearAllMocks();
+    });
+
+    it('should not call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).not.toHaveBeenCalled();
     });
 
     it('should return a map with the path parameter', () => {
@@ -123,6 +131,7 @@ describe(getParamParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };
@@ -185,6 +194,7 @@ describe(getParamParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };
@@ -232,10 +242,11 @@ describe(getParamParameterObjects, () => {
 
   describe('when called, and parameter is a $ref reference', () => {
     let openApiResolverFixture: OpenApiResolver;
+    let refFixture: OpenApi3Dot1ReferenceObject;
     let result: Map<string, ParamParameterEntry>;
 
     beforeAll(() => {
-      const refFixture: OpenApi3Dot1ReferenceObject = {
+      refFixture = {
         $ref: '#/components/parameters/UserIdParam',
       };
 
@@ -256,10 +267,22 @@ describe(getParamParameterObjects, () => {
       };
 
       openApiResolverFixture = {
-        deepResolveReference: vitest
-          .fn()
-          .mockReturnValueOnce(resolvedParamFixture),
-        resolveOpenApiReference: vitest.fn(),
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: true,
+          value: {
+            chain: [
+              {
+                $ref: refFixture.$ref,
+                canonicalId:
+                  'urn:inversifyjs:openapi-v3dot1-spec#/components/parameters/UserIdParam',
+                value: refFixture as unknown as JsonValue,
+              },
+            ],
+            value: resolvedParamFixture as unknown as JsonValue,
+          },
+        }),
         resolveReference: vitest.fn(),
       };
 
@@ -278,24 +301,117 @@ describe(getParamParameterObjects, () => {
       vitest.clearAllMocks();
     });
 
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
     it('should resolve the $ref and return the path parameter', () => {
       expect(result.size).toBe(1);
       expect(result.has('userId')).toBe(true);
     });
 
-    it('should call deepResolveReference', () => {
-      expect(
-        openApiResolverFixture.deepResolveReference,
-      ).toHaveBeenCalledExactlyOnceWith('#/components/parameters/UserIdParam');
+    it('should return entry with component pointer prefix', () => {
+      const entry: ParamParameterEntry = result.get(
+        'userId',
+      ) as ParamParameterEntry;
+
+      expect(entry.pointerPrefix).toBe('components/parameters/UserIdParam');
     });
   });
 
-  describe('when called, and path item deepResolveReference returns undefined', () => {
+  describe('when called, and path item parameter is a $ref reference', () => {
     let openApiResolverFixture: OpenApiResolver;
+    let refFixture: OpenApi3Dot1ReferenceObject;
+    let result: Map<string, ParamParameterEntry>;
+
+    beforeAll(() => {
+      refFixture = {
+        $ref: '#/components/parameters/UserIdParam',
+      };
+
+      const resolvedParamFixture: OpenApi3Dot1ParameterObject = {
+        in: 'path',
+        name: 'userId',
+        required: true,
+        schema: { type: 'string' },
+      };
+
+      const operationFixture: OpenApi3Dot1OperationObject = {
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot1PathItemObject = {
+        get: operationFixture,
+        parameters: [refFixture],
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: true,
+          value: {
+            chain: [
+              {
+                $ref: refFixture.$ref,
+                canonicalId:
+                  'urn:inversifyjs:openapi-v3dot1-spec#/components/parameters/UserIdParam',
+                value: refFixture as unknown as JsonValue,
+              },
+            ],
+            value: resolvedParamFixture as unknown as JsonValue,
+          },
+        }),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getParamParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
+    it('should resolve the $ref and return the path parameter', () => {
+      expect(result.size).toBe(1);
+      expect(result.has('userId')).toBe(true);
+    });
+
+    it('should return entry with component pointer prefix', () => {
+      const entry: ParamParameterEntry = result.get(
+        'userId',
+      ) as ParamParameterEntry;
+
+      expect(entry.pointerPrefix).toBe('components/parameters/UserIdParam');
+    });
+  });
+
+  describe('when called, and path item $ref fails to resolve', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let reasonFixture: string;
+    let refFixture: OpenApi3Dot1ReferenceObject;
     let result: unknown;
 
     beforeAll(() => {
-      const refFixture: OpenApi3Dot1ReferenceObject = {
+      reasonFixture =
+        'Failed to resolve JSON Pointer: /components/parameters/MissingUserIdParam';
+      refFixture = {
         $ref: '#/components/parameters/MissingUserIdParam',
       };
 
@@ -309,8 +425,15 @@ describe(getParamParameterObjects, () => {
       };
 
       openApiResolverFixture = {
-        deepResolveReference: vitest.fn().mockReturnValueOnce(undefined),
-        resolveOpenApiReference: vitest.fn(),
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: false,
+          value: {
+            reason: reasonFixture,
+            resolutionContextStack: [],
+          },
+        }),
         resolveReference: vitest.fn(),
       };
 
@@ -333,11 +456,17 @@ describe(getParamParameterObjects, () => {
       vitest.clearAllMocks();
     });
 
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
     it('should throw an InversifyOpenApiValidationError', () => {
       const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
         {
           kind: InversifyValidationErrorKind.validationFailed,
-          message: `Unable to resolve path parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0`,
+          message: `Could not resolve $ref pointer ${refFixture.$ref} for parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0: ${reasonFixture}`,
         };
 
       expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
@@ -345,12 +474,16 @@ describe(getParamParameterObjects, () => {
     });
   });
 
-  describe('when called, and operation deepResolveReference returns undefined', () => {
+  describe('when called, and operation $ref fails to resolve', () => {
     let openApiResolverFixture: OpenApiResolver;
+    let reasonFixture: string;
+    let refFixture: OpenApi3Dot1ReferenceObject;
     let result: unknown;
 
     beforeAll(() => {
-      const refFixture: OpenApi3Dot1ReferenceObject = {
+      reasonFixture =
+        'Failed to resolve JSON Pointer: /components/parameters/MissingUserIdParam';
+      refFixture = {
         $ref: '#/components/parameters/MissingUserIdParam',
       };
 
@@ -364,8 +497,84 @@ describe(getParamParameterObjects, () => {
       };
 
       openApiResolverFixture = {
-        deepResolveReference: vitest.fn().mockReturnValueOnce(undefined),
-        resolveOpenApiReference: vitest.fn(),
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: false,
+          value: {
+            reason: reasonFixture,
+            resolutionContextStack: [],
+          },
+        }),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      try {
+        getParamParameterObjects(
+          openApiObjectFixture,
+          openApiResolverFixture,
+          methodFixture,
+          pathFixture,
+        );
+      } catch (error: unknown) {
+        result = error;
+      }
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
+    it('should throw an InversifyOpenApiValidationError', () => {
+      const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+        {
+          kind: InversifyValidationErrorKind.validationFailed,
+          message: `Could not resolve $ref pointer ${refFixture.$ref} for parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0: ${reasonFixture}`,
+        };
+
+      expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
+      expect(result).toMatchObject(expectedErrorProperties);
+    });
+  });
+
+  describe('when called, and $ref resolves to a non-object', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let refFixture: OpenApi3Dot1ReferenceObject;
+    let result: unknown;
+
+    beforeAll(() => {
+      refFixture = {
+        $ref: '#/components/parameters/UserIdParam',
+      };
+
+      const operationFixture: OpenApi3Dot1OperationObject = {
+        parameters: [refFixture],
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot1PathItemObject = {
+        get: operationFixture,
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: true,
+          value: {
+            chain: [],
+            value: null,
+          },
+        }),
         resolveReference: vitest.fn(),
       };
 
@@ -392,7 +601,7 @@ describe(getParamParameterObjects, () => {
       const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
         {
           kind: InversifyValidationErrorKind.validationFailed,
-          message: `Unable to resolve path parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0`,
+          message: `Resolved $ref pointer ${refFixture.$ref} is not a valid parameter object at path: ${pathFixture} and method: ${methodFixture} and index: 0`,
         };
 
       expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
@@ -415,6 +624,7 @@ describe(getParamParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };
@@ -467,6 +677,7 @@ describe(getParamParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getParamParameterObjects.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getParamParameterObjects.ts
@@ -6,22 +6,18 @@ import {
   type OpenApi3Dot1PathItemObject,
   type OpenApi3Dot1ReferenceObject,
 } from '@inversifyjs/open-api-types/v3Dot1';
-import { InversifyValidationErrorKind } from '@inversifyjs/validation-common';
 
-import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
 import { getOperationObject } from './getOperationObject.js';
 import { getPathItemObject } from './getPathItemObject.js';
+import {
+  type ResolvedParameterObject,
+  resolveParameterObject,
+} from './resolveParameterObject.js';
 
 export interface ParamParameterEntry {
   parameter: OpenApi3Dot1ParameterObject;
   pointerPrefix: string;
-}
-
-function isReferenceObject(
-  param: OpenApi3Dot1ParameterObject | OpenApi3Dot1ReferenceObject,
-): param is OpenApi3Dot1ReferenceObject {
-  return '$ref' in param;
 }
 
 export function getParamParameterObjects(
@@ -48,23 +44,22 @@ export function getParamParameterObjects(
         pathItemObject.parameters[i] as
           OpenApi3Dot1ParameterObject | OpenApi3Dot1ReferenceObject;
 
-      const param: OpenApi3Dot1ParameterObject | null | undefined =
-        isReferenceObject(raw)
-          ? (openApiResolver.deepResolveReference(raw.$ref) as unknown as
-              OpenApi3Dot1ParameterObject | null | undefined)
-          : raw;
+      const resolved: ResolvedParameterObject = resolveParameterObject(
+        openApiResolver,
+        raw,
+        method,
+        path,
+        i,
+      );
 
-      if (param == undefined) {
-        throw new InversifyOpenApiValidationError(
-          InversifyValidationErrorKind.validationFailed,
-          `Unable to resolve path parameter at path: ${path} and method: ${method} and index: ${String(i)}`,
-        );
-      }
+      const param: OpenApi3Dot1ParameterObject = resolved.parameter;
 
       if (param.in === 'path') {
         result.set(param.name, {
           parameter: param,
-          pointerPrefix: `paths/${escapeJsonPointerFragments(path)}/parameters/${String(i)}`,
+          pointerPrefix:
+            resolved.pointerPrefix ??
+            `paths/${escapeJsonPointerFragments(path)}/parameters/${String(i)}`,
         });
       }
     }
@@ -76,23 +71,22 @@ export function getParamParameterObjects(
         operationObject.parameters[i] as
           OpenApi3Dot1ParameterObject | OpenApi3Dot1ReferenceObject;
 
-      const param: OpenApi3Dot1ParameterObject | null | undefined =
-        isReferenceObject(raw)
-          ? (openApiResolver.deepResolveReference(raw.$ref) as unknown as
-              OpenApi3Dot1ParameterObject | null | undefined)
-          : raw;
+      const resolved: ResolvedParameterObject = resolveParameterObject(
+        openApiResolver,
+        raw,
+        method,
+        path,
+        i,
+      );
 
-      if (param == undefined) {
-        throw new InversifyOpenApiValidationError(
-          InversifyValidationErrorKind.validationFailed,
-          `Unable to resolve path parameter at path: ${path} and method: ${method} and index: ${String(i)}`,
-        );
-      }
+      const param: OpenApi3Dot1ParameterObject = resolved.parameter;
 
       if (param.in === 'path') {
         result.set(param.name, {
           parameter: param,
-          pointerPrefix: `paths/${escapeJsonPointerFragments(path)}/${method}/parameters/${String(i)}`,
+          pointerPrefix:
+            resolved.pointerPrefix ??
+            `paths/${escapeJsonPointerFragments(path)}/${method}/parameters/${String(i)}`,
         });
       }
     }

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getQueryParameterObjects.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getQueryParameterObjects.spec.ts
@@ -5,6 +5,7 @@ vitest.mock(import('./getOperationObject.js'));
 vitest.mock(import('./getPathItemObject.js'));
 
 import { escapeJsonPointerFragments } from '@inversifyjs/json-schema-pointer';
+import { type JsonValue } from '@inversifyjs/json-schema-types';
 import {
   type OpenApi3Dot1Object,
   type OpenApi3Dot1OperationObject,
@@ -65,6 +66,7 @@ describe(getQueryParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };
@@ -82,6 +84,12 @@ describe(getQueryParameterObjects, () => {
 
     afterAll(() => {
       vitest.clearAllMocks();
+    });
+
+    it('should not call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).not.toHaveBeenCalled();
     });
 
     it('should return a map with the query parameter', () => {
@@ -122,6 +130,7 @@ describe(getQueryParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };
@@ -152,10 +161,11 @@ describe(getQueryParameterObjects, () => {
 
   describe('when called, and parameter is a $ref reference', () => {
     let openApiResolverFixture: OpenApiResolver;
+    let refFixture: OpenApi3Dot1ReferenceObject;
     let result: Map<string, QueryParameterEntry>;
 
     beforeAll(() => {
-      const refFixture: OpenApi3Dot1ReferenceObject = {
+      refFixture = {
         $ref: '#/components/parameters/PageParam',
       };
 
@@ -175,10 +185,22 @@ describe(getQueryParameterObjects, () => {
       };
 
       openApiResolverFixture = {
-        deepResolveReference: vitest
-          .fn()
-          .mockReturnValueOnce(resolvedParamFixture),
-        resolveOpenApiReference: vitest.fn(),
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: true,
+          value: {
+            chain: [
+              {
+                $ref: refFixture.$ref,
+                canonicalId:
+                  'urn:inversifyjs:openapi-v3dot1-spec#/components/parameters/PageParam',
+                value: refFixture as unknown as JsonValue,
+              },
+            ],
+            value: resolvedParamFixture as unknown as JsonValue,
+          },
+        }),
         resolveReference: vitest.fn(),
       };
 
@@ -197,24 +219,116 @@ describe(getQueryParameterObjects, () => {
       vitest.clearAllMocks();
     });
 
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
     it('should resolve the $ref and return the query parameter', () => {
       expect(result.size).toBe(1);
       expect(result.has('page')).toBe(true);
     });
 
-    it('should call deepResolveReference', () => {
-      expect(
-        openApiResolverFixture.deepResolveReference,
-      ).toHaveBeenCalledExactlyOnceWith('#/components/parameters/PageParam');
+    it('should return entry with component pointer prefix', () => {
+      const entry: QueryParameterEntry = result.get(
+        'page',
+      ) as QueryParameterEntry;
+
+      expect(entry.pointerPrefix).toBe('components/parameters/PageParam');
     });
   });
 
-  describe('when called, and path item deepResolveReference returns undefined', () => {
+  describe('when called, and path item parameter is a $ref reference', () => {
     let openApiResolverFixture: OpenApiResolver;
+    let refFixture: OpenApi3Dot1ReferenceObject;
+    let result: Map<string, QueryParameterEntry>;
+
+    beforeAll(() => {
+      refFixture = {
+        $ref: '#/components/parameters/PageParam',
+      };
+
+      const resolvedParamFixture: OpenApi3Dot1ParameterObject = {
+        in: 'query',
+        name: 'page',
+        schema: { type: 'integer' },
+      };
+
+      const operationFixture: OpenApi3Dot1OperationObject = {
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot1PathItemObject = {
+        get: operationFixture,
+        parameters: [refFixture],
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: true,
+          value: {
+            chain: [
+              {
+                $ref: refFixture.$ref,
+                canonicalId:
+                  'urn:inversifyjs:openapi-v3dot1-spec#/components/parameters/PageParam',
+                value: refFixture as unknown as JsonValue,
+              },
+            ],
+            value: resolvedParamFixture as unknown as JsonValue,
+          },
+        }),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getQueryParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
+    it('should resolve the $ref and return the query parameter', () => {
+      expect(result.size).toBe(1);
+      expect(result.has('page')).toBe(true);
+    });
+
+    it('should return entry with component pointer prefix', () => {
+      const entry: QueryParameterEntry = result.get(
+        'page',
+      ) as QueryParameterEntry;
+
+      expect(entry.pointerPrefix).toBe('components/parameters/PageParam');
+    });
+  });
+
+  describe('when called, and path item $ref fails to resolve', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let reasonFixture: string;
+    let refFixture: OpenApi3Dot1ReferenceObject;
     let result: unknown;
 
     beforeAll(() => {
-      const refFixture: OpenApi3Dot1ReferenceObject = {
+      reasonFixture =
+        'Failed to resolve JSON Pointer: /components/parameters/MissingPageParam';
+      refFixture = {
         $ref: '#/components/parameters/MissingPageParam',
       };
 
@@ -228,8 +342,15 @@ describe(getQueryParameterObjects, () => {
       };
 
       openApiResolverFixture = {
-        deepResolveReference: vitest.fn().mockReturnValueOnce(undefined),
-        resolveOpenApiReference: vitest.fn(),
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: false,
+          value: {
+            reason: reasonFixture,
+            resolutionContextStack: [],
+          },
+        }),
         resolveReference: vitest.fn(),
       };
 
@@ -252,11 +373,17 @@ describe(getQueryParameterObjects, () => {
       vitest.clearAllMocks();
     });
 
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
     it('should throw an InversifyOpenApiValidationError', () => {
       const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
         {
           kind: InversifyValidationErrorKind.validationFailed,
-          message: `Unable to resolve query parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0`,
+          message: `Could not resolve $ref pointer ${refFixture.$ref} for parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0: ${reasonFixture}`,
         };
 
       expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
@@ -264,12 +391,16 @@ describe(getQueryParameterObjects, () => {
     });
   });
 
-  describe('when called, and operation deepResolveReference returns undefined', () => {
+  describe('when called, and operation $ref fails to resolve', () => {
     let openApiResolverFixture: OpenApiResolver;
+    let reasonFixture: string;
+    let refFixture: OpenApi3Dot1ReferenceObject;
     let result: unknown;
 
     beforeAll(() => {
-      const refFixture: OpenApi3Dot1ReferenceObject = {
+      reasonFixture =
+        'Failed to resolve JSON Pointer: /components/parameters/MissingPageParam';
+      refFixture = {
         $ref: '#/components/parameters/MissingPageParam',
       };
 
@@ -283,8 +414,84 @@ describe(getQueryParameterObjects, () => {
       };
 
       openApiResolverFixture = {
-        deepResolveReference: vitest.fn().mockReturnValueOnce(undefined),
-        resolveOpenApiReference: vitest.fn(),
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: false,
+          value: {
+            reason: reasonFixture,
+            resolutionContextStack: [],
+          },
+        }),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      try {
+        getQueryParameterObjects(
+          openApiObjectFixture,
+          openApiResolverFixture,
+          methodFixture,
+          pathFixture,
+        );
+      } catch (error: unknown) {
+        result = error;
+      }
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
+    it('should throw an InversifyOpenApiValidationError', () => {
+      const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+        {
+          kind: InversifyValidationErrorKind.validationFailed,
+          message: `Could not resolve $ref pointer ${refFixture.$ref} for parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0: ${reasonFixture}`,
+        };
+
+      expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
+      expect(result).toMatchObject(expectedErrorProperties);
+    });
+  });
+
+  describe('when called, and $ref resolves to a non-object', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let refFixture: OpenApi3Dot1ReferenceObject;
+    let result: unknown;
+
+    beforeAll(() => {
+      refFixture = {
+        $ref: '#/components/parameters/PageParam',
+      };
+
+      const operationFixture: OpenApi3Dot1OperationObject = {
+        parameters: [refFixture],
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot1PathItemObject = {
+        get: operationFixture,
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: true,
+          value: {
+            chain: [],
+            value: null,
+          },
+        }),
         resolveReference: vitest.fn(),
       };
 
@@ -311,7 +518,7 @@ describe(getQueryParameterObjects, () => {
       const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
         {
           kind: InversifyValidationErrorKind.validationFailed,
-          message: `Unable to resolve query parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0`,
+          message: `Resolved $ref pointer ${refFixture.$ref} is not a valid parameter object at path: ${pathFixture} and method: ${methodFixture} and index: 0`,
         };
 
       expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
@@ -347,6 +554,7 @@ describe(getQueryParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getQueryParameterObjects.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getQueryParameterObjects.ts
@@ -6,22 +6,18 @@ import {
   type OpenApi3Dot1PathItemObject,
   type OpenApi3Dot1ReferenceObject,
 } from '@inversifyjs/open-api-types/v3Dot1';
-import { InversifyValidationErrorKind } from '@inversifyjs/validation-common';
 
-import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
 import { getOperationObject } from './getOperationObject.js';
 import { getPathItemObject } from './getPathItemObject.js';
+import {
+  type ResolvedParameterObject,
+  resolveParameterObject,
+} from './resolveParameterObject.js';
 
 export interface QueryParameterEntry {
   parameter: OpenApi3Dot1ParameterObject;
   pointerPrefix: string;
-}
-
-function isReferenceObject(
-  param: OpenApi3Dot1ParameterObject | OpenApi3Dot1ReferenceObject,
-): param is OpenApi3Dot1ReferenceObject {
-  return '$ref' in param;
 }
 
 export function getQueryParameterObjects(
@@ -48,23 +44,22 @@ export function getQueryParameterObjects(
         pathItemObject.parameters[i] as
           OpenApi3Dot1ParameterObject | OpenApi3Dot1ReferenceObject;
 
-      const param: OpenApi3Dot1ParameterObject | null | undefined =
-        isReferenceObject(raw)
-          ? (openApiResolver.deepResolveReference(raw.$ref) as unknown as
-              OpenApi3Dot1ParameterObject | null | undefined)
-          : raw;
+      const resolved: ResolvedParameterObject = resolveParameterObject(
+        openApiResolver,
+        raw,
+        method,
+        path,
+        i,
+      );
 
-      if (param == undefined) {
-        throw new InversifyOpenApiValidationError(
-          InversifyValidationErrorKind.validationFailed,
-          `Unable to resolve query parameter at path: ${path} and method: ${method} and index: ${String(i)}`,
-        );
-      }
+      const param: OpenApi3Dot1ParameterObject = resolved.parameter;
 
       if (param.in === 'query') {
         result.set(param.name, {
           parameter: param,
-          pointerPrefix: `paths/${escapeJsonPointerFragments(path)}/parameters/${String(i)}`,
+          pointerPrefix:
+            resolved.pointerPrefix ??
+            `paths/${escapeJsonPointerFragments(path)}/parameters/${String(i)}`,
         });
       }
     }
@@ -76,23 +71,22 @@ export function getQueryParameterObjects(
         operationObject.parameters[i] as
           OpenApi3Dot1ParameterObject | OpenApi3Dot1ReferenceObject;
 
-      const param: OpenApi3Dot1ParameterObject | null | undefined =
-        isReferenceObject(raw)
-          ? (openApiResolver.deepResolveReference(raw.$ref) as unknown as
-              OpenApi3Dot1ParameterObject | null | undefined)
-          : raw;
+      const resolved: ResolvedParameterObject = resolveParameterObject(
+        openApiResolver,
+        raw,
+        method,
+        path,
+        i,
+      );
 
-      if (param == undefined) {
-        throw new InversifyOpenApiValidationError(
-          InversifyValidationErrorKind.validationFailed,
-          `Unable to resolve query parameter at path: ${path} and method: ${method} and index: ${String(i)}`,
-        );
-      }
+      const param: OpenApi3Dot1ParameterObject = resolved.parameter;
 
       if (param.in === 'query') {
         result.set(param.name, {
           parameter: param,
-          pointerPrefix: `paths/${escapeJsonPointerFragments(path)}/${method}/parameters/${String(i)}`,
+          pointerPrefix:
+            resolved.pointerPrefix ??
+            `paths/${escapeJsonPointerFragments(path)}/${method}/parameters/${String(i)}`,
         });
       }
     }

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getRequestBodyObject.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getRequestBodyObject.spec.ts
@@ -11,8 +11,12 @@ import {
   InversifyValidationErrorKind,
 } from '@inversifyjs/validation-common';
 
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
-import { getRequestBodyObject } from './getRequestBodyObject.js';
+import {
+  getRequestBodyObject,
+  type ResolvedRequestBodyObject,
+} from './getRequestBodyObject.js';
 
 describe(getRequestBodyObject, () => {
   let openApiResolverMock: OpenApiResolver;
@@ -22,6 +26,7 @@ describe(getRequestBodyObject, () => {
   beforeAll(() => {
     openApiResolverMock = {
       deepResolveReference: vitest.fn(),
+      resolveJsonSchema: vitest.fn(),
       resolveOpenApiReference: vitest.fn(),
       resolveReference: vitest.fn(),
     };
@@ -105,7 +110,12 @@ describe(getRequestBodyObject, () => {
       });
 
       it('should return expected result', () => {
-        expect(result).toBe(requestBodyObjectFixture);
+        const expected: ResolvedRequestBodyObject = {
+          pointerPrefix: undefined,
+          requestBody: requestBodyObjectFixture,
+        };
+
+        expect(result).toStrictEqual(expected);
       });
     });
   });
@@ -163,13 +173,14 @@ describe(getRequestBodyObject, () => {
         ).toHaveBeenCalledExactlyOnceWith(requestBodyReferenceFixture);
       });
 
-      it('should throw an InversifyValidationError', () => {
-        const expectedErrorProperties: Partial<InversifyValidationError> = {
-          kind: InversifyValidationErrorKind.validationFailed,
-          message: `Could not resolve $ref pointer ${requestBodyReferenceFixture.$ref} for ${methodFixture.toUpperCase()} ${routeFixture}: ${reasonFixture}`,
-        };
+      it('should throw an InversifyOpenApiValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+          {
+            kind: InversifyValidationErrorKind.validationFailed,
+            message: `Could not resolve $ref pointer ${requestBodyReferenceFixture.$ref} for ${methodFixture.toUpperCase()} ${routeFixture}: ${reasonFixture}`,
+          };
 
-        expect(result).toBeInstanceOf(InversifyValidationError);
+        expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
         expect(result).toMatchObject(expectedErrorProperties);
       });
     });
@@ -225,13 +236,14 @@ describe(getRequestBodyObject, () => {
         ).toHaveBeenCalledExactlyOnceWith(requestBodyReferenceFixture);
       });
 
-      it('should throw an InversifyValidationError', () => {
-        const expectedErrorProperties: Partial<InversifyValidationError> = {
-          kind: InversifyValidationErrorKind.validationFailed,
-          message: `Resolved $ref pointer ${requestBodyReferenceFixture.$ref} is not a valid request body object for ${methodFixture.toUpperCase()} ${routeFixture}`,
-        };
+      it('should throw an InversifyOpenApiValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+          {
+            kind: InversifyValidationErrorKind.validationFailed,
+            message: `Resolved $ref pointer ${requestBodyReferenceFixture.$ref} is not a valid request body object for ${methodFixture.toUpperCase()} ${routeFixture}`,
+          };
 
-        expect(result).toBeInstanceOf(InversifyValidationError);
+        expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
         expect(result).toMatchObject(expectedErrorProperties);
       });
     });
@@ -287,13 +299,73 @@ describe(getRequestBodyObject, () => {
         ).toHaveBeenCalledExactlyOnceWith(requestBodyReferenceFixture);
       });
 
-      it('should throw an InversifyValidationError', () => {
-        const expectedErrorProperties: Partial<InversifyValidationError> = {
-          kind: InversifyValidationErrorKind.validationFailed,
-          message: `Resolved $ref pointer ${requestBodyReferenceFixture.$ref} is not a valid request body object for ${methodFixture.toUpperCase()} ${routeFixture}`,
-        };
+      it('should throw an InversifyOpenApiValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+          {
+            kind: InversifyValidationErrorKind.validationFailed,
+            message: `Resolved $ref pointer ${requestBodyReferenceFixture.$ref} is not a valid request body object for ${methodFixture.toUpperCase()} ${routeFixture}`,
+          };
 
-        expect(result).toBeInstanceOf(InversifyValidationError);
+        expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
+        expect(result).toMatchObject(expectedErrorProperties);
+      });
+    });
+  });
+
+  describe('having an operationObject with requestBody with $ref resolving to a schema object', () => {
+    let operationObjectFixture: OpenApi3Dot1OperationObject;
+    let requestBodyReferenceFixture: OpenApi3Dot1ReferenceObject;
+
+    beforeAll(() => {
+      requestBodyReferenceFixture = {
+        $ref: '#/components/schemas/User',
+      };
+      operationObjectFixture = {
+        requestBody: requestBodyReferenceFixture,
+        responses: {},
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest
+          .mocked(openApiResolverMock.resolveOpenApiReference)
+          .mockReturnValueOnce({
+            isRight: true,
+            value: {
+              chain: [],
+              value: {
+                type: 'object',
+              },
+            },
+          });
+
+        try {
+          getRequestBodyObject(
+            openApiResolverMock,
+            operationObjectFixture,
+            methodFixture,
+            routeFixture,
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should throw an InversifyOpenApiValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+          {
+            kind: InversifyValidationErrorKind.validationFailed,
+            message: `Resolved $ref pointer ${requestBodyReferenceFixture.$ref} is not a valid request body object for ${methodFixture.toUpperCase()} ${routeFixture}`,
+          };
+
+        expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
         expect(result).toMatchObject(expectedErrorProperties);
       });
     });
@@ -328,7 +400,14 @@ describe(getRequestBodyObject, () => {
           .mockReturnValueOnce({
             isRight: true,
             value: {
-              chain: [],
+              chain: [
+                {
+                  $ref: requestBodyReferenceFixture.$ref,
+                  canonicalId:
+                    'urn:inversifyjs:openapi-v3dot1-spec#/components/requestBodies/UserBody',
+                  value: requestBodyReferenceFixture as unknown as JsonValue,
+                },
+              ],
               value: resolvedObjectFixture as unknown as JsonValue,
             },
           });
@@ -352,7 +431,12 @@ describe(getRequestBodyObject, () => {
       });
 
       it('should return expected result', () => {
-        expect(result).toBe(resolvedObjectFixture);
+        const expected: ResolvedRequestBodyObject = {
+          pointerPrefix: 'components/requestBodies/UserBody',
+          requestBody: resolvedObjectFixture,
+        };
+
+        expect(result).toStrictEqual(expected);
       });
     });
   });

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getRequestBodyObject.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/getRequestBodyObject.ts
@@ -9,17 +9,38 @@ import {
   InversifyValidationErrorKind,
 } from '@inversifyjs/validation-common';
 
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import {
   type OpenApiRefResolutionResult,
   type OpenApiResolver,
 } from '../../services/OpenApiResolver.js';
+import { pointerPrefixFromResolutionChain } from './pointerPrefixFromResolutionChain.js';
+
+export interface ResolvedRequestBodyObject {
+  pointerPrefix: string | undefined;
+  requestBody: OpenApi3Dot1RequestBodyObject;
+}
+
+function isRequestBodyObject(
+  value: JsonValue,
+): value is JsonValue & OpenApi3Dot1RequestBodyObject {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const content: JsonValue | undefined = value['content'];
+
+  return (
+    typeof content === 'object' && content !== null && !Array.isArray(content)
+  );
+}
 
 export function getRequestBodyObject(
   openApiResolver: OpenApiResolver,
   operationObject: OpenApi3Dot1OperationObject,
   method: string,
   route: string,
-): OpenApi3Dot1RequestBodyObject {
+): ResolvedRequestBodyObject {
   const requestBodyObject:
     OpenApi3Dot1RequestBodyObject | OpenApi3Dot1ReferenceObject | undefined =
     operationObject.requestBody;
@@ -32,7 +53,10 @@ export function getRequestBodyObject(
   }
 
   if (!('$ref' in requestBodyObject)) {
-    return requestBodyObject;
+    return {
+      pointerPrefix: undefined,
+      requestBody: requestBodyObject,
+    };
   }
 
   const result: OpenApiRefResolutionResult =
@@ -41,7 +65,7 @@ export function getRequestBodyObject(
     );
 
   if (!result.isRight) {
-    throw new InversifyValidationError(
+    throw new InversifyOpenApiValidationError(
       InversifyValidationErrorKind.validationFailed,
       `Could not resolve $ref pointer ${requestBodyObject.$ref} for ${method.toUpperCase()} ${route}: ${result.value.reason}`,
     );
@@ -49,16 +73,15 @@ export function getRequestBodyObject(
 
   const resolvedRef: JsonValue = result.value.value;
 
-  if (
-    resolvedRef === null ||
-    typeof resolvedRef !== 'object' ||
-    Array.isArray(resolvedRef)
-  ) {
-    throw new InversifyValidationError(
+  if (!isRequestBodyObject(resolvedRef)) {
+    throw new InversifyOpenApiValidationError(
       InversifyValidationErrorKind.validationFailed,
       `Resolved $ref pointer ${requestBodyObject.$ref} is not a valid request body object for ${method.toUpperCase()} ${route}`,
     );
   }
 
-  return resolvedRef as unknown as OpenApi3Dot1RequestBodyObject;
+  return {
+    pointerPrefix: pointerPrefixFromResolutionChain(result.value.chain),
+    requestBody: resolvedRef,
+  };
 }

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleBodyValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleBodyValidation.spec.ts
@@ -62,7 +62,8 @@ describe(handleBodyValidation, () => {
     let contentTypeFixture: string;
     let operationObjectFixture: OpenApi3Dot1OperationObject;
     let requestBodyObjectFixture: OpenApi3Dot1RequestBodyObject;
-    let escapedPointerFixture: string;
+    let requestBodyPointerFixture: string;
+    let contentTypePointerFixture: string;
 
     beforeAll(() => {
       pathFixture = '/users';
@@ -84,7 +85,8 @@ describe(handleBodyValidation, () => {
           },
         },
       };
-      escapedPointerFixture = `paths/${pathFixture}/${methodFixture}/requestBody/content/${contentTypeFixture}/schema`;
+      requestBodyPointerFixture = `paths/${pathFixture}/${methodFixture}/requestBody`;
+      contentTypePointerFixture = contentTypeFixture;
     });
 
     describe('when called, and getEntry() returns empty entry and ajv.getSchema() returns undefined', () => {
@@ -101,7 +103,7 @@ describe(handleBodyValidation, () => {
           getSchema: vitest.fn().mockReturnValueOnce(undefined),
         } as Partial<Mocked<Ajv>> as Mocked<Ajv>;
 
-        schemaPointerFixture = `${SCHEMA_ID}#/${escapedPointerFixture}`;
+        schemaPointerFixture = `${SCHEMA_ID}#/${requestBodyPointerFixture}/content/${contentTypePointerFixture}/schema`;
 
         validationCacheEntryFixture = {
           body: undefined,
@@ -117,12 +119,14 @@ describe(handleBodyValidation, () => {
         vitest
           .mocked(getOperationObject)
           .mockReturnValueOnce(operationObjectFixture);
-        vitest
-          .mocked(getRequestBodyObject)
-          .mockReturnValueOnce(requestBodyObjectFixture);
+        vitest.mocked(getRequestBodyObject).mockReturnValueOnce({
+          pointerPrefix: undefined,
+          requestBody: requestBodyObjectFixture,
+        });
         vitest
           .mocked(escapeJsonPointerFragments)
-          .mockReturnValueOnce(escapedPointerFixture);
+          .mockReturnValueOnce(requestBodyPointerFixture)
+          .mockReturnValueOnce(contentTypePointerFixture);
 
         vitest
           .mocked(openApiRouterMock.findRoute)
@@ -170,14 +174,17 @@ describe(handleBodyValidation, () => {
       });
 
       it('should call escapeJsonPointerFragments()', () => {
-        expect(escapeJsonPointerFragments).toHaveBeenCalledExactlyOnceWith(
+        expect(escapeJsonPointerFragments).toHaveBeenCalledTimes(2);
+        expect(escapeJsonPointerFragments).toHaveBeenNthCalledWith(
+          1,
           'paths',
           pathFixture,
           methodFixture,
           'requestBody',
-          'content',
+        );
+        expect(escapeJsonPointerFragments).toHaveBeenNthCalledWith(
+          2,
           contentTypeFixture,
-          'schema',
         );
       });
 
@@ -230,12 +237,14 @@ describe(handleBodyValidation, () => {
         vitest
           .mocked(getOperationObject)
           .mockReturnValueOnce(operationObjectFixture);
-        vitest
-          .mocked(getRequestBodyObject)
-          .mockReturnValueOnce(requestBodyObjectFixture);
+        vitest.mocked(getRequestBodyObject).mockReturnValueOnce({
+          pointerPrefix: undefined,
+          requestBody: requestBodyObjectFixture,
+        });
         vitest
           .mocked(escapeJsonPointerFragments)
-          .mockReturnValueOnce(escapedPointerFixture);
+          .mockReturnValueOnce(requestBodyPointerFixture)
+          .mockReturnValueOnce(contentTypePointerFixture);
 
         vitest
           .mocked(openApiRouterMock.findRoute)
@@ -326,12 +335,14 @@ describe(handleBodyValidation, () => {
         vitest
           .mocked(getOperationObject)
           .mockReturnValueOnce(operationObjectFixture);
-        vitest
-          .mocked(getRequestBodyObject)
-          .mockReturnValueOnce(requestBodyObjectFixture);
+        vitest.mocked(getRequestBodyObject).mockReturnValueOnce({
+          pointerPrefix: undefined,
+          requestBody: requestBodyObjectFixture,
+        });
         vitest
           .mocked(escapeJsonPointerFragments)
-          .mockReturnValueOnce(escapedPointerFixture);
+          .mockReturnValueOnce(requestBodyPointerFixture)
+          .mockReturnValueOnce(contentTypePointerFixture);
 
         vitest
           .mocked(openApiRouterMock.findRoute)
@@ -384,7 +395,8 @@ describe(handleBodyValidation, () => {
     let contentTypeFixture: string;
     let operationObjectFixture: OpenApi3Dot1OperationObject;
     let requestBodyObjectFixture: OpenApi3Dot1RequestBodyObject;
-    let escapedPointerFixture: string;
+    let requestBodyPointerFixture: string;
+    let contentTypePointerFixture: string;
 
     beforeAll(() => {
       pathFixture = '/users';
@@ -406,7 +418,8 @@ describe(handleBodyValidation, () => {
           },
         },
       };
-      escapedPointerFixture = `paths/${pathFixture}/${methodFixture}/requestBody/content/${contentTypeFixture}/schema`;
+      requestBodyPointerFixture = `paths/${pathFixture}/${methodFixture}/requestBody`;
+      contentTypePointerFixture = contentTypeFixture;
     });
 
     describe('when called, and getEntry() returns empty entry and validation succeeds', () => {
@@ -441,12 +454,14 @@ describe(handleBodyValidation, () => {
         vitest
           .mocked(getOperationObject)
           .mockReturnValueOnce(operationObjectFixture);
-        vitest
-          .mocked(getRequestBodyObject)
-          .mockReturnValueOnce(requestBodyObjectFixture);
+        vitest.mocked(getRequestBodyObject).mockReturnValueOnce({
+          pointerPrefix: undefined,
+          requestBody: requestBodyObjectFixture,
+        });
         vitest
           .mocked(escapeJsonPointerFragments)
-          .mockReturnValueOnce(escapedPointerFixture);
+          .mockReturnValueOnce(requestBodyPointerFixture)
+          .mockReturnValueOnce(contentTypePointerFixture);
 
         vitest
           .mocked(openApiRouterMock.findRoute)
@@ -466,14 +481,17 @@ describe(handleBodyValidation, () => {
       });
 
       it('should call escapeJsonPointerFragments()', () => {
-        expect(escapeJsonPointerFragments).toHaveBeenCalledExactlyOnceWith(
+        expect(escapeJsonPointerFragments).toHaveBeenCalledTimes(2);
+        expect(escapeJsonPointerFragments).toHaveBeenNthCalledWith(
+          1,
           'paths',
           pathFixture,
           methodFixture,
           'requestBody',
-          'content',
+        );
+        expect(escapeJsonPointerFragments).toHaveBeenNthCalledWith(
+          2,
           contentTypeFixture,
-          'schema',
         );
       });
 
@@ -490,7 +508,8 @@ describe(handleBodyValidation, () => {
     let contentTypeFixture: string;
     let operationObjectFixture: OpenApi3Dot1OperationObject;
     let requestBodyObjectFixture: OpenApi3Dot1RequestBodyObject;
-    let escapedPointerFixture: string;
+    let requestBodyPointerFixture: string;
+    let contentTypePointerFixture: string;
 
     beforeAll(() => {
       pathFixture = '/users';
@@ -512,7 +531,8 @@ describe(handleBodyValidation, () => {
           },
         },
       };
-      escapedPointerFixture = `paths/${pathFixture}/${methodFixture}/requestBody/content/${contentTypeFixture}/schema`;
+      requestBodyPointerFixture = `paths/${pathFixture}/${methodFixture}/requestBody`;
+      contentTypePointerFixture = contentTypeFixture;
     });
 
     describe('when called, and getEntry() returns empty entry', () => {
@@ -547,12 +567,14 @@ describe(handleBodyValidation, () => {
         vitest
           .mocked(getOperationObject)
           .mockReturnValueOnce(operationObjectFixture);
-        vitest
-          .mocked(getRequestBodyObject)
-          .mockReturnValueOnce(requestBodyObjectFixture);
+        vitest.mocked(getRequestBodyObject).mockReturnValueOnce({
+          pointerPrefix: undefined,
+          requestBody: requestBodyObjectFixture,
+        });
         vitest
           .mocked(escapeJsonPointerFragments)
-          .mockReturnValueOnce(escapedPointerFixture);
+          .mockReturnValueOnce(requestBodyPointerFixture)
+          .mockReturnValueOnce(contentTypePointerFixture);
 
         vitest
           .mocked(openApiRouterMock.findRoute)
@@ -577,20 +599,22 @@ describe(handleBodyValidation, () => {
     });
   });
 
-  describe('having an inputParam with contentType and an operationObject whose requestBody is a Reference Object', () => {
+  describe('having an inputParam with contentType and a resolved request body with a component pointerPrefix', () => {
     let inputParamFixture: BodyValidationInputParam<unknown>;
     let pathFixture: string;
     let methodFixture: string;
     let contentTypeFixture: string;
     let operationObjectFixture: OpenApi3Dot1OperationObject;
     let requestBodyObjectFixture: OpenApi3Dot1RequestBodyObject;
-    let requestBodyReferenceFixture: { $ref: string };
-    let escapedPointerFixture: string;
+    let pointerPrefixFixture: string;
+    let contentTypePointerFixture: string;
 
     beforeAll(() => {
       pathFixture = '/users';
       methodFixture = 'post';
       contentTypeFixture = 'application/json';
+      pointerPrefixFixture = 'components/requestBodies/UserBody';
+      contentTypePointerFixture = contentTypeFixture;
       inputParamFixture = {
         body: { name: 'test' },
         contentType: contentTypeFixture,
@@ -598,11 +622,10 @@ describe(handleBodyValidation, () => {
         path: pathFixture,
         type: Symbol() as unknown as BodyValidationInputParam<unknown>['type'],
       };
-      requestBodyReferenceFixture = {
-        $ref: '#/components/requestBodies/UserBody',
-      };
       operationObjectFixture = {
-        requestBody: requestBodyReferenceFixture,
+        requestBody: {
+          $ref: '#/components/requestBodies/UserBody',
+        },
         responses: {},
       };
       requestBodyObjectFixture = {
@@ -612,10 +635,9 @@ describe(handleBodyValidation, () => {
           },
         },
       };
-      escapedPointerFixture = `paths/${pathFixture}/${methodFixture}/requestBody/content/${contentTypeFixture}/schema`;
     });
 
-    describe('when called, and getEntry() returns empty entry and ajv.getSchema() returns undefined', () => {
+    describe('when called, and getEntry() returns empty entry and validation succeeds', () => {
       let ajvMock: Mocked<Ajv>;
       let getEntryMock: Mock<
         (path: string, method: string) => ValidationCacheEntry
@@ -625,11 +647,16 @@ describe(handleBodyValidation, () => {
       let result: unknown;
 
       beforeAll(() => {
+        const validateMock: ValidateFunction = Object.assign(
+          vitest.fn().mockReturnValueOnce(true),
+          { errors: null, schema: {} },
+        ) as unknown as ValidateFunction;
+
         ajvMock = {
-          getSchema: vitest.fn().mockReturnValueOnce(undefined),
+          getSchema: vitest.fn().mockReturnValueOnce(validateMock),
         } as Partial<Mocked<Ajv>> as Mocked<Ajv>;
 
-        schemaPointerFixture = `${SCHEMA_ID}#/${escapedPointerFixture}`;
+        schemaPointerFixture = `${SCHEMA_ID}#/${pointerPrefixFixture}/content/${contentTypePointerFixture}/schema`;
 
         validationCacheEntryFixture = {
           body: undefined,
@@ -645,42 +672,45 @@ describe(handleBodyValidation, () => {
         vitest
           .mocked(getOperationObject)
           .mockReturnValueOnce(operationObjectFixture);
-        vitest
-          .mocked(getRequestBodyObject)
-          .mockReturnValueOnce(requestBodyObjectFixture);
+        vitest.mocked(getRequestBodyObject).mockReturnValueOnce({
+          pointerPrefix: pointerPrefixFixture,
+          requestBody: requestBodyObjectFixture,
+        });
         vitest
           .mocked(escapeJsonPointerFragments)
-          .mockReturnValueOnce(escapedPointerFixture);
+          .mockReturnValueOnce(contentTypePointerFixture);
 
         vitest
           .mocked(openApiRouterMock.findRoute)
           .mockReturnValueOnce(pathFixture);
 
-        try {
-          handleBodyValidation(
-            ajvMock,
-            openApiObjectFixture,
-            validationContextFixture,
-            inputParamFixture,
-            getEntryMock,
-          );
-        } catch (error: unknown) {
-          result = error;
-        }
+        result = handleBodyValidation(
+          ajvMock,
+          openApiObjectFixture,
+          validationContextFixture,
+          inputParamFixture,
+          getEntryMock,
+        );
       });
 
       afterAll(() => {
         vitest.clearAllMocks();
       });
 
-      it('should throw an InversifyValidationError', () => {
-        expect(result).toBeInstanceOf(InversifyValidationError);
+      it('should call escapeJsonPointerFragments()', () => {
+        expect(escapeJsonPointerFragments).toHaveBeenCalledExactlyOnceWith(
+          contentTypeFixture,
+        );
       });
 
-      it('should throw an error with expected message', () => {
-        expect((result as InversifyValidationError).message).toBe(
-          `Unable to find schema for pointer: ${schemaPointerFixture}. The operation requestBody is an OpenAPI Reference Object ($ref: "${requestBodyReferenceFixture.$ref}"); AJV looks up this pointer on the document and does not follow OpenAPI $ref`,
+      it('should call ajv.getSchema()', () => {
+        expect(ajvMock.getSchema).toHaveBeenCalledExactlyOnceWith(
+          schemaPointerFixture,
         );
+      });
+
+      it('should return expected result', () => {
+        expect(result).toBe(inputParamFixture.body);
       });
     });
   });

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleBodyValidation.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/handleBodyValidation.ts
@@ -2,8 +2,6 @@ import { escapeJsonPointerFragments } from '@inversifyjs/json-schema-pointer';
 import {
   type OpenApi3Dot1Object,
   type OpenApi3Dot1OperationObject,
-  type OpenApi3Dot1ReferenceObject,
-  type OpenApi3Dot1RequestBodyObject,
 } from '@inversifyjs/open-api-types/v3Dot1';
 import {
   InversifyValidationError,
@@ -22,7 +20,10 @@ import {
 } from '../../models/v3Dot1/ValidationCacheEntry.js';
 import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
 import { getOperationObject } from './getOperationObject.js';
-import { getRequestBodyObject } from './getRequestBodyObject.js';
+import {
+  getRequestBodyObject,
+  type ResolvedRequestBodyObject,
+} from './getRequestBodyObject.js';
 
 function getValidationCacheEntryBody(
   ajv: Ajv,
@@ -37,42 +38,32 @@ function getValidationCacheEntryBody(
     route,
   );
 
-  const openApi3Dot1RequestBodyObject: OpenApi3Dot1RequestBodyObject =
+  const resolvedRequestBodyObject: ResolvedRequestBodyObject =
     getRequestBodyObject(openApiResolver, operationObject, method, route);
 
-  const required: boolean = openApi3Dot1RequestBodyObject.required ?? false;
+  const required: boolean =
+    resolvedRequestBodyObject.requestBody.required ?? false;
 
   const contentToValidateMap: Map<string | undefined, ValidateFunction> =
     new Map();
 
   const contentTypes: string[] = Object.keys(
-    openApi3Dot1RequestBodyObject.content,
+    resolvedRequestBodyObject.requestBody.content,
   );
 
+  const requestBodyPointerPrefix: string =
+    resolvedRequestBodyObject.pointerPrefix ??
+    escapeJsonPointerFragments('paths', route, method, 'requestBody');
+
   for (const contentType of contentTypes) {
-    const schemaPointer: string = `${SCHEMA_ID}#/${escapeJsonPointerFragments(
-      'paths',
-      route,
-      method,
-      'requestBody',
-      'content',
-      contentType,
-      'schema',
-    )}`;
+    const schemaPointer: string = `${SCHEMA_ID}#/${requestBodyPointerPrefix}/content/${escapeJsonPointerFragments(contentType)}/schema`;
 
     const validate: ValidateFunction | undefined = ajv.getSchema(schemaPointer);
 
     if (validate === undefined) {
-      const requestBody:
-        | OpenApi3Dot1RequestBodyObject
-        | OpenApi3Dot1ReferenceObject
-        | undefined = operationObject.requestBody;
-
       throw new InversifyValidationError(
         InversifyValidationErrorKind.unknown,
-        requestBody !== undefined && '$ref' in requestBody
-          ? `Unable to find schema for pointer: ${schemaPointer}. The operation requestBody is an OpenAPI Reference Object ($ref: "${requestBody.$ref}"); AJV looks up this pointer on the document and does not follow OpenAPI $ref`
-          : `Unable to find schema for pointer: ${schemaPointer}`,
+        `Unable to find schema for pointer: ${schemaPointer}`,
       );
     }
 

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/pointerPrefixFromResolutionChain.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/pointerPrefixFromResolutionChain.spec.ts
@@ -1,0 +1,78 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { pointerPrefixFromResolutionChain } from './pointerPrefixFromResolutionChain.js';
+
+describe(pointerPrefixFromResolutionChain, () => {
+  describe('having an empty chain', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = pointerPrefixFromResolutionChain([]);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a chain whose last canonicalId has no fragment', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = pointerPrefixFromResolutionChain([
+          {
+            canonicalId: 'urn:inversifyjs:openapi-v3dot1-spec',
+          },
+        ]);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a chain whose last canonicalId fragment does not start with "/"', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = pointerPrefixFromResolutionChain([
+          {
+            canonicalId: 'urn:inversifyjs:openapi-v3dot1-spec#anchor',
+          },
+        ]);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a chain whose last canonicalId has a JSON pointer fragment', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = pointerPrefixFromResolutionChain([
+          {
+            canonicalId:
+              'urn:inversifyjs:openapi-v3dot1-spec#/components/parameters/First',
+          },
+          {
+            canonicalId:
+              'urn:inversifyjs:openapi-v3dot1-spec#/components/parameters/PageParam',
+          },
+        ]);
+      });
+
+      it('should return the last hop JSON pointer without a leading slash', () => {
+        expect(result).toBe('components/parameters/PageParam');
+      });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/pointerPrefixFromResolutionChain.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/pointerPrefixFromResolutionChain.ts
@@ -1,0 +1,24 @@
+export function pointerPrefixFromResolutionChain(
+  chain: readonly { canonicalId: string }[],
+): string | undefined {
+  const lastEntry: { canonicalId: string } | undefined =
+    chain[chain.length - 1];
+
+  if (lastEntry === undefined) {
+    return undefined;
+  }
+
+  const fragmentIndex: number = lastEntry.canonicalId.indexOf('#');
+
+  if (fragmentIndex === -1) {
+    return undefined;
+  }
+
+  const fragment: string = lastEntry.canonicalId.slice(fragmentIndex + 1);
+
+  if (!fragment.startsWith('/')) {
+    return undefined;
+  }
+
+  return fragment.slice(1);
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/resolveParameterObject.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/resolveParameterObject.spec.ts
@@ -1,0 +1,402 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+import { type JsonValue } from '@inversifyjs/json-schema-types';
+import {
+  type OpenApi3Dot1ParameterObject,
+  type OpenApi3Dot1ReferenceObject,
+} from '@inversifyjs/open-api-types/v3Dot1';
+import { InversifyValidationErrorKind } from '@inversifyjs/validation-common';
+
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
+import {
+  type ResolvedParameterObject,
+  resolveParameterObject,
+} from './resolveParameterObject.js';
+
+describe(resolveParameterObject, () => {
+  let indexFixture: number;
+  let methodFixture: string;
+  let pathFixture: string;
+
+  beforeAll(() => {
+    indexFixture = 0;
+    methodFixture = 'get';
+    pathFixture = '/users';
+  });
+
+  describe('having a parameter object with no $ref', () => {
+    let openApiResolverMock: OpenApiResolver;
+    let parameterFixture: OpenApi3Dot1ParameterObject;
+
+    beforeAll(() => {
+      openApiResolverMock = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+      parameterFixture = {
+        in: 'query',
+        name: 'page',
+        schema: { type: 'integer' },
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = resolveParameterObject(
+          openApiResolverMock,
+          parameterFixture,
+          methodFixture,
+          pathFixture,
+          indexFixture,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should not call openApiResolver.resolveOpenApiReference()', () => {
+        expect(
+          openApiResolverMock.resolveOpenApiReference,
+        ).not.toHaveBeenCalled();
+      });
+
+      it('should return the parameter object', () => {
+        const expected: ResolvedParameterObject = {
+          parameter: parameterFixture,
+          pointerPrefix: undefined,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having a $ref that fails to resolve', () => {
+    let openApiResolverMock: OpenApiResolver;
+    let reasonFixture: string;
+    let referenceFixture: OpenApi3Dot1ReferenceObject;
+
+    beforeAll(() => {
+      reasonFixture =
+        'Failed to resolve JSON Pointer: /components/parameters/Missing';
+      referenceFixture = {
+        $ref: '#/components/parameters/Missing',
+      };
+      openApiResolverMock = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest
+          .mocked(openApiResolverMock.resolveOpenApiReference)
+          .mockReturnValueOnce({
+            isRight: false,
+            value: {
+              reason: reasonFixture,
+              resolutionContextStack: [],
+            },
+          });
+
+        try {
+          resolveParameterObject(
+            openApiResolverMock,
+            referenceFixture,
+            methodFixture,
+            pathFixture,
+            indexFixture,
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call openApiResolver.resolveOpenApiReference()', () => {
+        expect(
+          openApiResolverMock.resolveOpenApiReference,
+        ).toHaveBeenCalledExactlyOnceWith(referenceFixture);
+      });
+
+      it('should throw an InversifyOpenApiValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+          {
+            kind: InversifyValidationErrorKind.validationFailed,
+            message: `Could not resolve $ref pointer ${referenceFixture.$ref} for parameter at path: ${pathFixture} and method: ${methodFixture} and index: ${String(indexFixture)}: ${reasonFixture}`,
+          };
+
+        expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
+        expect(result).toMatchObject(expectedErrorProperties);
+      });
+    });
+  });
+
+  describe('having a $ref that resolves to a valid parameter object', () => {
+    let openApiResolverMock: OpenApiResolver;
+    let referenceFixture: OpenApi3Dot1ReferenceObject & JsonValue;
+    let resolvedParameterFixture: OpenApi3Dot1ParameterObject;
+
+    beforeAll(() => {
+      referenceFixture = {
+        $ref: '#/components/parameters/PageParam',
+      };
+      resolvedParameterFixture = {
+        in: 'query',
+        name: 'page',
+        schema: { type: 'integer' },
+      };
+      openApiResolverMock = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest
+          .mocked(openApiResolverMock.resolveOpenApiReference)
+          .mockReturnValueOnce({
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: referenceFixture.$ref,
+                  canonicalId: `urn:inversifyjs:openapi-v3dot1-spec#/components/parameters/PageParam`,
+                  value: referenceFixture,
+                },
+              ],
+              value: resolvedParameterFixture as unknown as JsonValue,
+            },
+          });
+
+        result = resolveParameterObject(
+          openApiResolverMock,
+          referenceFixture,
+          methodFixture,
+          pathFixture,
+          indexFixture,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call openApiResolver.resolveOpenApiReference()', () => {
+        expect(
+          openApiResolverMock.resolveOpenApiReference,
+        ).toHaveBeenCalledExactlyOnceWith(referenceFixture);
+      });
+
+      it('should return the resolved parameter object', () => {
+        const expected: ResolvedParameterObject = {
+          parameter: resolvedParameterFixture,
+          pointerPrefix: 'components/parameters/PageParam',
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having a $ref that resolves to a schema object', () => {
+    let openApiResolverMock: OpenApiResolver;
+    let referenceFixture: OpenApi3Dot1ReferenceObject;
+
+    beforeAll(() => {
+      referenceFixture = {
+        $ref: '#/components/schemas/User',
+      };
+      openApiResolverMock = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest
+          .mocked(openApiResolverMock.resolveOpenApiReference)
+          .mockReturnValueOnce({
+            isRight: true,
+            value: {
+              chain: [],
+              value: {
+                type: 'object',
+              },
+            },
+          });
+
+        try {
+          resolveParameterObject(
+            openApiResolverMock,
+            referenceFixture,
+            methodFixture,
+            pathFixture,
+            indexFixture,
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should throw an InversifyOpenApiValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+          {
+            kind: InversifyValidationErrorKind.validationFailed,
+            message: `Resolved $ref pointer ${referenceFixture.$ref} is not a valid parameter object at path: ${pathFixture} and method: ${methodFixture} and index: ${String(indexFixture)}`,
+          };
+
+        expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
+        expect(result).toMatchObject(expectedErrorProperties);
+      });
+    });
+  });
+
+  describe('having a $ref that resolves to an array', () => {
+    let openApiResolverMock: OpenApiResolver;
+    let referenceFixture: OpenApi3Dot1ReferenceObject;
+
+    beforeAll(() => {
+      referenceFixture = {
+        $ref: '#/components/parameters/PageParam',
+      };
+      openApiResolverMock = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest
+          .mocked(openApiResolverMock.resolveOpenApiReference)
+          .mockReturnValueOnce({
+            isRight: true,
+            value: {
+              chain: [],
+              value: [],
+            },
+          });
+
+        try {
+          resolveParameterObject(
+            openApiResolverMock,
+            referenceFixture,
+            methodFixture,
+            pathFixture,
+            indexFixture,
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should throw an InversifyOpenApiValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+          {
+            kind: InversifyValidationErrorKind.validationFailed,
+            message: `Resolved $ref pointer ${referenceFixture.$ref} is not a valid parameter object at path: ${pathFixture} and method: ${methodFixture} and index: ${String(indexFixture)}`,
+          };
+
+        expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
+        expect(result).toMatchObject(expectedErrorProperties);
+      });
+    });
+  });
+
+  describe('having a $ref that resolves to null', () => {
+    let openApiResolverMock: OpenApiResolver;
+    let referenceFixture: OpenApi3Dot1ReferenceObject;
+
+    beforeAll(() => {
+      referenceFixture = {
+        $ref: '#/components/parameters/PageParam',
+      };
+      openApiResolverMock = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest
+          .mocked(openApiResolverMock.resolveOpenApiReference)
+          .mockReturnValueOnce({
+            isRight: true,
+            value: {
+              chain: [],
+              value: null,
+            },
+          });
+
+        try {
+          resolveParameterObject(
+            openApiResolverMock,
+            referenceFixture,
+            methodFixture,
+            pathFixture,
+            indexFixture,
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should throw an InversifyOpenApiValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+          {
+            kind: InversifyValidationErrorKind.validationFailed,
+            message: `Resolved $ref pointer ${referenceFixture.$ref} is not a valid parameter object at path: ${pathFixture} and method: ${methodFixture} and index: ${String(indexFixture)}`,
+          };
+
+        expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
+        expect(result).toMatchObject(expectedErrorProperties);
+      });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/resolveParameterObject.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot1/resolveParameterObject.ts
@@ -1,0 +1,75 @@
+import { type JsonValue } from '@inversifyjs/json-schema-types';
+import {
+  type OpenApi3Dot1ParameterObject,
+  type OpenApi3Dot1ReferenceObject,
+} from '@inversifyjs/open-api-types/v3Dot1';
+import { InversifyValidationErrorKind } from '@inversifyjs/validation-common';
+
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
+import {
+  type OpenApiRefResolutionResult,
+  type OpenApiResolver,
+} from '../../services/OpenApiResolver.js';
+import { pointerPrefixFromResolutionChain } from './pointerPrefixFromResolutionChain.js';
+
+export interface ResolvedParameterObject {
+  parameter: OpenApi3Dot1ParameterObject;
+  pointerPrefix: string | undefined;
+}
+
+function isReferenceObject(
+  param: OpenApi3Dot1ParameterObject | OpenApi3Dot1ReferenceObject,
+): param is OpenApi3Dot1ReferenceObject {
+  return '$ref' in param;
+}
+
+function isParameterObject(
+  value: JsonValue,
+): value is JsonValue & OpenApi3Dot1ParameterObject {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as Partial<OpenApi3Dot1ParameterObject>).in === 'string' &&
+    typeof (value as Partial<OpenApi3Dot1ParameterObject>).name === 'string'
+  );
+}
+
+export function resolveParameterObject(
+  openApiResolver: OpenApiResolver,
+  raw: OpenApi3Dot1ParameterObject | OpenApi3Dot1ReferenceObject,
+  method: string,
+  path: string,
+  index: number,
+): ResolvedParameterObject {
+  if (!isReferenceObject(raw)) {
+    return {
+      parameter: raw,
+      pointerPrefix: undefined,
+    };
+  }
+
+  const result: OpenApiRefResolutionResult =
+    openApiResolver.resolveOpenApiReference(raw as unknown as JsonValue);
+
+  if (!result.isRight) {
+    throw new InversifyOpenApiValidationError(
+      InversifyValidationErrorKind.validationFailed,
+      `Could not resolve $ref pointer ${raw.$ref} for parameter at path: ${path} and method: ${method} and index: ${String(index)}: ${result.value.reason}`,
+    );
+  }
+
+  const resolvedRef: JsonValue = result.value.value;
+
+  if (!isParameterObject(resolvedRef)) {
+    throw new InversifyOpenApiValidationError(
+      InversifyValidationErrorKind.validationFailed,
+      `Resolved $ref pointer ${raw.$ref} is not a valid parameter object at path: ${path} and method: ${method} and index: ${String(index)}`,
+    );
+  }
+
+  return {
+    parameter: resolvedRef,
+    pointerPrefix: pointerPrefixFromResolutionChain(result.value.chain),
+  };
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getHeaderParameterObjects.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getHeaderParameterObjects.spec.ts
@@ -5,6 +5,7 @@ vitest.mock(import('./getOperationObject.js'));
 vitest.mock(import('./getPathItemObject.js'));
 
 import { escapeJsonPointerFragments } from '@inversifyjs/json-schema-pointer';
+import { type JsonValue } from '@inversifyjs/json-schema-types';
 import {
   type OpenApi3Dot2Object,
   type OpenApi3Dot2OperationObject,
@@ -65,6 +66,7 @@ describe(getHeaderParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };
@@ -82,6 +84,12 @@ describe(getHeaderParameterObjects, () => {
 
     afterAll(() => {
       vitest.clearAllMocks();
+    });
+
+    it('should not call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).not.toHaveBeenCalled();
     });
 
     it('should return a map with the header parameter', () => {
@@ -123,6 +131,7 @@ describe(getHeaderParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };
@@ -185,6 +194,7 @@ describe(getHeaderParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };
@@ -222,10 +232,11 @@ describe(getHeaderParameterObjects, () => {
 
   describe('when called, and parameter is a $ref reference', () => {
     let openApiResolverFixture: OpenApiResolver;
+    let refFixture: OpenApi3Dot2ReferenceObject;
     let result: Map<string, HeaderParameterEntry>;
 
     beforeAll(() => {
-      const refFixture: OpenApi3Dot2ReferenceObject = {
+      refFixture = {
         $ref: '#/components/parameters/ApiKeyHeader',
       };
 
@@ -246,10 +257,22 @@ describe(getHeaderParameterObjects, () => {
       };
 
       openApiResolverFixture = {
-        deepResolveReference: vitest
-          .fn()
-          .mockReturnValueOnce(resolvedParamFixture),
-        resolveOpenApiReference: vitest.fn(),
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: true,
+          value: {
+            chain: [
+              {
+                $ref: refFixture.$ref,
+                canonicalId:
+                  'urn:inversifyjs:openapi-v3dot2-spec#/components/parameters/ApiKeyHeader',
+                value: refFixture as unknown as JsonValue,
+              },
+            ],
+            value: resolvedParamFixture as unknown as JsonValue,
+          },
+        }),
         resolveReference: vitest.fn(),
       };
 
@@ -268,18 +291,117 @@ describe(getHeaderParameterObjects, () => {
       vitest.clearAllMocks();
     });
 
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
     it('should resolve the $ref and return the header parameter', () => {
       expect(result.size).toBe(1);
       expect(result.has('x-api-key')).toBe(true);
     });
+
+    it('should return entry with component pointer prefix', () => {
+      const entry: HeaderParameterEntry = result.get(
+        'x-api-key',
+      ) as HeaderParameterEntry;
+
+      expect(entry.pointerPrefix).toBe('components/parameters/ApiKeyHeader');
+    });
   });
 
-  describe('when called, and path item deepResolveReference returns undefined', () => {
+  describe('when called, and path item parameter is a $ref reference', () => {
     let openApiResolverFixture: OpenApiResolver;
+    let refFixture: OpenApi3Dot2ReferenceObject;
+    let result: Map<string, HeaderParameterEntry>;
+
+    beforeAll(() => {
+      refFixture = {
+        $ref: '#/components/parameters/ApiKeyHeader',
+      };
+
+      const resolvedParamFixture: OpenApi3Dot2ParameterObject = {
+        in: 'header',
+        name: 'X-Api-Key',
+        required: true,
+        schema: { type: 'string' },
+      };
+
+      const operationFixture: OpenApi3Dot2OperationObject = {
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot2PathItemObject = {
+        get: operationFixture,
+        parameters: [refFixture],
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: true,
+          value: {
+            chain: [
+              {
+                $ref: refFixture.$ref,
+                canonicalId:
+                  'urn:inversifyjs:openapi-v3dot2-spec#/components/parameters/ApiKeyHeader',
+                value: refFixture as unknown as JsonValue,
+              },
+            ],
+            value: resolvedParamFixture as unknown as JsonValue,
+          },
+        }),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getHeaderParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
+    it('should resolve the $ref and return the header parameter', () => {
+      expect(result.size).toBe(1);
+      expect(result.has('x-api-key')).toBe(true);
+    });
+
+    it('should return entry with component pointer prefix', () => {
+      const entry: HeaderParameterEntry = result.get(
+        'x-api-key',
+      ) as HeaderParameterEntry;
+
+      expect(entry.pointerPrefix).toBe('components/parameters/ApiKeyHeader');
+    });
+  });
+
+  describe('when called, and path item $ref fails to resolve', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let reasonFixture: string;
+    let refFixture: OpenApi3Dot2ReferenceObject;
     let result: unknown;
 
     beforeAll(() => {
-      const refFixture: OpenApi3Dot2ReferenceObject = {
+      reasonFixture =
+        'Failed to resolve JSON Pointer: /components/parameters/MissingHeader';
+      refFixture = {
         $ref: '#/components/parameters/MissingHeader',
       };
 
@@ -293,8 +415,15 @@ describe(getHeaderParameterObjects, () => {
       };
 
       openApiResolverFixture = {
-        deepResolveReference: vitest.fn().mockReturnValueOnce(undefined),
-        resolveOpenApiReference: vitest.fn(),
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: false,
+          value: {
+            reason: reasonFixture,
+            resolutionContextStack: [],
+          },
+        }),
         resolveReference: vitest.fn(),
       };
 
@@ -317,11 +446,17 @@ describe(getHeaderParameterObjects, () => {
       vitest.clearAllMocks();
     });
 
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
     it('should throw an InversifyOpenApiValidationError', () => {
       const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
         {
           kind: InversifyValidationErrorKind.validationFailed,
-          message: `Unable to resolve header parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0`,
+          message: `Could not resolve $ref pointer ${refFixture.$ref} for parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0: ${reasonFixture}`,
         };
 
       expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
@@ -329,12 +464,16 @@ describe(getHeaderParameterObjects, () => {
     });
   });
 
-  describe('when called, and operation deepResolveReference returns undefined', () => {
+  describe('when called, and operation $ref fails to resolve', () => {
     let openApiResolverFixture: OpenApiResolver;
+    let reasonFixture: string;
+    let refFixture: OpenApi3Dot2ReferenceObject;
     let result: unknown;
 
     beforeAll(() => {
-      const refFixture: OpenApi3Dot2ReferenceObject = {
+      reasonFixture =
+        'Failed to resolve JSON Pointer: /components/parameters/MissingHeader';
+      refFixture = {
         $ref: '#/components/parameters/MissingHeader',
       };
 
@@ -348,8 +487,84 @@ describe(getHeaderParameterObjects, () => {
       };
 
       openApiResolverFixture = {
-        deepResolveReference: vitest.fn().mockReturnValueOnce(undefined),
-        resolveOpenApiReference: vitest.fn(),
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: false,
+          value: {
+            reason: reasonFixture,
+            resolutionContextStack: [],
+          },
+        }),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      try {
+        getHeaderParameterObjects(
+          openApiObjectFixture,
+          openApiResolverFixture,
+          methodFixture,
+          pathFixture,
+        );
+      } catch (error: unknown) {
+        result = error;
+      }
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
+    it('should throw an InversifyOpenApiValidationError', () => {
+      const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+        {
+          kind: InversifyValidationErrorKind.validationFailed,
+          message: `Could not resolve $ref pointer ${refFixture.$ref} for parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0: ${reasonFixture}`,
+        };
+
+      expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
+      expect(result).toMatchObject(expectedErrorProperties);
+    });
+  });
+
+  describe('when called, and $ref resolves to a non-object', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let refFixture: OpenApi3Dot2ReferenceObject;
+    let result: unknown;
+
+    beforeAll(() => {
+      refFixture = {
+        $ref: '#/components/parameters/ApiKeyHeader',
+      };
+
+      const operationFixture: OpenApi3Dot2OperationObject = {
+        parameters: [refFixture],
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot2PathItemObject = {
+        get: operationFixture,
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: true,
+          value: {
+            chain: [],
+            value: null,
+          },
+        }),
         resolveReference: vitest.fn(),
       };
 
@@ -376,7 +591,7 @@ describe(getHeaderParameterObjects, () => {
       const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
         {
           kind: InversifyValidationErrorKind.validationFailed,
-          message: `Unable to resolve header parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0`,
+          message: `Resolved $ref pointer ${refFixture.$ref} is not a valid parameter object at path: ${pathFixture} and method: ${methodFixture} and index: 0`,
         };
 
       expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
@@ -399,6 +614,7 @@ describe(getHeaderParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getHeaderParameterObjects.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getHeaderParameterObjects.ts
@@ -6,22 +6,18 @@ import {
   type OpenApi3Dot2PathItemObject,
   type OpenApi3Dot2ReferenceObject,
 } from '@inversifyjs/open-api-types/v3Dot2';
-import { InversifyValidationErrorKind } from '@inversifyjs/validation-common';
 
-import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
 import { getOperationObject } from './getOperationObject.js';
 import { getPathItemObject } from './getPathItemObject.js';
+import {
+  type ResolvedParameterObject,
+  resolveParameterObject,
+} from './resolveParameterObject.js';
 
 export interface HeaderParameterEntry {
   parameter: OpenApi3Dot2ParameterObject;
   pointerPrefix: string;
-}
-
-function isReferenceObject(
-  param: OpenApi3Dot2ParameterObject | OpenApi3Dot2ReferenceObject,
-): param is OpenApi3Dot2ReferenceObject {
-  return '$ref' in param;
 }
 
 export function getHeaderParameterObjects(
@@ -48,23 +44,22 @@ export function getHeaderParameterObjects(
         pathItemObject.parameters[i] as
           OpenApi3Dot2ParameterObject | OpenApi3Dot2ReferenceObject;
 
-      const param: OpenApi3Dot2ParameterObject | null | undefined =
-        isReferenceObject(raw)
-          ? (openApiResolver.deepResolveReference(raw.$ref) as unknown as
-              OpenApi3Dot2ParameterObject | null | undefined)
-          : raw;
+      const resolved: ResolvedParameterObject = resolveParameterObject(
+        openApiResolver,
+        raw,
+        method,
+        path,
+        i,
+      );
 
-      if (param == undefined) {
-        throw new InversifyOpenApiValidationError(
-          InversifyValidationErrorKind.validationFailed,
-          `Unable to resolve header parameter at path: ${path} and method: ${method} and index: ${String(i)}`,
-        );
-      }
+      const param: OpenApi3Dot2ParameterObject = resolved.parameter;
 
       if (param.in === 'header') {
         result.set(param.name.toLowerCase(), {
           parameter: param,
-          pointerPrefix: `paths/${escapeJsonPointerFragments(path)}/parameters/${String(i)}`,
+          pointerPrefix:
+            resolved.pointerPrefix ??
+            `paths/${escapeJsonPointerFragments(path)}/parameters/${String(i)}`,
         });
       }
     }
@@ -76,23 +71,22 @@ export function getHeaderParameterObjects(
         operationObject.parameters[i] as
           OpenApi3Dot2ParameterObject | OpenApi3Dot2ReferenceObject;
 
-      const param: OpenApi3Dot2ParameterObject | null | undefined =
-        isReferenceObject(raw)
-          ? (openApiResolver.deepResolveReference(raw.$ref) as unknown as
-              OpenApi3Dot2ParameterObject | null | undefined)
-          : raw;
+      const resolved: ResolvedParameterObject = resolveParameterObject(
+        openApiResolver,
+        raw,
+        method,
+        path,
+        i,
+      );
 
-      if (param == undefined) {
-        throw new InversifyOpenApiValidationError(
-          InversifyValidationErrorKind.validationFailed,
-          `Unable to resolve header parameter at path: ${path} and method: ${method} and index: ${String(i)}`,
-        );
-      }
+      const param: OpenApi3Dot2ParameterObject = resolved.parameter;
 
       if (param.in === 'header') {
         result.set(param.name.toLowerCase(), {
           parameter: param,
-          pointerPrefix: `paths/${escapeJsonPointerFragments(path)}/${method}/parameters/${String(i)}`,
+          pointerPrefix:
+            resolved.pointerPrefix ??
+            `paths/${escapeJsonPointerFragments(path)}/${method}/parameters/${String(i)}`,
         });
       }
     }

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getParamParameterObjects.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getParamParameterObjects.spec.ts
@@ -5,6 +5,7 @@ vitest.mock(import('./getOperationObject.js'));
 vitest.mock(import('./getPathItemObject.js'));
 
 import { escapeJsonPointerFragments } from '@inversifyjs/json-schema-pointer';
+import { type JsonValue } from '@inversifyjs/json-schema-types';
 import {
   type OpenApi3Dot2Object,
   type OpenApi3Dot2OperationObject,
@@ -65,6 +66,7 @@ describe(getParamParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };
@@ -82,6 +84,12 @@ describe(getParamParameterObjects, () => {
 
     afterAll(() => {
       vitest.clearAllMocks();
+    });
+
+    it('should not call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).not.toHaveBeenCalled();
     });
 
     it('should return a map with the path parameter', () => {
@@ -123,6 +131,7 @@ describe(getParamParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };
@@ -185,6 +194,7 @@ describe(getParamParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };
@@ -232,10 +242,11 @@ describe(getParamParameterObjects, () => {
 
   describe('when called, and parameter is a $ref reference', () => {
     let openApiResolverFixture: OpenApiResolver;
+    let refFixture: OpenApi3Dot2ReferenceObject;
     let result: Map<string, ParamParameterEntry>;
 
     beforeAll(() => {
-      const refFixture: OpenApi3Dot2ReferenceObject = {
+      refFixture = {
         $ref: '#/components/parameters/UserIdParam',
       };
 
@@ -256,10 +267,22 @@ describe(getParamParameterObjects, () => {
       };
 
       openApiResolverFixture = {
-        deepResolveReference: vitest
-          .fn()
-          .mockReturnValueOnce(resolvedParamFixture),
-        resolveOpenApiReference: vitest.fn(),
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: true,
+          value: {
+            chain: [
+              {
+                $ref: refFixture.$ref,
+                canonicalId:
+                  'urn:inversifyjs:openapi-v3dot2-spec#/components/parameters/UserIdParam',
+                value: refFixture as unknown as JsonValue,
+              },
+            ],
+            value: resolvedParamFixture as unknown as JsonValue,
+          },
+        }),
         resolveReference: vitest.fn(),
       };
 
@@ -278,24 +301,117 @@ describe(getParamParameterObjects, () => {
       vitest.clearAllMocks();
     });
 
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
     it('should resolve the $ref and return the path parameter', () => {
       expect(result.size).toBe(1);
       expect(result.has('userId')).toBe(true);
     });
 
-    it('should call deepResolveReference', () => {
-      expect(
-        openApiResolverFixture.deepResolveReference,
-      ).toHaveBeenCalledExactlyOnceWith('#/components/parameters/UserIdParam');
+    it('should return entry with component pointer prefix', () => {
+      const entry: ParamParameterEntry = result.get(
+        'userId',
+      ) as ParamParameterEntry;
+
+      expect(entry.pointerPrefix).toBe('components/parameters/UserIdParam');
     });
   });
 
-  describe('when called, and path item deepResolveReference returns undefined', () => {
+  describe('when called, and path item parameter is a $ref reference', () => {
     let openApiResolverFixture: OpenApiResolver;
+    let refFixture: OpenApi3Dot2ReferenceObject;
+    let result: Map<string, ParamParameterEntry>;
+
+    beforeAll(() => {
+      refFixture = {
+        $ref: '#/components/parameters/UserIdParam',
+      };
+
+      const resolvedParamFixture: OpenApi3Dot2ParameterObject = {
+        in: 'path',
+        name: 'userId',
+        required: true,
+        schema: { type: 'string' },
+      };
+
+      const operationFixture: OpenApi3Dot2OperationObject = {
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot2PathItemObject = {
+        get: operationFixture,
+        parameters: [refFixture],
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: true,
+          value: {
+            chain: [
+              {
+                $ref: refFixture.$ref,
+                canonicalId:
+                  'urn:inversifyjs:openapi-v3dot2-spec#/components/parameters/UserIdParam',
+                value: refFixture as unknown as JsonValue,
+              },
+            ],
+            value: resolvedParamFixture as unknown as JsonValue,
+          },
+        }),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getParamParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
+    it('should resolve the $ref and return the path parameter', () => {
+      expect(result.size).toBe(1);
+      expect(result.has('userId')).toBe(true);
+    });
+
+    it('should return entry with component pointer prefix', () => {
+      const entry: ParamParameterEntry = result.get(
+        'userId',
+      ) as ParamParameterEntry;
+
+      expect(entry.pointerPrefix).toBe('components/parameters/UserIdParam');
+    });
+  });
+
+  describe('when called, and path item $ref fails to resolve', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let reasonFixture: string;
+    let refFixture: OpenApi3Dot2ReferenceObject;
     let result: unknown;
 
     beforeAll(() => {
-      const refFixture: OpenApi3Dot2ReferenceObject = {
+      reasonFixture =
+        'Failed to resolve JSON Pointer: /components/parameters/MissingUserIdParam';
+      refFixture = {
         $ref: '#/components/parameters/MissingUserIdParam',
       };
 
@@ -309,8 +425,15 @@ describe(getParamParameterObjects, () => {
       };
 
       openApiResolverFixture = {
-        deepResolveReference: vitest.fn().mockReturnValueOnce(undefined),
-        resolveOpenApiReference: vitest.fn(),
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: false,
+          value: {
+            reason: reasonFixture,
+            resolutionContextStack: [],
+          },
+        }),
         resolveReference: vitest.fn(),
       };
 
@@ -333,11 +456,17 @@ describe(getParamParameterObjects, () => {
       vitest.clearAllMocks();
     });
 
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
     it('should throw an InversifyOpenApiValidationError', () => {
       const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
         {
           kind: InversifyValidationErrorKind.validationFailed,
-          message: `Unable to resolve path parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0`,
+          message: `Could not resolve $ref pointer ${refFixture.$ref} for parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0: ${reasonFixture}`,
         };
 
       expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
@@ -345,12 +474,16 @@ describe(getParamParameterObjects, () => {
     });
   });
 
-  describe('when called, and operation deepResolveReference returns undefined', () => {
+  describe('when called, and operation $ref fails to resolve', () => {
     let openApiResolverFixture: OpenApiResolver;
+    let reasonFixture: string;
+    let refFixture: OpenApi3Dot2ReferenceObject;
     let result: unknown;
 
     beforeAll(() => {
-      const refFixture: OpenApi3Dot2ReferenceObject = {
+      reasonFixture =
+        'Failed to resolve JSON Pointer: /components/parameters/MissingUserIdParam';
+      refFixture = {
         $ref: '#/components/parameters/MissingUserIdParam',
       };
 
@@ -364,8 +497,84 @@ describe(getParamParameterObjects, () => {
       };
 
       openApiResolverFixture = {
-        deepResolveReference: vitest.fn().mockReturnValueOnce(undefined),
-        resolveOpenApiReference: vitest.fn(),
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: false,
+          value: {
+            reason: reasonFixture,
+            resolutionContextStack: [],
+          },
+        }),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      try {
+        getParamParameterObjects(
+          openApiObjectFixture,
+          openApiResolverFixture,
+          methodFixture,
+          pathFixture,
+        );
+      } catch (error: unknown) {
+        result = error;
+      }
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
+    it('should throw an InversifyOpenApiValidationError', () => {
+      const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+        {
+          kind: InversifyValidationErrorKind.validationFailed,
+          message: `Could not resolve $ref pointer ${refFixture.$ref} for parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0: ${reasonFixture}`,
+        };
+
+      expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
+      expect(result).toMatchObject(expectedErrorProperties);
+    });
+  });
+
+  describe('when called, and $ref resolves to a non-object', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let refFixture: OpenApi3Dot2ReferenceObject;
+    let result: unknown;
+
+    beforeAll(() => {
+      refFixture = {
+        $ref: '#/components/parameters/UserIdParam',
+      };
+
+      const operationFixture: OpenApi3Dot2OperationObject = {
+        parameters: [refFixture],
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot2PathItemObject = {
+        get: operationFixture,
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: true,
+          value: {
+            chain: [],
+            value: null,
+          },
+        }),
         resolveReference: vitest.fn(),
       };
 
@@ -392,7 +601,7 @@ describe(getParamParameterObjects, () => {
       const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
         {
           kind: InversifyValidationErrorKind.validationFailed,
-          message: `Unable to resolve path parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0`,
+          message: `Resolved $ref pointer ${refFixture.$ref} is not a valid parameter object at path: ${pathFixture} and method: ${methodFixture} and index: 0`,
         };
 
       expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
@@ -415,6 +624,7 @@ describe(getParamParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };
@@ -467,6 +677,7 @@ describe(getParamParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getParamParameterObjects.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getParamParameterObjects.ts
@@ -6,22 +6,18 @@ import {
   type OpenApi3Dot2PathItemObject,
   type OpenApi3Dot2ReferenceObject,
 } from '@inversifyjs/open-api-types/v3Dot2';
-import { InversifyValidationErrorKind } from '@inversifyjs/validation-common';
 
-import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
 import { getOperationObject } from './getOperationObject.js';
 import { getPathItemObject } from './getPathItemObject.js';
+import {
+  type ResolvedParameterObject,
+  resolveParameterObject,
+} from './resolveParameterObject.js';
 
 export interface ParamParameterEntry {
   parameter: OpenApi3Dot2ParameterObject;
   pointerPrefix: string;
-}
-
-function isReferenceObject(
-  param: OpenApi3Dot2ParameterObject | OpenApi3Dot2ReferenceObject,
-): param is OpenApi3Dot2ReferenceObject {
-  return '$ref' in param;
 }
 
 export function getParamParameterObjects(
@@ -48,23 +44,22 @@ export function getParamParameterObjects(
         pathItemObject.parameters[i] as
           OpenApi3Dot2ParameterObject | OpenApi3Dot2ReferenceObject;
 
-      const param: OpenApi3Dot2ParameterObject | null | undefined =
-        isReferenceObject(raw)
-          ? (openApiResolver.deepResolveReference(raw.$ref) as unknown as
-              OpenApi3Dot2ParameterObject | null | undefined)
-          : raw;
+      const resolved: ResolvedParameterObject = resolveParameterObject(
+        openApiResolver,
+        raw,
+        method,
+        path,
+        i,
+      );
 
-      if (param == undefined) {
-        throw new InversifyOpenApiValidationError(
-          InversifyValidationErrorKind.validationFailed,
-          `Unable to resolve path parameter at path: ${path} and method: ${method} and index: ${String(i)}`,
-        );
-      }
+      const param: OpenApi3Dot2ParameterObject = resolved.parameter;
 
       if (param.in === 'path') {
         result.set(param.name, {
           parameter: param,
-          pointerPrefix: `paths/${escapeJsonPointerFragments(path)}/parameters/${String(i)}`,
+          pointerPrefix:
+            resolved.pointerPrefix ??
+            `paths/${escapeJsonPointerFragments(path)}/parameters/${String(i)}`,
         });
       }
     }
@@ -76,23 +71,22 @@ export function getParamParameterObjects(
         operationObject.parameters[i] as
           OpenApi3Dot2ParameterObject | OpenApi3Dot2ReferenceObject;
 
-      const param: OpenApi3Dot2ParameterObject | null | undefined =
-        isReferenceObject(raw)
-          ? (openApiResolver.deepResolveReference(raw.$ref) as unknown as
-              OpenApi3Dot2ParameterObject | null | undefined)
-          : raw;
+      const resolved: ResolvedParameterObject = resolveParameterObject(
+        openApiResolver,
+        raw,
+        method,
+        path,
+        i,
+      );
 
-      if (param == undefined) {
-        throw new InversifyOpenApiValidationError(
-          InversifyValidationErrorKind.validationFailed,
-          `Unable to resolve path parameter at path: ${path} and method: ${method} and index: ${String(i)}`,
-        );
-      }
+      const param: OpenApi3Dot2ParameterObject = resolved.parameter;
 
       if (param.in === 'path') {
         result.set(param.name, {
           parameter: param,
-          pointerPrefix: `paths/${escapeJsonPointerFragments(path)}/${method}/parameters/${String(i)}`,
+          pointerPrefix:
+            resolved.pointerPrefix ??
+            `paths/${escapeJsonPointerFragments(path)}/${method}/parameters/${String(i)}`,
         });
       }
     }

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getQueryParameterObjects.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getQueryParameterObjects.spec.ts
@@ -5,6 +5,7 @@ vitest.mock(import('./getOperationObject.js'));
 vitest.mock(import('./getPathItemObject.js'));
 
 import { escapeJsonPointerFragments } from '@inversifyjs/json-schema-pointer';
+import { type JsonValue } from '@inversifyjs/json-schema-types';
 import {
   type OpenApi3Dot2Object,
   type OpenApi3Dot2OperationObject,
@@ -65,6 +66,7 @@ describe(getQueryParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };
@@ -82,6 +84,12 @@ describe(getQueryParameterObjects, () => {
 
     afterAll(() => {
       vitest.clearAllMocks();
+    });
+
+    it('should not call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).not.toHaveBeenCalled();
     });
 
     it('should return a map with the query parameter', () => {
@@ -122,6 +130,7 @@ describe(getQueryParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };
@@ -152,10 +161,11 @@ describe(getQueryParameterObjects, () => {
 
   describe('when called, and parameter is a $ref reference', () => {
     let openApiResolverFixture: OpenApiResolver;
+    let refFixture: OpenApi3Dot2ReferenceObject;
     let result: Map<string, QueryParameterEntry>;
 
     beforeAll(() => {
-      const refFixture: OpenApi3Dot2ReferenceObject = {
+      refFixture = {
         $ref: '#/components/parameters/PageParam',
       };
 
@@ -175,10 +185,22 @@ describe(getQueryParameterObjects, () => {
       };
 
       openApiResolverFixture = {
-        deepResolveReference: vitest
-          .fn()
-          .mockReturnValueOnce(resolvedParamFixture),
-        resolveOpenApiReference: vitest.fn(),
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: true,
+          value: {
+            chain: [
+              {
+                $ref: refFixture.$ref,
+                canonicalId:
+                  'urn:inversifyjs:openapi-v3dot2-spec#/components/parameters/PageParam',
+                value: refFixture as unknown as JsonValue,
+              },
+            ],
+            value: resolvedParamFixture as unknown as JsonValue,
+          },
+        }),
         resolveReference: vitest.fn(),
       };
 
@@ -197,24 +219,116 @@ describe(getQueryParameterObjects, () => {
       vitest.clearAllMocks();
     });
 
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
     it('should resolve the $ref and return the query parameter', () => {
       expect(result.size).toBe(1);
       expect(result.has('page')).toBe(true);
     });
 
-    it('should call deepResolveReference', () => {
-      expect(
-        openApiResolverFixture.deepResolveReference,
-      ).toHaveBeenCalledExactlyOnceWith('#/components/parameters/PageParam');
+    it('should return entry with component pointer prefix', () => {
+      const entry: QueryParameterEntry = result.get(
+        'page',
+      ) as QueryParameterEntry;
+
+      expect(entry.pointerPrefix).toBe('components/parameters/PageParam');
     });
   });
 
-  describe('when called, and path item deepResolveReference returns undefined', () => {
+  describe('when called, and path item parameter is a $ref reference', () => {
     let openApiResolverFixture: OpenApiResolver;
+    let refFixture: OpenApi3Dot2ReferenceObject;
+    let result: Map<string, QueryParameterEntry>;
+
+    beforeAll(() => {
+      refFixture = {
+        $ref: '#/components/parameters/PageParam',
+      };
+
+      const resolvedParamFixture: OpenApi3Dot2ParameterObject = {
+        in: 'query',
+        name: 'page',
+        schema: { type: 'integer' },
+      };
+
+      const operationFixture: OpenApi3Dot2OperationObject = {
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot2PathItemObject = {
+        get: operationFixture,
+        parameters: [refFixture],
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: true,
+          value: {
+            chain: [
+              {
+                $ref: refFixture.$ref,
+                canonicalId:
+                  'urn:inversifyjs:openapi-v3dot2-spec#/components/parameters/PageParam',
+                value: refFixture as unknown as JsonValue,
+              },
+            ],
+            value: resolvedParamFixture as unknown as JsonValue,
+          },
+        }),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      result = getQueryParameterObjects(
+        openApiObjectFixture,
+        openApiResolverFixture,
+        methodFixture,
+        pathFixture,
+      );
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
+    it('should resolve the $ref and return the query parameter', () => {
+      expect(result.size).toBe(1);
+      expect(result.has('page')).toBe(true);
+    });
+
+    it('should return entry with component pointer prefix', () => {
+      const entry: QueryParameterEntry = result.get(
+        'page',
+      ) as QueryParameterEntry;
+
+      expect(entry.pointerPrefix).toBe('components/parameters/PageParam');
+    });
+  });
+
+  describe('when called, and path item $ref fails to resolve', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let reasonFixture: string;
+    let refFixture: OpenApi3Dot2ReferenceObject;
     let result: unknown;
 
     beforeAll(() => {
-      const refFixture: OpenApi3Dot2ReferenceObject = {
+      reasonFixture =
+        'Failed to resolve JSON Pointer: /components/parameters/MissingPageParam';
+      refFixture = {
         $ref: '#/components/parameters/MissingPageParam',
       };
 
@@ -228,8 +342,15 @@ describe(getQueryParameterObjects, () => {
       };
 
       openApiResolverFixture = {
-        deepResolveReference: vitest.fn().mockReturnValueOnce(undefined),
-        resolveOpenApiReference: vitest.fn(),
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: false,
+          value: {
+            reason: reasonFixture,
+            resolutionContextStack: [],
+          },
+        }),
         resolveReference: vitest.fn(),
       };
 
@@ -252,11 +373,17 @@ describe(getQueryParameterObjects, () => {
       vitest.clearAllMocks();
     });
 
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
     it('should throw an InversifyOpenApiValidationError', () => {
       const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
         {
           kind: InversifyValidationErrorKind.validationFailed,
-          message: `Unable to resolve query parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0`,
+          message: `Could not resolve $ref pointer ${refFixture.$ref} for parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0: ${reasonFixture}`,
         };
 
       expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
@@ -264,12 +391,16 @@ describe(getQueryParameterObjects, () => {
     });
   });
 
-  describe('when called, and operation deepResolveReference returns undefined', () => {
+  describe('when called, and operation $ref fails to resolve', () => {
     let openApiResolverFixture: OpenApiResolver;
+    let reasonFixture: string;
+    let refFixture: OpenApi3Dot2ReferenceObject;
     let result: unknown;
 
     beforeAll(() => {
-      const refFixture: OpenApi3Dot2ReferenceObject = {
+      reasonFixture =
+        'Failed to resolve JSON Pointer: /components/parameters/MissingPageParam';
+      refFixture = {
         $ref: '#/components/parameters/MissingPageParam',
       };
 
@@ -283,8 +414,84 @@ describe(getQueryParameterObjects, () => {
       };
 
       openApiResolverFixture = {
-        deepResolveReference: vitest.fn().mockReturnValueOnce(undefined),
-        resolveOpenApiReference: vitest.fn(),
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: false,
+          value: {
+            reason: reasonFixture,
+            resolutionContextStack: [],
+          },
+        }),
+        resolveReference: vitest.fn(),
+      };
+
+      vitest.mocked(getPathItemObject).mockReturnValueOnce(pathItemFixture);
+      vitest.mocked(getOperationObject).mockReturnValueOnce(operationFixture);
+
+      try {
+        getQueryParameterObjects(
+          openApiObjectFixture,
+          openApiResolverFixture,
+          methodFixture,
+          pathFixture,
+        );
+      } catch (error: unknown) {
+        result = error;
+      }
+    });
+
+    afterAll(() => {
+      vitest.clearAllMocks();
+    });
+
+    it('should call openApiResolver.resolveOpenApiReference()', () => {
+      expect(
+        openApiResolverFixture.resolveOpenApiReference,
+      ).toHaveBeenCalledExactlyOnceWith(refFixture);
+    });
+
+    it('should throw an InversifyOpenApiValidationError', () => {
+      const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+        {
+          kind: InversifyValidationErrorKind.validationFailed,
+          message: `Could not resolve $ref pointer ${refFixture.$ref} for parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0: ${reasonFixture}`,
+        };
+
+      expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
+      expect(result).toMatchObject(expectedErrorProperties);
+    });
+  });
+
+  describe('when called, and $ref resolves to a non-object', () => {
+    let openApiResolverFixture: OpenApiResolver;
+    let refFixture: OpenApi3Dot2ReferenceObject;
+    let result: unknown;
+
+    beforeAll(() => {
+      refFixture = {
+        $ref: '#/components/parameters/PageParam',
+      };
+
+      const operationFixture: OpenApi3Dot2OperationObject = {
+        parameters: [refFixture],
+        responses: {},
+      };
+
+      const pathItemFixture: OpenApi3Dot2PathItemObject = {
+        get: operationFixture,
+      };
+
+      openApiResolverFixture = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn().mockReturnValueOnce({
+          isRight: true,
+          value: {
+            chain: [],
+            value: null,
+          },
+        }),
         resolveReference: vitest.fn(),
       };
 
@@ -311,7 +518,7 @@ describe(getQueryParameterObjects, () => {
       const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
         {
           kind: InversifyValidationErrorKind.validationFailed,
-          message: `Unable to resolve query parameter at path: ${pathFixture} and method: ${methodFixture} and index: 0`,
+          message: `Resolved $ref pointer ${refFixture.$ref} is not a valid parameter object at path: ${pathFixture} and method: ${methodFixture} and index: 0`,
         };
 
       expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
@@ -347,6 +554,7 @@ describe(getQueryParameterObjects, () => {
 
       openApiResolverFixture = {
         deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
         resolveOpenApiReference: vitest.fn(),
         resolveReference: vitest.fn(),
       };

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getQueryParameterObjects.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getQueryParameterObjects.ts
@@ -6,22 +6,18 @@ import {
   type OpenApi3Dot2PathItemObject,
   type OpenApi3Dot2ReferenceObject,
 } from '@inversifyjs/open-api-types/v3Dot2';
-import { InversifyValidationErrorKind } from '@inversifyjs/validation-common';
 
-import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
 import { getOperationObject } from './getOperationObject.js';
 import { getPathItemObject } from './getPathItemObject.js';
+import {
+  type ResolvedParameterObject,
+  resolveParameterObject,
+} from './resolveParameterObject.js';
 
 export interface QueryParameterEntry {
   parameter: OpenApi3Dot2ParameterObject;
   pointerPrefix: string;
-}
-
-function isReferenceObject(
-  param: OpenApi3Dot2ParameterObject | OpenApi3Dot2ReferenceObject,
-): param is OpenApi3Dot2ReferenceObject {
-  return '$ref' in param;
 }
 
 export function getQueryParameterObjects(
@@ -48,23 +44,22 @@ export function getQueryParameterObjects(
         pathItemObject.parameters[i] as
           OpenApi3Dot2ParameterObject | OpenApi3Dot2ReferenceObject;
 
-      const param: OpenApi3Dot2ParameterObject | null | undefined =
-        isReferenceObject(raw)
-          ? (openApiResolver.deepResolveReference(raw.$ref) as unknown as
-              OpenApi3Dot2ParameterObject | null | undefined)
-          : raw;
+      const resolved: ResolvedParameterObject = resolveParameterObject(
+        openApiResolver,
+        raw,
+        method,
+        path,
+        i,
+      );
 
-      if (param == undefined) {
-        throw new InversifyOpenApiValidationError(
-          InversifyValidationErrorKind.validationFailed,
-          `Unable to resolve query parameter at path: ${path} and method: ${method} and index: ${String(i)}`,
-        );
-      }
+      const param: OpenApi3Dot2ParameterObject = resolved.parameter;
 
       if (param.in === 'query') {
         result.set(param.name, {
           parameter: param,
-          pointerPrefix: `paths/${escapeJsonPointerFragments(path)}/parameters/${String(i)}`,
+          pointerPrefix:
+            resolved.pointerPrefix ??
+            `paths/${escapeJsonPointerFragments(path)}/parameters/${String(i)}`,
         });
       }
     }
@@ -76,23 +71,22 @@ export function getQueryParameterObjects(
         operationObject.parameters[i] as
           OpenApi3Dot2ParameterObject | OpenApi3Dot2ReferenceObject;
 
-      const param: OpenApi3Dot2ParameterObject | null | undefined =
-        isReferenceObject(raw)
-          ? (openApiResolver.deepResolveReference(raw.$ref) as unknown as
-              OpenApi3Dot2ParameterObject | null | undefined)
-          : raw;
+      const resolved: ResolvedParameterObject = resolveParameterObject(
+        openApiResolver,
+        raw,
+        method,
+        path,
+        i,
+      );
 
-      if (param == undefined) {
-        throw new InversifyOpenApiValidationError(
-          InversifyValidationErrorKind.validationFailed,
-          `Unable to resolve query parameter at path: ${path} and method: ${method} and index: ${String(i)}`,
-        );
-      }
+      const param: OpenApi3Dot2ParameterObject = resolved.parameter;
 
       if (param.in === 'query') {
         result.set(param.name, {
           parameter: param,
-          pointerPrefix: `paths/${escapeJsonPointerFragments(path)}/${method}/parameters/${String(i)}`,
+          pointerPrefix:
+            resolved.pointerPrefix ??
+            `paths/${escapeJsonPointerFragments(path)}/${method}/parameters/${String(i)}`,
         });
       }
     }

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getRequestBodyObject.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getRequestBodyObject.spec.ts
@@ -11,8 +11,12 @@ import {
   InversifyValidationErrorKind,
 } from '@inversifyjs/validation-common';
 
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
-import { getRequestBodyObject } from './getRequestBodyObject.js';
+import {
+  getRequestBodyObject,
+  type ResolvedRequestBodyObject,
+} from './getRequestBodyObject.js';
 
 describe(getRequestBodyObject, () => {
   let openApiResolverMock: OpenApiResolver;
@@ -22,6 +26,7 @@ describe(getRequestBodyObject, () => {
   beforeAll(() => {
     openApiResolverMock = {
       deepResolveReference: vitest.fn(),
+      resolveJsonSchema: vitest.fn(),
       resolveOpenApiReference: vitest.fn(),
       resolveReference: vitest.fn(),
     };
@@ -105,7 +110,12 @@ describe(getRequestBodyObject, () => {
       });
 
       it('should return expected result', () => {
-        expect(result).toBe(requestBodyObjectFixture);
+        const expected: ResolvedRequestBodyObject = {
+          pointerPrefix: undefined,
+          requestBody: requestBodyObjectFixture,
+        };
+
+        expect(result).toStrictEqual(expected);
       });
     });
   });
@@ -163,13 +173,14 @@ describe(getRequestBodyObject, () => {
         ).toHaveBeenCalledExactlyOnceWith(requestBodyReferenceFixture);
       });
 
-      it('should throw an InversifyValidationError', () => {
-        const expectedErrorProperties: Partial<InversifyValidationError> = {
-          kind: InversifyValidationErrorKind.validationFailed,
-          message: `Could not resolve $ref pointer ${requestBodyReferenceFixture.$ref} for ${methodFixture.toUpperCase()} ${routeFixture}: ${reasonFixture}`,
-        };
+      it('should throw an InversifyOpenApiValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+          {
+            kind: InversifyValidationErrorKind.validationFailed,
+            message: `Could not resolve $ref pointer ${requestBodyReferenceFixture.$ref} for ${methodFixture.toUpperCase()} ${routeFixture}: ${reasonFixture}`,
+          };
 
-        expect(result).toBeInstanceOf(InversifyValidationError);
+        expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
         expect(result).toMatchObject(expectedErrorProperties);
       });
     });
@@ -225,13 +236,14 @@ describe(getRequestBodyObject, () => {
         ).toHaveBeenCalledExactlyOnceWith(requestBodyReferenceFixture);
       });
 
-      it('should throw an InversifyValidationError', () => {
-        const expectedErrorProperties: Partial<InversifyValidationError> = {
-          kind: InversifyValidationErrorKind.validationFailed,
-          message: `Resolved $ref pointer ${requestBodyReferenceFixture.$ref} is not a valid request body object for ${methodFixture.toUpperCase()} ${routeFixture}`,
-        };
+      it('should throw an InversifyOpenApiValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+          {
+            kind: InversifyValidationErrorKind.validationFailed,
+            message: `Resolved $ref pointer ${requestBodyReferenceFixture.$ref} is not a valid request body object for ${methodFixture.toUpperCase()} ${routeFixture}`,
+          };
 
-        expect(result).toBeInstanceOf(InversifyValidationError);
+        expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
         expect(result).toMatchObject(expectedErrorProperties);
       });
     });
@@ -287,13 +299,73 @@ describe(getRequestBodyObject, () => {
         ).toHaveBeenCalledExactlyOnceWith(requestBodyReferenceFixture);
       });
 
-      it('should throw an InversifyValidationError', () => {
-        const expectedErrorProperties: Partial<InversifyValidationError> = {
-          kind: InversifyValidationErrorKind.validationFailed,
-          message: `Resolved $ref pointer ${requestBodyReferenceFixture.$ref} is not a valid request body object for ${methodFixture.toUpperCase()} ${routeFixture}`,
-        };
+      it('should throw an InversifyOpenApiValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+          {
+            kind: InversifyValidationErrorKind.validationFailed,
+            message: `Resolved $ref pointer ${requestBodyReferenceFixture.$ref} is not a valid request body object for ${methodFixture.toUpperCase()} ${routeFixture}`,
+          };
 
-        expect(result).toBeInstanceOf(InversifyValidationError);
+        expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
+        expect(result).toMatchObject(expectedErrorProperties);
+      });
+    });
+  });
+
+  describe('having an operationObject with requestBody with $ref resolving to a schema object', () => {
+    let operationObjectFixture: OpenApi3Dot2OperationObject;
+    let requestBodyReferenceFixture: OpenApi3Dot2ReferenceObject;
+
+    beforeAll(() => {
+      requestBodyReferenceFixture = {
+        $ref: '#/components/schemas/User',
+      };
+      operationObjectFixture = {
+        requestBody: requestBodyReferenceFixture,
+        responses: {},
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest
+          .mocked(openApiResolverMock.resolveOpenApiReference)
+          .mockReturnValueOnce({
+            isRight: true,
+            value: {
+              chain: [],
+              value: {
+                type: 'object',
+              },
+            },
+          });
+
+        try {
+          getRequestBodyObject(
+            openApiResolverMock,
+            operationObjectFixture,
+            methodFixture,
+            routeFixture,
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should throw an InversifyOpenApiValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+          {
+            kind: InversifyValidationErrorKind.validationFailed,
+            message: `Resolved $ref pointer ${requestBodyReferenceFixture.$ref} is not a valid request body object for ${methodFixture.toUpperCase()} ${routeFixture}`,
+          };
+
+        expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
         expect(result).toMatchObject(expectedErrorProperties);
       });
     });
@@ -328,7 +400,14 @@ describe(getRequestBodyObject, () => {
           .mockReturnValueOnce({
             isRight: true,
             value: {
-              chain: [],
+              chain: [
+                {
+                  $ref: requestBodyReferenceFixture.$ref,
+                  canonicalId:
+                    'urn:inversifyjs:openapi-v3dot2-spec#/components/requestBodies/UserBody',
+                  value: requestBodyReferenceFixture as unknown as JsonValue,
+                },
+              ],
               value: resolvedObjectFixture as unknown as JsonValue,
             },
           });
@@ -352,7 +431,12 @@ describe(getRequestBodyObject, () => {
       });
 
       it('should return expected result', () => {
-        expect(result).toBe(resolvedObjectFixture);
+        const expected: ResolvedRequestBodyObject = {
+          pointerPrefix: 'components/requestBodies/UserBody',
+          requestBody: resolvedObjectFixture,
+        };
+
+        expect(result).toStrictEqual(expected);
       });
     });
   });

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getRequestBodyObject.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/getRequestBodyObject.ts
@@ -9,17 +9,38 @@ import {
   InversifyValidationErrorKind,
 } from '@inversifyjs/validation-common';
 
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
 import {
   type OpenApiRefResolutionResult,
   type OpenApiResolver,
 } from '../../services/OpenApiResolver.js';
+import { pointerPrefixFromResolutionChain } from './pointerPrefixFromResolutionChain.js';
+
+export interface ResolvedRequestBodyObject {
+  pointerPrefix: string | undefined;
+  requestBody: OpenApi3Dot2RequestBodyObject;
+}
+
+function isRequestBodyObject(
+  value: JsonValue,
+): value is JsonValue & OpenApi3Dot2RequestBodyObject {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const content: JsonValue | undefined = value['content'];
+
+  return (
+    typeof content === 'object' && content !== null && !Array.isArray(content)
+  );
+}
 
 export function getRequestBodyObject(
   openApiResolver: OpenApiResolver,
   operationObject: OpenApi3Dot2OperationObject,
   method: string,
   route: string,
-): OpenApi3Dot2RequestBodyObject {
+): ResolvedRequestBodyObject {
   const requestBodyObject:
     OpenApi3Dot2RequestBodyObject | OpenApi3Dot2ReferenceObject | undefined =
     operationObject.requestBody;
@@ -32,7 +53,10 @@ export function getRequestBodyObject(
   }
 
   if (!('$ref' in requestBodyObject)) {
-    return requestBodyObject;
+    return {
+      pointerPrefix: undefined,
+      requestBody: requestBodyObject,
+    };
   }
 
   const result: OpenApiRefResolutionResult =
@@ -41,7 +65,7 @@ export function getRequestBodyObject(
     );
 
   if (!result.isRight) {
-    throw new InversifyValidationError(
+    throw new InversifyOpenApiValidationError(
       InversifyValidationErrorKind.validationFailed,
       `Could not resolve $ref pointer ${requestBodyObject.$ref} for ${method.toUpperCase()} ${route}: ${result.value.reason}`,
     );
@@ -49,16 +73,15 @@ export function getRequestBodyObject(
 
   const resolvedRef: JsonValue = result.value.value;
 
-  if (
-    resolvedRef === null ||
-    typeof resolvedRef !== 'object' ||
-    Array.isArray(resolvedRef)
-  ) {
-    throw new InversifyValidationError(
+  if (!isRequestBodyObject(resolvedRef)) {
+    throw new InversifyOpenApiValidationError(
       InversifyValidationErrorKind.validationFailed,
       `Resolved $ref pointer ${requestBodyObject.$ref} is not a valid request body object for ${method.toUpperCase()} ${route}`,
     );
   }
 
-  return resolvedRef as unknown as OpenApi3Dot2RequestBodyObject;
+  return {
+    pointerPrefix: pointerPrefixFromResolutionChain(result.value.chain),
+    requestBody: resolvedRef,
+  };
 }

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleBodyValidation.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleBodyValidation.spec.ts
@@ -62,7 +62,8 @@ describe(handleBodyValidation, () => {
     let contentTypeFixture: string;
     let operationObjectFixture: OpenApi3Dot2OperationObject;
     let requestBodyObjectFixture: OpenApi3Dot2RequestBodyObject;
-    let escapedPointerFixture: string;
+    let requestBodyPointerFixture: string;
+    let contentTypePointerFixture: string;
 
     beforeAll(() => {
       pathFixture = '/users';
@@ -84,7 +85,8 @@ describe(handleBodyValidation, () => {
           },
         },
       };
-      escapedPointerFixture = `paths/${pathFixture}/${methodFixture}/requestBody/content/${contentTypeFixture}/schema`;
+      requestBodyPointerFixture = `paths/${pathFixture}/${methodFixture}/requestBody`;
+      contentTypePointerFixture = contentTypeFixture;
     });
 
     describe('when called, and getEntry() returns empty entry and ajv.getSchema() returns undefined', () => {
@@ -101,7 +103,7 @@ describe(handleBodyValidation, () => {
           getSchema: vitest.fn().mockReturnValueOnce(undefined),
         } as Partial<Mocked<Ajv>> as Mocked<Ajv>;
 
-        schemaPointerFixture = `${SCHEMA_ID}#/${escapedPointerFixture}`;
+        schemaPointerFixture = `${SCHEMA_ID}#/${requestBodyPointerFixture}/content/${contentTypePointerFixture}/schema`;
 
         validationCacheEntryFixture = {
           body: undefined,
@@ -117,12 +119,14 @@ describe(handleBodyValidation, () => {
         vitest
           .mocked(getOperationObject)
           .mockReturnValueOnce(operationObjectFixture);
-        vitest
-          .mocked(getRequestBodyObject)
-          .mockReturnValueOnce(requestBodyObjectFixture);
+        vitest.mocked(getRequestBodyObject).mockReturnValueOnce({
+          pointerPrefix: undefined,
+          requestBody: requestBodyObjectFixture,
+        });
         vitest
           .mocked(escapeJsonPointerFragments)
-          .mockReturnValueOnce(escapedPointerFixture);
+          .mockReturnValueOnce(requestBodyPointerFixture)
+          .mockReturnValueOnce(contentTypePointerFixture);
 
         vitest
           .mocked(openApiRouterMock.findRoute)
@@ -170,14 +174,17 @@ describe(handleBodyValidation, () => {
       });
 
       it('should call escapeJsonPointerFragments()', () => {
-        expect(escapeJsonPointerFragments).toHaveBeenCalledExactlyOnceWith(
+        expect(escapeJsonPointerFragments).toHaveBeenCalledTimes(2);
+        expect(escapeJsonPointerFragments).toHaveBeenNthCalledWith(
+          1,
           'paths',
           pathFixture,
           methodFixture,
           'requestBody',
-          'content',
+        );
+        expect(escapeJsonPointerFragments).toHaveBeenNthCalledWith(
+          2,
           contentTypeFixture,
-          'schema',
         );
       });
 
@@ -230,12 +237,14 @@ describe(handleBodyValidation, () => {
         vitest
           .mocked(getOperationObject)
           .mockReturnValueOnce(operationObjectFixture);
-        vitest
-          .mocked(getRequestBodyObject)
-          .mockReturnValueOnce(requestBodyObjectFixture);
+        vitest.mocked(getRequestBodyObject).mockReturnValueOnce({
+          pointerPrefix: undefined,
+          requestBody: requestBodyObjectFixture,
+        });
         vitest
           .mocked(escapeJsonPointerFragments)
-          .mockReturnValueOnce(escapedPointerFixture);
+          .mockReturnValueOnce(requestBodyPointerFixture)
+          .mockReturnValueOnce(contentTypePointerFixture);
 
         vitest
           .mocked(openApiRouterMock.findRoute)
@@ -326,12 +335,14 @@ describe(handleBodyValidation, () => {
         vitest
           .mocked(getOperationObject)
           .mockReturnValueOnce(operationObjectFixture);
-        vitest
-          .mocked(getRequestBodyObject)
-          .mockReturnValueOnce(requestBodyObjectFixture);
+        vitest.mocked(getRequestBodyObject).mockReturnValueOnce({
+          pointerPrefix: undefined,
+          requestBody: requestBodyObjectFixture,
+        });
         vitest
           .mocked(escapeJsonPointerFragments)
-          .mockReturnValueOnce(escapedPointerFixture);
+          .mockReturnValueOnce(requestBodyPointerFixture)
+          .mockReturnValueOnce(contentTypePointerFixture);
 
         vitest
           .mocked(openApiRouterMock.findRoute)
@@ -384,7 +395,8 @@ describe(handleBodyValidation, () => {
     let contentTypeFixture: string;
     let operationObjectFixture: OpenApi3Dot2OperationObject;
     let requestBodyObjectFixture: OpenApi3Dot2RequestBodyObject;
-    let escapedPointerFixture: string;
+    let requestBodyPointerFixture: string;
+    let contentTypePointerFixture: string;
 
     beforeAll(() => {
       pathFixture = '/users';
@@ -406,7 +418,8 @@ describe(handleBodyValidation, () => {
           },
         },
       };
-      escapedPointerFixture = `paths/${pathFixture}/${methodFixture}/requestBody/content/${contentTypeFixture}/schema`;
+      requestBodyPointerFixture = `paths/${pathFixture}/${methodFixture}/requestBody`;
+      contentTypePointerFixture = contentTypeFixture;
     });
 
     describe('when called, and getEntry() returns empty entry and validation succeeds', () => {
@@ -441,12 +454,14 @@ describe(handleBodyValidation, () => {
         vitest
           .mocked(getOperationObject)
           .mockReturnValueOnce(operationObjectFixture);
-        vitest
-          .mocked(getRequestBodyObject)
-          .mockReturnValueOnce(requestBodyObjectFixture);
+        vitest.mocked(getRequestBodyObject).mockReturnValueOnce({
+          pointerPrefix: undefined,
+          requestBody: requestBodyObjectFixture,
+        });
         vitest
           .mocked(escapeJsonPointerFragments)
-          .mockReturnValueOnce(escapedPointerFixture);
+          .mockReturnValueOnce(requestBodyPointerFixture)
+          .mockReturnValueOnce(contentTypePointerFixture);
 
         vitest
           .mocked(openApiRouterMock.findRoute)
@@ -466,14 +481,17 @@ describe(handleBodyValidation, () => {
       });
 
       it('should call escapeJsonPointerFragments()', () => {
-        expect(escapeJsonPointerFragments).toHaveBeenCalledExactlyOnceWith(
+        expect(escapeJsonPointerFragments).toHaveBeenCalledTimes(2);
+        expect(escapeJsonPointerFragments).toHaveBeenNthCalledWith(
+          1,
           'paths',
           pathFixture,
           methodFixture,
           'requestBody',
-          'content',
+        );
+        expect(escapeJsonPointerFragments).toHaveBeenNthCalledWith(
+          2,
           contentTypeFixture,
-          'schema',
         );
       });
 
@@ -490,7 +508,8 @@ describe(handleBodyValidation, () => {
     let contentTypeFixture: string;
     let operationObjectFixture: OpenApi3Dot2OperationObject;
     let requestBodyObjectFixture: OpenApi3Dot2RequestBodyObject;
-    let escapedPointerFixture: string;
+    let requestBodyPointerFixture: string;
+    let contentTypePointerFixture: string;
 
     beforeAll(() => {
       pathFixture = '/users';
@@ -512,7 +531,8 @@ describe(handleBodyValidation, () => {
           },
         },
       };
-      escapedPointerFixture = `paths/${pathFixture}/${methodFixture}/requestBody/content/${contentTypeFixture}/schema`;
+      requestBodyPointerFixture = `paths/${pathFixture}/${methodFixture}/requestBody`;
+      contentTypePointerFixture = contentTypeFixture;
     });
 
     describe('when called, and getEntry() returns empty entry', () => {
@@ -547,12 +567,14 @@ describe(handleBodyValidation, () => {
         vitest
           .mocked(getOperationObject)
           .mockReturnValueOnce(operationObjectFixture);
-        vitest
-          .mocked(getRequestBodyObject)
-          .mockReturnValueOnce(requestBodyObjectFixture);
+        vitest.mocked(getRequestBodyObject).mockReturnValueOnce({
+          pointerPrefix: undefined,
+          requestBody: requestBodyObjectFixture,
+        });
         vitest
           .mocked(escapeJsonPointerFragments)
-          .mockReturnValueOnce(escapedPointerFixture);
+          .mockReturnValueOnce(requestBodyPointerFixture)
+          .mockReturnValueOnce(contentTypePointerFixture);
 
         vitest
           .mocked(openApiRouterMock.findRoute)
@@ -577,20 +599,22 @@ describe(handleBodyValidation, () => {
     });
   });
 
-  describe('having an inputParam with contentType and an operationObject whose requestBody is a Reference Object', () => {
+  describe('having an inputParam with contentType and a resolved request body with a component pointerPrefix', () => {
     let inputParamFixture: BodyValidationInputParam<unknown>;
     let pathFixture: string;
     let methodFixture: string;
     let contentTypeFixture: string;
     let operationObjectFixture: OpenApi3Dot2OperationObject;
     let requestBodyObjectFixture: OpenApi3Dot2RequestBodyObject;
-    let requestBodyReferenceFixture: { $ref: string };
-    let escapedPointerFixture: string;
+    let pointerPrefixFixture: string;
+    let contentTypePointerFixture: string;
 
     beforeAll(() => {
       pathFixture = '/users';
       methodFixture = 'post';
       contentTypeFixture = 'application/json';
+      pointerPrefixFixture = 'components/requestBodies/UserBody';
+      contentTypePointerFixture = contentTypeFixture;
       inputParamFixture = {
         body: { name: 'test' },
         contentType: contentTypeFixture,
@@ -598,11 +622,10 @@ describe(handleBodyValidation, () => {
         path: pathFixture,
         type: Symbol() as unknown as BodyValidationInputParam<unknown>['type'],
       };
-      requestBodyReferenceFixture = {
-        $ref: '#/components/requestBodies/UserBody',
-      };
       operationObjectFixture = {
-        requestBody: requestBodyReferenceFixture,
+        requestBody: {
+          $ref: '#/components/requestBodies/UserBody',
+        },
         responses: {},
       };
       requestBodyObjectFixture = {
@@ -612,10 +635,9 @@ describe(handleBodyValidation, () => {
           },
         },
       };
-      escapedPointerFixture = `paths/${pathFixture}/${methodFixture}/requestBody/content/${contentTypeFixture}/schema`;
     });
 
-    describe('when called, and getEntry() returns empty entry and ajv.getSchema() returns undefined', () => {
+    describe('when called, and getEntry() returns empty entry and validation succeeds', () => {
       let ajvMock: Mocked<Ajv>;
       let getEntryMock: Mock<
         (path: string, method: string) => ValidationCacheEntry
@@ -625,11 +647,16 @@ describe(handleBodyValidation, () => {
       let result: unknown;
 
       beforeAll(() => {
+        const validateMock: ValidateFunction = Object.assign(
+          vitest.fn().mockReturnValueOnce(true),
+          { errors: null, schema: {} },
+        ) as unknown as ValidateFunction;
+
         ajvMock = {
-          getSchema: vitest.fn().mockReturnValueOnce(undefined),
+          getSchema: vitest.fn().mockReturnValueOnce(validateMock),
         } as Partial<Mocked<Ajv>> as Mocked<Ajv>;
 
-        schemaPointerFixture = `${SCHEMA_ID}#/${escapedPointerFixture}`;
+        schemaPointerFixture = `${SCHEMA_ID}#/${pointerPrefixFixture}/content/${contentTypePointerFixture}/schema`;
 
         validationCacheEntryFixture = {
           body: undefined,
@@ -645,42 +672,45 @@ describe(handleBodyValidation, () => {
         vitest
           .mocked(getOperationObject)
           .mockReturnValueOnce(operationObjectFixture);
-        vitest
-          .mocked(getRequestBodyObject)
-          .mockReturnValueOnce(requestBodyObjectFixture);
+        vitest.mocked(getRequestBodyObject).mockReturnValueOnce({
+          pointerPrefix: pointerPrefixFixture,
+          requestBody: requestBodyObjectFixture,
+        });
         vitest
           .mocked(escapeJsonPointerFragments)
-          .mockReturnValueOnce(escapedPointerFixture);
+          .mockReturnValueOnce(contentTypePointerFixture);
 
         vitest
           .mocked(openApiRouterMock.findRoute)
           .mockReturnValueOnce(pathFixture);
 
-        try {
-          handleBodyValidation(
-            ajvMock,
-            openApiObjectFixture,
-            validationContextFixture,
-            inputParamFixture,
-            getEntryMock,
-          );
-        } catch (error: unknown) {
-          result = error;
-        }
+        result = handleBodyValidation(
+          ajvMock,
+          openApiObjectFixture,
+          validationContextFixture,
+          inputParamFixture,
+          getEntryMock,
+        );
       });
 
       afterAll(() => {
         vitest.clearAllMocks();
       });
 
-      it('should throw an InversifyValidationError', () => {
-        expect(result).toBeInstanceOf(InversifyValidationError);
+      it('should call escapeJsonPointerFragments()', () => {
+        expect(escapeJsonPointerFragments).toHaveBeenCalledExactlyOnceWith(
+          contentTypeFixture,
+        );
       });
 
-      it('should throw an error with expected message', () => {
-        expect((result as InversifyValidationError).message).toBe(
-          `Unable to find schema for pointer: ${schemaPointerFixture}. The operation requestBody is an OpenAPI Reference Object ($ref: "${requestBodyReferenceFixture.$ref}"); AJV looks up this pointer on the document and does not follow OpenAPI $ref`,
+      it('should call ajv.getSchema()', () => {
+        expect(ajvMock.getSchema).toHaveBeenCalledExactlyOnceWith(
+          schemaPointerFixture,
         );
+      });
+
+      it('should return expected result', () => {
+        expect(result).toBe(inputParamFixture.body);
       });
     });
   });

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleBodyValidation.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/handleBodyValidation.ts
@@ -2,8 +2,6 @@ import { escapeJsonPointerFragments } from '@inversifyjs/json-schema-pointer';
 import {
   type OpenApi3Dot2Object,
   type OpenApi3Dot2OperationObject,
-  type OpenApi3Dot2ReferenceObject,
-  type OpenApi3Dot2RequestBodyObject,
 } from '@inversifyjs/open-api-types/v3Dot2';
 import {
   InversifyValidationError,
@@ -22,7 +20,10 @@ import {
 } from '../../models/v3Dot2/ValidationCacheEntry.js';
 import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
 import { getOperationObject } from './getOperationObject.js';
-import { getRequestBodyObject } from './getRequestBodyObject.js';
+import {
+  getRequestBodyObject,
+  type ResolvedRequestBodyObject,
+} from './getRequestBodyObject.js';
 
 function getValidationCacheEntryBody(
   ajv: Ajv,
@@ -37,42 +38,32 @@ function getValidationCacheEntryBody(
     route,
   );
 
-  const openApi3Dot2RequestBodyObject: OpenApi3Dot2RequestBodyObject =
+  const resolvedRequestBodyObject: ResolvedRequestBodyObject =
     getRequestBodyObject(openApiResolver, operationObject, method, route);
 
-  const required: boolean = openApi3Dot2RequestBodyObject.required ?? false;
+  const required: boolean =
+    resolvedRequestBodyObject.requestBody.required ?? false;
 
   const contentToValidateMap: Map<string | undefined, ValidateFunction> =
     new Map();
 
   const contentTypes: string[] = Object.keys(
-    openApi3Dot2RequestBodyObject.content,
+    resolvedRequestBodyObject.requestBody.content,
   );
 
+  const requestBodyPointerPrefix: string =
+    resolvedRequestBodyObject.pointerPrefix ??
+    escapeJsonPointerFragments('paths', route, method, 'requestBody');
+
   for (const contentType of contentTypes) {
-    const schemaPointer: string = `${SCHEMA_ID}#/${escapeJsonPointerFragments(
-      'paths',
-      route,
-      method,
-      'requestBody',
-      'content',
-      contentType,
-      'schema',
-    )}`;
+    const schemaPointer: string = `${SCHEMA_ID}#/${requestBodyPointerPrefix}/content/${escapeJsonPointerFragments(contentType)}/schema`;
 
     const validate: ValidateFunction | undefined = ajv.getSchema(schemaPointer);
 
     if (validate === undefined) {
-      const requestBody:
-        | OpenApi3Dot2RequestBodyObject
-        | OpenApi3Dot2ReferenceObject
-        | undefined = operationObject.requestBody;
-
       throw new InversifyValidationError(
         InversifyValidationErrorKind.unknown,
-        requestBody !== undefined && '$ref' in requestBody
-          ? `Unable to find schema for pointer: ${schemaPointer}. The operation requestBody is an OpenAPI Reference Object ($ref: "${requestBody.$ref}"); AJV looks up this pointer on the document and does not follow OpenAPI $ref`
-          : `Unable to find schema for pointer: ${schemaPointer}`,
+        `Unable to find schema for pointer: ${schemaPointer}`,
       );
     }
 

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/pointerPrefixFromResolutionChain.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/pointerPrefixFromResolutionChain.spec.ts
@@ -1,0 +1,78 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { pointerPrefixFromResolutionChain } from './pointerPrefixFromResolutionChain.js';
+
+describe(pointerPrefixFromResolutionChain, () => {
+  describe('having an empty chain', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = pointerPrefixFromResolutionChain([]);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a chain whose last canonicalId has no fragment', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = pointerPrefixFromResolutionChain([
+          {
+            canonicalId: 'urn:inversifyjs:openapi-v3dot2-spec',
+          },
+        ]);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a chain whose last canonicalId fragment does not start with "/"', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = pointerPrefixFromResolutionChain([
+          {
+            canonicalId: 'urn:inversifyjs:openapi-v3dot2-spec#anchor',
+          },
+        ]);
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a chain whose last canonicalId has a JSON pointer fragment', () => {
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = pointerPrefixFromResolutionChain([
+          {
+            canonicalId:
+              'urn:inversifyjs:openapi-v3dot2-spec#/components/parameters/First',
+          },
+          {
+            canonicalId:
+              'urn:inversifyjs:openapi-v3dot2-spec#/components/parameters/PageParam',
+          },
+        ]);
+      });
+
+      it('should return the last hop JSON pointer without a leading slash', () => {
+        expect(result).toBe('components/parameters/PageParam');
+      });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/pointerPrefixFromResolutionChain.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/pointerPrefixFromResolutionChain.ts
@@ -1,0 +1,24 @@
+export function pointerPrefixFromResolutionChain(
+  chain: readonly { canonicalId: string }[],
+): string | undefined {
+  const lastEntry: { canonicalId: string } | undefined =
+    chain[chain.length - 1];
+
+  if (lastEntry === undefined) {
+    return undefined;
+  }
+
+  const fragmentIndex: number = lastEntry.canonicalId.indexOf('#');
+
+  if (fragmentIndex === -1) {
+    return undefined;
+  }
+
+  const fragment: string = lastEntry.canonicalId.slice(fragmentIndex + 1);
+
+  if (!fragment.startsWith('/')) {
+    return undefined;
+  }
+
+  return fragment.slice(1);
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/resolveParameterObject.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/resolveParameterObject.spec.ts
@@ -1,0 +1,402 @@
+import { afterAll, beforeAll, describe, expect, it, vitest } from 'vitest';
+
+import { type JsonValue } from '@inversifyjs/json-schema-types';
+import {
+  type OpenApi3Dot2ParameterObject,
+  type OpenApi3Dot2ReferenceObject,
+} from '@inversifyjs/open-api-types/v3Dot2';
+import { InversifyValidationErrorKind } from '@inversifyjs/validation-common';
+
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
+import { type OpenApiResolver } from '../../services/OpenApiResolver.js';
+import {
+  type ResolvedParameterObject,
+  resolveParameterObject,
+} from './resolveParameterObject.js';
+
+describe(resolveParameterObject, () => {
+  let indexFixture: number;
+  let methodFixture: string;
+  let pathFixture: string;
+
+  beforeAll(() => {
+    indexFixture = 0;
+    methodFixture = 'get';
+    pathFixture = '/users';
+  });
+
+  describe('having a parameter object with no $ref', () => {
+    let openApiResolverMock: OpenApiResolver;
+    let parameterFixture: OpenApi3Dot2ParameterObject;
+
+    beforeAll(() => {
+      openApiResolverMock = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+      parameterFixture = {
+        in: 'query',
+        name: 'page',
+        schema: { type: 'integer' },
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = resolveParameterObject(
+          openApiResolverMock,
+          parameterFixture,
+          methodFixture,
+          pathFixture,
+          indexFixture,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should not call openApiResolver.resolveOpenApiReference()', () => {
+        expect(
+          openApiResolverMock.resolveOpenApiReference,
+        ).not.toHaveBeenCalled();
+      });
+
+      it('should return the parameter object', () => {
+        const expected: ResolvedParameterObject = {
+          parameter: parameterFixture,
+          pointerPrefix: undefined,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having a $ref that fails to resolve', () => {
+    let openApiResolverMock: OpenApiResolver;
+    let reasonFixture: string;
+    let referenceFixture: OpenApi3Dot2ReferenceObject;
+
+    beforeAll(() => {
+      reasonFixture =
+        'Failed to resolve JSON Pointer: /components/parameters/Missing';
+      referenceFixture = {
+        $ref: '#/components/parameters/Missing',
+      };
+      openApiResolverMock = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest
+          .mocked(openApiResolverMock.resolveOpenApiReference)
+          .mockReturnValueOnce({
+            isRight: false,
+            value: {
+              reason: reasonFixture,
+              resolutionContextStack: [],
+            },
+          });
+
+        try {
+          resolveParameterObject(
+            openApiResolverMock,
+            referenceFixture,
+            methodFixture,
+            pathFixture,
+            indexFixture,
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call openApiResolver.resolveOpenApiReference()', () => {
+        expect(
+          openApiResolverMock.resolveOpenApiReference,
+        ).toHaveBeenCalledExactlyOnceWith(referenceFixture);
+      });
+
+      it('should throw an InversifyOpenApiValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+          {
+            kind: InversifyValidationErrorKind.validationFailed,
+            message: `Could not resolve $ref pointer ${referenceFixture.$ref} for parameter at path: ${pathFixture} and method: ${methodFixture} and index: ${String(indexFixture)}: ${reasonFixture}`,
+          };
+
+        expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
+        expect(result).toMatchObject(expectedErrorProperties);
+      });
+    });
+  });
+
+  describe('having a $ref that resolves to a valid parameter object', () => {
+    let openApiResolverMock: OpenApiResolver;
+    let referenceFixture: OpenApi3Dot2ReferenceObject & JsonValue;
+    let resolvedParameterFixture: OpenApi3Dot2ParameterObject;
+
+    beforeAll(() => {
+      referenceFixture = {
+        $ref: '#/components/parameters/PageParam',
+      };
+      resolvedParameterFixture = {
+        in: 'query',
+        name: 'page',
+        schema: { type: 'integer' },
+      };
+      openApiResolverMock = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest
+          .mocked(openApiResolverMock.resolveOpenApiReference)
+          .mockReturnValueOnce({
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: referenceFixture.$ref,
+                  canonicalId: `urn:inversifyjs:openapi-v3dot2-spec#/components/parameters/PageParam`,
+                  value: referenceFixture,
+                },
+              ],
+              value: resolvedParameterFixture as unknown as JsonValue,
+            },
+          });
+
+        result = resolveParameterObject(
+          openApiResolverMock,
+          referenceFixture,
+          methodFixture,
+          pathFixture,
+          indexFixture,
+        );
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call openApiResolver.resolveOpenApiReference()', () => {
+        expect(
+          openApiResolverMock.resolveOpenApiReference,
+        ).toHaveBeenCalledExactlyOnceWith(referenceFixture);
+      });
+
+      it('should return the resolved parameter object', () => {
+        const expected: ResolvedParameterObject = {
+          parameter: resolvedParameterFixture,
+          pointerPrefix: 'components/parameters/PageParam',
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having a $ref that resolves to a schema object', () => {
+    let openApiResolverMock: OpenApiResolver;
+    let referenceFixture: OpenApi3Dot2ReferenceObject;
+
+    beforeAll(() => {
+      referenceFixture = {
+        $ref: '#/components/schemas/User',
+      };
+      openApiResolverMock = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest
+          .mocked(openApiResolverMock.resolveOpenApiReference)
+          .mockReturnValueOnce({
+            isRight: true,
+            value: {
+              chain: [],
+              value: {
+                type: 'object',
+              },
+            },
+          });
+
+        try {
+          resolveParameterObject(
+            openApiResolverMock,
+            referenceFixture,
+            methodFixture,
+            pathFixture,
+            indexFixture,
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should throw an InversifyOpenApiValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+          {
+            kind: InversifyValidationErrorKind.validationFailed,
+            message: `Resolved $ref pointer ${referenceFixture.$ref} is not a valid parameter object at path: ${pathFixture} and method: ${methodFixture} and index: ${String(indexFixture)}`,
+          };
+
+        expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
+        expect(result).toMatchObject(expectedErrorProperties);
+      });
+    });
+  });
+
+  describe('having a $ref that resolves to an array', () => {
+    let openApiResolverMock: OpenApiResolver;
+    let referenceFixture: OpenApi3Dot2ReferenceObject;
+
+    beforeAll(() => {
+      referenceFixture = {
+        $ref: '#/components/parameters/PageParam',
+      };
+      openApiResolverMock = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest
+          .mocked(openApiResolverMock.resolveOpenApiReference)
+          .mockReturnValueOnce({
+            isRight: true,
+            value: {
+              chain: [],
+              value: [],
+            },
+          });
+
+        try {
+          resolveParameterObject(
+            openApiResolverMock,
+            referenceFixture,
+            methodFixture,
+            pathFixture,
+            indexFixture,
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should throw an InversifyOpenApiValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+          {
+            kind: InversifyValidationErrorKind.validationFailed,
+            message: `Resolved $ref pointer ${referenceFixture.$ref} is not a valid parameter object at path: ${pathFixture} and method: ${methodFixture} and index: ${String(indexFixture)}`,
+          };
+
+        expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
+        expect(result).toMatchObject(expectedErrorProperties);
+      });
+    });
+  });
+
+  describe('having a $ref that resolves to null', () => {
+    let openApiResolverMock: OpenApiResolver;
+    let referenceFixture: OpenApi3Dot2ReferenceObject;
+
+    beforeAll(() => {
+      referenceFixture = {
+        $ref: '#/components/parameters/PageParam',
+      };
+      openApiResolverMock = {
+        deepResolveReference: vitest.fn(),
+        resolveJsonSchema: vitest.fn(),
+        resolveOpenApiReference: vitest.fn(),
+        resolveReference: vitest.fn(),
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        vitest
+          .mocked(openApiResolverMock.resolveOpenApiReference)
+          .mockReturnValueOnce({
+            isRight: true,
+            value: {
+              chain: [],
+              value: null,
+            },
+          });
+
+        try {
+          resolveParameterObject(
+            openApiResolverMock,
+            referenceFixture,
+            methodFixture,
+            pathFixture,
+            indexFixture,
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should throw an InversifyOpenApiValidationError', () => {
+        const expectedErrorProperties: Partial<InversifyOpenApiValidationError> =
+          {
+            kind: InversifyValidationErrorKind.validationFailed,
+            message: `Resolved $ref pointer ${referenceFixture.$ref} is not a valid parameter object at path: ${pathFixture} and method: ${methodFixture} and index: ${String(indexFixture)}`,
+          };
+
+        expect(result).toBeInstanceOf(InversifyOpenApiValidationError);
+        expect(result).toMatchObject(expectedErrorProperties);
+      });
+    });
+  });
+});

--- a/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/resolveParameterObject.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/calculations/v3Dot2/resolveParameterObject.ts
@@ -1,0 +1,75 @@
+import { type JsonValue } from '@inversifyjs/json-schema-types';
+import {
+  type OpenApi3Dot2ParameterObject,
+  type OpenApi3Dot2ReferenceObject,
+} from '@inversifyjs/open-api-types/v3Dot2';
+import { InversifyValidationErrorKind } from '@inversifyjs/validation-common';
+
+import { InversifyOpenApiValidationError } from '../../../models/InversifyOpenApiValidationError.js';
+import {
+  type OpenApiRefResolutionResult,
+  type OpenApiResolver,
+} from '../../services/OpenApiResolver.js';
+import { pointerPrefixFromResolutionChain } from './pointerPrefixFromResolutionChain.js';
+
+export interface ResolvedParameterObject {
+  parameter: OpenApi3Dot2ParameterObject;
+  pointerPrefix: string | undefined;
+}
+
+function isReferenceObject(
+  param: OpenApi3Dot2ParameterObject | OpenApi3Dot2ReferenceObject,
+): param is OpenApi3Dot2ReferenceObject {
+  return '$ref' in param;
+}
+
+function isParameterObject(
+  value: JsonValue,
+): value is JsonValue & OpenApi3Dot2ParameterObject {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as Partial<OpenApi3Dot2ParameterObject>).in === 'string' &&
+    typeof (value as Partial<OpenApi3Dot2ParameterObject>).name === 'string'
+  );
+}
+
+export function resolveParameterObject(
+  openApiResolver: OpenApiResolver,
+  raw: OpenApi3Dot2ParameterObject | OpenApi3Dot2ReferenceObject,
+  method: string,
+  path: string,
+  index: number,
+): ResolvedParameterObject {
+  if (!isReferenceObject(raw)) {
+    return {
+      parameter: raw,
+      pointerPrefix: undefined,
+    };
+  }
+
+  const result: OpenApiRefResolutionResult =
+    openApiResolver.resolveOpenApiReference(raw as unknown as JsonValue);
+
+  if (!result.isRight) {
+    throw new InversifyOpenApiValidationError(
+      InversifyValidationErrorKind.validationFailed,
+      `Could not resolve $ref pointer ${raw.$ref} for parameter at path: ${path} and method: ${method} and index: ${String(index)}: ${result.value.reason}`,
+    );
+  }
+
+  const resolvedRef: JsonValue = result.value.value;
+
+  if (!isParameterObject(resolvedRef)) {
+    throw new InversifyOpenApiValidationError(
+      InversifyValidationErrorKind.validationFailed,
+      `Resolved $ref pointer ${raw.$ref} is not a valid parameter object at path: ${path} and method: ${method} and index: ${String(index)}`,
+    );
+  }
+
+  return {
+    parameter: resolvedRef,
+    pointerPrefix: pointerPrefixFromResolutionChain(result.value.chain),
+  };
+}

--- a/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot1/OpenApiValidationPipe.int.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot1/OpenApiValidationPipe.int.spec.ts
@@ -1202,6 +1202,303 @@ describe(OpenApiValidationPipe, () => {
         });
       });
 
+      describe('having an OpenApiValidationPipe (v3.1) in an HTTP server with a $ref query parameter', () => {
+        @Controller('/products')
+        class ProductController {
+          @OasParameter({
+            $ref: '#/components/parameters/SearchParam',
+          })
+          @OasParameter({
+            $ref: '#/components/parameters/LimitParam',
+          })
+          @Get()
+          public async getProducts(
+            @ValidatedQuery() _query: Record<string, unknown>,
+          ): Promise<{ ok: boolean }> {
+            return { ok: true };
+          }
+        }
+
+        let server: Server;
+
+        beforeAll(async () => {
+          const container: Container = new Container();
+
+          container.bind(ValidationErrorFilter).toSelf().inSingletonScope();
+          container.bind(ProductController).toSelf().inSingletonScope();
+
+          const openApiObject: OpenApi3Dot1Object = {
+            components: {
+              parameters: {
+                LimitParam: {
+                  in: 'query',
+                  name: 'limit',
+                  required: false,
+                  schema: {
+                    type: 'integer',
+                  },
+                },
+                SearchParam: {
+                  in: 'query',
+                  name: 'search',
+                  required: true,
+                  schema: {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+            info: { title: 'Test API', version: '1.0.0' },
+            openapi: '3.1.0',
+          };
+
+          const swaggerProvider: SwaggerUiProvider = new SwaggerUiProvider({
+            api: {
+              openApiObject,
+              path: '/docs',
+            },
+          });
+
+          swaggerProvider.provide(container);
+
+          server = await buildServer(
+            container,
+            [ValidationErrorFilter],
+            [new OpenApiValidationPipe(swaggerProvider.openApiObject)],
+          );
+        });
+
+        afterAll(async () => {
+          await server.shutdown();
+        });
+
+        describe('when a GET /products request is made with valid query params', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/products?search=widget&limit=10`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(200);
+            expect(response.headers.get('content-type')).toStrictEqual(
+              expect.stringContaining('application/json'),
+            );
+            await expect(response.json()).resolves.toStrictEqual({ ok: true });
+          });
+        });
+
+        describe('when a GET /products request is made without the required query param', () => {
+          let response: Response;
+          let responseJson: unknown;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/products`,
+              {
+                method: 'GET',
+              },
+            );
+
+            responseJson = await response.json();
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(400);
+            expect(responseJson).toStrictEqual({
+              message: 'Missing required query: search',
+            });
+          });
+        });
+
+        describe('when a GET /products request is made with an invalid integer query param', () => {
+          let response: Response;
+          let responseJson: unknown;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/products?search=widget&limit=not-a-number`,
+              {
+                method: 'GET',
+              },
+            );
+
+            responseJson = await response.json();
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(400);
+            expect(responseJson).toStrictEqual({
+              message:
+                '[query: limit, schemaPath: #/type, instancePath: ]: "must be integer"',
+            });
+          });
+        });
+      });
+
+      describe('having an OpenApiValidationPipe (v3.1) in an HTTP server with a $ref request body', () => {
+        interface Message {
+          content: string;
+        }
+
+        @Controller('/messages')
+        class MessageController {
+          @OasRequestBody({
+            $ref: '#/components/requestBodies/MessageBody',
+          })
+          @Post()
+          public async createMessage(
+            @ValidatedBody() message: Message | undefined,
+          ): Promise<Message | undefined> {
+            return message;
+          }
+        }
+
+        let server: Server;
+
+        beforeAll(async () => {
+          const container: Container = new Container();
+
+          container.bind(ValidationErrorFilter).toSelf().inSingletonScope();
+          container.bind(MessageController).toSelf().inSingletonScope();
+
+          const openApiObject: OpenApi3Dot1Object = {
+            components: {
+              requestBodies: {
+                MessageBody: {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        additionalProperties: false,
+                        properties: {
+                          content: { maxLength: 100, type: 'string' },
+                        },
+                        required: ['content'],
+                        type: 'object',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            info: { title: 'Test API', version: '1.0.0' },
+            openapi: '3.1.0',
+          };
+
+          const swaggerProvider: SwaggerUiProvider = new SwaggerUiProvider({
+            api: {
+              openApiObject,
+              path: '/docs',
+            },
+          });
+
+          swaggerProvider.provide(container);
+
+          server = await buildServer(
+            container,
+            [ValidationErrorFilter],
+            [new OpenApiValidationPipe(swaggerProvider.openApiObject)],
+          );
+        });
+
+        afterAll(async () => {
+          await server.shutdown();
+        });
+
+        describe('when a valid POST /messages request with body is made', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/messages`,
+              {
+                body: JSON.stringify({ content: 'Hello, world!' }),
+                headers: { 'Content-Type': 'application/json' },
+                method: 'POST',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(200);
+            expect(response.headers.get('content-type')).toStrictEqual(
+              expect.stringContaining('application/json'),
+            );
+            await expect(response.json()).resolves.toStrictEqual({
+              content: 'Hello, world!',
+            });
+          });
+        });
+
+        describe('when an invalid POST /messages request with additional properties is made', () => {
+          let response: Response;
+          let responseJson: unknown;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/messages`,
+              {
+                body: JSON.stringify({
+                  content: 'Hello, world!',
+                  extra: 'not allowed',
+                }),
+                headers: { 'Content-Type': 'application/json' },
+                method: 'POST',
+              },
+            );
+
+            responseJson = await response.json();
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(400);
+            expect(response.headers.get('content-type')).toStrictEqual(
+              expect.stringContaining('application/json'),
+            );
+
+            expect(responseJson).toStrictEqual({
+              message:
+                '[schema: #/additionalProperties, instance: ]: "must NOT have additional properties"',
+            });
+          });
+        });
+
+        describe('when an invalid POST /messages request missing a required property is made', () => {
+          let response: Response;
+          let responseJson: unknown;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/messages`,
+              {
+                body: JSON.stringify({}),
+                headers: { 'Content-Type': 'application/json' },
+                method: 'POST',
+              },
+            );
+
+            responseJson = await response.json();
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(400);
+            expect(response.headers.get('content-type')).toStrictEqual(
+              expect.stringContaining('application/json'),
+            );
+
+            expect(responseJson).toStrictEqual({
+              message:
+                '[schema: #/required, instance: ]: "must have required property \'content\'"',
+            });
+          });
+        });
+      });
+
       describe('having an OpenApiValidationPipe (v3.1) in an HTTP server with an array of number query param', () => {
         @Controller('/numbers')
         class NumberController {

--- a/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot2/OpenApiValidationPipe.int.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/pipes/v3Dot2/OpenApiValidationPipe.int.spec.ts
@@ -1202,6 +1202,303 @@ describe(OpenApiValidationPipe, () => {
         });
       });
 
+      describe('having an OpenApiValidationPipe (v3.2) in an HTTP server with a $ref query parameter', () => {
+        @Controller('/products')
+        class ProductController {
+          @OasParameter({
+            $ref: '#/components/parameters/SearchParam',
+          })
+          @OasParameter({
+            $ref: '#/components/parameters/LimitParam',
+          })
+          @Get()
+          public async getProducts(
+            @ValidatedQuery() _query: Record<string, unknown>,
+          ): Promise<{ ok: boolean }> {
+            return { ok: true };
+          }
+        }
+
+        let server: Server;
+
+        beforeAll(async () => {
+          const container: Container = new Container();
+
+          container.bind(ValidationErrorFilter).toSelf().inSingletonScope();
+          container.bind(ProductController).toSelf().inSingletonScope();
+
+          const openApiObject: OpenApi3Dot2Object = {
+            components: {
+              parameters: {
+                LimitParam: {
+                  in: 'query',
+                  name: 'limit',
+                  required: false,
+                  schema: {
+                    type: 'integer',
+                  },
+                },
+                SearchParam: {
+                  in: 'query',
+                  name: 'search',
+                  required: true,
+                  schema: {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+            info: { title: 'Test API', version: '1.0.0' },
+            openapi: '3.2.0',
+          };
+
+          const swaggerProvider: SwaggerUiProvider = new SwaggerUiProvider({
+            api: {
+              openApiObject,
+              path: '/docs',
+            },
+          });
+
+          swaggerProvider.provide(container);
+
+          server = await buildServer(
+            container,
+            [ValidationErrorFilter],
+            [new OpenApiValidationPipe(swaggerProvider.openApiObject)],
+          );
+        });
+
+        afterAll(async () => {
+          await server.shutdown();
+        });
+
+        describe('when a GET /products request is made with valid query params', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/products?search=widget&limit=10`,
+              {
+                method: 'GET',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(200);
+            expect(response.headers.get('content-type')).toStrictEqual(
+              expect.stringContaining('application/json'),
+            );
+            await expect(response.json()).resolves.toStrictEqual({ ok: true });
+          });
+        });
+
+        describe('when a GET /products request is made without the required query param', () => {
+          let response: Response;
+          let responseJson: unknown;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/products`,
+              {
+                method: 'GET',
+              },
+            );
+
+            responseJson = await response.json();
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(400);
+            expect(responseJson).toStrictEqual({
+              message: 'Missing required query: search',
+            });
+          });
+        });
+
+        describe('when a GET /products request is made with an invalid integer query param', () => {
+          let response: Response;
+          let responseJson: unknown;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/products?search=widget&limit=not-a-number`,
+              {
+                method: 'GET',
+              },
+            );
+
+            responseJson = await response.json();
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(400);
+            expect(responseJson).toStrictEqual({
+              message:
+                '[query: limit, schemaPath: #/type, instancePath: ]: "must be integer"',
+            });
+          });
+        });
+      });
+
+      describe('having an OpenApiValidationPipe (v3.2) in an HTTP server with a $ref request body', () => {
+        interface Message {
+          content: string;
+        }
+
+        @Controller('/messages')
+        class MessageController {
+          @OasRequestBody({
+            $ref: '#/components/requestBodies/MessageBody',
+          })
+          @Post()
+          public async createMessage(
+            @ValidatedBody() message: Message | undefined,
+          ): Promise<Message | undefined> {
+            return message;
+          }
+        }
+
+        let server: Server;
+
+        beforeAll(async () => {
+          const container: Container = new Container();
+
+          container.bind(ValidationErrorFilter).toSelf().inSingletonScope();
+          container.bind(MessageController).toSelf().inSingletonScope();
+
+          const openApiObject: OpenApi3Dot2Object = {
+            components: {
+              requestBodies: {
+                MessageBody: {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        additionalProperties: false,
+                        properties: {
+                          content: { maxLength: 100, type: 'string' },
+                        },
+                        required: ['content'],
+                        type: 'object',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            info: { title: 'Test API', version: '1.0.0' },
+            openapi: '3.2.0',
+          };
+
+          const swaggerProvider: SwaggerUiProvider = new SwaggerUiProvider({
+            api: {
+              openApiObject,
+              path: '/docs',
+            },
+          });
+
+          swaggerProvider.provide(container);
+
+          server = await buildServer(
+            container,
+            [ValidationErrorFilter],
+            [new OpenApiValidationPipe(swaggerProvider.openApiObject)],
+          );
+        });
+
+        afterAll(async () => {
+          await server.shutdown();
+        });
+
+        describe('when a valid POST /messages request with body is made', () => {
+          let response: Response;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/messages`,
+              {
+                body: JSON.stringify({ content: 'Hello, world!' }),
+                headers: { 'Content-Type': 'application/json' },
+                method: 'POST',
+              },
+            );
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(200);
+            expect(response.headers.get('content-type')).toStrictEqual(
+              expect.stringContaining('application/json'),
+            );
+            await expect(response.json()).resolves.toStrictEqual({
+              content: 'Hello, world!',
+            });
+          });
+        });
+
+        describe('when an invalid POST /messages request with additional properties is made', () => {
+          let response: Response;
+          let responseJson: unknown;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/messages`,
+              {
+                body: JSON.stringify({
+                  content: 'Hello, world!',
+                  extra: 'not allowed',
+                }),
+                headers: { 'Content-Type': 'application/json' },
+                method: 'POST',
+              },
+            );
+
+            responseJson = await response.json();
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(400);
+            expect(response.headers.get('content-type')).toStrictEqual(
+              expect.stringContaining('application/json'),
+            );
+
+            expect(responseJson).toStrictEqual({
+              message:
+                '[schema: #/additionalProperties, instance: ]: "must NOT have additional properties"',
+            });
+          });
+        });
+
+        describe('when an invalid POST /messages request missing a required property is made', () => {
+          let response: Response;
+          let responseJson: unknown;
+
+          beforeAll(async () => {
+            response = await fetch(
+              `http://${server.host}:${server.port.toString()}/messages`,
+              {
+                body: JSON.stringify({}),
+                headers: { 'Content-Type': 'application/json' },
+                method: 'POST',
+              },
+            );
+
+            responseJson = await response.json();
+          });
+
+          it('should return expected Response', async () => {
+            expect(response.status).toBe(400);
+            expect(response.headers.get('content-type')).toStrictEqual(
+              expect.stringContaining('application/json'),
+            );
+
+            expect(responseJson).toStrictEqual({
+              message:
+                '[schema: #/required, instance: ]: "must have required property \'content\'"',
+            });
+          });
+        });
+      });
+
       describe('having an OpenApiValidationPipe (v3.2) in an HTTP server with an array of number query param', () => {
         @Controller('/numbers')
         class NumberController {

--- a/packages/framework/validation/libraries/openapi/src/validation/services/BaseOpenApiResolver.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/services/BaseOpenApiResolver.ts
@@ -2,6 +2,7 @@ import { type JsonValue } from '@inversifyjs/json-schema-types';
 
 import { deepResolveJsonSchemaPointer } from '../calculations/deepResolveJsonSchemaPointer.js';
 import {
+  type JsonSchemaResolutionResult,
   type OpenApiRefResolutionResult,
   type OpenApiResolver,
 } from './OpenApiResolver.js';
@@ -67,6 +68,10 @@ export abstract class BaseOpenApiResolver implements OpenApiResolver {
       typeof object.$ref === 'string'
     );
   }
+
+  public abstract resolveJsonSchema(
+    schema: JsonValue,
+  ): JsonSchemaResolutionResult;
 
   public abstract resolveOpenApiReference(
     reference: JsonValue,

--- a/packages/framework/validation/libraries/openapi/src/validation/services/OpenApiResolver.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/services/OpenApiResolver.ts
@@ -1,4 +1,8 @@
 import { type JsonValue } from '@inversifyjs/json-schema-types';
+import {
+  type ResolutionFailure,
+  type SchemaResolutionSuccessTree,
+} from '@inversifyjs/json-schema-utils/2020-12';
 
 interface OpenApiRefResolutionContext {
   readonly $ref: string;
@@ -19,6 +23,16 @@ interface OpenApiRefResolutionSuccess {
   readonly value: JsonValue;
 }
 
+export type JsonSchemaResolutionResult =
+  | {
+      isRight: false;
+      value: ResolutionFailure;
+    }
+  | {
+      isRight: true;
+      value: SchemaResolutionSuccessTree;
+    };
+
 export type OpenApiRefResolutionResult =
   | {
       isRight: false;
@@ -31,6 +45,7 @@ export type OpenApiRefResolutionResult =
 
 export interface OpenApiResolver {
   deepResolveReference(reference: string): JsonValue | undefined;
+  resolveJsonSchema(schema: JsonValue): JsonSchemaResolutionResult;
   resolveOpenApiReference(reference: JsonValue): OpenApiRefResolutionResult;
   resolveReference(reference: string): JsonValue | undefined;
 }

--- a/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot1/DefaultOpenApiResolver.int.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot1/DefaultOpenApiResolver.int.spec.ts
@@ -752,4 +752,117 @@ describe(DefaultOpenApiResolver, () => {
       });
     });
   });
+
+  describe('having an OpenAPI object with JSON Schema $id resources', () => {
+    let defaultOpenApiResolver: DefaultOpenApiResolver;
+    let itemSchemaFixture: JsonSchema;
+    let openApiObjectFixture: OpenApi3Dot1Object;
+    let otherSchemaFixture: JsonSchema;
+
+    beforeAll(() => {
+      itemSchemaFixture = {
+        $id: 'https://example.com/schemas/Item.json',
+        $ref: 'Other.json',
+        type: 'object',
+      };
+      otherSchemaFixture = {
+        $id: 'https://example.com/schemas/Other.json',
+        type: 'string',
+      };
+
+      openApiObjectFixture = {
+        components: {
+          schemas: {
+            Item: itemSchemaFixture,
+            Other: otherSchemaFixture,
+          },
+        },
+        info: { title: 'Test API', version: '1.0.0' },
+        openapi: '3.1.0',
+      };
+
+      defaultOpenApiResolver = new DefaultOpenApiResolver(openApiObjectFixture);
+    });
+
+    describe('.resolveJsonSchema', () => {
+      describe('when called with a boolean schema', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.resolveJsonSchema(true);
+        });
+
+        it('should return an empty resolution tree', () => {
+          expect(result).toStrictEqual({
+            isRight: true,
+            value: {
+              $dynamicRef: undefined,
+              $ref: undefined,
+            },
+          });
+        });
+      });
+
+      describe('when called with a schema object with no $ref', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.resolveJsonSchema(otherSchemaFixture);
+        });
+
+        it('should return an empty resolution tree', () => {
+          expect(result).toStrictEqual({
+            isRight: true,
+            value: {
+              $dynamicRef: undefined,
+              $ref: undefined,
+            },
+          });
+        });
+      });
+
+      describe('when called with a schema whose $ref targets another schema $id', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.resolveJsonSchema(itemSchemaFixture);
+        });
+
+        it('should return a tree with the referenced schema', () => {
+          expect(result).toMatchObject({
+            isRight: true,
+            value: {
+              $dynamicRef: undefined,
+              $ref: {
+                $dynamicRef: undefined,
+                $ref: undefined,
+                value: otherSchemaFixture,
+              },
+            },
+          });
+        });
+      });
+
+      describe('when called with a schema whose $ref targets a missing resource', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.resolveJsonSchema({
+            $id: 'https://example.com/schemas/MissingRef.json',
+            $ref: 'https://example.com/schemas/DoesNotExist.json',
+          });
+        });
+
+        it('should return a resolution failure', () => {
+          expect(result).toMatchObject({
+            isRight: false,
+            value: {
+              reason:
+                'Failed to resolve resource identified by: https://example.com/schemas/DoesNotExist.json',
+            },
+          });
+        });
+      });
+    });
+  });
 });

--- a/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot1/DefaultOpenApiResolver.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot1/DefaultOpenApiResolver.ts
@@ -3,7 +3,10 @@ import {
   type JsonRootSchemaObject,
   type JsonSchemaObject,
 } from '@inversifyjs/json-schema-types/2020-12';
-import { type TraverseJsonSchemaCallbackParams } from '@inversifyjs/json-schema-utils/2020-12';
+import {
+  JsonSchemaResolver,
+  type TraverseJsonSchemaCallbackParams,
+} from '@inversifyjs/json-schema-utils/2020-12';
 import { type OpenApi3Dot1Object } from '@inversifyjs/open-api-types/v3Dot1';
 import {
   OpenApi3Dot1Resolver,
@@ -14,11 +17,15 @@ import { Uri } from '@inversifyjs/uri';
 import { getClosestAncestorId } from '../../calculations/getClosestAncestorId.js';
 import { getClosestAncestorOrNodeId } from '../../calculations/getClosestAncestorOrNodeId.js';
 import { BaseOpenApiResolver } from '../BaseOpenApiResolver.js';
-import { type OpenApiRefResolutionResult } from '../OpenApiResolver.js';
+import {
+  type JsonSchemaResolutionResult,
+  type OpenApiRefResolutionResult,
+} from '../OpenApiResolver.js';
 
 const OPEN_API_DOCUMENT_URI: string = 'urn:inversifyjs:openapi-v3dot1-spec';
 
 export class DefaultOpenApiResolver extends BaseOpenApiResolver {
+  readonly #jsonSchemaResolver: JsonSchemaResolver;
   readonly #openApi3Dot1Resolver: OpenApi3Dot1Resolver;
   readonly #openApiObject: JsonValue;
   readonly #uriToSchemaMap: Map<string, JsonValue>;
@@ -31,10 +38,17 @@ export class DefaultOpenApiResolver extends BaseOpenApiResolver {
 
     this.#populateUriToSchemaMap(openApiObject);
 
+    this.#jsonSchemaResolver = new JsonSchemaResolver((id: string) =>
+      this._maybeResolveUri(id),
+    );
     this.#openApi3Dot1Resolver = new OpenApi3Dot1Resolver(
       OPEN_API_DOCUMENT_URI,
       (id: string) => this.#maybeResolveOpenApiDocument(id),
     );
+  }
+
+  public resolveJsonSchema(schema: JsonValue): JsonSchemaResolutionResult {
+    return this.#jsonSchemaResolver.resolveSchema(schema);
   }
 
   public resolveOpenApiReference(
@@ -63,6 +77,10 @@ export class DefaultOpenApiResolver extends BaseOpenApiResolver {
 
   #populateUriToSchemaMap(openApiObject: OpenApi3Dot1Object): void {
     this.#uriToSchemaMap.set('', openApiObject as unknown as JsonValue);
+    this.#uriToSchemaMap.set(
+      OPEN_API_DOCUMENT_URI,
+      openApiObject as unknown as JsonValue,
+    );
 
     traverseOpenApiObjectJsonSchemas(
       openApiObject,

--- a/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot2/DefaultOpenApiResolver.int.spec.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot2/DefaultOpenApiResolver.int.spec.ts
@@ -752,4 +752,187 @@ describe(DefaultOpenApiResolver, () => {
       });
     });
   });
+
+  describe('having an OpenAPI object with JSON Schema $id resources', () => {
+    let defaultOpenApiResolver: DefaultOpenApiResolver;
+    let itemSchemaFixture: JsonSchema;
+    let openApiObjectFixture: OpenApi3Dot2Object;
+    let otherSchemaFixture: JsonSchema;
+
+    beforeAll(() => {
+      itemSchemaFixture = {
+        $id: 'https://example.com/schemas/Item.json',
+        $ref: 'Other.json',
+        type: 'object',
+      };
+      otherSchemaFixture = {
+        $id: 'https://example.com/schemas/Other.json',
+        type: 'string',
+      };
+
+      openApiObjectFixture = {
+        components: {
+          schemas: {
+            Item: itemSchemaFixture,
+            Other: otherSchemaFixture,
+          },
+        },
+        info: { title: 'Test API', version: '1.0.0' },
+        openapi: '3.2.0',
+      };
+
+      defaultOpenApiResolver = new DefaultOpenApiResolver(openApiObjectFixture);
+    });
+
+    describe('.resolveJsonSchema', () => {
+      describe('when called with a boolean schema', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.resolveJsonSchema(true);
+        });
+
+        it('should return an empty resolution tree', () => {
+          expect(result).toStrictEqual({
+            isRight: true,
+            value: {
+              $dynamicRef: undefined,
+              $ref: undefined,
+            },
+          });
+        });
+      });
+
+      describe('when called with a schema object with no $ref', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.resolveJsonSchema(otherSchemaFixture);
+        });
+
+        it('should return an empty resolution tree', () => {
+          expect(result).toStrictEqual({
+            isRight: true,
+            value: {
+              $dynamicRef: undefined,
+              $ref: undefined,
+            },
+          });
+        });
+      });
+
+      describe('when called with a schema whose $ref targets another schema $id', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.resolveJsonSchema(itemSchemaFixture);
+        });
+
+        it('should return a tree with the referenced schema', () => {
+          expect(result).toMatchObject({
+            isRight: true,
+            value: {
+              $dynamicRef: undefined,
+              $ref: {
+                $dynamicRef: undefined,
+                $ref: undefined,
+                value: otherSchemaFixture,
+              },
+            },
+          });
+        });
+      });
+
+      describe('when called with a schema whose $ref targets a missing resource', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.resolveJsonSchema({
+            $id: 'https://example.com/schemas/MissingRef.json',
+            $ref: 'https://example.com/schemas/DoesNotExist.json',
+          });
+        });
+
+        it('should return a resolution failure', () => {
+          expect(result).toMatchObject({
+            isRight: false,
+            value: {
+              reason:
+                'Failed to resolve resource identified by: https://example.com/schemas/DoesNotExist.json',
+            },
+          });
+        });
+      });
+    });
+  });
+
+  describe('having an OpenAPI object with $self and a schema $ref to that URI', () => {
+    let defaultOpenApiResolver: DefaultOpenApiResolver;
+    let itemSchemaFixture: JsonSchema;
+    let openApiObjectFixture: OpenApi3Dot2Object;
+    let otherSchemaFixture: JsonSchema;
+
+    beforeAll(() => {
+      otherSchemaFixture = {
+        type: 'string',
+      };
+      itemSchemaFixture = {
+        $id: 'https://example.com/schemas/Item.json',
+        $ref: 'https://example.com/api/openapi.json#/components/schemas/Other',
+      };
+      openApiObjectFixture = {
+        $self: 'https://example.com/api/openapi.json',
+        components: {
+          schemas: {
+            Item: itemSchemaFixture,
+            Other: otherSchemaFixture,
+          },
+        },
+        info: { title: 'Test API', version: '1.0.0' },
+        openapi: '3.2.0',
+      };
+
+      defaultOpenApiResolver = new DefaultOpenApiResolver(openApiObjectFixture);
+    });
+
+    describe('.resolveJsonSchema', () => {
+      describe('when called with a schema whose $ref targets the document $self URI', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.resolveJsonSchema(itemSchemaFixture);
+        });
+
+        it('should return a tree with the referenced schema', () => {
+          expect(result).toMatchObject({
+            isRight: true,
+            value: {
+              $dynamicRef: undefined,
+              $ref: {
+                $dynamicRef: undefined,
+                $ref: undefined,
+                value: otherSchemaFixture,
+              },
+            },
+          });
+        });
+      });
+    });
+
+    describe('.resolveReference', () => {
+      describe('when called with the $self URI and a JSON pointer fragment', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = defaultOpenApiResolver.resolveReference(
+            'https://example.com/api/openapi.json#/components/schemas/Other',
+          );
+        });
+
+        it('should return the schema at the JSON pointer', () => {
+          expect(result).toBe(otherSchemaFixture);
+        });
+      });
+    });
+  });
 });

--- a/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot2/DefaultOpenApiResolver.ts
+++ b/packages/framework/validation/libraries/openapi/src/validation/services/v3Dot2/DefaultOpenApiResolver.ts
@@ -3,7 +3,10 @@ import {
   type JsonRootSchemaObject,
   type JsonSchemaObject,
 } from '@inversifyjs/json-schema-types/2020-12';
-import { type TraverseJsonSchemaCallbackParams } from '@inversifyjs/json-schema-utils/2020-12';
+import {
+  JsonSchemaResolver,
+  type TraverseJsonSchemaCallbackParams,
+} from '@inversifyjs/json-schema-utils/2020-12';
 import { type OpenApi3Dot2Object } from '@inversifyjs/open-api-types/v3Dot2';
 import {
   OpenApi3Dot2Resolver,
@@ -14,11 +17,15 @@ import { Uri } from '@inversifyjs/uri';
 import { getClosestAncestorId } from '../../calculations/getClosestAncestorId.js';
 import { getClosestAncestorOrNodeId } from '../../calculations/getClosestAncestorOrNodeId.js';
 import { BaseOpenApiResolver } from '../BaseOpenApiResolver.js';
-import { type OpenApiRefResolutionResult } from '../OpenApiResolver.js';
+import {
+  type JsonSchemaResolutionResult,
+  type OpenApiRefResolutionResult,
+} from '../OpenApiResolver.js';
 
 const OPEN_API_DOCUMENT_URI: string = 'urn:inversifyjs:openapi-v3dot2-spec';
 
 export class DefaultOpenApiResolver extends BaseOpenApiResolver {
+  readonly #jsonSchemaResolver: JsonSchemaResolver;
   readonly #openApi3Dot2Resolver: OpenApi3Dot2Resolver;
   readonly #openApiObject: JsonValue;
   readonly #uriToSchemaMap: Map<string, JsonValue>;
@@ -31,10 +38,17 @@ export class DefaultOpenApiResolver extends BaseOpenApiResolver {
 
     this.#populateUriToSchemaMap(openApiObject);
 
+    this.#jsonSchemaResolver = new JsonSchemaResolver((id: string) =>
+      this._maybeResolveUri(id),
+    );
     this.#openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
       OPEN_API_DOCUMENT_URI,
       (id: string) => this.#maybeResolveOpenApiDocument(id),
     );
+  }
+
+  public resolveJsonSchema(schema: JsonValue): JsonSchemaResolutionResult {
+    return this.#jsonSchemaResolver.resolveSchema(schema);
   }
 
   public resolveOpenApiReference(
@@ -63,6 +77,34 @@ export class DefaultOpenApiResolver extends BaseOpenApiResolver {
 
   #populateUriToSchemaMap(openApiObject: OpenApi3Dot2Object): void {
     this.#uriToSchemaMap.set('', openApiObject as unknown as JsonValue);
+    this.#uriToSchemaMap.set(
+      OPEN_API_DOCUMENT_URI,
+      openApiObject as unknown as JsonValue,
+    );
+
+    let documentBaseId: string | undefined = openApiObject.$self;
+
+    if (openApiObject.$self !== undefined) {
+      const selfUri: Uri = new Uri(openApiObject.$self, OPEN_API_DOCUMENT_URI);
+      const canonicalSelf: string = Uri.fromAttributes({
+        ...selfUri.attributes,
+        fragment: undefined,
+      }).toString();
+
+      this.#uriToSchemaMap.set(
+        canonicalSelf,
+        openApiObject as unknown as JsonValue,
+      );
+
+      if (openApiObject.$self !== canonicalSelf) {
+        this.#uriToSchemaMap.set(
+          openApiObject.$self,
+          openApiObject as unknown as JsonValue,
+        );
+      }
+
+      documentBaseId = canonicalSelf;
+    }
 
     traverseOpenApiObjectJsonSchemas(
       openApiObject,
@@ -75,7 +117,7 @@ export class DefaultOpenApiResolver extends BaseOpenApiResolver {
           const baseId: string | undefined = getClosestAncestorId(
             params.rootSchema,
             params.jsonPointer,
-            openApiObject.$self,
+            documentBaseId,
           );
           const idUri: Uri = new Uri(params.schema.$id, baseId);
 
@@ -87,7 +129,7 @@ export class DefaultOpenApiResolver extends BaseOpenApiResolver {
             getClosestAncestorOrNodeId(
               params.rootSchema,
               params.jsonPointer,
-              openApiObject.$self,
+              documentBaseId,
             );
 
           if (anchorRelatedId !== undefined) {


### PR DESCRIPTION
### Changed
- Updated OpenApi resolution flow to rely on OpenApi resolvers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved OpenAPI 3.1 and 3.2 support for referenced parameters and request bodies.
  * References now preserve component paths during validation, improving schema and error reporting accuracy.
  * Added JSON Schema resolution, including `$id`, `$ref`, and document `$self` support.

* **Bug Fixes**
  * Validation now reports detailed errors when references fail or resolve to invalid values.
  * Corrected request-body schema resolution for referenced components.

* **Tests**
  * Added comprehensive coverage for referenced parameters, request bodies, JSON Schemas, and resolution failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->