### PR TITLE
Update transformJsonSchema with merge strategy

### DIFF
--- a/.changeset/unify-colliding-type-metadata-ids.md
+++ b/.changeset/unify-colliding-type-metadata-ids.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/json-schema-2-type-metadata": minor
+---
+
+Unify TypeMetadata nodes that share an id when they denote the same type, and keep throwing when that id names two different types.

--- a/packages/json-schema/libraries/json-schema-2-type-metadata/src/jsonSchema/202012/actions/transformJsonSchema.int.spec.ts
+++ b/packages/json-schema/libraries/json-schema-2-type-metadata/src/jsonSchema/202012/actions/transformJsonSchema.int.spec.ts
@@ -196,4 +196,536 @@ describe(transformJsonSchema, () => {
       });
     });
   });
+
+  describe('having two equivalent titled object schemas with nested object properties', () => {
+    let jsonSchemaFixture: JsonSchemaObject;
+
+    beforeAll(() => {
+      jsonSchemaFixture = {
+        properties: {
+          a: {
+            properties: {
+              address: {
+                properties: {
+                  city: {
+                    type: 'string',
+                  },
+                },
+                required: ['city'],
+                type: 'object',
+              },
+            },
+            required: ['address'],
+            title: 'Foo',
+            type: 'object',
+          },
+          b: {
+            properties: {
+              address: {
+                properties: {
+                  city: {
+                    type: 'string',
+                  },
+                },
+                required: ['city'],
+                type: 'object',
+              },
+            },
+            required: ['address'],
+            title: 'Foo',
+            type: 'object',
+          },
+        },
+        required: ['a', 'b'],
+        type: 'object',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = transformJsonSchema(
+          jsonSchemaFixture,
+          generateTransformJsonSchemaContext(),
+        );
+      });
+
+      it('should reuse one TypeMetadata node for both titled objects', () => {
+        const firstFooTypeMetadata: TypeMetadata | undefined =
+          findPropertyTypeMetadata(result as TypeMetadata, 'a')?.child;
+        const secondFooTypeMetadata: TypeMetadata | undefined =
+          findPropertyTypeMetadata(result as TypeMetadata, 'b')?.child;
+
+        expect(firstFooTypeMetadata).toBe(secondFooTypeMetadata);
+        expect(firstFooTypeMetadata?.id).toBe('Foo');
+      });
+
+      it('should keep TypeMetadata ids unique', () => {
+        const typeMetadataIds: string[] = collectTypeMetadata(
+          result as TypeMetadata,
+        )
+          .map((typeMetadata: TypeMetadata) => typeMetadata.id)
+          .filter((id: string | undefined): id is string => id !== undefined);
+
+        expect(typeMetadataIds).toStrictEqual([...new Set(typeMetadataIds)]);
+      });
+    });
+  });
+
+  describe('having two titled object schemas that differ in a nested object property', () => {
+    let jsonSchemaFixture: JsonSchemaObject;
+
+    beforeAll(() => {
+      jsonSchemaFixture = {
+        properties: {
+          a: {
+            properties: {
+              address: {
+                properties: {
+                  city: {
+                    type: 'string',
+                  },
+                },
+                required: ['city'],
+                type: 'object',
+              },
+            },
+            required: ['address'],
+            title: 'Foo',
+            type: 'object',
+          },
+          b: {
+            properties: {
+              address: {
+                properties: {
+                  city: {
+                    type: 'number',
+                  },
+                },
+                required: ['city'],
+                type: 'object',
+              },
+            },
+            required: ['address'],
+            title: 'Foo',
+            type: 'object',
+          },
+        },
+        required: ['a', 'b'],
+        type: 'object',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        try {
+          transformJsonSchema(
+            jsonSchemaFixture,
+            generateTransformJsonSchemaContext(),
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      it('should throw an Error', () => {
+        expect(result).toBeInstanceOf(Error);
+        expect((result as Error).message).toBe(
+          'Duplicated TypeMetadata id "Foo"',
+        );
+      });
+    });
+  });
+
+  describe('having two equivalent titled object schemas with array properties', () => {
+    let jsonSchemaFixture: JsonSchemaObject;
+
+    beforeAll(() => {
+      jsonSchemaFixture = {
+        properties: {
+          a: {
+            properties: {
+              tags: {
+                items: {
+                  type: 'string',
+                },
+                type: 'array',
+              },
+            },
+            required: ['tags'],
+            title: 'Foo',
+            type: 'object',
+          },
+          b: {
+            properties: {
+              tags: {
+                items: {
+                  type: 'string',
+                },
+                type: 'array',
+              },
+            },
+            required: ['tags'],
+            title: 'Foo',
+            type: 'object',
+          },
+        },
+        required: ['a', 'b'],
+        type: 'object',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = transformJsonSchema(
+          jsonSchemaFixture,
+          generateTransformJsonSchemaContext(),
+        );
+      });
+
+      it('should reuse one TypeMetadata node for both titled objects', () => {
+        const firstFooTypeMetadata: TypeMetadata | undefined =
+          findPropertyTypeMetadata(result as TypeMetadata, 'a')?.child;
+        const secondFooTypeMetadata: TypeMetadata | undefined =
+          findPropertyTypeMetadata(result as TypeMetadata, 'b')?.child;
+
+        expect(firstFooTypeMetadata).toBe(secondFooTypeMetadata);
+        expect(firstFooTypeMetadata?.id).toBe('Foo');
+      });
+
+      it('should keep TypeMetadata ids unique', () => {
+        const typeMetadataIds: string[] = collectTypeMetadata(
+          result as TypeMetadata,
+        )
+          .map((typeMetadata: TypeMetadata) => typeMetadata.id)
+          .filter((id: string | undefined): id is string => id !== undefined);
+
+        expect(typeMetadataIds).toStrictEqual([...new Set(typeMetadataIds)]);
+      });
+    });
+  });
+
+  describe('having two equivalent titled object schemas with array of object properties', () => {
+    let jsonSchemaFixture: JsonSchemaObject;
+
+    beforeAll(() => {
+      jsonSchemaFixture = {
+        properties: {
+          a: {
+            properties: {
+              items: {
+                items: {
+                  properties: {
+                    id: {
+                      type: 'string',
+                    },
+                  },
+                  required: ['id'],
+                  type: 'object',
+                },
+                type: 'array',
+              },
+            },
+            required: ['items'],
+            title: 'Foo',
+            type: 'object',
+          },
+          b: {
+            properties: {
+              items: {
+                items: {
+                  properties: {
+                    id: {
+                      type: 'string',
+                    },
+                  },
+                  required: ['id'],
+                  type: 'object',
+                },
+                type: 'array',
+              },
+            },
+            required: ['items'],
+            title: 'Foo',
+            type: 'object',
+          },
+        },
+        required: ['a', 'b'],
+        type: 'object',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = transformJsonSchema(
+          jsonSchemaFixture,
+          generateTransformJsonSchemaContext(),
+        );
+      });
+
+      it('should reuse one TypeMetadata node for both titled objects', () => {
+        const firstFooTypeMetadata: TypeMetadata | undefined =
+          findPropertyTypeMetadata(result as TypeMetadata, 'a')?.child;
+        const secondFooTypeMetadata: TypeMetadata | undefined =
+          findPropertyTypeMetadata(result as TypeMetadata, 'b')?.child;
+
+        expect(firstFooTypeMetadata).toBe(secondFooTypeMetadata);
+        expect(firstFooTypeMetadata?.id).toBe('Foo');
+      });
+
+      it('should keep TypeMetadata ids unique', () => {
+        const typeMetadataIds: string[] = collectTypeMetadata(
+          result as TypeMetadata,
+        )
+          .map((typeMetadata: TypeMetadata) => typeMetadata.id)
+          .filter((id: string | undefined): id is string => id !== undefined);
+
+        expect(typeMetadataIds).toStrictEqual([...new Set(typeMetadataIds)]);
+      });
+    });
+  });
+
+  describe('having two titled object schemas that differ in an array item type', () => {
+    let jsonSchemaFixture: JsonSchemaObject;
+
+    beforeAll(() => {
+      jsonSchemaFixture = {
+        properties: {
+          a: {
+            properties: {
+              items: {
+                items: {
+                  properties: {
+                    id: {
+                      type: 'string',
+                    },
+                  },
+                  required: ['id'],
+                  type: 'object',
+                },
+                type: 'array',
+              },
+            },
+            required: ['items'],
+            title: 'Foo',
+            type: 'object',
+          },
+          b: {
+            properties: {
+              items: {
+                items: {
+                  properties: {
+                    id: {
+                      type: 'number',
+                    },
+                  },
+                  required: ['id'],
+                  type: 'object',
+                },
+                type: 'array',
+              },
+            },
+            required: ['items'],
+            title: 'Foo',
+            type: 'object',
+          },
+        },
+        required: ['a', 'b'],
+        type: 'object',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        try {
+          transformJsonSchema(
+            jsonSchemaFixture,
+            generateTransformJsonSchemaContext(),
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      it('should throw an Error', () => {
+        expect(result).toBeInstanceOf(Error);
+        expect((result as Error).message).toBe(
+          'Duplicated TypeMetadata id "Foo"',
+        );
+      });
+    });
+  });
+
+  describe('having two equivalent titled object schemas with nested titled object and array properties', () => {
+    let jsonSchemaFixture: JsonSchemaObject;
+
+    beforeAll(() => {
+      jsonSchemaFixture = {
+        properties: {
+          a: {
+            properties: {
+              address: {
+                properties: {
+                  city: {
+                    type: 'string',
+                  },
+                },
+                required: ['city'],
+                title: 'Address',
+                type: 'object',
+              },
+              tags: {
+                items: {
+                  type: 'string',
+                },
+                type: 'array',
+              },
+            },
+            required: ['address', 'tags'],
+            title: 'Foo',
+            type: 'object',
+          },
+          b: {
+            properties: {
+              address: {
+                properties: {
+                  city: {
+                    type: 'string',
+                  },
+                },
+                required: ['city'],
+                title: 'Address',
+                type: 'object',
+              },
+              tags: {
+                items: {
+                  type: 'string',
+                },
+                type: 'array',
+              },
+            },
+            required: ['address', 'tags'],
+            title: 'Foo',
+            type: 'object',
+          },
+        },
+        required: ['a', 'b'],
+        type: 'object',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = transformJsonSchema(
+          jsonSchemaFixture,
+          generateTransformJsonSchemaContext(),
+        );
+      });
+
+      it('should reuse one TypeMetadata node for both titled objects and both nested titles', () => {
+        const firstFooTypeMetadata: TypeMetadata | undefined =
+          findPropertyTypeMetadata(result as TypeMetadata, 'a')?.child;
+        const secondFooTypeMetadata: TypeMetadata | undefined =
+          findPropertyTypeMetadata(result as TypeMetadata, 'b')?.child;
+        const addressTypeMetadata: TypeMetadata | undefined =
+          firstFooTypeMetadata === undefined
+            ? undefined
+            : findPropertyTypeMetadata(firstFooTypeMetadata, 'address')?.child;
+
+        expect(firstFooTypeMetadata).toBe(secondFooTypeMetadata);
+        expect(firstFooTypeMetadata?.id).toBe('Foo');
+        expect(addressTypeMetadata?.id).toBe('Address');
+      });
+
+      it('should keep TypeMetadata ids unique', () => {
+        const typeMetadataIds: string[] = collectTypeMetadata(
+          result as TypeMetadata,
+        )
+          .map((typeMetadata: TypeMetadata) => typeMetadata.id)
+          .filter((id: string | undefined): id is string => id !== undefined);
+
+        expect(typeMetadataIds).toStrictEqual([...new Set(typeMetadataIds)]);
+      });
+    });
+  });
+
+  describe('having two titled object schemas with the same nested title and a different nested property type', () => {
+    let jsonSchemaFixture: JsonSchemaObject;
+
+    beforeAll(() => {
+      jsonSchemaFixture = {
+        properties: {
+          a: {
+            properties: {
+              address: {
+                properties: {
+                  city: {
+                    type: 'string',
+                  },
+                },
+                required: ['city'],
+                title: 'Address',
+                type: 'object',
+              },
+            },
+            required: ['address'],
+            title: 'Foo',
+            type: 'object',
+          },
+          b: {
+            properties: {
+              address: {
+                properties: {
+                  city: {
+                    type: 'number',
+                  },
+                },
+                required: ['city'],
+                title: 'Address',
+                type: 'object',
+              },
+            },
+            required: ['address'],
+            title: 'Foo',
+            type: 'object',
+          },
+        },
+        required: ['a', 'b'],
+        type: 'object',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        try {
+          transformJsonSchema(
+            jsonSchemaFixture,
+            generateTransformJsonSchemaContext(),
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      it('should throw an Error', () => {
+        expect(result).toBeInstanceOf(Error);
+        expect((result as Error).message).toBe(
+          'Duplicated TypeMetadata id "Address"',
+        );
+      });
+    });
+  });
 });

--- a/packages/json-schema/libraries/json-schema-2-type-metadata/src/jsonSchema/202012/actions/transformJsonSchema.spec.ts
+++ b/packages/json-schema/libraries/json-schema-2-type-metadata/src/jsonSchema/202012/actions/transformJsonSchema.spec.ts
@@ -1070,7 +1070,7 @@ describe(transformJsonSchema, () => {
         );
       });
 
-      it('should not reuse the titled TypeMetadata for the $ref', () => {
+      it('should unify the titled TypeMetadata for the $ref', () => {
         const resultTypeMetadata: OrTypeMetadata = result as OrTypeMetadata;
         const addressTypeMetadata: TypeMetadata = resultTypeMetadata
           .children[0] as TypeMetadata;
@@ -1082,7 +1082,7 @@ describe(transformJsonSchema, () => {
               child.kind === TypeMetadataKind.propertyType,
           ) as PropertyTypeMetadata;
 
-        expect(addressPropertyTypeMetadata.child).not.toBe(addressTypeMetadata);
+        expect(addressPropertyTypeMetadata.child).toBe(addressTypeMetadata);
       });
     });
   });
@@ -1649,7 +1649,7 @@ describe(transformJsonSchema, () => {
     });
   });
 
