### PR TITLE
fix(open-api-utils): validate declared $self and $id types in OpenApi3Dot2Resolver

### DIFF
--- a/.changeset/ten-seas-look.md
+++ b/.changeset/ten-seas-look.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/open-api-utils": patch
+---
+
+- Fixed OpenAPI 3.2 document base URI validation for declared `$self` and `$id` values

--- a/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot2/services/OpenApi3Dot2Resolver.int.spec.ts
+++ b/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot2/services/OpenApi3Dot2Resolver.int.spec.ts
@@ -2553,5 +2553,326 @@ describe(OpenApi3Dot2Resolver, () => {
         });
       });
     });
+
+    describe('having an entry document declaring an absolute $self URI', () => {
+      let documentFixture: JsonValue;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let petSchemaFixture: JsonValue;
+      let refFixture: JsonValue;
+      let resolveIdMock: Mock<(id: string) => JsonValue | undefined>;
+
+      beforeAll(() => {
+        petSchemaFixture = {
+          type: 'object',
+        };
+        documentFixture = {
+          $self: 'https://example.com/v2/api.json',
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          ['https://example.com/api.json', documentFixture],
+          ['https://example.com/v2/schemas/pet.json', petSchemaFixture],
+        ]);
+
+        resolveIdMock = vitest.fn((id: string) => documentById.get(id));
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          'https://example.com/api.json',
+          resolveIdMock,
+        );
+
+        refFixture = {
+          $ref: 'schemas/pet.json',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should rebase relative references to the declared $self base URI', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: 'schemas/pet.json',
+                  canonicalId: 'https://example.com/v2/schemas/pet.json',
+                  value: refFixture,
+                },
+              ],
+              value: petSchemaFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having an entry document declaring a relative $self URI', () => {
+      let documentFixture: JsonValue;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let petSchemaFixture: JsonValue;
+      let refFixture: JsonValue;
+      let resolveIdMock: Mock<(id: string) => JsonValue | undefined>;
+
+      beforeAll(() => {
+        petSchemaFixture = {
+          type: 'object',
+        };
+        documentFixture = {
+          $self: '../v2/api.json',
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          ['https://example.com/v1/sub/api.json', documentFixture],
+          ['https://example.com/v1/v2/schemas/pet.json', petSchemaFixture],
+        ]);
+
+        resolveIdMock = vitest.fn((id: string) => documentById.get(id));
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          'https://example.com/v1/sub/api.json',
+          resolveIdMock,
+        );
+
+        refFixture = {
+          $ref: 'schemas/pet.json',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should resolve the relative $self against retrieval URI and rebase references', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: 'schemas/pet.json',
+                  canonicalId: 'https://example.com/v1/v2/schemas/pet.json',
+                  value: refFixture,
+                },
+              ],
+              value: petSchemaFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having an entry document declaring a root Schema Object $id', () => {
+      let documentFixture: JsonValue;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let petSchemaFixture: JsonValue;
+      let refFixture: JsonValue;
+      let resolveIdMock: Mock<(id: string) => JsonValue | undefined>;
+
+      beforeAll(() => {
+        petSchemaFixture = {
+          type: 'object',
+        };
+        documentFixture = {
+          $id: 'https://example.com/schemas/root.json',
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          ['https://example.com/api.json', documentFixture],
+          ['https://example.com/schemas/pet.json', petSchemaFixture],
+        ]);
+
+        resolveIdMock = vitest.fn((id: string) => documentById.get(id));
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          'https://example.com/api.json',
+          resolveIdMock,
+        );
+
+        refFixture = {
+          $ref: 'pet.json',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should rebase relative references to the declared $id base URI', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: true,
+            value: {
+              chain: [
+                {
+                  $ref: 'pet.json',
+                  canonicalId: 'https://example.com/schemas/pet.json',
+                  value: refFixture,
+                },
+              ],
+              value: petSchemaFixture,
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a document declaring an invalid non-string $self property', () => {
+      let documentFixture: JsonValue;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let resolveIdMock: Mock<(id: string) => JsonValue | undefined>;
+
+      beforeAll(() => {
+        documentFixture = {
+          $self: 12345,
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          ['https://example.com/api.json', documentFixture],
+        ]);
+
+        resolveIdMock = vitest.fn((id: string) => documentById.get(id));
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          'https://example.com/api.json',
+          resolveIdMock,
+        );
+
+        refFixture = {
+          $ref: '#/components/schemas/Pet',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a resolution failure', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: 'Invalid $self URI: 12345',
+              resolutionContextStack: [],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a document declaring an invalid non-string $id property', () => {
+      let documentFixture: JsonValue;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let resolveIdMock: Mock<(id: string) => JsonValue | undefined>;
+
+      beforeAll(() => {
+        documentFixture = {
+          $id: true,
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          ['https://example.com/api.json', documentFixture],
+        ]);
+
+        resolveIdMock = vitest.fn((id: string) => documentById.get(id));
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          'https://example.com/api.json',
+          resolveIdMock,
+        );
+
+        refFixture = {
+          $ref: '#/components/schemas/Pet',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a resolution failure', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: 'Invalid $id URI: true',
+              resolutionContextStack: [],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
+
+    describe('having a document declaring an unparseable $self URI', () => {
+      let documentFixture: JsonValue;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let resolveIdMock: Mock<(id: string) => JsonValue | undefined>;
+
+      beforeAll(() => {
+        documentFixture = {
+          $self: 'ht tp://invalid',
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          ['https://example.com/api.json', documentFixture],
+        ]);
+
+        resolveIdMock = vitest.fn((id: string) => documentById.get(id));
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          'https://example.com/api.json',
+          resolveIdMock,
+        );
+
+        refFixture = {
+          $ref: '#/components/schemas/Pet',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a resolution failure', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: 'Invalid $self URI: ht tp://invalid',
+              resolutionContextStack: [],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
   });
 });

--- a/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot2/services/OpenApi3Dot2Resolver.int.spec.ts
+++ b/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot2/services/OpenApi3Dot2Resolver.int.spec.ts
@@ -2874,5 +2874,53 @@ describe(OpenApi3Dot2Resolver, () => {
         });
       });
     });
