### PR TITLE
Mintlify docs - migrate version 6 modules

### DIFF
--- a/packages/docs-mintlify/docs.json
+++ b/packages/docs-mintlify/docs.json
@@ -56,7 +56,36 @@
               {
                 "group": "Introduction",
                 "pages": [
-                  "versioned_docs/version-6.x/introduction/getting-started"
+                  "versioned_docs/version-6.x/introduction/getting-started",
+                  "versioned_docs/version-6.x/introduction/dependency-inversion"
+                ]
+              },
+              {
+                "group": "Fundamentals",
+                "pages": [
+                  "versioned_docs/version-6.x/fundamentals/binding",
+                  "versioned_docs/version-6.x/fundamentals/di-hierarchy",
+                  {
+                    "group": "Lifecycle",
+                    "pages": [
+                      "versioned_docs/version-6.x/fundamentals/lifecycle/activation",
+                      "versioned_docs/version-6.x/fundamentals/lifecycle/deactivation",
+                      "versioned_docs/version-6.x/fundamentals/lifecycle/middleware"
+                    ]
+                  },
+                  "versioned_docs/version-6.x/fundamentals/inheritance",
+                  "versioned_docs/version-6.x/fundamentals/snapshot"
+                ]
+              },
+              {
+                "group": "API",
+                "pages": [
+                  "versioned_docs/version-6.x/api/binding-syntax",
+                  "versioned_docs/version-6.x/api/container",
+                  "versioned_docs/version-6.x/api/container-module",
+                  "versioned_docs/version-6.x/api/decorator",
+                  "versioned_docs/version-6.x/api/lazy-service-identifier",
+                  "versioned_docs/version-6.x/api/service-identifier"
                 ]
               }
             ]