-  describe('having two schemas with the same title', () => {
+  describe('having two inequivalent schemas with the same title', () => {
     let jsonSchemaFixture: JsonSchemaObject;
 
     beforeAll(() => {
@@ -1686,6 +1686,188 @@ describe(transformJsonSchema, () => {
         expect((result as Error).message).toBe(
           'Duplicated TypeMetadata id "Foo"',
         );
+      });
+    });
+  });
+
+  describe('having two equivalent schemas with the same title', () => {
+    let jsonSchemaFixture: JsonSchemaObject;
+
+    beforeAll(() => {
+      jsonSchemaFixture = {
+        properties: {
+          a: {
+            title: 'Foo',
+            type: 'string',
+          },
+          b: {
+            title: 'Foo',
+            type: 'string',
+          },
+        },
+        required: ['a', 'b'],
+        type: 'object',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = transformJsonSchema(
+          jsonSchemaFixture,
+          generateTransformJsonSchemaContext(),
+        );
+      });
+
+      it('should reuse one TypeMetadata node for both properties', () => {
+        const resultTypeMetadata: AndTypeMetadata = result as AndTypeMetadata;
+        const firstPropertyTypeMetadata: PropertyTypeMetadata =
+          resultTypeMetadata.children.find(
+            (child: TypeMetadata) =>
+              child.kind === TypeMetadataKind.propertyType &&
+              child.property === 'a',
+          ) as PropertyTypeMetadata;
+        const secondPropertyTypeMetadata: PropertyTypeMetadata =
+          resultTypeMetadata.children.find(
+            (child: TypeMetadata) =>
+              child.kind === TypeMetadataKind.propertyType &&
+              child.property === 'b',
+          ) as PropertyTypeMetadata;
+
+        expect(firstPropertyTypeMetadata.child).toBe(
+          secondPropertyTypeMetadata.child,
+        );
+        expect(firstPropertyTypeMetadata.child.id).toBe('Foo');
+      });
+    });
+  });
+
+  describe('having two equivalent schemas with different titles', () => {
+    let jsonSchemaFixture: JsonSchemaObject;
+
+    beforeAll(() => {
+      jsonSchemaFixture = {
+        properties: {
+          person: {
+            title: 'Person',
+            type: 'string',
+          },
+          user: {
+            title: 'User',
+            type: 'string',
+          },
+        },
+        required: ['person', 'user'],
+        type: 'object',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = transformJsonSchema(
+          jsonSchemaFixture,
+          generateTransformJsonSchemaContext(),
+        );
+      });
+
+      it('should keep both named TypeMetadata nodes', () => {
+        const resultTypeMetadata: AndTypeMetadata = result as AndTypeMetadata;
+        const personPropertyTypeMetadata: PropertyTypeMetadata =
+          resultTypeMetadata.children.find(
+            (child: TypeMetadata) =>
+              child.kind === TypeMetadataKind.propertyType &&
+              child.property === 'person',
+          ) as PropertyTypeMetadata;
+        const userPropertyTypeMetadata: PropertyTypeMetadata =
+          resultTypeMetadata.children.find(
+            (child: TypeMetadata) =>
+              child.kind === TypeMetadataKind.propertyType &&
+              child.property === 'user',
+          ) as PropertyTypeMetadata;
+
+        expect(personPropertyTypeMetadata.child).not.toBe(
+          userPropertyTypeMetadata.child,
+        );
+        expect(personPropertyTypeMetadata.child.id).toBe('Person');
+        expect(userPropertyTypeMetadata.child.id).toBe('User');
+      });
+    });
+  });
+
+  describe('having a titled schema both as a property and as array items via $ref', () => {
+    let jsonSchemaFixture: JsonSchemaObject;
+    let todoJsonSchemaFixture: JsonSchemaObject;
+
+    beforeAll(() => {
+      todoJsonSchemaFixture = {
+        $id: 'https://example.com/todo',
+        properties: {
+          id: {
+            type: 'string',
+          },
+        },
+        required: ['id'],
+        title: 'TodoV1',
+        type: 'object',
+      };
+      jsonSchemaFixture = {
+        $id: 'https://example.com/root',
+        properties: {
+          items: {
+            items: {
+              $ref: 'https://example.com/todo',
+            },
+            type: 'array',
+          },
+          todo: {
+            $ref: 'https://example.com/todo',
+          },
+        },
+        required: ['items', 'todo'],
+        type: 'object',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = transformJsonSchema(
+          jsonSchemaFixture,
+          generateTransformJsonSchemaContext([
+            jsonSchemaFixture,
+            todoJsonSchemaFixture,
+          ]),
+        );
+      });
+
+      it('should reuse one TypeMetadata node for the property and the array items', () => {
+        const resultTypeMetadata: AndTypeMetadata = result as AndTypeMetadata;
+        const itemsPropertyTypeMetadata: PropertyTypeMetadata =
+          resultTypeMetadata.children.find(
+            (child: TypeMetadata) =>
+              child.kind === TypeMetadataKind.propertyType &&
+              child.property === 'items',
+          ) as PropertyTypeMetadata;
+        const todoPropertyTypeMetadata: PropertyTypeMetadata =
+          resultTypeMetadata.children.find(
+            (child: TypeMetadata) =>
+              child.kind === TypeMetadataKind.propertyType &&
+              child.property === 'todo',
+          ) as PropertyTypeMetadata;
+
+        expect(itemsPropertyTypeMetadata.child.kind).toBe(
+          TypeMetadataKind.arrayType,
+        );
+        expect(
+          itemsPropertyTypeMetadata.child.kind === TypeMetadataKind.arrayType
+            ? itemsPropertyTypeMetadata.child.child
+            : undefined,
+        ).toBe(todoPropertyTypeMetadata.child);
+        expect(todoPropertyTypeMetadata.child.id).toBe('TodoV1');
       });
     });
   });

