### PR TITLE
feat(container): update jitless container option to be false by default

### DIFF
--- a/.changeset/update-jitless-default-false.md
+++ b/.changeset/update-jitless-default-false.md
@@ -1,0 +1,6 @@
+---
+"@inversifyjs/container": major
+"inversify": major
+---
+
+- Updated `ContainerOptions.jitless` to default to `false`.

--- a/packages/container/libraries/container/src/container/services/Container.spec.ts
+++ b/packages/container/libraries/container/src/container/services/Container.spec.ts
@@ -410,8 +410,8 @@ describe(Container, () => {
 
         it('should call PlanResultCacheService()', () => {
           expect(PlanResultCacheService).toHaveBeenCalledTimes(2);
-          expect(PlanResultCacheService).toHaveBeenNthCalledWith(1, false);
-          expect(PlanResultCacheService).toHaveBeenNthCalledWith(2, false);
+          expect(PlanResultCacheService).toHaveBeenNthCalledWith(1, true);
+          expect(PlanResultCacheService).toHaveBeenNthCalledWith(2, true);
         });
 
         it('should call planResultCacheService.subscribe()', () => {
@@ -495,7 +495,7 @@ describe(Container, () => {
         });
 
         it('should call PlanResultCacheService()', () => {
-          expect(PlanResultCacheService).toHaveBeenCalledExactlyOnceWith(false);
+          expect(PlanResultCacheService).toHaveBeenCalledExactlyOnceWith(true);
         });
 
         it('should not call planResultCacheService.subscribe()', () => {
@@ -510,6 +510,38 @@ describe(Container, () => {
             expect.any(PlanResultCacheService),
           );
         });
+      });
+    });
+
+    describe('having jitless true option', () => {
+      beforeAll(() => {
+        new Container({
+          jitless: true,
+        });
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call PlanResultCacheService() with false', () => {
+        expect(PlanResultCacheService).toHaveBeenCalledExactlyOnceWith(false);
+      });
+    });
+
+    describe('having jitless false option', () => {
+      beforeAll(() => {
+        new Container({
+          jitless: false,
+        });
+      });
+
+      afterAll(() => {
+        vitest.clearAllMocks();
+      });
+
+      it('should call PlanResultCacheService() with true', () => {
+        expect(PlanResultCacheService).toHaveBeenCalledExactlyOnceWith(true);
       });
     });
   });

--- a/packages/container/libraries/container/src/container/services/Container.ts
+++ b/packages/container/libraries/container/src/container/services/Container.ts
@@ -30,7 +30,7 @@ import { ServiceResolutionManager } from './ServiceResolutionManager.js';
 import { SnapshotManager } from './SnapshotManager.js';
 
 const DEFAULT_DEFAULT_SCOPE: BindingScope = bindingScopeValues.Transient;
-const DEFAULT_JITLESS: boolean = true;
+const DEFAULT_JITLESS: boolean = false;
 
 export class Container {
   readonly #bindingManager: BindingManager;

--- a/packages/docs/services/inversify-site/docs/api/container.mdx
+++ b/packages/docs/services/inversify-site/docs/api/container.mdx
@@ -59,9 +59,9 @@ The default scope for bindings.
 jitless?: boolean | undefined;
 ```
 
-Option to disable just-in-time resolution optimizations that rely on the `Function` constructor. When `true` (the default), the container uses CSP-compatible resolution paths that work in environments enforcing a strict Content Security Policy without `unsafe-eval`.
+Option to disable just-in-time resolution optimizations that rely on the `Function` constructor. When `false` (the default), the container uses JIT optimizations for better performance in environments where `unsafe-eval` is permitted.
 
-Set `jitless` to `false` to enable JIT optimizations for better performance in environments where `unsafe-eval` is permitted. In the next major release, `jitless` is planned to default to `false`.
+Set `jitless` to `true` to use CSP-compatible resolution paths that work in environments enforcing a strict Content Security Policy without `unsafe-eval`.
 
 ## bind
 

--- a/packages/docs/services/inversify-site/i18n/zh/docusaurus-plugin-content-docs/current/api/container.mdx
+++ b/packages/docs/services/inversify-site/i18n/zh/docusaurus-plugin-content-docs/current/api/container.mdx
@@ -59,9 +59,9 @@ defaultScope?: BindingScope | undefined;
 jitless?: boolean | undefined;
 ```
 
-用于禁用依赖 `Function` 构造函数的即时（JIT）解析优化的选项。当为 `true`（默认值）时，容器使用与 CSP 兼容的解析路径，可在强制执行严格内容安全策略（不允许 `unsafe-eval`）的环境中正常工作。
+用于禁用依赖 `Function` 构造函数的即时（JIT）解析优化的选项。当为 `false`（默认值）时，容器使用 JIT 优化以在允许 `unsafe-eval` 的环境中获得更好的性能。
 
-在允许 `unsafe-eval` 的环境中，将 `jitless` 设置为 `false` 可启用 JIT 优化以获得更好的性能。在下一个主要版本中，`jitless` 计划默认值为 `false`。
+将 `jitless` 设置为 `true` 可使用与 CSP 兼容的解析路径，适用于强制执行严格内容安全策略且不允许 `unsafe-eval` 的环境。
 
 ## bind
 


### PR DESCRIPTION
Closes #2020. Updates DEFAULT_JITLESS to false by default for v9, adds unit tests in Container.spec.ts, updates docs, and adds changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * The container now uses JIT-optimized resolution by default.
  * Set `jitless: true` to use CSP-compatible resolution in environments that disallow `unsafe-eval`.

* **Documentation**
  * Updated English and Chinese API documentation to describe the new default behavior and configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->