--- a/packages/docs-mintlify/versioned_docs/version-6.x/api/binding-syntax.mdx
+++ b/packages/docs-mintlify/versioned_docs/version-6.x/api/binding-syntax.mdx
@@ -1,0 +1,371 @@
+---
+sidebar_position: 1
+title: Binding Syntax
+---
+
+import BindingOnSyntaxApiOnActivationSource from '../../../snippets/code-examples/examples/bindingOnSyntaxApiOnActivation.ts.md'
+import BindingToSyntaxApiToSource from '../../../snippets/code-examples/examples/bindingToSyntaxApiTo.ts.md'
+import BindingToSyntaxApiToAutoFactorySource from '../../../snippets/code-examples/examples/bindingToSyntaxApiToAutoFactory.ts.md'
+import BindingToSyntaxApiToAutoNamedFactorySource from '../../../snippets/code-examples/examples/bindingToSyntaxApiToAutoNamedFactory.ts.md'
+import BindingToSyntaxApiToConstantValueSource from '../../../snippets/code-examples/examples/bindingToSyntaxApiToConstantValue.ts.md'
+import BindingToSyntaxApiToConstructorSource from '../../../snippets/code-examples/examples/bindingToSyntaxApiToConstructor.ts.md'
+import BindingToSyntaxApiToDynamicValueSource from '../../../snippets/code-examples/examples/bindingToSyntaxApiToDynamicValue.ts.md'
+import BindingToSyntaxApiToFactorySource from '../../../snippets/code-examples/examples/bindingToSyntaxApiToFactory.ts.md'
+import BindingToSyntaxApiToProviderSource from '../../../snippets/code-examples/examples/bindingToSyntaxApiToProvider.ts.md'
+import BindingToSyntaxApiToSelfSource from '../../../snippets/code-examples/examples/bindingToSyntaxApiToSelf.ts.md'
+import BindingToSyntaxApiToServiceSource from '../../../snippets/code-examples/examples/bindingToSyntaxApiToService.ts.md'
+import BindingWhenSyntaxApiWhenSource from '../../../snippets/code-examples/examples/bindingWhenSyntaxApiWhen.ts.md'
+
+# Binding Syntax
+
+Binding syntax is provided as a fluent interface resulting from using the [container API](./container.mdx#bind) or the [container module API](./container-module.mdx#bind).
+
+## BindingToSyntax
+
+```ts
+interface BindingToSyntax<T> {
+  // ...
+}
+```
+
+Represents a service binding given a service identifier.
+
+```ts
+const bindingToSyntax = container.bind('service-id');
+```
+
+Further documentation refers to this service identifier as the "given service identifier".
+
+### to
+
+```ts
+to(constructor: interfaces.Newable<T>): interfaces.BindingInWhenOnSyntax<T>;
+```
+
+Binds a class instantiation to the given service binding. Whenever the service is resolved, the class constructor will be invoked to build the resolved value.
+
+<BindingToSyntaxApiToSource />
+
+### toSelf
+
+```ts
+toSelf(): interfaces.BindingInWhenOnSyntax<T>;
+```
+
+If the given service identifier is a class, establish a type binding to that class.
+
+<BindingToSyntaxApiToSelfSource />
+
+### toConstantValue
+
+```ts
+toConstantValue(value: T): interfaces.BindingWhenOnSyntax<T>;
+```
+
+Binds a value in singleton scope to the given service identifier.
+
+<BindingToSyntaxApiToConstantValueSource />
+
+### toDynamicValue
+
+```ts
+toDynamicValue(func: interfaces.DynamicValue<T>): interfaces.BindingInWhenOnSyntax<T>;
+```
+
+Binds a function to the given service id. Whenever the service is resolved, the function passed will be invoked to build the resolved value.
+
+<Info>
+
+Keep in mind a service is not resolved if it's cached in the current scope.
+
+</Info>
+
+<BindingToSyntaxApiToDynamicValueSource />
+
+### toConstructor
+
+```ts
+toConstructor<T2>(constructor: interfaces.Newable<T2>): interfaces.BindingWhenOnSyntax<T>;
+```
+
+Binds a class to the given service id. Whenever the service is resolved, the class constructor will be passed as the resolved value.
+
+<BindingToSyntaxApiToConstructorSource />
+
+### toFactory
+
+```ts
+toFactory<T2>(factory: interfaces.FactoryCreator<T2>): interfaces.BindingWhenOnSyntax<T>;
+```
+
+Binds a factory to the given service identifier. Whenever the service is resolved, the factory will be passed as the resolved value.
+
+<BindingToSyntaxApiToFactorySource />
+
+### toFunction
+
+```ts
+toFunction(func: T): interfaces.BindingWhenOnSyntax<T>;
+```
+
+An alias of `BindingToSyntax.toConstantValue` restricted to functions.
+
+### toAutoFactory
+
+```ts
+toAutoFactory<T2>(serviceIdentifier: interfaces.ServiceIdentifier<T2>): interfaces.BindingWhenOnSyntax<T>;
+```
+
+Binds a factory of services associated with a target service identifier to the given service identifier.
+
+<BindingToSyntaxApiToAutoFactorySource />
+
+### toAutoNamedFactory
+
+```ts
+toAutoNamedFactory<T2>(serviceIdentifier: interfaces.ServiceIdentifier<T2>): BindingWhenOnSyntax<T>;
+```
+
+Binds a factory of services associated with a target service identifier and a name to the given service identifier.
+
+<BindingToSyntaxApiToAutoNamedFactorySource />
+
+### toProvider
+
+```ts
+toProvider<T2>(provider: interfaces.ProviderCreator<T2>): interfaces.BindingWhenOnSyntax<T>;
+```
+
+Binds a provider of services associated with a target service identifier to the given service identifier. A provider is just an asynchronous factory.
+
+<BindingToSyntaxApiToProviderSource />
+
+### toService
+
+```ts
+toService(service: interfaces.ServiceIdentifier<T>): void;
+```
+
+Binds the services bound to a target service identifier to the given service identifier.
+
+<BindingToSyntaxApiToServiceSource />
+
+## BindingInSyntax
+
+```ts
+interface BindingInSyntax<T> {
+  // ...
+}
+```
+
+Represents a service binding given a service identifier and a service resolution such as a constructor, a factory, or a provider.
+
+### inSingletonScope
+
+```ts
+inSingletonScope(): BindingWhenOnSyntax<T>;
+```
+
+Sets the binding scope to singleton. Refer to the [docs](../fundamentals/binding.mdx#singleton) for more information.
+
+### inTransientScope
+
+```ts
+inTransientScope(): BindingWhenOnSyntax<T>;
+```
+
+Sets the binding scope to transient. Refer to the [docs](../fundamentals/binding.mdx#transient) for more information.
+
+### inRequestScope
+
+```ts
+inRequestScope(): BindingWhenOnSyntax<T>;
+```
+
+Sets the binding scope to request. Refer to the [docs](../fundamentals/binding.mdx#request) for more information.
+
+## BindingOnSyntax
+
+```ts
+interface BindingOnSyntax<T> {
+  // ...
+}
+```
+
+Allows setting binding activation and deactivation handlers.
+
+### onActivation
+
+```ts
+onActivation(fn: (context: Context, injectable: T) => T | Promise<T>): BindingWhenSyntax<T>;
+```
+
+Sets a binding activation handler. The activation handler is invoked after a dependency has been resolved and before it is added to a scope cache. The activation handler will not be invoked if the dependency is taken from a scope cache.
+
+<BindingOnSyntaxApiOnActivationSource />
+
+### onDeactivation
+
+```ts
+onDeactivation(fn: (injectable: T) => void | Promise<void>): BindingWhenSyntax<T>;
+```
+
+Sets a binding deactivation handler on a singleton scope binding. The deactivation handler is called when the binding is unbound from a container.
+
+<Warning>
+
+Only singleton scoped bindings can have deactivation handlers. If you try to add a deactivation handler to a non-singleton binding, an error will be thrown.
+
+</Warning>
+
+## BindingWhenSyntax
+
+```ts
+interface BindingWhenSyntax<T> {
+  // ...
+}
+```
+
+Allows setting binding constraints.
+
+### when
+
+Sets a constraint for the current binding.
+
+```ts
+when(constraint: (request: Request) => boolean): BindingOnSyntax<T>;
+```
+
+<BindingWhenSyntaxApiWhenSource />
+
+In the previous example, a custom constraint is implemented to use the binding if and only if the target name is a certain one.
+
+### whenTargetNamed
+
+Constrains the binding to be used if and only if the target name is a certain one.
+
+```ts
+whenTargetNamed(name: string | number | symbol): BindingOnSyntax<T>;
+```
+
+### whenTargetIsDefault
+
+```ts
+whenTargetIsDefault(): BindingOnSyntax<T>;
+```
+
+Constrains the binding to be used if and only if the target has no name nor tags.
+
+### whenTargetTagged
+
+```ts
+whenTargetTagged(tag: string | number | symbol, value: unknown): BindingOnSyntax<T>;
+```
+
+Constrains the binding to be used if and only if the target tag is a certain one.
+
+### whenInjectedInto
+
+```ts
+whenInjectedInto(parent: NewableFunction | string): BindingOnSyntax<T>;
+```
+
+Constrains the binding to be used if and only if the parent target service identifier is a certain one.
+
+### whenParentNamed
+
+```ts
+whenParentNamed(name: string | number | symbol): BindingOnSyntax<T>;
+```
+
+Constrains the binding to be used if and only if the parent target name is a certain one.
+
+### whenParentTagged
+
+```ts
+whenParentTagged(tag: string | number | symbol, value: unknown): BindingOnSyntax<T>;
+```
+
+Constrains the binding to be used if and only if the parent target tag is a certain one.
+
+### whenAnyAncestorIs
+
+```ts
+whenAnyAncestorIs(ancestor: NewableFunction | string): BindingOnSyntax<T>;
+```
+
+Constrains the binding to be used if and only if any ancestor target service identifier is a certain one.
+
+### whenNoAncestorIs
+
+```ts
+whenNoAncestorIs(ancestor: NewableFunction | string): BindingOnSyntax<T>;
+```
+
+Constrains the binding to be used if and only if no ancestor target service identifier is a certain one.
+
+### whenAnyAncestorNamed
+
+```ts
+whenAnyAncestorNamed(name: string | number | symbol): BindingOnSyntax<T>;
+```
+
+Constrains the binding to be used if and only if any ancestor target name is a certain one.
+
+### whenAnyAncestorTagged
+
+```ts
+whenAnyAncestorTagged(tag: string | number | symbol, value: unknown): BindingOnSyntax<T>;
+```
+
+Constrains the binding to be used if and only if any ancestor target tag is a certain one.
+
+### whenNoAncestorNamed
+
+```ts
+whenNoAncestorNamed(name: string | number | symbol): BindingOnSyntax<T>;
+```
+
+Constrains the binding to be used if and only if no ancestor target name is a certain one.
+
+### whenNoAncestorTagged
+
+```ts
+whenNoAncestorTagged(tag: string | number | symbol, value: unknown): BindingOnSyntax<T>;
+```
+
+Constrains the binding to be used if and only if no ancestor target tag is a certain one.
+
+### whenAnyAncestorMatches
+
+```ts
+whenAnyAncestorMatches(constraint: (request: Request) => boolean): BindingOnSyntax<T>;
+```
+
+Constrains the binding to be used if and only if any ancestor matches a certain constraint.
+
+### whenNoAncestorMatches
+
+```ts
+whenNoAncestorMatches(constraint: (request: Request) => boolean): BindingOnSyntax<T>;
+```
+
+Constrains the binding to be used if and only if no ancestor matches a certain constraint.
+
+## BindingWhenOnSyntax
+
+The union of [BindingWhenSyntax](#bindingwhensyntax) and [BindingOnSyntax](#bindingonsyntax).
+
+```ts
+export interface BindingWhenOnSyntax<T>
+  extends BindingWhenSyntax<T>, BindingOnSyntax<T> {}
+```
+
+## BindingInWhenOnSyntax
+
+The union of [BindingInSyntax](#bindinginsyntax) and [BindingWhenOnSyntax](#bindingwhenonsyntax).
+
+```ts
+export interface BindingInWhenOnSyntax<T>
+  extends BindingInSyntax<T>, BindingWhenOnSyntax<T> {}
+```

--- a/packages/docs-mintlify/versioned_docs/version-6.x/api/container-module.mdx
+++ b/packages/docs-mintlify/versioned_docs/version-6.x/api/container-module.mdx
@@ -1,0 +1,82 @@
+---
+sidebar_position: 3
+title: Container Module
+---
+
+import ContainerModuleApiExampleSource from '../../../snippets/code-examples/examples/containerModuleApiExample.ts.md'
+
+# ContainerModule
+
+Container modules help manage the complexity of bindings in large applications.
+
+## Constructor
+
+```ts
+constructor(registry: interfaces.ContainerModuleCallBack)
+```
+
+The constructor argument for `ContainerModule` is a registration callback with function parameters to manage bindings within the scope of the container module.
+
+### bind
+
+```ts
+bind: interfaces.Bind;
+```
+
+Refer to the [docs](./container.mdx#bind) for more information.
+
+### unbind
+
+```
+unbind: interfaces.Unbind
+```
+
+Refer to the [docs](./container.mdx#unbind) for more information.
+
+### isBound
+
+```ts
+isBound: interfaces.IsBound;
+```
+
+Refer to the [docs](./container.mdx#isbound) for more information.
+
+### rebind
+
+```ts
+rebind: interfaces.Rebind;
+```
+
+Refer to the [docs](./container.mdx#rebind) for more information.
+
+### unbindAsync
+
+```ts
+unbindAsync: interfaces.UnbindAsync;
+```
+
+Refer to the [docs](./container.mdx#unbindasync) for more information.
+
+### onActivation
+
+```ts
+onActivation: interfaces.Container['onActivation'];
+```
+
+Refer to the [docs](./container.mdx#onactivation) for more information.
+
+### onDeactivation
+
+```ts
+onDeactivation: interfaces.Container['onDeactivation'];
+```
+
+Refer to the [docs](./container.mdx#ondeactivation) for more information.
+
+## Example: binding services through ContainerModule API
+
+When a container module is loaded into a Container, the registration callback is invoked. This is the opportunity for the container module to register bindings and handlers. Use the Container `load` method for `ContainerModule` instances and the Container `loadAsync` method for `AsyncContainerModule` instances.
+
+When a container module is unloaded from a Container, the bindings added by that container will be removed, and the [deactivation process](../fundamentals/lifecycle/deactivation.mdx) will occur for each of them. Container deactivation and [activation handlers](../fundamentals/lifecycle/activation.mdx) will also be removed. Use the `unloadAsync` method to unload when there will be an async deactivation handler or async [preDestroy](./decorator.mdx#predestroy).
+
+<ContainerModuleApiExampleSource />

--- a/packages/docs-mintlify/versioned_docs/version-6.x/api/container.mdx
+++ b/packages/docs-mintlify/versioned_docs/version-6.x/api/container.mdx
@@ -1,0 +1,534 @@
+---
+sidebar_position: 2
+title: Container
+---
+
+import ContainerApiGetAllSource from '../../../snippets/code-examples/examples/containerApiGetAll.ts.md'
+import ContainerApiGetAllAsyncSource from '../../../snippets/code-examples/examples/containerApiGetAllAsync.ts.md'
+import ContainerApiGetAllAsyncEnforcedSource from '../../../snippets/code-examples/examples/containerApiGetAllAsyncEnforced.ts.md'
+import ContainerApiGetAllEnforcedSource from '../../../snippets/code-examples/examples/containerApiGetAllEnforced.ts.md'
+import ContainerApiGetAllNamedSource from '../../../snippets/code-examples/examples/containerApiGetAllNamed.ts.md'
+import ContainerApiGetAllNamedAsyncSource from '../../../snippets/code-examples/examples/containerApiGetAllNamedAsync.ts.md'
+import ContainerApiGetAllTaggedSource from '../../../snippets/code-examples/examples/containerApiGetAllTagged.ts.md'
+import ContainerApiGetAllTaggedAsyncSource from '../../../snippets/code-examples/examples/containerApiGetAllTaggedAsync.ts.md'
+import ContainerApiGetAsyncSource from '../../../snippets/code-examples/examples/containerApiGetAsync.ts.md'
+import ContainerApiGetNamedAsyncSource from '../../../snippets/code-examples/examples/containerApiGetNamedAsync.ts.md'
+import ContainerApiGetNamedSource from '../../../snippets/code-examples/examples/containerApiGetNamed.ts.md'
+import ContainerApiGetSource from '../../../snippets/code-examples/examples/containerApiGet.ts.md'
+import ContainerApiGetTaggedAsyncSource from '../../../snippets/code-examples/examples/containerApiGetTaggedAsync.ts.md'
+import ContainerApiGetTaggedSource from '../../../snippets/code-examples/examples/containerApiGetTagged.ts.md'
+import ContainerApiIsBoundSource from '../../../snippets/code-examples/examples/containerApiIsBound.ts.md'
+import ContainerApiIsBoundNamedSource from '../../../snippets/code-examples/examples/containerApiIsBoundNamed.ts.md'
+import ContainerApiIsBoundTaggedSource from '../../../snippets/code-examples/examples/containerApiIsBoundTagged.ts.md'
+import ContainerApiIsCurrentBoundSource from '../../../snippets/code-examples/examples/containerApiIsCurrentBound.ts.md'
+import ContainerApiMergeSource from '../../../snippets/code-examples/examples/containerApiMerge.ts.md'
+import ContainerApiOptionsAutoBindInjectablePrecedenceSource from '../../../snippets/code-examples/examples/containerApiOptionsAutoBindInjectablePrecedence.ts.md'
+import ContainerApiOptionsAutoBindInjectableSource from '../../../snippets/code-examples/examples/containerApiOptionsAutoBindInjectable.ts.md'
+import ContainerApiOptionsDefaultScopeSource from '../../../snippets/code-examples/examples/containerApiOptionsDefaultScope.ts.md'
+import ContainerApiOnActivationSource from '../../../snippets/code-examples/examples/containerApiOnActivation.ts.md'
+import ContainerApiOnDeactivationSource from '../../../snippets/code-examples/examples/containerApiOnDeactivation.ts.md'
+import ContainerApiRebindSource from '../../../snippets/code-examples/examples/containerApiRebind.ts.md'
+import ContainerApiResolveSource from '../../../snippets/code-examples/examples/containerApiResolve.ts.md'
+
+# Container
+
+The InversifyJS container is where dependencies are first configured through binding and, possibly later, reconfigured and removed. The container can be worked on directly in this regard or container modules can be utilized.
+You can query the configuration and resolve configured dependencies with the `get` methods.
+You can react to resolutions with container activation handlers and unbinding with container deactivation handlers.
+You can create container hierarchies where container ascendants can supply the dependencies for descendants.
+For testing, state can be saved as a snapshot on a stack and later restored.
+For advanced control, you can apply middleware to intercept the resolution request and the resolved dependency.
+You can even provide your own annotation solution.
+
+## Container Options
+
+Container options can be passed to the Container constructor, and defaults will be provided if you do not or if you do but omit an option.
+Options can be changed after construction and will be shared by child containers created from the Container if you do not provide options for them.
+
+### defaultScope
+
+The default scope is `transient` when binding to/toSelf/toDynamicValue/toService.
+Other bindings can only be bound in `singleton` scope.
+
+You can use container options to change the default scope for the bindings that default to `transient` at the application level:
+
+<ContainerApiOptionsDefaultScopeSource />
+
+### autoBindInjectable
+
+You can use this to activate automatic binding for `@injectable()` decorated classes.
+Whenever an instance is requested via `get`, the container attempts to add a binding if no binding is found for the requested service.
+
+<ContainerApiOptionsAutoBindInjectableSource />
+
+Manually defined bindings will take precedence:
+
+<ContainerApiOptionsAutoBindInjectablePrecedenceSource />
+
+### skipBaseClassChecks
+
+You can use this to skip checking base classes for the `@injectable` property, which is especially useful if any of your `@injectable` classes extend classes that you don't control (third-party classes). By default, this value is `false`.
+
+```ts
+const container = new Container({ skipBaseClassChecks: true });
+```
+
+## Container.merge
+
+```ts
+Container.merge(a: interfaces.Container, b: interfaces.Container, ...containers: interfaces.Container[]): interfaces.Container;
+```
+
+Creates a new Container containing the bindings ( cloned bindings ) of two or more containers:
+
+<ContainerApiMergeSource />
+
+## applyCustomMetadataReader
+
+```ts
+applyCustomMetadataReader(metadataReader: interfaces.MetadataReader): void;
+```
+
+Sets a custom metadata reader. See [middleware](../fundamentals/lifecycle/middleware.mdx).
+
+## applyMiddleware
+
+```ts
+applyMiddleware(...middleware: interfaces.Middleware[]): void;
+```
+
+An advanced feature that can be used for cross cutting concerns. See [middleware](../fundamentals/lifecycle/middleware.mdx).
+
+## bind
+
+```ts
+bind<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>): interfaces.BindingToSyntax<T>
+```
+
+Sets a new binding.
+
+<Info>
+
+Unless specified otherwise, binding scopes are [transient](fundamentals/binding.mdx#transient) by default.
+
+</Info>
+
+## createChild
+
+```ts
+createChild(containerOptions?: interfaces.ContainerOptions): Container;
+```
+
+Create a [container hierarchy](../fundamentals/di-hierarchy.mdx). Parent `ContainerOptions` are provided by default.
+
+## get
+
+```ts
+get<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>): T;
+```
+
+Resolves a dependency by its runtime identifier. The runtime identifier must be associated with only one binding and the binding must be synchronously resolved, otherwise an error is thrown.
+
+<ContainerApiGetSource />
+
+## getAsync
+
+```ts
+getAsync<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>): Promise<T>;
+```
+
+Resolves a dependency by its runtime identifier. The runtime identifier must be associated with only one binding, otherwise an error is thrown.
+
+<ContainerApiGetAsyncSource />
+
+## getNamed
+
+```ts
+getNamed<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, named: string | number | symbol): T;
+```
+
+Resolves a dependency by its runtime identifier that matches the given named constraint. The runtime identifier must be associated with only one binding and the binding must be synchronously resolved, otherwise an error is thrown:
+
+<ContainerApiGetNamedSource />
+
+## getNamedAsync
+
+```ts
+getNamedAsync<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, named: string | number | symbol): Promise<T>;
+```
+
+Resolves a dependency by its runtime identifier that matches the given named constraint. The runtime identifier must be associated with only one binding, otherwise an error is thrown:
+
+<ContainerApiGetNamedAsyncSource />
+
+## getTagged
+
+```ts
+getTagged<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, key: string | number | symbol, value: unknown): T;
+```
+
+Resolves a dependency by its runtime identifier that matches the given tagged constraint. The runtime identifier must be associated with only one binding and the binding must be synchronously resolved, otherwise an error is thrown:
+
+<ContainerApiGetTaggedSource />
+
+## getTaggedAsync
+
+```ts
+getTaggedAsync<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, key: string | number | symbol, value: unknown): Promise<T>;
+```
+
+Resolves a dependency by its runtime identifier that matches the given tagged constraint. The runtime identifier must be associated with only one binding, otherwise an error is thrown:
+
+<ContainerApiGetTaggedAsyncSource />
+
+## getAll
+
+```ts
+getAll(serviceIdentifier: interfaces.ServiceIdentifier<T>, options?: interfaces.GetAllOptions): T[];
+```
+
+Get all available bindings for a given identifier. All the bindings must be synchronously resolved, otherwise an error is thrown:
+
+<ContainerApiGetAllSource />
+
+Keep in mind `container.getAll` doesn't enforce binding contraints by default in the root level, enable the `enforceBindingConstraints` flag to force this binding constraint check:
+
+<ContainerApiGetAllEnforcedSource />
+
+## getAllAsync
+
+```ts
+getAllAsync<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, options?: interfaces.GetAllOptions): Promise<T[]>
+```
+
+Get all available bindings for a given identifier:
+
+<ContainerApiGetAllAsyncSource />
+
+Keep in mind `container.getAll` doesn't enforce binding contraints by default in the root level, enable the `enforceBindingConstraints` flag to force this binding constraint check:
+
+<ContainerApiGetAllAsyncEnforcedSource />
+
+## getAllNamed
+
+```ts
+getAllNamed<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, named: string | number | symbol): T[];
+```
+
+Resolves all the dependencies by its runtime identifier that matches the given named constraint. All the binding must be synchronously resolved, otherwise an error is thrown:
+
+<ContainerApiGetAllNamedSource />
+
+## getAllNamedAsync
+
+```ts
+getAllNamedAsync<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, named: string | number | symbol): Promise<T[]>;
+```
+
+Resolves all the dependencies by its runtime identifier that matches the given named constraint:
+
+<ContainerApiGetAllNamedAsyncSource />
+
+## getAllTagged
+
+```ts
+getAllTagged<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, key: string | number | symbol, value: unknown): T[];
+```
+
+Resolves all the dependencies by its runtime identifier that matches the given tagged constraint. All the binding must be synchronously resolved, otherwise an error is thrown:
+
+<ContainerApiGetAllTaggedSource />
+
+## getAllTaggedAsync
+
+```ts
+getAllTaggedAsync<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, key: string | number | symbol, value: unknown): Promise<T[]>;
+```
+
+Resolves all the dependencies by its runtime identifier that matches the given tagged constraint:
+
+<ContainerApiGetAllTaggedAsyncSource />
+
+## isBound
+
+```ts
+isBound(serviceIdentifier: interfaces.ServiceIdentifier<unknown>): boolean;
+```
+
+You can use the `isBound` method to check if there are registered bindings for a given service identifier.
+
+<ContainerApiIsBoundSource />
+
+## isCurrentBound
+
+```ts
+isCurrentBound(serviceIdentifier: interfaces.ServiceIdentifier<unknown>): boolean;
+```
+
+You can use the `isCurrentBound` method to check if there are registered bindings for a given service identifier only in the current container.
+
+<ContainerApiIsCurrentBoundSource />
+
+## isBoundNamed
+
+```ts
+isBoundNamed(serviceIdentifier: interfaces.ServiceIdentifier<unknown>, named: string): boolean;
+```
+
+You can use the `isBoundNamed` method to check if there are registered bindings for a given service identifier with a given named constraint.
+
+<ContainerApiIsBoundNamedSource />
+
+## isBoundTagged
+
+```ts
+isBoundTagged(serviceIdentifier: interfaces.ServiceIdentifier<unknown>, key: string, value: unknown): boolean;
+```
+
+You can use the `isBoundTagged` method to check if there are registered bindings for a given service identifier with a given tagged constraint.
+
+<ContainerApiIsBoundTaggedSource />
+
+## load
+
+```ts
+load(...modules: interfaces.ContainerModule[]): void;
+```
+
+Calls the registration method of each module. See [ContainerModule API docs](./container-module.mdx)
+
+## loadAsync
+
+```ts
+loadAsync(...modules: interfaces.AsyncContainerModule[]): Promise<void>;
+```
+
+As per load but for asynchronous registration.
+
+## rebind
+
+```ts
+rebind<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>): interfaces.BindingToSyntax<T>;
+```
+
+Replaces all the existing bindings for a given `serviceIdentifier`.
+The function returns an instance of `BindingToSyntax` which allows to create the replacement binding.
+
+<ContainerApiRebindSource />
+
+## rebindAsync
+
+```ts
+rebindAsync<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>): Promise<interfaces.BindingToSyntax<T>>;
+```
+
+This is an asynchronous version of rebind. If you know deactivation is asynchronous then this should be used.
+
+## resolve
+
+```ts
+resolve<T>(constructor: interfaces.Newable<T>): T;
+```
+
+Resolve works the same way `container.get`, but an automatic binding will be added to the container if no bindings are found for the type provided.
+
+<ContainerApiResolveSource />
+
+Please note that it only allows to skip declaring a binding for the root element in the dependency graph (composition root). All the sub-dependencies (e.g. `Katana` in the preceding example) will require a binding to be declared.
+
+## onActivation
+
+```ts
+onActivation<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, onActivation: interfaces.BindingActivation<T>): void;
+```
+
+Adds an activation handler for all services associated to the service identifier.
+
+<ContainerApiOnActivationSource />
+
+## onDeactivation
+
+```ts
+onDeactivation<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, onDeactivation: interfaces.BindingDeactivation<T>): void;
+```
+
+Adds a deactivation handler for a service identifier.
+
+<ContainerApiOnDeactivationSource />
+
+## restore
+
+```ts
+restore(): void;
+```
+
+Restore container state to last snapshot. Refer to the [docs](../fundamentals/snapshot.mdx) for more information.
+
+## snapshot
+
+```ts
+snapshot(): void;
+```
+
+Save the state of the container to be later restored with the restore method. Refer to the [docs](../fundamentals/snapshot.mdx) for more information.
+
+## tryGet
+
+```ts
+tryGet<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>): T | undefined;
+```
+
+Same as `container.get`, but returns `undefined` in the event no bindings are bound to `serviceIdentifier`.
+
+## tryGetAsync
+
+```ts
+tryGetAsync<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>): Promise<T | undefined>;
+```
+
+Same as `container.getAsync`, but returns `Promise<undefined>` in the event no bindings are bound to `serviceIdentifier`.
+
+## tryGetNamed
+
+```ts
+tryGetNamed<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, named: string | number | symbol): T | undefined;
+```
+
+Same as `container.getNamed`, but returns `undefined` in the event no bindings are bound to `serviceIdentifier`.
+
+## tryGetNamedAsync
+
+```ts
+tryGetNamedAsync<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, named: string | number | symbol): Promise<T | undefined>;
+```
+
+Same as `container.getNamedAsync`, but returns `Promise<undefined>` in the event no bindings are bound to `serviceIdentifier`.
+
+## tryGetTagged
+
+```ts
+tryGetTagged<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, key: string | number | symbol, value: unknown): T | undefined;
+```
+
+Same as `container.getTagged`, but returns `undefined` in the event no bindings are bound to `serviceIdentifier`.
+
+## tryGetTaggedAsync
+
+```ts
+tryGetTaggedAsync<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, key: string | number | symbol, value: unknown): Promise<T | undefined>
+```
+
+Same as `container.getTaggedAsync`, but returns `Promise<undefined>` in the event no bindings are bound to `serviceIdentifier`.
+
+## tryGetAll
+
+```ts
+tryGetAll<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, options?: interfaces.GetAllOptions): T[]
+```
+
+Same as `container.getAll`, but returns `[]` in the event no bindings are bound to `serviceIdentifier`.
+
+## tryGetAllAsync
+
+```ts
+tryGetAllAsync<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, options?: interfaces.GetAllOptions): Promise<T[]>;
+```
+
+Same as `container.getAllAsync`, but returns `Promise<[]>` in the event no bindings are bound to `serviceIdentifier`.
+
+## tryGetAllNamed
+
+```ts
+tryGetAllNamed<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, named: string | number | symbol): T[];
+```
+
+Same as `container.getAllNamed`, but returns `[]` in the event no bindings are bound to `serviceIdentifier`.
+
+## tryGetAllNamedAsync
+
+```ts
+tryGetAllNamedAsync<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, named: string | number | symbol): Promise<T[]>;
+```
+
+Same as `container.getAllNamedAsync`, but returns `Promise<[]>` in the event no bindings are bound to `serviceIdentifier`.
+
+## tryGetAllTagged
+
+```ts
+tryGetAllTagged<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, key: string | number | symbol, value: unknown): T[];
+```
+
+Same as `container.getAllTagged`, but returns `[]` in the event no bindings are bound to `serviceIdentifier`.
+
+## tryGetAllTaggedAsync
+
+```ts
+tryGetAllTaggedAsync<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, key: string | number | symbol, value: unknown): Promise<T[]>;
+```
+
+Same as `container.getAllTaggedAsync`, but returns `Promise<[]>` in the event no bindings are bound to `serviceIdentifier`.
+
+## unbind
+
+```ts
+unbind(serviceIdentifier: interfaces.ServiceIdentifier): void;
+```
+
+Remove all bindings binded in this container to the service identifier. This will result in the [deactivation process](../fundamentals/lifecycle/deactivation.mdx).
+
+## unbindAsync
+
+```ts
+unbindAsync(serviceIdentifier: interfaces.ServiceIdentifier<unknown>): Promise<void>;
+```
+
+This is the asynchronous version of unbind. If any deactivation realated to this service identifier is asynchronous then this method should be used instead of `container.unbind`.
+
+## unbindAll
+
+```ts
+unbindAll(): void;
+```
+
+Remove all bindings binded in this container. This will result in the [deactivation process](../fundamentals/lifecycle/deactivation.mdx).
+
+## unbindAllAsync
+
+```ts
+unbindAllAsync(): Promise<void>;
+```
+
+This is the asynchronous version of unbindAll. If any of the container's deactivations is asynchronous then this method should be used instead of `container.unbindAll`.
+
+## unload
+
+```ts
+unload(...modules: interfaces.ContainerModuleBase[]): void;
+```
+
+Removes bindings and handlers added by the modules. This will result in the [deactivation process](../fundamentals/lifecycle/deactivation.mdx).
+See [ContainerModule API docs](./container-module.mdx).
+
+## unloadAsync
+
+```ts
+unloadAsync(...modules: interfaces.ContainerModuleBase[]): Promise<void>;
+```
+
+Asynchronous version of unload. If any of the container modules's deactivations is asynchronous then this method should be used instead of `container.unload`.
+
+## parent
+
+```ts
+parent: Container | null;
+```
+
+Access the parent container.
+
+## id
+
+```ts
+id: number;
+```
+
+The container's unique identifier.

--- a/packages/docs-mintlify/versioned_docs/version-6.x/api/decorator.mdx
+++ b/packages/docs-mintlify/versioned_docs/version-6.x/api/decorator.mdx
@@ -1,0 +1,175 @@
+---
+sidebar_position: 4
+title: Decorator
+---
+
+import DecoratorApiInjectConstructorArgumentSource from '../../../snippets/code-examples/examples/decoratorApiInjectConstructorArgument.ts.md'
+import DecoratorApiInjectPropertySource from '../../../snippets/code-examples/examples/decoratorApiInjectProperty.ts.md'
+import DecoratorApiMultiInjectPropertySource from '../../../snippets/code-examples/examples/decoratorApiMultiInjectProperty.ts.md'
+import DecoratorApiNamedSource from '../../../snippets/code-examples/examples/decoratorApiNamed.ts.md'
+import DecoratorApiOptionalSource from '../../../snippets/code-examples/examples/decoratorApiOptional.ts.md'
+import DecoratorApiPostConstructSource from '../../../snippets/code-examples/examples/decoratorApiPostConstruct.ts.md'
+import DecoratorApiPreDestroySource from '../../../snippets/code-examples/examples/decoratorApiPreDestroy.ts.md'
+import DecoratorApiTaggedSource from '../../../snippets/code-examples/examples/decoratorApiTagged.ts.md'
+import DecoratorApiUnmanagedSource from '../../../snippets/code-examples/examples/decoratorApiUnmanaged.ts.md'
+
+# Decorators
+
+This section covers Inversify decorators used to provide class metadata.
+
+## injectable
+
+Decorator used to set class metadata so containers can receive class-emitted metadata.
+
+It's highly recommended to annotate every class provided as a service with the `@injectable` decorator. However, it's not mandatory in every single case.
+
+### When is injectable mandatory?
+
+Whenever class-emitted metadata is expected.
+
+Consider the following sample code:
+
+```ts
+import 'reflect-metadata/lite';
+import { injectable } from 'inversify';
+
+@injectable()
+class B {
+  readonly foo: string = 'foo';
+}
+
+@injectable()
+class A {
+  constructor(public readonly b: B) {}
+}
+```
+
+A CommonJS transpilation with the [emitDecoratorMetadata](https://www.typescriptlang.org/tsconfig/#emitDecoratorMetadata) option enabled might look like this:
+
+```js
+Object.defineProperty(exports, '__esModule', { value: true });
+require('reflect-metadata');
+const inversify_1 = require('inversify');
+let B = class B {
+  foo = 'foo';
+};
+B = __decorate([(0, inversify_1.injectable)()], B);
+let A = class A {
+  b;
+  constructor(b) {
+    this.b = b;
+  }
+};
+A = __decorate(
+  [(0, inversify_1.injectable)(), __metadata('design:paramtypes', [B])],
+  A,
+);
+```
+
+TypeScript emits class metadata if and only if there are any class decorators applied to the target class. If we remove the `@injectable` from `A`, the transpiled code looks very different:
+
+```js
+Object.defineProperty(exports, '__esModule', { value: true });
+require('reflect-metadata');
+class B {
+  foo = 'foo';
+}
+class A {
+  b;
+  constructor(b) {
+    this.b = b;
+  }
+}
+```
+
+This time, no class metadata is emitted even if the `emitDecoratorMetadata` TypeScript option is enabled, causing trouble at execution time.
+
+## inject
+
+Decorator used to establish a relation between a constructor argument or a class property and a service ID.
+
+When resolving an instance of the class, the target constructor argument or property will be resolved in the same way [container.get](./container.mdx#get) behaves.
+
+### Example: decorating a class constructor argument
+
+<DecoratorApiInjectConstructorArgumentSource />
+
+### Example: decorating a property
+
+<DecoratorApiInjectPropertySource />
+
+## multiInject
+
+Decorator used to establish a relation between a constructor argument or a class property and a service ID.
+
+When resolving an instance of the class, the target constructor argument or property will be resolved in the same way [container.getAll](./container.mdx#getall) behaves with the `enforceBindingConstraints` flag enabled.
+
+### Example: decorating a property
+
+<DecoratorApiMultiInjectPropertySource />
+
+## named
+
+Decorator used to establish a relation between a constructor argument or a class property and a metadata name.
+
+<DecoratorApiNamedSource />
+
+## optional
+
+Decorator used to establish that a target constructor argument or property is optional and, therefore, it shall not be resolved if no bindings are found for the associated service ID.
+
+<DecoratorApiOptionalSource />
+
+## postConstruct
+
+Decorator used to establish an activation handler for the target class. Refer to the [docs](../fundamentals/lifecycle/activation.mdx) for more information.
+
+<DecoratorApiPostConstructSource />
+
+## preDestroy
+
+Decorator used to establish a deactivation handler for the target class. Refer to the [docs](../fundamentals/lifecycle/deactivation.mdx) for more information.
+
+<DecoratorApiPreDestroySource />
+
+## tagged
+
+Decorator used to establish a relation between a constructor argument or a class property and a metadata tag.
+
+<DecoratorApiTaggedSource />
+
+## targetName
+
+Decorator used to establish a relation between a constructor argument or a class property name at design time.
+
+Bundlers might minify code, altering class property names. This decorator keeps track of the original name.
+
+This property is kept in the `name` property of the `target` request in a binding constraint.
+
+```ts
+@injectable()
+class Ninja implements Ninja {
+  public katana: Weapon;
+  public shuriken: Weapon;
+  constructor(
+    @inject('Weapon') @targetName('katana') katana: Weapon,
+    @inject('Weapon') @targetName('shuriken') shuriken: Weapon,
+  ) {
+    this.katana = katana;
+    this.shuriken = shuriken;
+  }
+}
+
+container
+  .bind<Weapon>('Weapon')
+  .to(Katana)
+  .when((request: interfaces.Request) => {
+    return request.target.name.equals('katana');
+  });
+```
+
+## unmanaged
+
+Decorator used to establish that Inversify should not inject the target constructor argument or property whatsoever.
+
+<DecoratorApiUnmanagedSource />

--- a/packages/docs-mintlify/versioned_docs/version-6.x/api/lazy-service-identifier.mdx
+++ b/packages/docs-mintlify/versioned_docs/version-6.x/api/lazy-service-identifier.mdx
@@ -1,0 +1,62 @@
+---
+sidebar_position: 5
+title: LazyServiceIdentifier
+---
+
+import LazyServiceIdentifierSource from '../../../snippets/code-examples/examples/v6/lazyServiceIdentifier.ts.md'
+
+# LazyServiceIdentifier
+
+## Overview
+
+The `LazyServiceIdentifier` class is a utility that delays the resolution of service identifiers until they're actually needed during dependency injection. Its primary purpose is to prevent accessing class service identifiers before they're fully initialized.
+
+## Problem: Accessing Class Service Identifiers Prematurely
+
+In TypeScript/JavaScript applications, when you directly reference a class as a service identifier before the class is fully defined, you might encounter initialization issues:
+
+```typescript
+// ServiceModule.ts
+import { injectable, inject } from 'inversify';
+
+@injectable()
+export class Service {
+  // Potential issue - Service class used before fully defined
+  constructor(@inject(AnotherService) private dependency: AnotherService) {}
+}
+
+class AnotherService {
+  // Implementation
+}
+```
+
+This can lead to several issues:
+
+1. TypeScript errors about using variables before they're declared
+2. Runtime errors as the class might not be fully initialized when used as a service identifier
+
+## Solution: LazyServiceIdentifier
+
+`LazyServiceIdentifier` solves this problem by deferring the service identifier resolution until the injection process actually requires it:
+
+<LazyServiceIdentifierSource />
+
+## API Reference
+
+### Constructor
+
+```typescript
+constructor(buildServiceId: () => ServiceIdentifier<TInstance>)
+```
+
+- `buildServiceId`: A function that returns a `ServiceIdentifier`. This function is called only when the service identifier is actually needed.
+
+### Methods
+
+#### unwrap(): ServiceIdentifier\<TInstance>
+
+Returns the resolved service identifier by calling the function provided in the constructor.
+
+#### static is\<TInstance>(value: unknown): value is LazyServiceIdentifier\<TInstance>
+
+Checks if a value is an instance of `LazyServiceIdentifier`.

--- a/packages/docs-mintlify/versioned_docs/version-6.x/api/service-identifier.mdx
+++ b/packages/docs-mintlify/versioned_docs/version-6.x/api/service-identifier.mdx
@@ -1,0 +1,58 @@
+---
+sidebar_position: 6
+title: ServiceIdentifier
+---
+
+import ServiceIdentifierApiSource from '../../../snippets/code-examples/examples/v6/serviceIdentifierApi.ts.md'
+
+# ServiceIdentifier
+
+## Overview
+
+`ServiceIdentifier` is a fundamental type that identifies services within the InversifyJS dependency injection container. It serves as a key for registering, locating, and retrieving services, acting as a bridge between service registration and resolution.
+
+## Definition
+
+`ServiceIdentifier` is a union type that can be one of:
+
+```typescript
+type ServiceIdentifier<TInstance = unknown> =
+  string | symbol | Newable<TInstance> | AbstractNewable<TInstance>;
+```
+
+Where `Newable` is defined as:
+
+```typescript
+type Newable<TInstance = unknown, TArgs extends unknown[] = any[]> = new (
+  ...args: TArgs
+) => TInstance;
+```
+
+## Usage
+
+`ServiceIdentifier` is used throughout the InversifyJS API for:
+
+1. **Service Registration**: Binding services to the container
+2. **Service Resolution**: Retrieving services from the container
+3. **Service Configuration**: Setting activation/deactivation handlers
+
+### Examples
+
+<ServiceIdentifierApiSource />
+
+<Info>
+**Type Inference support**
+
+When using generics with `ServiceIdentifier<T>`, TypeScript can infer the resolved type. In the example above, `firstUserService` is automatically typed as `UserService` because `UserService` is inferred as `ServiceIdentifier<UserService>`.
+
+</Info>
+
+<Warning>
+**Assignment reduced type**
+
+In TypeScript, when a variable annotated with a union is assigned, the actual initial type of that variable becomes "an assignment reduced type".
+
+In the example above, `userServiceId` is automatically reduced as `symbol` and therefore, `firstUserService` is typed as `unknown`.
+Using a casting prevents this reduction and maintains the original type. Consider `fourthUserService` as an example.
+
+</Warning>

--- a/packages/docs-mintlify/versioned_docs/version-6.x/fundamentals/binding.mdx
+++ b/packages/docs-mintlify/versioned_docs/version-6.x/fundamentals/binding.mdx
@@ -1,0 +1,69 @@
+---
+sidebar_position: 1
+title: Binding
+---
+
+import BindingScopeRequestSource from '../../../snippets/code-examples/examples/bindingScopeRequest.ts.md'
+import BindingScopeSingletonSource from '../../../snippets/code-examples/examples/bindingScopeSingleton.ts.md'
+import BindingScopeTransientSource from '../../../snippets/code-examples/examples/bindingScopeTransient.ts.md'
+import FundamentalsBindingExampleSource from '../../../snippets/code-examples/examples/v6/fundamentalsBindingExample.ts.md'
+import FundamentalsBindingFromClassMetadataSource from '../../../snippets/code-examples/examples/v6/fundamentalsBindingFromClassMetadata.ts.md'
+import FundamentalsAutobindingSource from '../../../snippets/code-examples/examples/v6/fundamentalsAutobinding.ts.md'
+
+# Binding
+
+A binding represents the relationship between a service identifier and its resolution. Bindings are added to a container to configure it to provide services.
+
+<FundamentalsBindingExampleSource />
+
+When the binding is added to the container, the container is configured to provide a resolved value for the service identifier `Weapon` by resolving the `Katana` class. `container.bind` creates a new binding with certain properties, which are explained below.
+
+## Relying on emitted class metadata
+
+When using TypeScript, you can rely on the emitted class metadata to avoid having to manually specify the service identifier. This is done by using the `@injectable` decorator from `inversify` on the class you want to bind. You need to enable the `emitDecoratorMetadata` TypeScript compiler option.
+
+<FundamentalsBindingFromClassMetadataSource />
+
+## Autobinding
+
+InversifyJS provides a feature called autobinding that allows you to automatically bind classes. Whenever a class service is being resolved and no bindings are found in the planning phase, the container adds a type binding to the requested class before proceeding with the planning phase. This feature is disabled by default. To enable it, you need to pass the `autoBindInjectable` option to the container.
+
+<FundamentalsAutobindingSource />
+
+## Binding properties
+
+A binding has the following properties:
+
+### Service identifier
+
+The identifier of the service for which a resolution is provided.
+
+### Scope
+
+The scope determines the caching strategy used to decide whether the service should be resolved or a cached value should be provided.
+
+#### Request
+
+When the service is resolved within the same `container.get` request, the same resolved value will be used.
+
+<BindingScopeRequestSource />
+
+#### Singleton
+
+When the service is resolved, the same cached resolved value will be used.
+
+<BindingScopeSingletonSource />
+
+#### Transient
+
+When the service is resolved, a new resolved value will be used each time.
+
+<BindingScopeTransientSource />
+
+### Constraint
+
+Specifies whether the binding is used to provide a resolved value for the given service identifier. Refer to the [API docs](../api/binding-syntax.mdx#bindingwhensyntax) for more information.
+
+### Lifecycle handlers
+
+Handlers that are called after a resolved value is provided or a singleton-scoped binding is deactivated. Refer to the [API docs](../api/binding-syntax.mdx#bindingonsyntax) for more information.

--- a/packages/docs-mintlify/versioned_docs/version-6.x/fundamentals/di-hierarchy.mdx
+++ b/packages/docs-mintlify/versioned_docs/version-6.x/fundamentals/di-hierarchy.mdx
@@ -1,0 +1,37 @@
+---
+sidebar_position: 2
+title: DI Hierarchy
+---
+
+import DiHierarchySource from '../../../snippets/code-examples/examples/diHierarchy.ts.md'
+import DiHierarchyAndCachedBindingsSource from '../../../snippets/code-examples/examples/v6/diHierarchyAndCachedBindings.ts.md'
+
+# DI Hierarchy
+
+InversifyJS is a popular library for implementing inversion of control (IoC) and dependency injection (DI) in TypeScript applications. It supports hierarchical dependency injection, which can be a powerful tool in complex applications.
+
+With InversifyJS's hierarchical injection system, you can create a hierarchy of containers where each container can have a parent container. This allows for better organization and separation of concerns in your application.
+
+When a dependency needs to be injected, InversifyJS starts by looking in the current container for a binding. If the binding is not found, it moves up the hierarchy to the parent container and continues the search. This process continues until a binding is found or the top-level parent container is reached.
+
+<Warning>
+**Binding overrides**
+
+Found bindings might override ancestor bindings even if their constraints are not met. For example, if a named binding is found in the child container for the requested service, that binding overrides parent bindings even if this binding is later discarded in a non-named resolution request.
+
+</Warning>
+
+<Warning>
+**DI hierarchies and cached bindings**
+
+When using hierarchical injection, be aware that cached bindings from the first resolution will be used for subsequent resolution, even if the call comes from another child container.
+
+<DiHierarchyAndCachedBindingsSource />
+
+If this behaviour is unwanted, consider using `ContainerModule` instead. This way, you can load it in both containers. Different containers will have different binding and therefore different cached values.
+
+</Warning>
+
+By using InversifyJS's hierarchical injection system, you can easily manage complex dependencies and keep your code clean and modular. It provides a flexible and scalable solution for handling dependencies in your TypeScript applications.
+
+<DiHierarchySource />

--- a/packages/docs-mintlify/versioned_docs/version-6.x/fundamentals/inheritance.mdx
+++ b/packages/docs-mintlify/versioned_docs/version-6.x/fundamentals/inheritance.mdx
@@ -1,0 +1,57 @@
+---
+sidebar_position: 4
+title: Inheritance
+---
+
+# Inheritance
+
+Inheritance can be achieved as long as constructor parameters are properly decorated. There are two ways to ensure this:
+
+- The number of decorated constructor arguments in a derived class is greater than or equal to the number of constructor arguments in its base class.
+- The [skipBaseClassChecks](../api/container.mdx#skipbaseclasschecks) option is enabled.
+
+## Example of incorrect inheritance injection
+
+```ts
+@injectable()
+class Warrior {
+  public rank: string;
+  constructor(rank: string) {
+    // args count = 1
+    this.rank = rank;
+  }
+}
+
+@injectable()
+class SamuraiMaster extends Warrior {
+  constructor() {
+    // args count = 0
+    super('master');
+  }
+}
+```
+
+When trying to get a `SamuraiMaster`, the container throws an error indicating that the constructor parameters are not properly decorated.
+
+## Using the @unmanaged decorator
+
+The [unmanaged](../api/decorator.mdx#unmanaged) decorator tells Inversify that a base type constructor parameter should not be managed. This is often the case when dealing with inheritance hierarchies where only leaf types are injected.
+
+```ts
+@injectable()
+class Warrior {
+  public rank: string;
+  constructor(@unmanaged() rank: string) {
+    // args count = 0, unmanaged args are not included
+    this.rank = rank;
+  }
+}
+
+@injectable()
+class SamuraiMaster extends Warrior {
+  constructor() {
+    // args count = 0
+    super('master');
+  }
+}
+```

--- a/packages/docs-mintlify/versioned_docs/version-6.x/fundamentals/lifecycle/activation.mdx
+++ b/packages/docs-mintlify/versioned_docs/version-6.x/fundamentals/lifecycle/activation.mdx
@@ -1,0 +1,18 @@
+---
+sidebar_position: 1
+title: Activation
+---
+
+import ContainerApiOnActivationSource from '../../../../snippets/code-examples/examples/containerApiOnActivation.ts.md'
+
+Whenever a service is resolved, the activation event is dispatched. An activation handler receives a context and a resolved value and returns the handled resolved value.
+
+<ContainerApiOnActivationSource />
+
+There are multiple ways to provide an activation handler
+
+- Adding the handler to the [container](../../api/container.mdx#onactivation).
+- Adding the handler to the [binding](../../api/binding-syntax.mdx#onactivation).
+- Adding the handler to the class through the [postConstruct decorator](../../api/decorator.mdx#postconstruct).
+
+When multiple activation handlers are binded to a service identifier, the `postConstruct` handler is called before any others. After that, the binding handler is called. Then, container handlers are called, starting at the root container and descending the descendant containers stopping at the container with the binding.

--- a/packages/docs-mintlify/versioned_docs/version-6.x/fundamentals/lifecycle/deactivation.mdx
+++ b/packages/docs-mintlify/versioned_docs/version-6.x/fundamentals/lifecycle/deactivation.mdx
@@ -1,0 +1,18 @@
+---
+sidebar_position: 2
+title: Deactivation
+---
+
+import ContainerApiOnDeactivationSource from '../../../../snippets/code-examples/examples/containerApiOnDeactivation.ts.md'
+
+Whenever a singleton scoped service is unbound, the deactivation event is dispatched. A deactivation handler receives a resolved value and returns nothing.
+
+<ContainerApiOnDeactivationSource />
+
+It's possible to add a deactivation handler in multiple ways
+
+- Adding the handler to the [container](../../api/container.mdx#ondeactivation).
+- Adding the handler to a [binding](../../api/binding-syntax.mdx#ondeactivation).
+- Adding the handler to the class through the [preDestroy decorator](../../api/decorator.mdx#predestroy).
+
+Handlers added to the container are the first ones to be resolved. Any handler added to a child container is called before the ones added to their parent. Relevant bindings from the container are called next and finally the `preDestroy` method is called. In the example above, relevant bindings are those bindings bound to the unbinded "Destroyable" service identifier.

--- a/packages/docs-mintlify/versioned_docs/version-6.x/fundamentals/lifecycle/middleware.mdx
+++ b/packages/docs-mintlify/versioned_docs/version-6.x/fundamentals/lifecycle/middleware.mdx
@@ -1,0 +1,161 @@
+---
+sidebar_position: 3
+title: Middleware
+---
+
+# Middleware
+
+<Warning>
+
+Middleware docs are included for historical reasons. They are likely to be remove in favor of more appropiate features.
+
+</Warning>
+
+Middlewares can be added to a container in order to intercept service resolution requests:
+
+## Basic middleware
+
+```ts
+import { interfaces, Container } from 'inversify';
+
+function logger(planAndResolve: interfaces.Next): interfaces.Next {
+  return (args: interfaces.NextArgs) => {
+    let start = new Date().getTime();
+    let result = planAndResolve(args);
+    let end = new Date().getTime();
+    console.log(`wooooo  ${end - start}`);
+    return result;
+  };
+}
+
+let container = new Container();
+container.applyMiddleware(logger);
+```
+
+## Multiple middleware functions
+
+When multiple middleware functions are applied:
+
+```ts
+container.applyMiddleware(middleware1, middleware2);
+```
+
+The middleware will be invoked from right to left.
+This means that `middleware2` is invoked before `middleware1`.
+
+## Context interceptor
+
+In some cases you may want to intercept the resolution plan.
+
+The default `contextInterceptor` is passed to the middleware as an property of `args`.
+
+```ts
+function middleware1(
+  planAndResolve: interfaces.Next,
+): interfaces.Next<unknown> {
+  return (args: interfaces.NextArgs) => {
+    // args.nextContextInterceptor
+    // ...
+  };
+}
+```
+
+You can extend the default `contextInterceptor` using a function:
+
+```ts
+function middleware1(
+  planAndResolve: interfaces.Next<unknown>,
+): interfaces.Next<unknown> {
+  return (args: interfaces.NextArgs) => {
+    let nextContextInterceptor = args.contextInterceptor;
+    args.contextInterceptor = (context: interfaces.Context) => {
+      console.log(context);
+      return nextContextInterceptor(context);
+    };
+    return planAndResolve(args);
+  };
+}
+```
+
+## Custom metadata reader
+
+<Warning>
+
+It is not recommended to create your own custom
+metadata reader. We have included this feature to allow library / framework creators
+to have a higher level of customization but the average user should not use a custom
+metadata reader. In general, a custom metadata reader should only be used when
+developing a framework in order to provide users with an annotation APIs
+less explicit than the default annotation API.
+
+If you are developing a framework or library and you create a custom metadata reader,
+Please remember to provide your framework with support for an alternative for all the
+decorators in the default API: `@injectable`, `@inject`, `@multiInject`, `@tagged`,
+`@named`, `@optional`, `@postConstruct`, `@preDestroy` `@targetName` & `@unmanaged`.
+
+</Warning>
+
+Middleware allows you to intercept a plan and resolve it but you are not allowed to change the way the annotation phase behaves.
+
+There is a second extension point that allows you to decide what kind of annotation
+system you would like to use. The default annotation system is powered by decorators and
+reflect-metadata:
+
+```ts
+@injectable()
+class Ninja implements Ninja {
+  private _katana: Katana;
+  private _shuriken: Shuriken;
+
+  constructor(
+    @inject('Katana') katana: Katana,
+    @inject('Shuriken') shuriken: Shuriken,
+  ) {
+    this._katana = katana;
+    this._shuriken = shuriken;
+  }
+
+  public fight() {
+    return this._katana.hit();
+  }
+  public sneak() {
+    return this._shuriken.throw();
+  }
+}
+```
+
+You can use a custom metadata reader to implement a custom annotation system.
+
+For example, you could implement an annotation system based on static properties:
+
+```ts
+class Ninja implements Ninja {
+  public static constructorInjections = ['Katana', 'Shuriken'];
+
+  private _katana: Katana;
+  private _shuriken: Shuriken;
+
+  constructor(katana: Katana, shuriken: Shuriken) {
+    this._katana = katana;
+    this._shuriken = shuriken;
+  }
+
+  public fight() {
+    return this._katana.hit();
+  }
+  public sneak() {
+    return this._shuriken.throw();
+  }
+}
+```
+
+A custom metadata reader must implement the `interfaces.MetadataReader` interface.
+
+A full example [can be found in our unit tests](https://github.com/inversify/InversifyJS/blob/master/test/features/metadata_reader.test.ts).
+
+Once you have a custom metadata reader you will be ready to apply it:
+
+```ts
+let container = new Container();
+container.applyCustomMetadataReader(new StaticPropsMetadataReader());
+```

--- a/packages/docs-mintlify/versioned_docs/version-6.x/fundamentals/snapshot.mdx
+++ b/packages/docs-mintlify/versioned_docs/version-6.x/fundamentals/snapshot.mdx
@@ -1,0 +1,14 @@
+---
+sidebar_position: 5
+title: Snapshot
+---
+
+# Snapshot
+
+Snapshots allow you to save the state of your Inversify container at a specific moment in time. These snapshots capture the container's state, enabling you to revert back to that state if needed.
+
+Think of it as taking a picture of your container, preserving the exact configurations and dependencies present when the snapshot was taken. This can be incredibly useful for debugging, testing, or tracking changes made to your container over time.
+
+By creating snapshots of your Inversify container, you can easily roll back to a previous working state or compare different configurations without manually recreating them. This functionality can save you time and effort, making your development process smoother and more efficient.
+
+Refer to the [API documentation](../api/container.mdx#snapshot) for more information on how to create and use snapshots in Inversify.

--- a/packages/docs-mintlify/versioned_docs/version-6.x/introduction/dependency-inversion.mdx
+++ b/packages/docs-mintlify/versioned_docs/version-6.x/introduction/dependency-inversion.mdx
@@ -1,0 +1,20 @@
+---
+sidebar_position: 2
+title: Dependency inversion
+---
+
+import DependencyInversionSource from '../../../snippets/code-examples/examples/dependencyInversion.ts.md'
+
+# Dependency inversion
+
+To apply the dependency inversion principle, you can use injection symbols:
+
+<DependencyInversionSource />
+
+By using symbols, you can provide interface implementations in a way that the dependent class is not aware of the dependency implementation details.
+
+<Note>
+
+Although symbols are recommended for this purpose, InversifyJS also supports using Classes and string literals as service identifiers.
+
+</Note>

--- a/packages/docs-mintlify/versioned_docs/version-6.x/introduction/getting-started.mdx
+++ b/packages/docs-mintlify/versioned_docs/version-6.x/introduction/getting-started.mdx
@@ -3,8 +3,7 @@ sidebar_position: 1
 title: Getting started
 ---
 
-import CodeBlock from '@theme/CodeBlock';
-import gettingStartedSource from '@inversifyjs/code-examples/generated/examples/gettingStarted.ts.txt';
+import GettingStartedSource from '../../../snippets/code-examples/examples/gettingStarted.ts.md'
 
 # Getting started
 
@@ -22,7 +21,7 @@ Make sure to enable [Experimental decorators](https://www.typescriptlang.org/tsc
 
 </Warning>
 
-<CodeBlock language="ts">{gettingStartedSource}</CodeBlock>
+<GettingStartedSource />
 
 The `@injectable` decorator allows both `Katana` and `Ninja` classes to be used as container bindings. The `@inject` decorator provides metadata about `Ninja` dependencies, so the container knows that a `Katana` should be provided as the first argument of `Ninja`'s constructor.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded the version 6.x documentation with new guidance on dependency inversion, bindings, dependency hierarchies, inheritance, lifecycles, middleware, snapshots, and getting started.
  - Added comprehensive API references for containers, modules, decorators, binding syntax, service identifiers, and lazy service identifiers.
  - Added practical code examples throughout the new documentation pages.
  - Updated version navigation to organize the new Fundamentals and API sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->