### PR TITLE
Update simplifyTypeMetadata

### DIFF
--- a/packages/json-schema/libraries/json-schema-2-type-metadata/src/jsonSchema/202012/actions/simplifyTypeMetadata.spec.ts
+++ b/packages/json-schema/libraries/json-schema-2-type-metadata/src/jsonSchema/202012/actions/simplifyTypeMetadata.spec.ts
@@ -1155,6 +1155,267 @@ describe(simplifyTypeMetadata, () => {
         kind: TypeMetadataKind.and,
       },
       {
+        kind: TypeMetadataKind.integerType,
+      },
+    ],
+    [
+      'an and TypeMetadata with two disjoint or children',
+      {
+        children: [
+          {
+            children: [
+              {
+                kind: TypeMetadataKind.stringType,
+              },
+              {
+                kind: TypeMetadataKind.booleanType,
+              },
+            ],
+            kind: TypeMetadataKind.or,
+          },
+          {
+            children: [
+              {
+                kind: TypeMetadataKind.literalType,
+                literal: null,
+              },
+              {
+                kind: TypeMetadataKind.objectType,
+              },
+            ],
+            kind: TypeMetadataKind.or,
+          },
+        ],
+        kind: TypeMetadataKind.and,
+      },
+      {
+        kind: TypeMetadataKind.noneType,
+      },
+    ],
+    [
+      'an and TypeMetadata with an items-like or child and a type-like or child',
+      {
+        children: [
+          {
+            children: [
+              {
+                child: {
+                  kind: TypeMetadataKind.stringType,
+                },
+                kind: TypeMetadataKind.arrayType,
+              },
+              {
+                kind: TypeMetadataKind.booleanType,
+              },
+              {
+                kind: TypeMetadataKind.floatType,
+              },
+              {
+                kind: TypeMetadataKind.literalType,
+                literal: null,
+              },
+              {
+                kind: TypeMetadataKind.objectType,
+              },
+              {
+                kind: TypeMetadataKind.stringType,
+              },
+            ],
+            kind: TypeMetadataKind.or,
+          },
+          {
+            children: [
+              {
+                child: {
+                  kind: TypeMetadataKind.anyType,
+                },
+                kind: TypeMetadataKind.arrayType,
+              },
+              {
+                kind: TypeMetadataKind.literalType,
+                literal: null,
+              },
+            ],
+            kind: TypeMetadataKind.or,
+          },
+        ],
+        kind: TypeMetadataKind.and,
+      },
+      {
+        children: [
+          {
+            child: {
+              kind: TypeMetadataKind.stringType,
+            },
+            kind: TypeMetadataKind.arrayType,
+          },
+          {
+            kind: TypeMetadataKind.literalType,
+            literal: null,
+          },
+        ],
+        kind: TypeMetadataKind.or,
+      },
+    ],
+    [
+      'an and TypeMetadata with a nested and arrayType or branch',
+      {
+        children: [
+          {
+            children: [
+              {
+                child: {
+                  kind: TypeMetadataKind.stringType,
+                },
+                kind: TypeMetadataKind.arrayType,
+              },
+              {
+                kind: TypeMetadataKind.booleanType,
+              },
+              {
+                kind: TypeMetadataKind.literalType,
+                literal: null,
+              },
+            ],
+            kind: TypeMetadataKind.or,
+          },
+          {
+            children: [
+              {
+                children: [
+                  {
+                    child: {
+                      kind: TypeMetadataKind.anyType,
+                    },
+                    kind: TypeMetadataKind.arrayType,
+                  },
+                  {
+                    child: {
+                      kind: TypeMetadataKind.stringType,
+                    },
+                    kind: TypeMetadataKind.arrayType,
+                  },
+                ],
+                kind: TypeMetadataKind.and,
+              },
+              {
+                kind: TypeMetadataKind.literalType,
+                literal: null,
+              },
+            ],
+            kind: TypeMetadataKind.or,
+          },
+        ],
+        kind: TypeMetadataKind.and,
+      },
+      {
+        children: [
+          {
+            child: {
+              kind: TypeMetadataKind.stringType,
+            },
+            kind: TypeMetadataKind.arrayType,
+          },
+          {
+            kind: TypeMetadataKind.literalType,
+            literal: null,
+          },
+        ],
+        kind: TypeMetadataKind.or,
+      },
+    ],
+    [
+      'an and TypeMetadata with two items-like or children',
+      {
+        children: [
+          {
+            children: [
+              {
+                child: {
+                  kind: TypeMetadataKind.stringType,
+                },
+                kind: TypeMetadataKind.arrayType,
+              },
+              {
+                kind: TypeMetadataKind.booleanType,
+              },
+              {
+                kind: TypeMetadataKind.floatType,
+              },
+              {
+                kind: TypeMetadataKind.literalType,
+                literal: null,
+              },
+              {
+                kind: TypeMetadataKind.objectType,
+              },
+              {
+                kind: TypeMetadataKind.stringType,
+              },
+            ],
+            kind: TypeMetadataKind.or,
+          },
+          {
+            children: [
+              {
+                child: {
+                  kind: TypeMetadataKind.floatType,
+                },
+                kind: TypeMetadataKind.arrayType,
+              },
+              {
+                kind: TypeMetadataKind.booleanType,
+              },
+              {
+                kind: TypeMetadataKind.floatType,
+              },
+              {
+                kind: TypeMetadataKind.literalType,
+                literal: null,
+              },
+              {
+                kind: TypeMetadataKind.objectType,
+              },
+              {
+                kind: TypeMetadataKind.stringType,
+              },
+            ],
+            kind: TypeMetadataKind.or,
+          },
+        ],
+        kind: TypeMetadataKind.and,
+      },
+      {
+        children: [
+          {
+            child: {
+              kind: TypeMetadataKind.noneType,
+            },
+            kind: TypeMetadataKind.arrayType,
+          },
+          {
+            kind: TypeMetadataKind.booleanType,
+          },
+          {
+            kind: TypeMetadataKind.floatType,
+          },
+          {
+            kind: TypeMetadataKind.literalType,
+            literal: null,
+          },
+          {
+            kind: TypeMetadataKind.objectType,
+          },
+          {
+            kind: TypeMetadataKind.stringType,
+          },
+        ],
+        kind: TypeMetadataKind.or,
+      },
+    ],
+    [
+      'an and TypeMetadata with two or children and a propertyType child',
+      {
         children: [
           {
             children: [
@@ -1170,12 +1431,272 @@ describe(simplifyTypeMetadata, () => {
           {
             children: [
               {
-                kind: TypeMetadataKind.booleanType,
+                kind: TypeMetadataKind.stringType,
               },
               {
-                kind: TypeMetadataKind.integerType,
+                kind: TypeMetadataKind.literalType,
+                literal: null,
               },
             ],
+            kind: TypeMetadataKind.or,
+          },
+          {
+            child: {
+              kind: TypeMetadataKind.stringType,
+            },
+            isOptional: true,
+            kind: TypeMetadataKind.propertyType,
+            property: 'foo',
+          },
+        ],
+        kind: TypeMetadataKind.and,
+      },
+      {
+        children: [
+          {
+            kind: TypeMetadataKind.stringType,
+          },
+          {
+            child: {
+              kind: TypeMetadataKind.stringType,
+            },
+            isOptional: true,
+            kind: TypeMetadataKind.propertyType,
+            property: 'foo',
+          },
+        ],
+        kind: TypeMetadataKind.and,
+      },
+    ],
+    [
+      'an and TypeMetadata with two propertyType or children',
+      {
+        children: [
+          {
+            children: [
+              {
+                child: {
+                  kind: TypeMetadataKind.stringType,
+                },
+                isOptional: true,
+                kind: TypeMetadataKind.propertyType,
+                property: 'foo',
+              },
+              {
+                child: {
+                  kind: TypeMetadataKind.floatType,
+                },
+                isOptional: true,
+                kind: TypeMetadataKind.propertyType,
+                property: 'bar',
+              },
+            ],
+            kind: TypeMetadataKind.or,
+          },
+          {
+            children: [
+              {
+                child: {
+                  kind: TypeMetadataKind.booleanType,
+                },
+                isOptional: true,
+                kind: TypeMetadataKind.propertyType,
+                property: 'baz',
+              },
+              {
+                child: {
+                  kind: TypeMetadataKind.stringType,
+                },
+                isOptional: true,
+                kind: TypeMetadataKind.propertyType,
+                property: 'qux',
+              },
+            ],
+            kind: TypeMetadataKind.or,
+          },
+        ],
+        kind: TypeMetadataKind.and,
+      },
+      {
+        children: [
+          {
+            children: [
+              {
+                child: {
+                  kind: TypeMetadataKind.stringType,
+                },
+                isOptional: true,
+                kind: TypeMetadataKind.propertyType,
+                property: 'foo',
+              },
+              {
+                child: {
+                  kind: TypeMetadataKind.floatType,
+                },
+                isOptional: true,
+                kind: TypeMetadataKind.propertyType,
+                property: 'bar',
+              },
+            ],
+            kind: TypeMetadataKind.or,
+          },
+          {
+            children: [
+              {
+                child: {
+                  kind: TypeMetadataKind.booleanType,
+                },
+                isOptional: true,
+                kind: TypeMetadataKind.propertyType,
+                property: 'baz',
+              },
+              {
+                child: {
+                  kind: TypeMetadataKind.stringType,
+                },
+                isOptional: true,
+                kind: TypeMetadataKind.propertyType,
+                property: 'qux',
+              },
+            ],
+            kind: TypeMetadataKind.or,
+          },
+        ],
+        kind: TypeMetadataKind.and,
+      },
+    ],
+    [
+      'an and TypeMetadata with an instance-shaped or child and a propertyType or child',
+      {
+        children: [
+          {
+            children: [
+              {
+                kind: TypeMetadataKind.stringType,
+              },
+              {
+                kind: TypeMetadataKind.floatType,
+              },
+            ],
+            kind: TypeMetadataKind.or,
+          },
+          {
+            children: [
+              {
+                child: {
+                  kind: TypeMetadataKind.stringType,
+                },
+                isOptional: true,
+                kind: TypeMetadataKind.propertyType,
+                property: 'foo',
+              },
+              {
+                child: {
+                  kind: TypeMetadataKind.floatType,
+                },
+                isOptional: true,
+                kind: TypeMetadataKind.propertyType,
+                property: 'bar',
+              },
+            ],
+            kind: TypeMetadataKind.or,
+          },
+        ],
+        kind: TypeMetadataKind.and,
+      },
+      {
+        children: [
+          {
+            children: [
+              {
+                kind: TypeMetadataKind.stringType,
+              },
+              {
+                kind: TypeMetadataKind.floatType,
+              },
+            ],
+            kind: TypeMetadataKind.or,
+          },
+          {
+            children: [
+              {
+                child: {
+                  kind: TypeMetadataKind.stringType,
+                },
+                isOptional: true,
+                kind: TypeMetadataKind.propertyType,
+                property: 'foo',
+              },
+              {
+                child: {
+                  kind: TypeMetadataKind.floatType,
+                },
+                isOptional: true,
+                kind: TypeMetadataKind.propertyType,
+                property: 'bar',
+              },
+            ],
+            kind: TypeMetadataKind.or,
+          },
+        ],
+        kind: TypeMetadataKind.and,
+      },
+    ],
+    [
+      'an and TypeMetadata with a foldable or child and a named or child',
+      {
+        children: [
+          {
+            children: [
+              {
+                kind: TypeMetadataKind.stringType,
+              },
+              {
+                kind: TypeMetadataKind.floatType,
+              },
+            ],
+            kind: TypeMetadataKind.or,
+          },
+          {
+            children: [
+              {
+                kind: TypeMetadataKind.stringType,
+              },
+              {
+                kind: TypeMetadataKind.literalType,
+                literal: null,
+              },
+            ],
+            id: 'Foo',
+            kind: TypeMetadataKind.or,
+          },
+        ],
+        kind: TypeMetadataKind.and,
+      },
+      {
+        children: [
+          {
+            children: [
+              {
+                kind: TypeMetadataKind.stringType,
+              },
+              {
+                kind: TypeMetadataKind.floatType,
+              },
+            ],
+            kind: TypeMetadataKind.or,
+          },
+          {
+            children: [
+              {
+                kind: TypeMetadataKind.stringType,
+              },
+              {
+                kind: TypeMetadataKind.literalType,
+                literal: null,
+              },
+            ],
+            id: 'Foo',
             kind: TypeMetadataKind.or,
           },
         ],

--- a/packages/json-schema/libraries/json-schema-2-type-metadata/src/jsonSchema/202012/actions/simplifyTypeMetadata.ts
+++ b/packages/json-schema/libraries/json-schema-2-type-metadata/src/jsonSchema/202012/actions/simplifyTypeMetadata.ts
@@ -82,6 +82,89 @@ function distributeJsonSchemaInstanceTypeIntoOr(
   );
 }
 
+function canFoldJsonSchemaInstanceShapedOr(
+  typeMetadata: TypeMetadata,
+  ancestorTypeMetadataSet: Set<TypeMetadata>,
+): typeMetadata is OrTypeMetadata {
+  return (
+    canDistributeJsonSchemaInstanceTypeIntoOr(
+      typeMetadata,
+      ancestorTypeMetadataSet,
+    ) &&
+    typeMetadata.id === undefined &&
+    isJsonSchemaInstanceShapedType(typeMetadata)
+  );
+}
+
+function canJsonSchemaInstanceKindsMeet(
+  left: TypeMetadata,
+  right: TypeMetadata,
+): boolean {
+  const leftKind: TypeMetadataKind | undefined =
+    getJsonSchemaInstanceTypeKind(left);
+  const rightKind: TypeMetadataKind | undefined =
+    getJsonSchemaInstanceTypeKind(right);
+
+  if (leftKind === undefined || rightKind === undefined) {
+    return true;
+  }
+
+  if (leftKind === rightKind) {
+    return true;
+  }
+
+  return (
+    (leftKind === TypeMetadataKind.integerType &&
+      rightKind === TypeMetadataKind.floatType) ||
+    (leftKind === TypeMetadataKind.floatType &&
+      rightKind === TypeMetadataKind.integerType)
+  );
+}
+
+function cartesianJsonSchemaInstanceShapedOrs(
+  left: OrTypeMetadata,
+  right: OrTypeMetadata,
+  ancestorTypeMetadataSet: Set<TypeMetadata>,
+  simplifiedTypeMetadataSet: Set<TypeMetadata>,
+): TypeMetadata {
+  const children: TypeMetadata[] = [];
+
+  for (const leftBranch of left.children) {
+    for (const rightBranch of right.children) {
+      if (!canJsonSchemaInstanceKindsMeet(leftBranch, rightBranch)) {
+        continue;
+      }
+
+      const productTypeMetadata: AndTypeMetadata = {
+        children: [leftBranch, rightBranch],
+        kind: TypeMetadataKind.and,
+      };
+
+      const simplifiedProductTypeMetadata: TypeMetadata =
+        simplifyTypeMetadataRecursive(
+          productTypeMetadata,
+          ancestorTypeMetadataSet,
+          simplifiedTypeMetadataSet,
+        );
+
+      if (simplifiedProductTypeMetadata.kind !== TypeMetadataKind.noneType) {
+        children.push(simplifiedProductTypeMetadata);
+      }
+    }
+  }
+
+  const distributedOrTypeMetadata: OrTypeMetadata = {
+    children,
+    kind: TypeMetadataKind.or,
+  };
+
+  return simplifyTypeMetadataRecursive(
+    distributedOrTypeMetadata,
+    ancestorTypeMetadataSet,
+    simplifiedTypeMetadataSet,
+  );
+}
+
 function flattenSameKindChildren(
   typeMetadata: AndTypeMetadata | OrTypeMetadata,
   ancestorTypeMetadataSet: Set<TypeMetadata>,
@@ -104,6 +187,39 @@ function flattenSameKindChildren(
   typeMetadata.children = flattenedChildren;
 }
 
+function foldJsonSchemaInstanceShapedTerms(
+  terms: TypeMetadata[],
+  ancestorTypeMetadataSet: Set<TypeMetadata>,
+  simplifiedTypeMetadataSet: Set<TypeMetadata>,
+): TypeMetadata {
+  let foldedTypeMetadata: TypeMetadata = terms[0] as TypeMetadata;
+
+  for (let i: number = 1; i < terms.length; i++) {
+    foldedTypeMetadata = intersectJsonSchemaInstanceShapedTerms(
+      foldedTypeMetadata,
+      terms[i] as TypeMetadata,
+      ancestorTypeMetadataSet,
+      simplifiedTypeMetadataSet,
+    );
+
+    if (foldedTypeMetadata.kind === TypeMetadataKind.noneType) {
+      return foldedTypeMetadata;
+    }
+  }
+
+  return foldedTypeMetadata;
+}
+
+function getJsonSchemaInstanceTypeKind(
+  typeMetadata: TypeMetadata,
+): TypeMetadataKind | undefined {
+  if (isJsonSchemaInstanceType(typeMetadata)) {
+    return typeMetadata.kind;
+  }
+
+  return undefined;
+}
+
 function intersectAndTypes(
   typeMetadata: AndTypeMetadata,
   ancestorTypeMetadataSet: Set<TypeMetadata>,
@@ -120,6 +236,8 @@ function intersectAndTypes(
   }
 
   let mergedJsonSchemaInstanceType: TypeMetadata | undefined;
+  const foldableOrTypeMetadata: OrTypeMetadata[] = [];
+  const otherChildren: TypeMetadata[] = [];
 
   for (const child of typeMetadata.children) {
     if (isJsonSchemaInstanceType(child)) {
@@ -139,33 +257,79 @@ function intersectAndTypes(
           return;
         }
       }
+    } else if (
+      canFoldJsonSchemaInstanceShapedOr(child, ancestorTypeMetadataSet)
+    ) {
+      foldableOrTypeMetadata.push(child);
+    } else {
+      otherChildren.push(child);
     }
   }
 
-  if (mergedJsonSchemaInstanceType === undefined) {
+  if (
+    mergedJsonSchemaInstanceType === undefined &&
+    (foldableOrTypeMetadata.length === 0 || foldableOrTypeMetadata.length === 1)
+  ) {
     return;
   }
 
-  const hasOrChild: boolean = typeMetadata.children.some(
-    (child: TypeMetadata) =>
+  let foldedTypeMetadata: TypeMetadata;
+
+  if (
+    mergedJsonSchemaInstanceType !== undefined &&
+    foldableOrTypeMetadata.length === 0
+  ) {
+    foldedTypeMetadata = mergedJsonSchemaInstanceType;
+  } else {
+    const terms: TypeMetadata[] =
+      mergedJsonSchemaInstanceType === undefined
+        ? foldableOrTypeMetadata
+        : [mergedJsonSchemaInstanceType, ...foldableOrTypeMetadata];
+
+    foldedTypeMetadata = foldJsonSchemaInstanceShapedTerms(
+      terms,
+      ancestorTypeMetadataSet,
+      simplifiedTypeMetadataSet,
+    );
+
+    if (foldedTypeMetadata.kind === TypeMetadataKind.noneType) {
+      copyTypeMetadataOnto(typeMetadata, foldedTypeMetadata);
+
+      return;
+    }
+  }
+
+  const shouldDistributeFoldedInstanceTypeIntoOtherOrs: boolean =
+    isJsonSchemaInstanceType(foldedTypeMetadata) &&
+    otherChildren.some((child: TypeMetadata) =>
       canDistributeJsonSchemaInstanceTypeIntoOr(child, ancestorTypeMetadataSet),
+    );
+  const foldableOrTypeMetadataSet: Set<TypeMetadata> = new Set(
+    foldableOrTypeMetadata,
   );
 
   const nextChildren: TypeMetadata[] = [];
-  let insertedMergedJsonSchemaInstanceType: boolean = false;
+  let insertedFoldedTypeMetadata: boolean = false;
 
   for (const child of typeMetadata.children) {
-    if (isJsonSchemaInstanceType(child)) {
-      if (!hasOrChild && !insertedMergedJsonSchemaInstanceType) {
-        nextChildren.push(mergedJsonSchemaInstanceType);
-        insertedMergedJsonSchemaInstanceType = true;
+    if (
+      isJsonSchemaInstanceType(child) ||
+      foldableOrTypeMetadataSet.has(child)
+    ) {
+      if (
+        !shouldDistributeFoldedInstanceTypeIntoOtherOrs &&
+        !insertedFoldedTypeMetadata
+      ) {
+        nextChildren.push(foldedTypeMetadata);
+        insertedFoldedTypeMetadata = true;
       }
     } else if (
+      shouldDistributeFoldedInstanceTypeIntoOtherOrs &&
       canDistributeJsonSchemaInstanceTypeIntoOr(child, ancestorTypeMetadataSet)
     ) {
       nextChildren.push(
         distributeJsonSchemaInstanceTypeIntoOr(
-          mergedJsonSchemaInstanceType,
+          foldedTypeMetadata,
           child,
           ancestorTypeMetadataSet,
           simplifiedTypeMetadataSet,
@@ -177,6 +341,69 @@ function intersectAndTypes(
   }
 
   typeMetadata.children = nextChildren;
+}
+
+function intersectJsonSchemaInstanceShapedTerms(
+  left: TypeMetadata,
+  right: TypeMetadata,
+  ancestorTypeMetadataSet: Set<TypeMetadata>,
+  simplifiedTypeMetadataSet: Set<TypeMetadata>,
+): TypeMetadata {
+  if (
+    canFoldJsonSchemaInstanceShapedOr(left, ancestorTypeMetadataSet) &&
+    canFoldJsonSchemaInstanceShapedOr(right, ancestorTypeMetadataSet)
+  ) {
+    return cartesianJsonSchemaInstanceShapedOrs(
+      left,
+      right,
+      ancestorTypeMetadataSet,
+      simplifiedTypeMetadataSet,
+    );
+  }
+
+  if (
+    canFoldJsonSchemaInstanceShapedOr(left, ancestorTypeMetadataSet) &&
+    isJsonSchemaInstanceType(right)
+  ) {
+    return distributeJsonSchemaInstanceTypeIntoOr(
+      right,
+      left,
+      ancestorTypeMetadataSet,
+      simplifiedTypeMetadataSet,
+    );
+  }
+
+  if (
+    canFoldJsonSchemaInstanceShapedOr(right, ancestorTypeMetadataSet) &&
+    isJsonSchemaInstanceType(left)
+  ) {
+    return distributeJsonSchemaInstanceTypeIntoOr(
+      left,
+      right,
+      ancestorTypeMetadataSet,
+      simplifiedTypeMetadataSet,
+    );
+  }
+
+  if (isJsonSchemaInstanceType(left) && isJsonSchemaInstanceType(right)) {
+    return intersectJsonSchemaInstanceTypes(
+      left,
+      right,
+      ancestorTypeMetadataSet,
+      simplifiedTypeMetadataSet,
+    );
+  }
+
+  const fallbackTypeMetadata: AndTypeMetadata = {
+    children: [left, right],
+    kind: TypeMetadataKind.and,
+  };
+
+  return simplifyTypeMetadataRecursive(
+    fallbackTypeMetadata,
+    ancestorTypeMetadataSet,
+    simplifiedTypeMetadataSet,
+  );
 }
 
 function intersectAndPropertyTypes(
@@ -339,6 +566,32 @@ function canDistributeJsonSchemaInstanceTypeIntoOr(
     typeMetadata.kind === TypeMetadataKind.or &&
     !ancestorTypeMetadataSet.has(typeMetadata) &&
     !isTypeMetadataCyclic(typeMetadata)
+  );
+}
+
+function isJsonSchemaInstanceShapedType(
+  typeMetadata: TypeMetadata,
+  visitedTypeMetadataSet: Set<TypeMetadata> = new Set(),
+): boolean {
+  if (isJsonSchemaInstanceType(typeMetadata)) {
+    return true;
+  }
+
+  if (
+    typeMetadata.kind !== TypeMetadataKind.and &&
+    typeMetadata.kind !== TypeMetadataKind.or
+  ) {
+    return false;
+  }
+
+  if (visitedTypeMetadataSet.has(typeMetadata)) {
+    return false;
+  }
+
+  visitedTypeMetadataSet.add(typeMetadata);
+
+  return typeMetadata.children.every((child: TypeMetadata) =>
+    isJsonSchemaInstanceShapedType(child, visitedTypeMetadataSet),
   );
 }
 

--- a/packages/json-schema/libraries/json-schema-2-type-metadata/src/jsonSchema/202012/actions/transformJsonSchema.spec.ts
+++ b/packages/json-schema/libraries/json-schema-2-type-metadata/src/jsonSchema/202012/actions/transformJsonSchema.spec.ts
@@ -742,6 +742,30 @@ describe(transformJsonSchema, () => {
       },
     ],
     [
+      'an schema with type array or null and items',
+      {
+        items: {
+          type: 'string',
+        },
+        type: ['array', 'null'],
+      },
+      {
+        children: [
+          {
+            child: {
+              kind: TypeMetadataKind.stringType,
+            },
+            kind: TypeMetadataKind.arrayType,
+          },
+          {
+            kind: TypeMetadataKind.literalType,
+            literal: null,
+          },
+        ],
+        kind: TypeMetadataKind.or,
+      },
+    ],
+    [
       'an schema with a title, type array and items',
       {
         items: {

--- a/packages/json-schema/libraries/json-schema-2-typescript/src/jsonSchema/202012/actions/transformJsonSchemaToTypeScript.int.spec.ts
+++ b/packages/json-schema/libraries/json-schema-2-typescript/src/jsonSchema/202012/actions/transformJsonSchemaToTypeScript.int.spec.ts
@@ -185,7 +185,44 @@ describe(transformJsonSchemaToTypeScript, () => {
         },
         type: ['array', 'null'],
       },
-      'export type Root = (string[] | boolean | number | null | object | string) & (unknown[] | null);',
+      'export type Root = string[] | null;',
+    ],
+    [
+      'a titled nullable array schema with string items',
+      {
+        items: {
+          type: 'string',
+        },
+        title: 'Names',
+        type: ['array', 'null'],
+      },
+      'export type Names = string[] | null;',
+    ],
+    [
+      'an allOf items schema and a nullable array type',
+      {
+        allOf: [
+          {
+            items: {
+              type: 'string',
+            },
+          },
+          {
+            type: ['array', 'null'],
+          },
+        ],
+      },
+      'export type Root = string[] | null;',
+    ],
+    [
+      'a nullable array schema with union items',
+      {
+        items: {
+          type: ['string', 'number'],
+        },
+        type: ['array', 'null'],
+      },
+      'export type Root = (string | number)[] | null;',
     ],
     [
       'a titled array schema',
@@ -357,6 +394,20 @@ describe(transformJsonSchemaToTypeScript, () => {
         ],
       },
       'export type Root = { id?: never };',
+    ],
+    [
+      'an allOf schema of overlapping type unions',
+      {
+        allOf: [
+          {
+            type: ['string', 'number'],
+          },
+          {
+            type: ['number', 'boolean'],
+          },
+        ],
+      },
+      'export type Root = number;',
     ],
     [
       'an allOf schema including true',


### PR DESCRIPTION
### Changed
- Updated `simplifyTypeMetadata` to properly apply type cartesian distribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of combined schema conditions, including nullable arrays, nested unions, and intersecting type alternatives.
  * Correctly identifies incompatible type combinations as impossible.

* **Tests**
  * Added coverage for array-and-null schemas, overlapping unions, nested conditions, and preserved metadata cases.
  * Expanded validation of generated TypeScript types for nullable arrays and combined schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->