### PR TITLE
Update renovate config to bump node dev engine dep

### DIFF
--- a/.changeset/twelve-canyons-sin.md
+++ b/.changeset/twelve-canyons-sin.md
@@ -1,0 +1,5 @@
+---
+"@inversifyjs/http-uwebsockets": patch
+---
+
+- Updated `InversifyUwebSocketsHttpAdapter` to allow sending http body separator on chunked responses

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,23 +13,25 @@
     },
     {
       "customType": "regex",
-      "description": "Update node version tracked in package.json engines field",
+      "description": "Update node version tracked in package.json devEngines field",
       "managerFilePatterns": ["/(^|/)package\\.json$/"],
       "matchStrings": [
         "\"devEngines\"\\s*:\\s*\\{[\\s\\S]*?\"node\"\\s*:\\s*\"(?<currentValue>[^\"]+)\""
       ],
       "depNameTemplate": "node",
-      "datasourceTemplate": "node-version"
+      "datasourceTemplate": "node-version",
+      "versioningTemplate": "npm"
     },
     {
       "customType": "regex",
-      "description": "Update pnpm version tracked in package.json engines field",
+      "description": "Update pnpm version tracked in package.json devEngines field",
       "managerFilePatterns": ["/(^|/)package\\.json$/"],
       "matchStrings": [
         "\"devEngines\"\\s*:\\s*\\{[\\s\\S]*?\"pnpm\"\\s*:\\s*\"(?<currentValue>[^\"]+)\""
       ],
       "depNameTemplate": "pnpm",
-      "datasourceTemplate": "npm"
+      "datasourceTemplate": "npm",
+      "versioningTemplate": "npm"
     },
     {
       "customType": "regex",

--- a/packages/container/libraries/core/src/planning/calculations/buildZeroResolvedValueArgumentsResolver.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildZeroResolvedValueArgumentsResolver.spec.ts
@@ -7,6 +7,14 @@ import { type ResolvedValueBindingNode } from '../models/ResolvedValueBindingNod
 import { buildZeroResolvedValueArgumentsResolver } from './buildZeroResolvedValueArgumentsResolver.js';
 
 class TestFixtures {
+  public static get params(): ResolutionParams {
+    return Symbol() as unknown as ResolutionParams;
+  }
+
+  public static get resolvedValue(): object {
+    return {};
+  }
+
   public static node(
     factory: () => object,
   ): ResolvedValueBindingNode<ResolvedValueBinding<object>> {
@@ -19,14 +27,6 @@ class TestFixtures {
       },
       params: [],
     } as unknown as ResolvedValueBindingNode<ResolvedValueBinding<object>>;
-  }
-
-  public static get params(): ResolutionParams {
-    return Symbol() as unknown as ResolutionParams;
-  }
-
-  public static get resolvedValue(): object {
-    return {};
   }
 }
 

--- a/packages/container/libraries/core/src/planning/calculations/buildZeroResolvedValueArgumentsResolverJit.spec.ts
+++ b/packages/container/libraries/core/src/planning/calculations/buildZeroResolvedValueArgumentsResolverJit.spec.ts
@@ -7,6 +7,14 @@ import { type ResolvedValueBindingNode } from '../models/ResolvedValueBindingNod
 import { buildZeroResolvedValueArgumentsResolverJit } from './buildZeroResolvedValueArgumentsResolverJit.js';
 
 class TestFixtures {
+  public static get params(): ResolutionParams {
+    return Symbol() as unknown as ResolutionParams;
+  }
+
+  public static get resolvedValue(): object {
+    return {};
+  }
+
   public static node(
     factory: () => object,
   ): ResolvedValueBindingNode<ResolvedValueBinding<object>> {
@@ -19,14 +27,6 @@ class TestFixtures {
       },
       params: [],
     } as unknown as ResolvedValueBindingNode<ResolvedValueBinding<object>>;
-  }
-
-  public static get params(): ResolutionParams {
-    return Symbol() as unknown as ResolutionParams;
-  }
-
-  public static get resolvedValue(): object {
-    return {};
   }
 }
 

--- a/packages/framework/http/libraries/uwebsockets/src/adapter/InversifyUwebSocketsHttpAdapter.ts
+++ b/packages/framework/http/libraries/uwebsockets/src/adapter/InversifyUwebSocketsHttpAdapter.ts
@@ -245,18 +245,11 @@ export class InversifyUwebSocketsHttpAdapter extends InversifyHttpAdapter<
 
   protected _sendBodySeparator(
     _request: HttpRequest,
-    _response: HttpResponse,
+    response: HttpResponse,
   ): void {
-    /*
-     * Once https://github.com/uNetworking/uWebSockets/pull/1897 is merged and released,
-     * we can implement this method to use `response.beginWrite()`.
-     * For now, we log a warning if logger is enabled.
-     */
-    if (this.httpAdapterOptions.logger !== false) {
-      this._logger.warn(
-        'Unable to send body separator. Headers will be delivered with the first chunk of the body.',
-      );
-    }
+    response.cork((): void => {
+      response.beginWrite();
+    });
   }
 
   protected _setStatus(


### PR DESCRIPTION
### Changed
- Updated renovate to bum node devEngine dep.
- Updated `uwebsocketsjs` adapter to rely on `beginWrite`.
- Fixed lint warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chunked HTTP responses in the uWebSockets adapter by enabling HTTP body separators to be sent correctly.
  - Chunked responses using body separators now complete without the previous unsupported-operation warning.

- **Maintenance**
  - Updated internal release and dependency-management configuration.
  - Reorganized test fixtures without changing test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->