+
+    describe('having a document declaring an unparseable $id URI', () => {
+      let documentFixture: JsonValue;
+      let openApi3Dot2Resolver: OpenApi3Dot2Resolver;
+      let refFixture: JsonValue;
+      let resolveIdMock: Mock<(id: string) => JsonValue | undefined>;
+
+      beforeAll(() => {
+        documentFixture = {
+          $id: 'ht tp://invalid',
+        };
+
+        const documentById: Map<string, JsonValue> = new Map([
+          ['https://example.com/api.json', documentFixture],
+        ]);
+
+        resolveIdMock = vitest.fn((id: string) => documentById.get(id));
+
+        openApi3Dot2Resolver = new OpenApi3Dot2Resolver(
+          'https://example.com/api.json',
+          resolveIdMock,
+        );
+
+        refFixture = {
+          $ref: '#/components/schemas/Pet',
+        };
+      });
+
+      describe('when called', () => {
+        let result: OpenApi3Dot2RefResolutionResult;
+
+        beforeAll(() => {
+          result = openApi3Dot2Resolver.resolveRef(refFixture);
+        });
+
+        it('should return a resolution failure', () => {
+          const expected: OpenApi3Dot2RefResolutionResult = {
+            isRight: false,
+            value: {
+              reason: 'Invalid $id URI: ht tp://invalid',
+              resolutionContextStack: [],
+            },
+          };
+
+          expect(result).toStrictEqual(expected);
+        });
+      });
+    });
   });
 });

--- a/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot2/services/OpenApi3Dot2Resolver.ts
+++ b/packages/open-api/libraries/open-api-utils/src/openApi/v3Dot2/services/OpenApi3Dot2Resolver.ts
@@ -373,10 +373,22 @@ export class OpenApi3Dot2Resolver {
     let declaredField: '$id' | '$self';
     let declaredUri: string;
 
-    if (typeof document['$self'] === 'string') {
+    if (document['$self'] !== undefined) {
+      if (typeof document['$self'] !== 'string') {
+        return {
+          isRight: false,
+          value: `Invalid $self URI: ${JSON.stringify(document['$self'])}`,
+        };
+      }
       declaredField = '$self';
       declaredUri = document['$self'];
-    } else if (typeof document['$id'] === 'string') {
+    } else if (document['$id'] !== undefined) {
+      if (typeof document['$id'] !== 'string') {
+        return {
+          isRight: false,
+          value: `Invalid $id URI: ${JSON.stringify(document['$id'])}`,
+        };
+      }
       declaredField = '$id';
       declaredUri = document['$id'];
     } else {


### PR DESCRIPTION
## Description

In OpenAPI 3.2, document base URIs can be declared via `` (for OpenAPI root documents) or `` (for root Schema Object documents).

Previously, if a loaded document declared an invalid non-string `` or `` property (such as a number, boolean, or object), `OpenApi3Dot2Resolver.#resolveDocumentBaseUri` would silently fall through to subsequent checks and default to the retrieval URI without signaling an error.

This PR improves `OpenApi3Dot2Resolver` by:
- Explicitly detecting when `` or `` properties are defined and validating that their values are strings.
- Returning an `OpenApi3Dot2RefResolutionResult` failure with descriptive error messages (e.g., `Invalid  URI: <value>` or `Invalid  URI: <value>`) when non-string types or unparseable URIs are encountered.
- Adding comprehensive integration test coverage for `` and `` base URI declarations, relative reference rebasing, and invalid type handling.

## Validation

- Tested with Vitest: 6/6 test files passed (227 tests passed) in `@inversifyjs/open-api-utils`.
- Linted with ESLint and formatted with Prettier.
- Built cleanly with `pnpm run build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Relative references now resolve correctly against declared absolute or relative `$self` and root schema `$id` base URIs.
  * Invalid non-string or unparseable `$self` and `$id` declarations now produce clear resolution failures instead of being silently ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->