--- a/packages/json-schema/libraries/json-schema-2-type-metadata/src/jsonSchema/202012/actions/transformJsonSchema.ts
+++ b/packages/json-schema/libraries/json-schema-2-type-metadata/src/jsonSchema/202012/actions/transformJsonSchema.ts
@@ -21,6 +21,7 @@ import {
 import { type TransformJsonSchemaContext } from '../models/TransformJsonSchemaContext.js';
 import { type TransformJsonSchemaInternalContext } from '../models/TransformJsonSchemaInternalContext.js';
 import { simplifyTypeMetadata } from './simplifyTypeMetadata.js';
+import { unifyCollidingTypeMetadataIds } from './unifyCollidingTypeMetadataIds.js';
 
 const DYNAMIC_SCOPE_KEY_SEPARATOR: string = '|';
 
@@ -50,32 +51,33 @@ export function transformJsonSchema(
   schema: JsonRootSchema | JsonSchema,
   context: TransformJsonSchemaContext,
 ): TypeMetadata {
-  return simplifyTypeMetadata(
-    transformJsonSchemaNode(schema, {
-      dynamicScopeEntries: context.dynamicScopeEntries ?? [],
-      inProgressJsonSchemaToTypeMap: new Map(),
-      jsonSchemaToTypeMap: new Map(),
-      resolver: context.resolver,
-      typeMetadataIdSet: new Set(),
-    }),
+  const titledTypeMetadata: TypeMetadata[] = [];
+
+  return unifyCollidingTypeMetadataIds(
+    simplifyTypeMetadata(
+      transformJsonSchemaNode(schema, {
+        dynamicScopeEntries: context.dynamicScopeEntries ?? [],
+        inProgressJsonSchemaToTypeMap: new Map(),
+        jsonSchemaToTypeMap: new Map(),
+        resolver: context.resolver,
+        titledTypeMetadata,
+      }),
+    ),
+    titledTypeMetadata,
   );
 }
 
 function assignTypeMetadataId(
   typeMetadata: Partial<TypeMetadata>,
   id: string | undefined,
-  typeMetadataIdSet: Set<string>,
+  titledTypeMetadata: TypeMetadata[],
 ): void {
   if (id === undefined || typeMetadata.id !== undefined) {
     return;
   }
 
-  if (typeMetadataIdSet.has(id)) {
-    throw new Error(`Duplicated TypeMetadata id "${id}"`);
-  }
-
-  typeMetadataIdSet.add(id);
   typeMetadata.id = id;
+  titledTypeMetadata.push(typeMetadata as TypeMetadata);
 }
 
 function assertJsonSchema(
@@ -136,7 +138,7 @@ function buildTypeMetadata(
   id: string | undefined,
   typeMetadataPartial: Partial<TypeMetadata>,
   typeConstraints: TypeMetadata[],
-  typeMetadataIdSet: Set<string>,
+  titledTypeMetadata: TypeMetadata[],
 ): TypeMetadata {
   let typeMetadata: TypeMetadata;
 
@@ -161,7 +163,7 @@ function buildTypeMetadata(
          * Cycle to another in-progress schema. Keep that node so applicators
          * such as properties can close the loop once the target is completed.
          */
-        assignTypeMetadataId(childType, id, typeMetadataIdSet);
+        assignTypeMetadataId(childType, id, titledTypeMetadata);
 
         return childType as TypeMetadata;
       }
@@ -175,7 +177,7 @@ function buildTypeMetadata(
     };
   }
 
-  assignTypeMetadataId(typeMetadataPartial, id, typeMetadataIdSet);
+  assignTypeMetadataId(typeMetadataPartial, id, titledTypeMetadata);
 
   const typeMetadataId: string | undefined = typeMetadataPartial.id;
 
@@ -549,7 +551,7 @@ function transformObjectJsonSchema(
         id,
         typeMetadataPartial,
         typeConstraints,
-        scopedContext.typeMetadataIdSet,
+        scopedContext.titledTypeMetadata,
       );
 
   scopedTypeMetadataMap.set(dynamicScopeKey, typeMetadata);

--- a/packages/json-schema/libraries/json-schema-2-type-metadata/src/jsonSchema/202012/actions/unifyCollidingTypeMetadataIds.spec.ts
+++ b/packages/json-schema/libraries/json-schema-2-type-metadata/src/jsonSchema/202012/actions/unifyCollidingTypeMetadataIds.spec.ts
@@ -1,0 +1,847 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  type AndTypeMetadata,
+  type ArrayTypeMetadata,
+  type OrTypeMetadata,
+  type PropertyTypeMetadata,
+  type TypeMetadata,
+  TypeMetadataKind,
+} from '@inversifyjs/json-schema-type-metadata';
+
+import { unifyCollidingTypeMetadataIds } from './unifyCollidingTypeMetadataIds.js';
+
+function findPropertyTypeMetadata(
+  typeMetadata: TypeMetadata,
+  property: string,
+  seenTypeMetadataSet: Set<TypeMetadata> = new Set(),
+): PropertyTypeMetadata | undefined {
+  if (seenTypeMetadataSet.has(typeMetadata)) {
+    return undefined;
+  }
+
+  seenTypeMetadataSet.add(typeMetadata);
+
+  if (
+    typeMetadata.kind === TypeMetadataKind.propertyType &&
+    typeMetadata.property === property
+  ) {
+    return typeMetadata;
+  }
+
+  switch (typeMetadata.kind) {
+    case TypeMetadataKind.and:
+    case TypeMetadataKind.or:
+      for (const child of typeMetadata.children) {
+        const propertyTypeMetadata: PropertyTypeMetadata | undefined =
+          findPropertyTypeMetadata(child, property, seenTypeMetadataSet);
+
+        if (propertyTypeMetadata !== undefined) {
+          return propertyTypeMetadata;
+        }
+      }
+      break;
+    case TypeMetadataKind.arrayType:
+    case TypeMetadataKind.propertyType:
+    case TypeMetadataKind.stringIndexSignatureType:
+      return findPropertyTypeMetadata(
+        typeMetadata.child,
+        property,
+        seenTypeMetadataSet,
+      );
+    default:
+      break;
+  }
+
+  return undefined;
+}
+
+describe(unifyCollidingTypeMetadataIds, () => {
+  describe('having two untitled string TypeMetadata nodes', () => {
+    let leftStringTypeMetadata: TypeMetadata;
+    let rightStringTypeMetadata: TypeMetadata;
+    let typeMetadataFixture: OrTypeMetadata;
+
+    beforeAll(() => {
+      leftStringTypeMetadata = {
+        kind: TypeMetadataKind.stringType,
+      };
+      rightStringTypeMetadata = {
+        kind: TypeMetadataKind.stringType,
+      };
+      typeMetadataFixture = {
+        children: [leftStringTypeMetadata, rightStringTypeMetadata],
+        kind: TypeMetadataKind.or,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = unifyCollidingTypeMetadataIds(typeMetadataFixture);
+      });
+
+      it('should keep both nodes', () => {
+        const resultTypeMetadata: OrTypeMetadata = result as OrTypeMetadata;
+
+        expect(resultTypeMetadata.children[0]).toBe(leftStringTypeMetadata);
+        expect(resultTypeMetadata.children[1]).toBe(rightStringTypeMetadata);
+      });
+    });
+  });
+
+  describe('having two string TypeMetadata nodes with different ids', () => {
+    let personTypeMetadata: TypeMetadata;
+    let userTypeMetadata: TypeMetadata;
+    let typeMetadataFixture: OrTypeMetadata;
+
+    beforeAll(() => {
+      personTypeMetadata = {
+        id: 'Person',
+        kind: TypeMetadataKind.stringType,
+      };
+      userTypeMetadata = {
+        id: 'User',
+        kind: TypeMetadataKind.stringType,
+      };
+      typeMetadataFixture = {
+        children: [personTypeMetadata, userTypeMetadata],
+        kind: TypeMetadataKind.or,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = unifyCollidingTypeMetadataIds(typeMetadataFixture);
+      });
+
+      it('should keep both named nodes', () => {
+        const resultTypeMetadata: OrTypeMetadata = result as OrTypeMetadata;
+
+        expect(resultTypeMetadata.children[0]).toBe(personTypeMetadata);
+        expect(resultTypeMetadata.children[1]).toBe(userTypeMetadata);
+      });
+    });
+  });
+
+  describe('having two equivalent string TypeMetadata nodes with the same id', () => {
+    let firstFooTypeMetadata: TypeMetadata;
+    let secondFooTypeMetadata: TypeMetadata;
+    let typeMetadataFixture: OrTypeMetadata;
+
+    beforeAll(() => {
+      firstFooTypeMetadata = {
+        id: 'Foo',
+        kind: TypeMetadataKind.stringType,
+      };
+      secondFooTypeMetadata = {
+        id: 'Foo',
+        kind: TypeMetadataKind.stringType,
+      };
+      typeMetadataFixture = {
+        children: [firstFooTypeMetadata, secondFooTypeMetadata],
+        kind: TypeMetadataKind.or,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = unifyCollidingTypeMetadataIds(typeMetadataFixture);
+      });
+
+      it('should retarget both children to one node', () => {
+        const resultTypeMetadata: OrTypeMetadata = result as OrTypeMetadata;
+
+        expect(resultTypeMetadata.children[0]).toBe(firstFooTypeMetadata);
+        expect(resultTypeMetadata.children[1]).toBe(firstFooTypeMetadata);
+      });
+    });
+  });
+
+  describe('having two inequivalent TypeMetadata nodes with the same id', () => {
+    let typeMetadataFixture: AndTypeMetadata;
+
+    beforeAll(() => {
+      typeMetadataFixture = {
+        children: [
+          {
+            id: 'Foo',
+            kind: TypeMetadataKind.stringType,
+          },
+          {
+            id: 'Foo',
+            kind: TypeMetadataKind.floatType,
+          },
+        ],
+        kind: TypeMetadataKind.and,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        try {
+          unifyCollidingTypeMetadataIds(typeMetadataFixture);
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      it('should throw an Error', () => {
+        expect(result).toBeInstanceOf(Error);
+        expect((result as Error).message).toBe(
+          'Duplicated TypeMetadata id "Foo"',
+        );
+      });
+    });
+  });
+
+  describe('having two object TypeMetadata nodes with the same id and properties in opposite order', () => {
+    let firstFooTypeMetadata: AndTypeMetadata;
+    let secondFooTypeMetadata: AndTypeMetadata;
+    let typeMetadataFixture: OrTypeMetadata;
+
+    beforeAll(() => {
+      firstFooTypeMetadata = {
+        children: [
+          {
+            child: {
+              kind: TypeMetadataKind.stringType,
+            },
+            isOptional: false,
+            kind: TypeMetadataKind.propertyType,
+            property: 'id',
+          },
+          {
+            child: {
+              kind: TypeMetadataKind.booleanType,
+            },
+            isOptional: false,
+            kind: TypeMetadataKind.propertyType,
+            property: 'done',
+          },
+          {
+            kind: TypeMetadataKind.objectType,
+          },
+        ],
+        id: 'Foo',
+        kind: TypeMetadataKind.and,
+      };
+      secondFooTypeMetadata = {
+        children: [
+          {
+            child: {
+              kind: TypeMetadataKind.booleanType,
+            },
+            isOptional: false,
+            kind: TypeMetadataKind.propertyType,
+            property: 'done',
+          },
+          {
+            child: {
+              kind: TypeMetadataKind.stringType,
+            },
+            isOptional: false,
+            kind: TypeMetadataKind.propertyType,
+            property: 'id',
+          },
+          {
+            kind: TypeMetadataKind.objectType,
+          },
+        ],
+        id: 'Foo',
+        kind: TypeMetadataKind.and,
+      };
+      typeMetadataFixture = {
+        children: [firstFooTypeMetadata, secondFooTypeMetadata],
+        kind: TypeMetadataKind.or,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = unifyCollidingTypeMetadataIds(typeMetadataFixture);
+      });
+
+      it('should merge the titled objects', () => {
+        const resultTypeMetadata: OrTypeMetadata = result as OrTypeMetadata;
+
+        expect(resultTypeMetadata.children[0]).toBe(firstFooTypeMetadata);
+        expect(resultTypeMetadata.children[1]).toBe(firstFooTypeMetadata);
+      });
+    });
+  });
+
+  describe('having two object TypeMetadata nodes with the same id and a differently typed property', () => {
+    let typeMetadataFixture: OrTypeMetadata;
+
+    beforeAll(() => {
+      typeMetadataFixture = {
+        children: [
+          {
+            children: [
+              {
+                child: {
+                  kind: TypeMetadataKind.stringType,
+                },
+                isOptional: false,
+                kind: TypeMetadataKind.propertyType,
+                property: 'id',
+              },
+              {
+                kind: TypeMetadataKind.objectType,
+              },
+            ],
+            id: 'Foo',
+            kind: TypeMetadataKind.and,
+          },
+          {
+            children: [
+              {
+                child: {
+                  kind: TypeMetadataKind.integerType,
+                },
+                isOptional: false,
+                kind: TypeMetadataKind.propertyType,
+                property: 'id',
+              },
+              {
+                kind: TypeMetadataKind.objectType,
+              },
+            ],
+            id: 'Foo',
+            kind: TypeMetadataKind.and,
+          },
+        ],
+        kind: TypeMetadataKind.or,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        try {
+          unifyCollidingTypeMetadataIds(typeMetadataFixture);
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      it('should throw an Error', () => {
+        expect(result).toBeInstanceOf(Error);
+        expect((result as Error).message).toBe(
+          'Duplicated TypeMetadata id "Foo"',
+        );
+      });
+    });
+  });
+
+  describe('having two object TypeMetadata nodes with the same id and a required versus optional property', () => {
+    let typeMetadataFixture: OrTypeMetadata;
+
+    beforeAll(() => {
+      typeMetadataFixture = {
+        children: [
+          {
+            children: [
+              {
+                child: {
+                  kind: TypeMetadataKind.stringType,
+                },
+                isOptional: false,
+                kind: TypeMetadataKind.propertyType,
+                property: 'id',
+              },
+            ],
+            id: 'Foo',
+            kind: TypeMetadataKind.and,
+          },
+          {
+            children: [
+              {
+                child: {
+                  kind: TypeMetadataKind.stringType,
+                },
+                isOptional: true,
+                kind: TypeMetadataKind.propertyType,
+                property: 'id',
+              },
+            ],
+            id: 'Foo',
+            kind: TypeMetadataKind.and,
+          },
+        ],
+        kind: TypeMetadataKind.or,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        try {
+          unifyCollidingTypeMetadataIds(typeMetadataFixture);
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      it('should throw an Error', () => {
+        expect(result).toBeInstanceOf(Error);
+        expect((result as Error).message).toBe(
+          'Duplicated TypeMetadata id "Foo"',
+        );
+      });
+    });
+  });
+
+  describe('having two recursive TypeMetadata nodes with the same id', () => {
+    let firstNodeTypeMetadata: AndTypeMetadata;
+    let secondNodeTypeMetadata: AndTypeMetadata;
+    let typeMetadataFixture: OrTypeMetadata;
+
+    beforeAll(() => {
+      const firstChildPropertyTypeMetadata: PropertyTypeMetadata = {
+        child: {
+          kind: TypeMetadataKind.anyType,
+        },
+        isOptional: false,
+        kind: TypeMetadataKind.propertyType,
+        property: 'next',
+      };
+      firstNodeTypeMetadata = {
+        children: [firstChildPropertyTypeMetadata],
+        id: 'Node',
+        kind: TypeMetadataKind.and,
+      };
+      firstChildPropertyTypeMetadata.child = firstNodeTypeMetadata;
+
+      const secondChildPropertyTypeMetadata: PropertyTypeMetadata = {
+        child: {
+          kind: TypeMetadataKind.anyType,
+        },
+        isOptional: false,
+        kind: TypeMetadataKind.propertyType,
+        property: 'next',
+      };
+      secondNodeTypeMetadata = {
+        children: [secondChildPropertyTypeMetadata],
+        id: 'Node',
+        kind: TypeMetadataKind.and,
+      };
+      secondChildPropertyTypeMetadata.child = secondNodeTypeMetadata;
+
+      typeMetadataFixture = {
+        children: [firstNodeTypeMetadata, secondNodeTypeMetadata],
+        kind: TypeMetadataKind.or,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = unifyCollidingTypeMetadataIds(typeMetadataFixture);
+      });
+
+      it('should merge the recursive titled nodes', () => {
+        const resultTypeMetadata: OrTypeMetadata = result as OrTypeMetadata;
+        const propertyTypeMetadata: PropertyTypeMetadata | undefined =
+          findPropertyTypeMetadata(resultTypeMetadata, 'next');
+
+        expect(resultTypeMetadata.children[0]).toBe(firstNodeTypeMetadata);
+        expect(resultTypeMetadata.children[1]).toBe(firstNodeTypeMetadata);
+        expect(propertyTypeMetadata?.child).toBe(firstNodeTypeMetadata);
+      });
+    });
+  });
+
+  describe('having two recursive TypeMetadata nodes with the same id and different child types', () => {
+    let typeMetadataFixture: OrTypeMetadata;
+
+    beforeAll(() => {
+      const firstChildPropertyTypeMetadata: PropertyTypeMetadata = {
+        child: {
+          kind: TypeMetadataKind.anyType,
+        },
+        isOptional: false,
+        kind: TypeMetadataKind.propertyType,
+        property: 'next',
+      };
+      const firstNodeTypeMetadata: AndTypeMetadata = {
+        children: [firstChildPropertyTypeMetadata],
+        id: 'Node',
+        kind: TypeMetadataKind.and,
+      };
+      firstChildPropertyTypeMetadata.child = firstNodeTypeMetadata;
+
+      typeMetadataFixture = {
+        children: [
+          firstNodeTypeMetadata,
+          {
+            children: [
+              {
+                child: {
+                  kind: TypeMetadataKind.stringType,
+                },
+                isOptional: false,
+                kind: TypeMetadataKind.propertyType,
+                property: 'next',
+              },
+            ],
+            id: 'Node',
+            kind: TypeMetadataKind.and,
+          },
+        ],
+        kind: TypeMetadataKind.or,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        try {
+          unifyCollidingTypeMetadataIds(typeMetadataFixture);
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      it('should throw an Error', () => {
+        expect(result).toBeInstanceOf(Error);
+        expect((result as Error).message).toBe(
+          'Duplicated TypeMetadata id "Node"',
+        );
+      });
+    });
+  });
+
+  describe('having two parent TypeMetadata nodes with the same id and differently named but equally shaped children', () => {
+    let typeMetadataFixture: OrTypeMetadata;
+
+    beforeAll(() => {
+      typeMetadataFixture = {
+        children: [
+          {
+            children: [
+              {
+                child: {
+                  id: 'Bar',
+                  kind: TypeMetadataKind.stringType,
+                },
+                isOptional: false,
+                kind: TypeMetadataKind.propertyType,
+                property: 'child',
+              },
+            ],
+            id: 'Foo',
+            kind: TypeMetadataKind.and,
+          },
+          {
+            children: [
+              {
+                child: {
+                  id: 'Baz',
+                  kind: TypeMetadataKind.stringType,
+                },
+                isOptional: false,
+                kind: TypeMetadataKind.propertyType,
+                property: 'child',
+              },
+            ],
+            id: 'Foo',
+            kind: TypeMetadataKind.and,
+          },
+        ],
+        kind: TypeMetadataKind.or,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        try {
+          unifyCollidingTypeMetadataIds(typeMetadataFixture);
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      it('should throw an Error', () => {
+        expect(result).toBeInstanceOf(Error);
+        expect((result as Error).message).toBe(
+          'Duplicated TypeMetadata id "Foo"',
+        );
+      });
+    });
+  });
+
+  describe('having two parent TypeMetadata nodes with the same id and independently built children that share an id', () => {
+    let firstBarTypeMetadata: TypeMetadata;
+    let firstFooTypeMetadata: AndTypeMetadata;
+    let secondBarTypeMetadata: TypeMetadata;
+    let secondFooTypeMetadata: AndTypeMetadata;
+    let typeMetadataFixture: OrTypeMetadata;
+
+    beforeAll(() => {
+      firstBarTypeMetadata = {
+        id: 'Bar',
+        kind: TypeMetadataKind.stringType,
+      };
+      secondBarTypeMetadata = {
+        id: 'Bar',
+        kind: TypeMetadataKind.stringType,
+      };
+      firstFooTypeMetadata = {
+        children: [
+          {
+            child: firstBarTypeMetadata,
+            isOptional: false,
+            kind: TypeMetadataKind.propertyType,
+            property: 'child',
+          },
+        ],
+        id: 'Foo',
+        kind: TypeMetadataKind.and,
+      };
+      secondFooTypeMetadata = {
+        children: [
+          {
+            child: secondBarTypeMetadata,
+            isOptional: false,
+            kind: TypeMetadataKind.propertyType,
+            property: 'child',
+          },
+        ],
+        id: 'Foo',
+        kind: TypeMetadataKind.and,
+      };
+      typeMetadataFixture = {
+        children: [firstFooTypeMetadata, secondFooTypeMetadata],
+        kind: TypeMetadataKind.or,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = unifyCollidingTypeMetadataIds(typeMetadataFixture);
+      });
+
+      it('should merge both collision classes', () => {
+        const resultTypeMetadata: OrTypeMetadata = result as OrTypeMetadata;
+        const propertyTypeMetadata: PropertyTypeMetadata | undefined =
+          findPropertyTypeMetadata(resultTypeMetadata, 'child');
+
+        expect(resultTypeMetadata.children[0]).toBe(firstFooTypeMetadata);
+        expect(resultTypeMetadata.children[1]).toBe(firstFooTypeMetadata);
+        expect(propertyTypeMetadata?.child).toBe(firstBarTypeMetadata);
+      });
+    });
+  });
+
+  describe('having an array TypeMetadata whose item TypeMetadata is a clone with the same id', () => {
+    let itemTypeMetadata: AndTypeMetadata;
+    let clonedItemTypeMetadata: AndTypeMetadata;
+    let typeMetadataFixture: AndTypeMetadata;
+
+    beforeAll(() => {
+      itemTypeMetadata = {
+        children: [
+          {
+            child: {
+              kind: TypeMetadataKind.stringType,
+            },
+            isOptional: false,
+            kind: TypeMetadataKind.propertyType,
+            property: 'id',
+          },
+        ],
+        id: 'TodoV1',
+        kind: TypeMetadataKind.and,
+      };
+      clonedItemTypeMetadata = {
+        children: itemTypeMetadata.children,
+        id: 'TodoV1',
+        kind: TypeMetadataKind.and,
+      };
+      typeMetadataFixture = {
+        children: [
+          {
+            child: itemTypeMetadata,
+            isOptional: false,
+            kind: TypeMetadataKind.propertyType,
+            property: 'todo',
+          },
+          {
+            child: {
+              child: clonedItemTypeMetadata,
+              kind: TypeMetadataKind.arrayType,
+            },
+            isOptional: false,
+            kind: TypeMetadataKind.propertyType,
+            property: 'items',
+          },
+        ],
+        kind: TypeMetadataKind.and,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = unifyCollidingTypeMetadataIds(typeMetadataFixture);
+      });
+
+      it('should retarget the array item to the titled node', () => {
+        const itemsPropertyTypeMetadata: PropertyTypeMetadata | undefined =
+          findPropertyTypeMetadata(result as TypeMetadata, 'items');
+        const todoPropertyTypeMetadata: PropertyTypeMetadata | undefined =
+          findPropertyTypeMetadata(result as TypeMetadata, 'todo');
+        const arrayTypeMetadata: ArrayTypeMetadata | undefined =
+          itemsPropertyTypeMetadata?.child.kind === TypeMetadataKind.arrayType
+            ? itemsPropertyTypeMetadata.child
+            : undefined;
+
+        expect(todoPropertyTypeMetadata?.child).toBe(itemTypeMetadata);
+        expect(arrayTypeMetadata?.child).toBe(itemTypeMetadata);
+      });
+    });
+  });
+
+  describe('having inequivalent titled TypeMetadata nodes that are not reachable from the root', () => {
+    let typeMetadataFixture: TypeMetadata;
+    let titledTypeMetadata: TypeMetadata[];
+
+    beforeAll(() => {
+      typeMetadataFixture = {
+        kind: TypeMetadataKind.noneType,
+      };
+      titledTypeMetadata = [
+        {
+          id: 'Foo',
+          kind: TypeMetadataKind.stringType,
+        },
+        {
+          id: 'Foo',
+          kind: TypeMetadataKind.floatType,
+        },
+      ];
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        try {
+          unifyCollidingTypeMetadataIds(
+            typeMetadataFixture,
+            titledTypeMetadata,
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      it('should throw an Error', () => {
+        expect(result).toBeInstanceOf(Error);
+        expect((result as Error).message).toBe(
+          'Duplicated TypeMetadata id "Foo"',
+        );
+      });
+    });
+  });
+
+  describe('having equivalent titled TypeMetadata nodes that are not reachable from the root', () => {
+    let typeMetadataFixture: TypeMetadata;
+
+    beforeAll(() => {
+      typeMetadataFixture = {
+        kind: TypeMetadataKind.noneType,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = unifyCollidingTypeMetadataIds(typeMetadataFixture, [
+          {
+            id: 'Foo',
+            kind: TypeMetadataKind.stringType,
+          },
+          {
+            id: 'Foo',
+            kind: TypeMetadataKind.stringType,
+          },
+        ]);
+      });
+
+      it('should return the root TypeMetadata', () => {
+        expect(result).toBe(typeMetadataFixture);
+      });
+    });
+  });
+
+  describe('having a string index signature TypeMetadata whose child is a colliding titled clone', () => {
+    let firstFooTypeMetadata: TypeMetadata;
+    let secondFooTypeMetadata: TypeMetadata;
+    let typeMetadataFixture: AndTypeMetadata;
+
+    beforeAll(() => {
+      firstFooTypeMetadata = {
+        id: 'Foo',
+        kind: TypeMetadataKind.stringType,
+      };
+      secondFooTypeMetadata = {
+        id: 'Foo',
+        kind: TypeMetadataKind.stringType,
+      };
+      typeMetadataFixture = {
+        children: [
+          firstFooTypeMetadata,
+          {
+            child: secondFooTypeMetadata,
+            kind: TypeMetadataKind.stringIndexSignatureType,
+          },
+        ],
+        kind: TypeMetadataKind.and,
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = unifyCollidingTypeMetadataIds(typeMetadataFixture);
+      });
+
+      it('should retarget the index signature child', () => {
+        const resultTypeMetadata: AndTypeMetadata = result as AndTypeMetadata;
+        const indexSignatureTypeMetadata: TypeMetadata | undefined =
+          resultTypeMetadata.children[1];
+
+        expect(resultTypeMetadata.children[0]).toBe(firstFooTypeMetadata);
+        expect(
+          indexSignatureTypeMetadata?.kind ===
+            TypeMetadataKind.stringIndexSignatureType
+            ? indexSignatureTypeMetadata.child
+            : undefined,
+        ).toBe(firstFooTypeMetadata);
+      });
+    });
+  });
+});

--- a/packages/json-schema/libraries/json-schema-2-type-metadata/src/jsonSchema/202012/actions/unifyCollidingTypeMetadataIds.ts
+++ b/packages/json-schema/libraries/json-schema-2-type-metadata/src/jsonSchema/202012/actions/unifyCollidingTypeMetadataIds.ts
@@ -1,0 +1,305 @@
+import {
+  type TypeMetadata,
+  TypeMetadataKind,
+} from '@inversifyjs/json-schema-type-metadata';
+
+export function duplicatedTypeMetadataIdError(id: string): Error {
+  return new Error(`Duplicated TypeMetadata id "${id}"`);
+}
+
+/*
+ * Moore partition refinement over the TypeMetadata graph. Named nodes that
+ * share an id start together; untitled nodes start by kind and payload.
+ * Blocks only split. After refinement, an id that occupies more than one
+ * block is a real name collision of different types. A block that stayed
+ * together is contracted. Untitled blocks are never contracted.
+ */
+export function unifyCollidingTypeMetadataIds(
+  typeMetadata: TypeMetadata,
+  titledTypeMetadata: Iterable<TypeMetadata> = [],
+): TypeMetadata {
+  const nodeToBlockId: Map<TypeMetadata, number> = new Map();
+  const observationToBlockId: Map<string, number> = new Map();
+  let nextBlockId: number = 0;
+
+  function visit(node: TypeMetadata): void {
+    if (nodeToBlockId.has(node)) {
+      return;
+    }
+
+    const observation: string = buildInitialObservation(node);
+    let blockId: number | undefined = observationToBlockId.get(observation);
+
+    if (blockId === undefined) {
+      blockId = nextBlockId;
+      nextBlockId += 1;
+      observationToBlockId.set(observation, blockId);
+    }
+
+    nodeToBlockId.set(node, blockId);
+    visitTypeMetadataChildren(node, visit);
+  }
+
+  visit(typeMetadata);
+
+  for (const titledNode of titledTypeMetadata) {
+    visit(titledNode);
+  }
+
+  refineTypeMetadataPartition(nodeToBlockId, () => {
+    const blockId: number = nextBlockId;
+    nextBlockId += 1;
+    return blockId;
+  });
+
+  assertUniqueIdBlocks(nodeToBlockId);
+
+  const retargetMap: Map<TypeMetadata, TypeMetadata> =
+    buildRetargetMap(nodeToBlockId);
+
+  return retargetTypeMetadata(typeMetadata, retargetMap);
+}
+
+function assertUniqueIdBlocks(nodeToBlockId: Map<TypeMetadata, number>): void {
+  const idToBlockIds: Map<string, Set<number>> = new Map();
+
+  for (const [node, blockId] of nodeToBlockId) {
+    if (node.id === undefined) {
+      continue;
+    }
+
+    const blockIds: Set<number> = idToBlockIds.get(node.id) ?? new Set();
+
+    blockIds.add(blockId);
+    idToBlockIds.set(node.id, blockIds);
+  }
+
+  const collidingIds: string[] = [...idToBlockIds.entries()]
+    .filter(([, blockIds]: [string, Set<number>]) => blockIds.size > 1)
+    .map(([id]: [string, Set<number>]) => id)
+    .sort();
+
+  const collidingId: string | undefined = collidingIds[0];
+
+  if (collidingId !== undefined) {
+    throw duplicatedTypeMetadataIdError(collidingId);
+  }
+}
+
+function buildInitialObservation(typeMetadata: TypeMetadata): string {
+  return JSON.stringify([
+    typeMetadata.id ?? null,
+    typeMetadata.kind,
+    typeMetadata.kind === TypeMetadataKind.literalType
+      ? typeMetadata.literal
+      : null,
+    typeMetadata.kind === TypeMetadataKind.propertyType
+      ? typeMetadata.property
+      : null,
+    typeMetadata.kind === TypeMetadataKind.propertyType
+      ? typeMetadata.isOptional
+      : null,
+  ]);
+}
+
+function buildChildSignature(
+  typeMetadata: TypeMetadata,
+  nodeToBlockId: Map<TypeMetadata, number>,
+): string {
+  switch (typeMetadata.kind) {
+    case TypeMetadataKind.and:
+    case TypeMetadataKind.or:
+      return typeMetadata.children
+        .map((child: TypeMetadata) => requireBlockId(child, nodeToBlockId))
+        .sort((left: number, right: number) => left - right)
+        .join(',');
+    case TypeMetadataKind.arrayType:
+    case TypeMetadataKind.propertyType:
+    case TypeMetadataKind.stringIndexSignatureType:
+      return requireBlockId(typeMetadata.child, nodeToBlockId).toString();
+    default:
+      return '';
+  }
+}
+
+function buildRetargetMap(
+  nodeToBlockId: Map<TypeMetadata, number>,
+): Map<TypeMetadata, TypeMetadata> {
+  const blockToTitledTypeMetadata: Map<number, TypeMetadata[]> = new Map();
+
+  for (const [node, blockId] of nodeToBlockId) {
+    if (node.id === undefined) {
+      continue;
+    }
+
+    const titledTypeMetadata: TypeMetadata[] =
+      blockToTitledTypeMetadata.get(blockId) ?? [];
+
+    titledTypeMetadata.push(node);
+    blockToTitledTypeMetadata.set(blockId, titledTypeMetadata);
+  }
+
+  const retargetMap: Map<TypeMetadata, TypeMetadata> = new Map();
+
+  for (const titledTypeMetadata of blockToTitledTypeMetadata.values()) {
+    const representative: TypeMetadata | undefined = titledTypeMetadata[0];
+
+    if (representative === undefined || titledTypeMetadata.length === 1) {
+      continue;
+    }
+
+    for (let i: number = 1; i < titledTypeMetadata.length; i += 1) {
+      retargetMap.set(titledTypeMetadata[i] as TypeMetadata, representative);
+    }
+  }
+
+  return retargetMap;
+}
+
+function refineTypeMetadataPartition(
+  nodeToBlockId: Map<TypeMetadata, number>,
+  allocateBlockId: () => number,
+): void {
+  let hasSplit: boolean = true;
+
+  while (hasSplit) {
+    hasSplit = false;
+
+    const snapshotNodeToBlockId: Map<TypeMetadata, number> = new Map(
+      nodeToBlockId,
+    );
+    const blockToNodes: Map<number, TypeMetadata[]> = new Map();
+
+    for (const [node, blockId] of snapshotNodeToBlockId) {
+      const blockNodes: TypeMetadata[] = blockToNodes.get(blockId) ?? [];
+
+      blockNodes.push(node);
+      blockToNodes.set(blockId, blockNodes);
+    }
+
+    for (const [blockId, blockNodes] of blockToNodes) {
+      if (blockNodes.length === 1) {
+        continue;
+      }
+
+      const signatureToNodes: Map<string, TypeMetadata[]> = new Map();
+
+      for (const node of blockNodes) {
+        const signature: string = buildChildSignature(
+          node,
+          snapshotNodeToBlockId,
+        );
+        const signatureNodes: TypeMetadata[] =
+          signatureToNodes.get(signature) ?? [];
+
+        signatureNodes.push(node);
+        signatureToNodes.set(signature, signatureNodes);
+      }
+
+      if (signatureToNodes.size === 1) {
+        continue;
+      }
+
+      hasSplit = true;
+
+      let isFirstSignature: boolean = true;
+
+      for (const signatureNodes of signatureToNodes.values()) {
+        const nextBlockId: number = isFirstSignature
+          ? blockId
+          : allocateBlockId();
+
+        isFirstSignature = false;
+
+        for (const node of signatureNodes) {
+          nodeToBlockId.set(node, nextBlockId);
+        }
+      }
+    }
+  }
+}
+
+function requireBlockId(
+  typeMetadata: TypeMetadata,
+  nodeToBlockId: Map<TypeMetadata, number>,
+): number {
+  const blockId: number | undefined = nodeToBlockId.get(typeMetadata);
+
+  if (blockId === undefined) {
+    throw new Error('TypeMetadata node is missing from the partition');
+  }
+
+  return blockId;
+}
+
+function retargetTypeMetadata(
+  typeMetadata: TypeMetadata,
+  retargetMap: Map<TypeMetadata, TypeMetadata>,
+): TypeMetadata {
+  const rootTypeMetadata: TypeMetadata =
+    retargetMap.get(typeMetadata) ?? typeMetadata;
+
+  if (retargetMap.size === 0) {
+    return rootTypeMetadata;
+  }
+
+  const seenTypeMetadataSet: Set<TypeMetadata> = new Set();
+
+  function visit(node: TypeMetadata): void {
+    if (seenTypeMetadataSet.has(node)) {
+      return;
+    }
+
+    seenTypeMetadataSet.add(node);
+
+    switch (node.kind) {
+      case TypeMetadataKind.and:
+      case TypeMetadataKind.or:
+        for (let i: number = 0; i < node.children.length; i += 1) {
+          const child: TypeMetadata = node.children[i] as TypeMetadata;
+          const retargetedChild: TypeMetadata = retargetMap.get(child) ?? child;
+
+          node.children[i] = retargetedChild;
+          visit(retargetedChild);
+        }
+        break;
+      case TypeMetadataKind.arrayType:
+      case TypeMetadataKind.propertyType:
+      case TypeMetadataKind.stringIndexSignatureType: {
+        const retargetedChild: TypeMetadata =
+          retargetMap.get(node.child) ?? node.child;
+
+        node.child = retargetedChild;
+        visit(retargetedChild);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  visit(rootTypeMetadata);
+
+  return rootTypeMetadata;
+}
+
+function visitTypeMetadataChildren(
+  typeMetadata: TypeMetadata,
+  visit: (child: TypeMetadata) => void,
+): void {
+  switch (typeMetadata.kind) {
+    case TypeMetadataKind.and:
+    case TypeMetadataKind.or:
+      for (const child of typeMetadata.children) {
+        visit(child);
+      }
+      break;
+    case TypeMetadataKind.arrayType:
+    case TypeMetadataKind.propertyType:
+    case TypeMetadataKind.stringIndexSignatureType:
+      visit(typeMetadata.child);
+      break;
+    default:
+      break;
+  }
+}

--- a/packages/json-schema/libraries/json-schema-2-type-metadata/src/jsonSchema/202012/actions/unifyCollidingTypeMetadataIds.ts
+++ b/packages/json-schema/libraries/json-schema-2-type-metadata/src/jsonSchema/202012/actions/unifyCollidingTypeMetadataIds.ts
@@ -3,7 +3,7 @@ import {
   TypeMetadataKind,
 } from '@inversifyjs/json-schema-type-metadata';
 
-export function duplicatedTypeMetadataIdError(id: string): Error {
+function duplicatedTypeMetadataIdError(id: string): Error {
   return new Error(`Duplicated TypeMetadata id "${id}"`);
 }
 

--- a/packages/json-schema/libraries/json-schema-2-type-metadata/src/jsonSchema/202012/models/TransformJsonSchemaInternalContext.ts
+++ b/packages/json-schema/libraries/json-schema-2-type-metadata/src/jsonSchema/202012/models/TransformJsonSchemaInternalContext.ts
@@ -17,5 +17,5 @@ export interface TransformJsonSchemaInternalContext extends TransformJsonSchemaC
     JsonRootSchema | JsonSchema,
     Map<string, TypeMetadata>
   >;
-  typeMetadataIdSet: Set<string>;
+  titledTypeMetadata: TypeMetadata[];
 }

--- a/packages/json-schema/libraries/json-schema-2-typescript/src/jsonSchema/202012/actions/transformJsonSchemaToTypeScript.int.spec.ts
+++ b/packages/json-schema/libraries/json-schema-2-typescript/src/jsonSchema/202012/actions/transformJsonSchemaToTypeScript.int.spec.ts
@@ -1323,7 +1323,7 @@ describe(transformJsonSchemaToTypeScript, () => {
     });
   });
 
-  describe('having two schemas with the same title', () => {
+  describe('having two inequivalent schemas with the same title', () => {
     let jsonSchemaFixture: JsonSchemaObject;
 
     beforeAll(() => {
@@ -1359,6 +1359,653 @@ describe(transformJsonSchemaToTypeScript, () => {
         expect(result).toBeInstanceOf(Error);
         expect((result as Error).message).toBe(
           'Duplicated TypeMetadata id "Foo"',
+        );
+      });
+    });
+  });
+
+  describe('having two equivalent schemas with the same title', () => {
+    let jsonSchemaFixture: JsonSchemaObject;
+
+    beforeAll(() => {
+      jsonSchemaFixture = {
+        properties: {
+          a: {
+            title: 'Foo',
+            type: 'string',
+          },
+          b: {
+            title: 'Foo',
+            type: 'string',
+          },
+        },
+        required: ['a', 'b'],
+        type: 'object',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = transformJsonSchemaToTypeScript(
+          jsonSchemaFixture,
+          generateTransformJsonSchemaContext(),
+        );
+      });
+
+      it('should reuse one type alias', () => {
+        expect(result).toBe(
+          'export type Foo = string;\nexport type Root = { a: Foo; b: Foo };',
+        );
+      });
+
+      it('should return a TypeScript module that compiles', () => {
+        expect(getTypeScriptDiagnosticMessages(result as string)).toStrictEqual(
+          [],
+        );
+      });
+    });
+  });
+
+  describe('having two equivalent schemas with different titles', () => {
+    let jsonSchemaFixture: JsonSchemaObject;
+
+    beforeAll(() => {
+      jsonSchemaFixture = {
+        properties: {
+          person: {
+            title: 'Person',
+            type: 'string',
+          },
+          user: {
+            title: 'User',
+            type: 'string',
+          },
+        },
+        required: ['person', 'user'],
+        type: 'object',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = transformJsonSchemaToTypeScript(
+          jsonSchemaFixture,
+          generateTransformJsonSchemaContext(),
+        );
+      });
+
+      it('should keep both type aliases', () => {
+        expect(result).toBe(
+          'export type Person = string;\nexport type User = string;\nexport type Root = { person: Person; user: User };',
+        );
+      });
+
+      it('should return a TypeScript module that compiles', () => {
+        expect(getTypeScriptDiagnosticMessages(result as string)).toStrictEqual(
+          [],
+        );
+      });
+    });
+  });
+
+  describe('having a titled schema both as a property and as array items via $ref', () => {
+    let jsonSchemaFixture: JsonSchemaObject;
+    let todoJsonSchemaFixture: JsonSchemaObject;
+
+    beforeAll(() => {
+      todoJsonSchemaFixture = {
+        $id: 'https://example.com/todo',
+        properties: {
+          completed: {
+            type: 'boolean',
+          },
+          id: {
+            type: 'string',
+          },
+        },
+        required: ['completed', 'id'],
+        title: 'TodoV1',
+        type: 'object',
+      };
+      jsonSchemaFixture = {
+        $id: 'https://example.com/root',
+        properties: {
+          items: {
+            items: {
+              $ref: 'https://example.com/todo',
+            },
+            type: 'array',
+          },
+          todo: {
+            $ref: 'https://example.com/todo',
+          },
+        },
+        required: ['items', 'todo'],
+        type: 'object',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = transformJsonSchemaToTypeScript(
+          jsonSchemaFixture,
+          generateTransformJsonSchemaContext([
+            jsonSchemaFixture,
+            todoJsonSchemaFixture,
+          ]),
+        );
+      });
+
+      it('should reuse one TodoV1 alias for the property and the array items', () => {
+        expect(result).toBe(
+          'export type TodoV1 = { completed: boolean; id: string };\nexport type Root = { items: TodoV1[]; todo: TodoV1 };',
+        );
+      });
+
+      it('should return a TypeScript module that compiles', () => {
+        expect(getTypeScriptDiagnosticMessages(result as string)).toStrictEqual(
+          [],
+        );
+      });
+    });
+  });
+
+  describe('having two equivalent titled object schemas with nested object properties', () => {
+    let jsonSchemaFixture: JsonSchemaObject;
+
+    beforeAll(() => {
+      jsonSchemaFixture = {
+        properties: {
+          a: {
+            properties: {
+              address: {
+                properties: {
+                  city: {
+                    type: 'string',
+                  },
+                },
+                required: ['city'],
+                type: 'object',
+              },
+            },
+            required: ['address'],
+            title: 'Foo',
+            type: 'object',
+          },
+          b: {
+            properties: {
+              address: {
+                properties: {
+                  city: {
+                    type: 'string',
+                  },
+                },
+                required: ['city'],
+                type: 'object',
+              },
+            },
+            required: ['address'],
+            title: 'Foo',
+            type: 'object',
+          },
+        },
+        required: ['a', 'b'],
+        type: 'object',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = transformJsonSchemaToTypeScript(
+          jsonSchemaFixture,
+          generateTransformJsonSchemaContext(),
+        );
+      });
+
+      it('should reuse one Foo alias for both nested objects', () => {
+        expect(result).toBe(
+          'export type Foo = { address: { city: string } };\nexport type Root = { a: Foo; b: Foo };',
+        );
+      });
+
+      it('should return a TypeScript module that compiles', () => {
+        expect(getTypeScriptDiagnosticMessages(result as string)).toStrictEqual(
+          [],
+        );
+      });
+    });
+  });
+
+  describe('having two titled object schemas that differ in a nested object property', () => {
+    let jsonSchemaFixture: JsonSchemaObject;
+
+    beforeAll(() => {
+      jsonSchemaFixture = {
+        properties: {
+          a: {
+            properties: {
+              address: {
+                properties: {
+                  city: {
+                    type: 'string',
+                  },
+                },
+                required: ['city'],
+                type: 'object',
+              },
+            },
+            required: ['address'],
+            title: 'Foo',
+            type: 'object',
+          },
+          b: {
+            properties: {
+              address: {
+                properties: {
+                  city: {
+                    type: 'number',
+                  },
+                },
+                required: ['city'],
+                type: 'object',
+              },
+            },
+            required: ['address'],
+            title: 'Foo',
+            type: 'object',
+          },
+        },
+        required: ['a', 'b'],
+        type: 'object',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        try {
+          transformJsonSchemaToTypeScript(
+            jsonSchemaFixture,
+            generateTransformJsonSchemaContext(),
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      it('should throw an Error', () => {
+        expect(result).toBeInstanceOf(Error);
+        expect((result as Error).message).toBe(
+          'Duplicated TypeMetadata id "Foo"',
+        );
+      });
+    });
+  });
+
+  describe('having two equivalent titled object schemas with array properties', () => {
+    let jsonSchemaFixture: JsonSchemaObject;
+
+    beforeAll(() => {
+      jsonSchemaFixture = {
+        properties: {
+          a: {
+            properties: {
+              tags: {
+                items: {
+                  type: 'string',
+                },
+                type: 'array',
+              },
+            },
+            required: ['tags'],
+            title: 'Foo',
+            type: 'object',
+          },
+          b: {
+            properties: {
+              tags: {
+                items: {
+                  type: 'string',
+                },
+                type: 'array',
+              },
+            },
+            required: ['tags'],
+            title: 'Foo',
+            type: 'object',
+          },
+        },
+        required: ['a', 'b'],
+        type: 'object',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = transformJsonSchemaToTypeScript(
+          jsonSchemaFixture,
+          generateTransformJsonSchemaContext(),
+        );
+      });
+
+      it('should reuse one Foo alias for both array properties', () => {
+        expect(result).toBe(
+          'export type Foo = { tags: string[] };\nexport type Root = { a: Foo; b: Foo };',
+        );
+      });
+
+      it('should return a TypeScript module that compiles', () => {
+        expect(getTypeScriptDiagnosticMessages(result as string)).toStrictEqual(
+          [],
+        );
+      });
+    });
+  });
+
+  describe('having two equivalent titled object schemas with array of object properties', () => {
+    let jsonSchemaFixture: JsonSchemaObject;
+
+    beforeAll(() => {
+      jsonSchemaFixture = {
+        properties: {
+          a: {
+            properties: {
+              items: {
+                items: {
+                  properties: {
+                    id: {
+                      type: 'string',
+                    },
+                  },
+                  required: ['id'],
+                  type: 'object',
+                },
+                type: 'array',
+              },
+            },
+            required: ['items'],
+            title: 'Foo',
+            type: 'object',
+          },
+          b: {
+            properties: {
+              items: {
+                items: {
+                  properties: {
+                    id: {
+                      type: 'string',
+                    },
+                  },
+                  required: ['id'],
+                  type: 'object',
+                },
+                type: 'array',
+              },
+            },
+            required: ['items'],
+            title: 'Foo',
+            type: 'object',
+          },
+        },
+        required: ['a', 'b'],
+        type: 'object',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = transformJsonSchemaToTypeScript(
+          jsonSchemaFixture,
+          generateTransformJsonSchemaContext(),
+        );
+      });
+
+      it('should reuse one Foo alias for both array of object properties', () => {
+        expect(result).toBe(
+          'export type Foo = { items: { id: string }[] };\nexport type Root = { a: Foo; b: Foo };',
+        );
+      });
+
+      it('should return a TypeScript module that compiles', () => {
+        expect(getTypeScriptDiagnosticMessages(result as string)).toStrictEqual(
+          [],
+        );
+      });
+    });
+  });
+
+  describe('having two titled object schemas that differ in an array item type', () => {
+    let jsonSchemaFixture: JsonSchemaObject;
+
+    beforeAll(() => {
+      jsonSchemaFixture = {
+        properties: {
+          a: {
+            properties: {
+              items: {
+                items: {
+                  properties: {
+                    id: {
+                      type: 'string',
+                    },
+                  },
+                  required: ['id'],
+                  type: 'object',
+                },
+                type: 'array',
+              },
+            },
+            required: ['items'],
+            title: 'Foo',
+            type: 'object',
+          },
+          b: {
+            properties: {
+              items: {
+                items: {
+                  properties: {
+                    id: {
+                      type: 'number',
+                    },
+                  },
+                  required: ['id'],
+                  type: 'object',
+                },
+                type: 'array',
+              },
+            },
+            required: ['items'],
+            title: 'Foo',
+            type: 'object',
+          },
+        },
+        required: ['a', 'b'],
+        type: 'object',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        try {
+          transformJsonSchemaToTypeScript(
+            jsonSchemaFixture,
+            generateTransformJsonSchemaContext(),
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      it('should throw an Error', () => {
+        expect(result).toBeInstanceOf(Error);
+        expect((result as Error).message).toBe(
+          'Duplicated TypeMetadata id "Foo"',
+        );
+      });
+    });
+  });
+
+  describe('having two equivalent titled object schemas with nested titled object and array properties', () => {
+    let jsonSchemaFixture: JsonSchemaObject;
+
+    beforeAll(() => {
+      jsonSchemaFixture = {
+        properties: {
+          a: {
+            properties: {
+              address: {
+                properties: {
+                  city: {
+                    type: 'string',
+                  },
+                },
+                required: ['city'],
+                title: 'Address',
+                type: 'object',
+              },
+              tags: {
+                items: {
+                  type: 'string',
+                },
+                type: 'array',
+              },
+            },
+            required: ['address', 'tags'],
+            title: 'Foo',
+            type: 'object',
+          },
+          b: {
+            properties: {
+              address: {
+                properties: {
+                  city: {
+                    type: 'string',
+                  },
+                },
+                required: ['city'],
+                title: 'Address',
+                type: 'object',
+              },
+              tags: {
+                items: {
+                  type: 'string',
+                },
+                type: 'array',
+              },
+            },
+            required: ['address', 'tags'],
+            title: 'Foo',
+            type: 'object',
+          },
+        },
+        required: ['a', 'b'],
+        type: 'object',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = transformJsonSchemaToTypeScript(
+          jsonSchemaFixture,
+          generateTransformJsonSchemaContext(),
+        );
+      });
+
+      it('should reuse Foo and Address aliases', () => {
+        expect(result).toBe(
+          'export type Foo = { address: Address; tags: string[] };\nexport type Address = { city: string };\nexport type Root = { a: Foo; b: Foo };',
+        );
+      });
+
+      it('should return a TypeScript module that compiles', () => {
+        expect(getTypeScriptDiagnosticMessages(result as string)).toStrictEqual(
+          [],
+        );
+      });
+    });
+  });
+
+  describe('having two titled object schemas with the same nested title and a different nested property type', () => {
+    let jsonSchemaFixture: JsonSchemaObject;
+
+    beforeAll(() => {
+      jsonSchemaFixture = {
+        properties: {
+          a: {
+            properties: {
+              address: {
+                properties: {
+                  city: {
+                    type: 'string',
+                  },
+                },
+                required: ['city'],
+                title: 'Address',
+                type: 'object',
+              },
+            },
+            required: ['address'],
+            title: 'Foo',
+            type: 'object',
+          },
+          b: {
+            properties: {
+              address: {
+                properties: {
+                  city: {
+                    type: 'number',
+                  },
+                },
+                required: ['city'],
+                title: 'Address',
+                type: 'object',
+              },
+            },
+            required: ['address'],
+            title: 'Foo',
+            type: 'object',
+          },
+        },
+        required: ['a', 'b'],
+        type: 'object',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        try {
+          transformJsonSchemaToTypeScript(
+            jsonSchemaFixture,
+            generateTransformJsonSchemaContext(),
+          );
+        } catch (error: unknown) {
+          result = error;
+        }
+      });
+
+      it('should throw an Error', () => {
+        expect(result).toBeInstanceOf(Error);
+        expect((result as Error).message).toBe(
+          'Duplicated TypeMetadata id "Address"',
         );
       });
     });

--- a/packages/open-api/libraries/open-api-2-typescript/src/openApi/v3Dot1/actions/transformOpenApiToTypeScript.int.spec.ts
+++ b/packages/open-api/libraries/open-api-2-typescript/src/openApi/v3Dot1/actions/transformOpenApiToTypeScript.int.spec.ts
@@ -139,6 +139,136 @@ describe(transformOpenApiToTypeScript, () => {
     },
   );
 
+  describe('having a component schema referenced as array items', () => {
+    let openApiObjectFixture: OpenApi3Dot1Object;
+
+    beforeAll(() => {
+      openApiObjectFixture = {
+        components: {
+          schemas: {
+            PaginatedTodosV1Response: {
+              properties: {
+                items: {
+                  items: {
+                    $ref: '#/components/schemas/TodoV1',
+                  },
+                  type: 'array',
+                },
+              },
+              required: ['items'],
+              type: 'object',
+            },
+            TodoV1: {
+              properties: {
+                id: {
+                  type: 'string',
+                },
+                title: {
+                  type: 'string',
+                },
+              },
+              required: ['id', 'title'],
+              type: 'object',
+            },
+          },
+        },
+        info: { title: 'API', version: '1.0.0' },
+        openapi: '3.1.0',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = transformOpenApiToTypeScript(openApiObjectFixture);
+      });
+
+      it('should reuse TodoV1 for the array items', () => {
+        expect(result).toBe(
+          'export type PaginatedTodosV1Response = { items: TodoV1[] };\nexport type TodoV1 = { id: string; title: string };\nexport type Root = PaginatedTodosV1Response | TodoV1;',
+        );
+      });
+
+      it('should return a TypeScript module that compiles', () => {
+        expect(getTypeScriptDiagnosticMessages(result as string)).toStrictEqual(
+          [],
+        );
+      });
+    });
+  });
+
+  describe('having a component schema with nested object and array properties referenced as array items', () => {
+    let openApiObjectFixture: OpenApi3Dot1Object;
+
+    beforeAll(() => {
+      openApiObjectFixture = {
+        components: {
+          schemas: {
+            PaginatedTodosV1Response: {
+              properties: {
+                items: {
+                  items: {
+                    $ref: '#/components/schemas/TodoV1',
+                  },
+                  type: 'array',
+                },
+              },
+              required: ['items'],
+              type: 'object',
+            },
+            TodoV1: {
+              properties: {
+                address: {
+                  properties: {
+                    city: {
+                      type: 'string',
+                    },
+                  },
+                  required: ['city'],
+                  type: 'object',
+                },
+                tags: {
+                  items: {
+                    type: 'string',
+                  },
+                  type: 'array',
+                },
+                title: {
+                  type: 'string',
+                },
+              },
+              required: ['address', 'tags', 'title'],
+              type: 'object',
+            },
+          },
+        },
+        info: { title: 'API', version: '1.0.0' },
+        openapi: '3.1.0',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = transformOpenApiToTypeScript(openApiObjectFixture);
+      });
+
+      it('should reuse TodoV1 including its nested object and array properties', () => {
+        expect(result).toBe(
+          'export type PaginatedTodosV1Response = { items: TodoV1[] };\nexport type TodoV1 = { address: { city: string }; tags: string[]; title: string };\nexport type Root = PaginatedTodosV1Response | TodoV1;',
+        );
+      });
+
+      it('should return a TypeScript module that compiles', () => {
+        expect(getTypeScriptDiagnosticMessages(result as string)).toStrictEqual(
+          [],
+        );
+      });
+    });
+  });
+
   describe('having component schemas that $ref each other', () => {
     let openApiObjectFixture: OpenApi3Dot1Object;
 

--- a/packages/open-api/libraries/open-api-2-typescript/src/openApi/v3Dot2/actions/transformOpenApiToTypeScript.int.spec.ts
+++ b/packages/open-api/libraries/open-api-2-typescript/src/openApi/v3Dot2/actions/transformOpenApiToTypeScript.int.spec.ts
@@ -170,6 +170,136 @@ describe(transformOpenApiToTypeScript, () => {
     });
   });
 
+  describe('having a component schema referenced as array items', () => {
+    let openApiObjectFixture: OpenApi3Dot2Object;
+
+    beforeAll(() => {
+      openApiObjectFixture = {
+        components: {
+          schemas: {
+            PaginatedTodosV1Response: {
+              properties: {
+                items: {
+                  items: {
+                    $ref: '#/components/schemas/TodoV1',
+                  },
+                  type: 'array',
+                },
+              },
+              required: ['items'],
+              type: 'object',
+            },
+            TodoV1: {
+              properties: {
+                id: {
+                  type: 'string',
+                },
+                title: {
+                  type: 'string',
+                },
+              },
+              required: ['id', 'title'],
+              type: 'object',
+            },
+          },
+        },
+        info: { title: 'API', version: '1.0.0' },
+        openapi: '3.2.0',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = transformOpenApiToTypeScript(openApiObjectFixture);
+      });
+
+      it('should reuse TodoV1 for the array items', () => {
+        expect(result).toBe(
+          'export type PaginatedTodosV1Response = { items: TodoV1[] };\nexport type TodoV1 = { id: string; title: string };\nexport type Root = PaginatedTodosV1Response | TodoV1;',
+        );
+      });
+
+      it('should return a TypeScript module that compiles', () => {
+        expect(getTypeScriptDiagnosticMessages(result as string)).toStrictEqual(
+          [],
+        );
+      });
+    });
+  });
+
+  describe('having a component schema with nested object and array properties referenced as array items', () => {
+    let openApiObjectFixture: OpenApi3Dot2Object;
+
+    beforeAll(() => {
+      openApiObjectFixture = {
+        components: {
+          schemas: {
+            PaginatedTodosV1Response: {
+              properties: {
+                items: {
+                  items: {
+                    $ref: '#/components/schemas/TodoV1',
+                  },
+                  type: 'array',
+                },
+              },
+              required: ['items'],
+              type: 'object',
+            },
+            TodoV1: {
+              properties: {
+                address: {
+                  properties: {
+                    city: {
+                      type: 'string',
+                    },
+                  },
+                  required: ['city'],
+                  type: 'object',
+                },
+                tags: {
+                  items: {
+                    type: 'string',
+                  },
+                  type: 'array',
+                },
+                title: {
+                  type: 'string',
+                },
+              },
+              required: ['address', 'tags', 'title'],
+              type: 'object',
+            },
+          },
+        },
+        info: { title: 'API', version: '1.0.0' },
+        openapi: '3.2.0',
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = transformOpenApiToTypeScript(openApiObjectFixture);
+      });
+
+      it('should reuse TodoV1 including its nested object and array properties', () => {
+        expect(result).toBe(
+          'export type PaginatedTodosV1Response = { items: TodoV1[] };\nexport type TodoV1 = { address: { city: string }; tags: string[]; title: string };\nexport type Root = PaginatedTodosV1Response | TodoV1;',
+        );
+      });
+
+      it('should return a TypeScript module that compiles', () => {
+        expect(getTypeScriptDiagnosticMessages(result as string)).toStrictEqual(
+          [],
+        );
+      });
+    });
+  });
+
   describe('having a $self identifier and a relative schema $id', () => {
     let openApiObjectFixture: OpenApi3Dot2Object;
 


### PR DESCRIPTION
### Changed
- Updated `transformJsonSchema` with merge strategy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Equivalent titled schemas now reuse a single generated type metadata node and TypeScript type alias, including nested objects and arrays.
  - OpenAPI component schemas referenced as array items now correctly reuse their generated TypeScript types.

- **Bug Fixes**
  - Schemas with the same title but different structures continue to raise a clear duplicate metadata error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->