### PR TITLE
fix: install pnpm via pnpm/setup in CI

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -17,15 +17,16 @@ runs:
         package-manager-cache: false
         registry-url: ${{ inputs.registry-url }}
 
-    - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+    - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
       name: Install pnpm
       with:
-        run_install: false
+        install: false
 
     - name: Get pnpm store directory
       id: pnpm-cache
       run: |
-        echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
+        pnpm_cache_dir="$(pnpm store path)"
+        echo "pnpm_cache_dir=${pnpm_cache_dir}" >> "$GITHUB_OUTPUT"
       shell: bash
 
     - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -17,10 +17,11 @@ runs:
         package-manager-cache: false
         registry-url: ${{ inputs.registry-url }}
 
-    - uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+    - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       name: Install pnpm
       with:
-        install: false
+        run_install: false
+        standalone: true
 
     - name: Get pnpm store directory
       id: pnpm-cache


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CI’s composite setup action installed pnpm through `pnpm/action-setup`’s npm self-installer. After this branch pinned `packageManager` to `pnpm@12.3.2`, that left a shebang-less placeholder on `PATH`. `pnpm store path` then failed with `Syntax error: ")" unexpected`, the cache path was empty, and `actions/cache` aborted with `Input required and not supplied: path`.

The preferred installer is `pnpm/setup` (native GitHub-release binary). That action is **not on the org Actions allowlist**. The first commit was rejected immediately:

```text
The action pnpm/setup@… is not allowed in inversify/monorepo because all
actions must be from a repository owned by inversify, created by GitHub,
verified in the GitHub Marketplace, or match one of the patterns:
… pnpm/action-setup@* …
```

This PR therefore keeps the allowed `pnpm/action-setup@v6.0.8` and sets `standalone: true`, which bootstraps `@pnpm/exe` (the native binary) and self-updates to the `packageManager` version instead of using the npm wrapper.

The store-path step now assigns `$(pnpm store path)` before writing `$GITHUB_OUTPUT`, so a broken `pnpm` fails that step instead of `actions/cache`.

To switch to `pnpm/setup` later, add `pnpm/setup@*` to the org/repo allowed-actions list, then replace this step with `pnpm/setup` and `install: false`.

## Test plan

- [x] Confirm the Build job’s `Run ./.github/actions/setup` step succeeds (Node, standalone pnpm, `pnpm store path`, cache, `pnpm install`).
- [x] Confirm later Build steps can run `pnpm` (affected packages, compile, lint).
- [x] Full `build` workflow on this branch is green (Build + HTTP E2E): https://github.com/inversify/monorepo/actions/runs/34102674832

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a28e2f6-a326-4b1b-a9f0-4ad452295bda?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a28e2f6-a326-4b1b-a9f0-4ad452295bda&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

